### PR TITLE
proposal for get and observe

### DIFF
--- a/src/pages/patientView/example.tsx
+++ b/src/pages/patientView/example.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+//// QuerySession.ts
+interface IExampleDataModel {
+    id:number;
+    type:string;
+}
+
+
+interface IExampleDataResponse {
+
+    fetchStatus:'fetching'|'complete';
+    data?: Array<IExampleDataModel>;
+
+}
+
+declare type MyHandler = (myArgument: IExampleDataResponse) => void;
+
+const QuerySession = {
+
+    fetchAndObserveExampleData(mutationIds:Array<number>, callback:MyHandler){
+
+        // check to see if data is already available for these ids
+        // IF YES: return data and observe future changes
+        // IF NO: fetch data and observe future changes
+        // respond now and on future changes by invoking the callback
+        callback({ fetchStatus:'fetching' });
+
+        // for example, when network request finishes we would fire something like this
+        setTimeout(()=>callback({ fetchStatus:'complete', data:[{ id:0, type:'whatever' },{ id:1, type:'whatever' }] }), 5000);
+
+    }
+
+};
+
+interface IExampleComponentState {
+    exampleData:IExampleDataResponse; // i want this to be IExampleDataModel but I want to also track it's status here.
+}
+
+
+//// ExampleComponent.tsx
+export default class ExampleComponent extends React.Component<{}, IExampleComponentState> {
+
+    componentWillMount(){
+
+        //NOTE: this cannot be used in constructor because setState is called syncronously here
+        //and you cannot call setState in constructor
+        // PROBLEM: how do we unsubscribe
+        QuerySession.fetchAndObserveExampleData([0,1], (dataObject)=>{
+            this.setState({ exampleData: dataObject });
+        });
+
+    }
+
+    public render(){
+
+        return (<div>{ this.state.exampleData.fetchStatus }</div>);
+
+    }
+
+
+
+}
+


### PR DESCRIPTION
# What? Why?
Components need to be able to fetch data and then observe change to that same data.   Rather than put the data in redux store, we allow components to subscribe to the QuerySession object. 

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:

