### PR TITLE
Add patientViewHeader sample ids and tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.7.0",
-    "lodash": "^4.13.1",
     "mocha": "^2.5.3",
     "node-sass": "^3.8.0",
     "phantomjs-polyfill": "0.0.2",

--- a/src/features/patientView/PatientViewPage.jsx
+++ b/src/features/patientView/PatientViewPage.jsx
@@ -1,22 +1,65 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {Button, Overlay, Tooltip, Popover} from 'react-bootstrap';
 import ClinicalInformationContainer from './clinicalInformation/ClinicalInformationContainer';
 import PatientHeaderUnconnected from './patientHeader/PatientHeader';
 import { connect } from 'react-redux';
+
+const Example = React.createClass({
+  getInitialState() {
+    return { show: false };
+  },
+
+  toggle() {
+    this.setState({ show: !this.state.show });
+  },
+
+  show() {
+    this.setState({ show: true });
+  },
+
+  hide() {
+    this.setState({ show: false });
+  },
+
+  render() {
+    const sharedProps = {
+      show: this.state.show,
+      container: this,
+      target: () => ReactDOM.findDOMNode(this.refs.target)
+    };
+
+    return (
+      <div style={{ height: 100, paddingLeft: 150, position: 'relative' }}>
+        <Button onMouseOver={this.show} onMouseOut={this.hide} ref="target" onClick={this.toggle}>
+          Click me!
+        </Button>
+
+        <Overlay {...sharedProps} placement="bottom">
+          <Tooltip onMouseOver={this.show} onMouseOut={this.hide} id="overload-bottom">Tooltip overload!</Tooltip>
+        </Overlay>
+      </div>
+    );
+  }
+});
 
 class PatientViewPage extends React.Component {
 
     componentDidMount() {
         const mapStateToProps = function mapStateToProps(state) {
             return {
-                status: state.get('clinicalInformation').get('status')
+                samples: state.get('clinicalInformation').get('samples'),
+                status: state.get('clinicalInformation').get('status'),
+                patient: state.get('clinicalInformation').get('patient'),
             };
         };
 
         const PatientHeader = connect(mapStateToProps)(PatientHeaderUnconnected);
 
         ReactDOM.render(<PatientHeader store={this.props.store} />,
-            document.getElementById("clinical_div"));
+          document.getElementById("clinical_div"));
+        //ReactDOM.render(<div><Example /><Example /></div>, document.getElementById("clinical_div"));
+
     }
     render() {
         return (
@@ -25,14 +68,4 @@ class PatientViewPage extends React.Component {
     }
 }
 
-
 export default PatientViewPage;
-
-
-
-
-
-
-
-
-

--- a/src/features/patientView/SampleLabel.js
+++ b/src/features/patientView/SampleLabel.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export default class SampleLabelSVG extends React.Component {
+    constructor(props) {
+        super(props);
+        this.render = this.render.bind(this);
+    }
+
+    render() {
+        const { label, color, x, y } = this.props;
+        return (<g>
+             <circle cx={x} cy={y} fill={color} r={10} />
+             <text x={x} y={y + 5} fill={'white'} fontSize={10} textAnchor={'middle'}>{label}</text>
+           </g>);
+    }
+}
+
+SampleLabelSVG.propTypes = {
+    label: React.PropTypes.string.isRequired,
+    color: React.PropTypes.string.isRequired,
+    x: React.PropTypes.number.isRequired,
+    y: React.PropTypes.number.isRequired,
+};
+
+export class SampleLabelHTML extends React.Component {
+    constructor(props) {
+        super(props);
+        this.render = this.render.bind(this);
+    }
+
+    render() {
+        const { label, color } = this.props;
+        return (<svg width="12" height="12" className="case-label-header" alt="HCI002T">
+                    <g transform="translate(6,6)">
+                        <circle r="6" fill={color} />
+                        <text y="4" textAnchor="middle" fontSize="10" fill="white">{label}</text>
+                    </g>
+                </svg>);
+    }
+}
+
+SampleLabelHTML.propTypes = {
+    label: React.PropTypes.string.isRequired,
+    color: React.PropTypes.string.isRequired,
+};

--- a/src/features/patientView/clinicalInformation/ClinicalInformationContainer.jsx
+++ b/src/features/patientView/clinicalInformation/ClinicalInformationContainer.jsx
@@ -40,7 +40,7 @@ export class ClinicalInformationContainerUnconnected extends React.Component {
                 <h4>Samples</h4>
                 <FixedExample data={this.props.samples} />
 
-                <h4>Clinical Data</h4>
+                <h4>Patient</h4>
                 <ClinicalInformationPatientTable data={this.props.patient.get('clinicalData')} />
             </div>
         );

--- a/src/features/patientView/clinicalInformation/ClinicalInformationPatientTable.jsx
+++ b/src/features/patientView/clinicalInformation/ClinicalInformationPatientTable.jsx
@@ -16,6 +16,7 @@ export default class ClinicalInformationPatientTable extends React.Component {
     render() {
         const rows = [];
 
+        ;
         this.props.data.forEach((item) => {
             rows.push(
                 <tr key={item.get('id')}>

--- a/src/features/patientView/clinicalInformation/ClinicalInformationSamples.jsx
+++ b/src/features/patientView/clinicalInformation/ClinicalInformationSamples.jsx
@@ -1,5 +1,9 @@
 import React, { PropTypes as T } from 'react';
 
+import Immutable from 'immutable';
+
+import {Table, Column, Cell} from 'fixed-data-table';
+
 import EnhancedFixedDataTable from 'shared/components/enhancedFixedDataTable/EnhancedFixedDataTable';
 
 import covertSampleData from './lib/convertSamplesData';

--- a/src/features/patientView/clinicalInformation/ClinicalInformationSamplesTable.js
+++ b/src/features/patientView/clinicalInformation/ClinicalInformationSamplesTable.js
@@ -1,0 +1,67 @@
+import React, { PropTypes as T } from 'react';
+import { Table } from 'react-bootstrap';
+import Immutable from 'immutable';
+import { SampleLabelHTML } from '../SampleLabel';
+import convertSamplesData from './lib/convertSamplesData';
+
+
+export class ClinicalInformationSamplesTable extends React.Component {
+
+    componentDidMount() {
+
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+        return (nextProps === this.props);
+    }
+
+
+    render() {
+        const data = convertSamplesData(this.props.data.toArray());
+
+        const headerCells = data.columns.map((col, i) => {
+            return (<th style={{ whiteSpace: 'nowrap' }} key={i}>
+                       <SampleLabelHTML color={'black'} label={(i + 1).toString()} />
+                       {' ' + col.id}
+                   </th>);
+        });
+
+        const rows = [];
+
+        Object.keys(data.items).forEach((key) => {
+            const row = data.items[key];
+            rows.push(
+                <tr key={key}>
+                    <td key={-1}>{row.id}</td>
+                    {
+                        data.columns.map((col, i) => {
+                            if (col.id in row) {
+                                return <td key={i}>{row[col.id]}</td>;
+                            } else {
+                                return <td key={i}>N/A</td>;
+                            }
+                        })
+                    }
+
+                </tr>
+            );
+        });
+
+        return (
+            <Table striped>
+                <thead><tr>
+                    <th key={-1} />
+                    { headerCells }
+                </tr></thead>
+                <tbody>{ rows }</tbody>
+            </Table>
+        );
+    }
+}
+
+export default ClinicalInformationSamplesTable;
+
+
+// ClinicalInformationSamplesTable.propTypes = {
+//     data: T.any.isRequired,
+// };

--- a/src/features/patientView/clinicalInformation/PDXTree.jsx
+++ b/src/features/patientView/clinicalInformation/PDXTree.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SampleLabelSVG from './SampleLabel';
+import SampleLabelSVG from '../SampleLabel';
 
 export default class PDXTree extends React.Component {
 

--- a/src/features/patientView/patientHeader/PatientHeader.jsx
+++ b/src/features/patientView/patientHeader/PatientHeader.jsx
@@ -1,18 +1,67 @@
 import React from 'react';
+import {Button, OverlayTrigger, Popover} from 'react-bootstrap';
+import SampleInline from './SampleInline'
+import TooltipTable from '../clinicalInformation/ClinicalInformationPatientTable'
+import Immutable from 'immutable';
+import Spinner from 'react-spinkit';
+
 
 class PatientHeader extends React.Component {
 
-    render() {
-
-        console.log("patient header render");
+    getPopover(sample, number) {
         return (
-            <div>
-                <div>
-                    <a onClick={() => { this.props.setTab(2); }}>do it</a>
-                    {this.props.status}
-                </div>
-            </div>
+            <Popover key={number} id={'popover-sample-' + number}>
+                <TooltipTable data={Immutable.fromJS(sample.clinicalData)} />
+            </Popover>
         );
+    }
+
+    drawHeader() {
+        if (this.props.samples && this.props.samples.size > 0) {
+            return (
+                <div>
+                    {this.props.samples.map((sample, number) => {
+                        //let clinicalData = this.props.samples.get('items').keys().map(attr_id => { 
+                        //    return Object({'id': x, 
+                        //                  'value': this.props.samples.get('items').get(attr_id).get('TCGA-P6-A5OH-01')
+                        //    }) 
+                        //}).filter(x => x.value);
+                        console.log(sample);
+
+                        return (
+                            <OverlayTrigger delayHide={100} key={number} trigger={['hover', 'focus']} placement="bottom" 
+                             overlay={this.getPopover(sample, number+1)}>
+                                <span>
+                                    <SampleInline sample={sample} number={number+1} />
+                                </span>
+                            </OverlayTrigger>
+                        );
+                    })}
+                </div>
+            );
+        } else {
+            return <div>There was an error.</div>;
+        }
+    }
+
+    render() {
+        switch (this.props.status) {
+
+            case 'fetching':
+
+                return <div><Spinner spinnerName="three-bounce" /></div>;
+
+            case 'complete':
+
+                return this.drawHeader();
+
+            case 'error':
+
+                return <div>There was an error.</div>;
+
+            default:
+                return <div />;
+        }
     }
 }
 

--- a/src/features/patientView/patientHeader/SampleInline.jsx
+++ b/src/features/patientView/patientHeader/SampleInline.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {Button, OverlayTrigger, Popover} from 'react-bootstrap';
+import { SampleLabelHTML } from '../SampleLabel';
+
+export default class SampleInline extends React.Component {
+    render() {
+
+        const { sample, number } = this.props;
+
+        return (
+            <span style={{"paddingRight":"10px"}}>
+                <SampleLabelHTML color={'black'} label={(number).toString()} />
+                {' ' + sample.id}
+            </span>
+        );
+    }
+}
+SampleInline.propTypes = {
+    sample: React.PropTypes.object.isRequired,
+    number: React.PropTypes.number.isRequired
+}

--- a/src/shared/api/oldAPIWrapper.js
+++ b/src/shared/api/oldAPIWrapper.js
@@ -3,8 +3,6 @@
 import cbioportal_client from 'shared/api/cbioportal-client';
 import { renameKeys, dropKeys } from 'shared/lib/ObjectManipulation';
 
-const API_ROOT = 'http://www.cbioportal.org/pdx/api';
-
 /* Return patient data in new API format */
 export function getPatient(studyId, patientId) {
     /* Get data from Old API */


### PR DESCRIPTION
Use react-bootstrap OverlayTrigger to make tooltips with clinical data tables
for each sample id. Eventually we should use a tooltip that does not fade when
hovering over the tooltip.

Signed-off-by: Ino de Bruijn <ino@ino.pm>