### PR TITLE
Styling clinical attributes at top of patient view page

### DIFF
--- a/src/pages/pageHeader/styles.scss
+++ b/src/pages/pageHeader/styles.scss
@@ -1,7 +1,7 @@
 .cbioOnePageApp {
 
 
-  padding: 90px 20px 20px 20px;
+  padding: 99px 20px 20px 20px;
 
 
   header {

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -21,6 +21,9 @@ import queryString from "query-string";
 import SampleManager from './sampleManager';
 import SelectCallback = ReactBootstrap.SelectCallback;
 import {MrnaPercentile, default as CBioPortalAPIInternal} from "../../shared/api/CBioPortalAPIInternal";
+import PatientHeader from './patientHeader/PatientHeader';
+
+import './patientHeader/style/clinicalAttributes.scss';
 
 export interface IPatientViewPageProps {
     store?: RootState;
@@ -235,22 +238,22 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
     public render() {
 
         let sampleManager: SampleManager | null = null;
-        let sampleHeader: JSX.Element[] | null = null;
+        let sampleHeader: (JSX.Element | undefined)[] | null = null;
 
         if (this.props.samples) {
             sampleManager = new SampleManager(this.props.samples);
 
             sampleHeader = _.map(sampleManager!.samples,(sample: ClinicalDataBySampleId) => {
-                return <span style={{ marginRight:10 }}>{sampleManager!.getComponentForSample(sample.id)} {sample.id}</span>;
+                return sampleManager!.getComponentForSample(sample.id, true);
             });
-
         }
 
         return (
             <div>
 
                 <If condition={sampleHeader}>
-                    <div style={{marginBottom:20}}>
+                    <div style={{padding:20, borderRadius:5, background: '#eee', marginBottom: 20}}>
+                        <PatientHeader patient={this.props.patient} />
                         {sampleHeader}
                     </div>
                 </If>

--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
@@ -1,0 +1,200 @@
+import * as $ from 'jquery';
+import _ from 'underscore';
+
+/**
+ * Functions for dealing with clinical attributes.
+ */
+/**
+ * Clean clinical attributes. Useful for rounding numbers, or other types of
+ * data cleanup steps. Probably differs per institution.
+ * @param {object} clinicalData - key/value pairs of clinical data
+ */
+function clean(clinicalData) {
+    // Shallow Copy clinicalData
+    const cleanClinicalData = $.extend({}, clinicalData);
+    const NULL_VALUES = [
+        'not applicable',
+        'not available',
+        'pending',
+        'discrepancy',
+        'completed',
+        '',
+        'null',
+        'unknown',
+        'na',
+        'n/a',
+        '[unkown]',
+        '[not submitted]',
+        '[not evaluated]',
+        '[not applicable]',
+        '[not available]',
+        '[undefined]'
+    ];
+
+    const keys = Object.keys(clinicalData);
+    for (let i = 0; i < keys.length; i += 1) {
+        let value;
+        const key = keys[i];
+
+        value = clinicalData[key];
+
+        // Remove null values
+        if (NULL_VALUES.indexOf(value.toLowerCase()) > -1) {
+            delete cleanClinicalData[key];
+        } else {
+            // Change values for certain attributes, e.g. rounding
+            switch (key) {
+                case 'OS_MONTHS':
+                case 'DFS_MONTHS':
+                    if ($.isNumeric(value)) {
+                        value = Math.round(value);
+                    }
+                    cleanClinicalData[key] = value;
+                    break;
+                default:
+            }
+        }
+    }
+    return cleanClinicalData;
+}
+
+/**
+ * Get first key found in object. Otherwise return null.
+ * @param {object} object - object with key/value pairs
+ * @param {array} keys - array of keys
+ */
+function getFirstKeyFound(object, keys) {
+    if (!object) {
+        return null;
+    }
+
+    for (let i = 0; i < keys.length; i += 1) {
+        const value = object[keys[i]];
+        if (typeof value !== 'undefined' && value !== null) {
+            return value;
+        }
+    }
+    return null;
+}
+
+
+/**
+ * Derive clinical attributes from existing clinical attributes .e.g. age based
+ * on a date of birth. TODO: Now only includes a funky hack to keep current
+ * derived clinical attributes working.
+ * @param {object} clinicalData - key/value pairs of clinical data
+ */
+function derive(clinicalData) {
+    const derivedClinicalAttributes = $.extend({}, clinicalData);
+
+    /**
+     * TODO: Pretty funky function to get a normalized case type. This should
+     * probably also be a clinical attribute with a restricted vocabulary. Once
+     * the database has been changed to include normalized case types, this
+     * function should be removed.
+     * @param {object} clinicalData - key/value pairs of clinical data
+     * @param {string} caseTypeAttrs - TUMOR_TYPE or SAMPLE_TYPE value to normalize
+     */
+    function normalizedCaseType(cData, caseTypeAttrs) {
+        let caseTypeNormalized = null;
+        let caseType;
+        let caseTypeLower;
+        let i;
+
+        for (i = 0; i < caseTypeAttrs.length; i += 1) {
+            caseType = cData[caseTypeAttrs[i]];
+
+            if (caseType !== null && typeof caseType !== 'undefined') {
+                caseTypeLower = caseType.toLowerCase();
+
+                if (caseTypeLower.indexOf('metasta') >= 0) {
+                    caseTypeNormalized = 'Metastasis';
+                } else if (caseTypeLower.indexOf('recurr') >= 0) {
+                    caseTypeNormalized = 'Recurrence';
+                } else if (caseTypeLower.indexOf('progr') >= 0) {
+                    caseTypeNormalized = 'Progressed';
+                } else if (caseTypeLower.indexOf('prim') >= 0 ||
+                                    caseTypeLower.indexOf('prim') >= 0) {
+                    caseTypeNormalized = 'Primary';
+                }
+                if (caseTypeNormalized !== null && typeof caseTypeNormalized !== 'undefined') {
+                    break;
+                }
+            }
+        }
+
+        return caseTypeNormalized;
+    }
+
+    const caseTypeNormalized = normalizedCaseType(clinicalData, ['SAMPLE_TYPE', 'TUMOR_TISSUE_SITE', 'TUMOR_TYPE']);
+    if (caseTypeNormalized !== null) {
+        let loc;
+
+        derivedClinicalAttributes.DERIVED_NORMALIZED_CASE_TYPE = caseTypeNormalized;
+
+        // TODO: DERIVED_SAMPLE_LOCATION should probably be a clinical attribute.
+        if (derivedClinicalAttributes.DERIVED_NORMALIZED_CASE_TYPE === 'Metastasis') {
+            loc = getFirstKeyFound(clinicalData, ['METASTATIC_SITE', 'TUMOR_SITE']);
+        } else if (derivedClinicalAttributes.DERIVED_NORMALIZED_CASE_TYPE === 'Primary') {
+            loc = getFirstKeyFound(clinicalData, ['PRIMARY_SITE', 'TUMOR_SITE']);
+        } else {
+            loc = getFirstKeyFound(clinicalData, ['TUMOR_SITE']);
+        }
+        if (loc !== null) {
+            derivedClinicalAttributes.DERIVED_SAMPLE_LOCATION = loc;
+        }
+    }
+
+    return derivedClinicalAttributes;
+}
+
+/**
+ * Run both clean and derive on the clinicalData.
+ */
+function cleanAndDerive(clinicalData) {
+    return derive(clean(clinicalData));
+}
+
+/**
+ * Return string of spans representing the clinical attributes. The spans
+ * have been made specifically to add clinical attribute information as
+ * attributes to allow for easy styling with CSS.
+ * @param {object} clinicalData     - key/value pairs of clinical data
+ * @param {string} cancerStudyId    - short name of cancer study
+ */
+function getSpans(clinicalData, cancerStudyId) {
+    let spans = '';
+    const clinicalAttributesCleanDerived = cleanAndDerive(clinicalData);
+
+    const keys = Object.keys(clinicalAttributesCleanDerived);
+    for (let i = 0; i < keys.length; i += 1) {
+        const key = keys[i];
+        const value = clinicalAttributesCleanDerived[key];
+        spans += `<span class="clinical-attribute" attr-id="${key}" attr-value="${value}" study="${cancerStudyId}">${value}</span>`;
+    }
+
+    return spans;
+}
+
+/*
+ * Add .first-order class to all elements with the lowest order attribute.
+ * This way the first element can be styled in a different manner. If flex
+ * order attributes were working properly in CSS, one would be able to say
+ * .clinical-attribute:first, this is unfortunately not the case, therefore
+ * this hack is required. See clinical-attributes.css to see how this is
+ * used.
+ */
+function addFirstOrderClass() {
+    $('.sample-record-inline, #more-patient-info').each(() => {
+        const orderSortedAttributes = _.sortBy($(this).find('a > .clinical-attribute'), (y) => {
+            const order = parseInt($(y).css('order'), 10);
+            if (isNaN(order)) {
+                console.log('Warning: No order attribute found in .clinical-attribute.');
+            }
+            return order;
+        });
+        $(orderSortedAttributes[0]).addClass('first-order');
+    });
+}
+
+export { cleanAndDerive, getSpans, addFirstOrderClass };

--- a/src/pages/patientView/mutation/column/TumorColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/TumorColumnFormatter.tsx
@@ -19,7 +19,7 @@ export default class TumorColumnFormatter {
                 return (
                     <li className={(sample.id in presentSamples) ? '' : 'invisible'}>
                         {
-                        columnProps.sampleManager.getComponentForSample(sample.id, { showText: false })
+                        columnProps.sampleManager.getComponentForSample(sample.id, false)
                         }
                     </li>
                 );

--- a/src/pages/patientView/patientHeader/ClinicalAttributesInline.tsx
+++ b/src/pages/patientView/patientHeader/ClinicalAttributesInline.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {ClinicalData} from "../../../shared/api/CBioPortalAPI";
+
+export type IClinicalAttributesInlineProps = {
+    clinicalData?: ClinicalData;
+    cancerStudyId: string;
+};
+
+//export default class ClinicalAttributesInline extends React.Component<IClinicalAttributesInlineProps, {}> {
+//    public render() {
+//        switch (this.props.status) {
+//            case 'fetching':
+//                return <div><Spinner spinnerName='three-bounce' /></div>;
+//
+//            case 'complete':
+//                return this.draw();
+//
+//            case 'error':
+//                return <div>There was an error.</div>;
+//
+//            default:
+//                return <div />;
+//        }
+//    }
+//}
+
+type IClinicalAttributeProps ={
+    key: string;
+    value: string;
+};
+
+// class ClinicalAttribute extends React.Component<IClinicalAttributeProps, {}> {
+//     public render() {
+//         return <span className={`clinical-attribute`} attrId={key} attrValue={value} study={cancerStudyId}>{value}</span>;
+//     }
+// }

--- a/src/pages/patientView/patientHeader/PatientHeader.tsx
+++ b/src/pages/patientView/patientHeader/PatientHeader.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
+import {fromPairs} from 'lodash';
 import {OverlayTrigger, Popover} from 'react-bootstrap';
 
 import ClinicalInformationPatientTable from '../clinicalInformation/ClinicalInformationPatientTable';
-import SampleInline from './SampleInline';
 import {ClinicalInformationData} from "../Connector";
-import { ClinicalDataBySampleId } from "../../../shared/api/api-types-extended";
+import {getSpans} from '../clinicalInformation/lib/clinicalAttributesUtil.js';
 
 import styles from './styles.module.scss';
 
@@ -15,22 +15,11 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
 
         return (
             <div className={styles.patientHeader}>
-                <div>
-                    <i className="fa fa-female fa-2 genderIcon hidden" aria-hidden="true"></i>
-                    {this.props.patient && this.getOverlayTriggerPatient(this.props.patient)}
-                </div>
-                {this.props.samples && this.props.samples.map((s, n) => this.getOverlayTriggerSample(s, n))}
+                <i className="fa fa-female fa-2 genderIcon hidden" aria-hidden="true"></i>
+                {this.props.patient && this.getOverlayTriggerPatient(this.props.patient)}
             </div>
         );
 
-    }
-
-    private getPopoverSample(sample: ClinicalDataBySampleId, sampleNumber: number) {
-        return (
-            <Popover key={sampleNumber} id={'popover-sample-' + sampleNumber}>
-                <ClinicalInformationPatientTable showTitleBar={false} data={sample.clinicalData} />
-            </Popover>
-        );
     }
 
     private getPopoverPatient(patient: ClinicalInformationData['patient']) {
@@ -52,25 +41,11 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
             >
                 <span>
                     {patient.id}
+                    <span className='clinical-spans' id='patient-attributes' dangerouslySetInnerHTML={{__html:
+                        getSpans(fromPairs(patient.clinicalData.map((x) => [x.clinicalAttributeId, x.value])), 'lgg_ucsf_2014')}}>
+                    </span>
                 </span>
             </OverlayTrigger>
         );
     }
-
-    private getOverlayTriggerSample(sample: ClinicalDataBySampleId, sampleNumber: number) {
-        return (
-            <OverlayTrigger
-                delayHide={100}
-                key={sampleNumber}
-                trigger={['hover', 'focus']}
-                placement='bottom'
-                overlay={this.getPopoverSample(sample, sampleNumber + 1)}
-            >
-                <span>
-                    <SampleInline sample={sample} sampleNumber={sampleNumber + 1} />
-                </span>
-            </OverlayTrigger>
-        );
-    }
-
 }

--- a/src/pages/patientView/patientHeader/SampleInline.tsx
+++ b/src/pages/patientView/patientHeader/SampleInline.tsx
@@ -1,18 +1,36 @@
 import * as React from "react";
 import {SampleLabelHTML} from "../../../shared/components/sampleLabel/SampleLabel";
 import { ClinicalDataBySampleId } from "../../../shared/api/api-types-extended";
+import {fromPairs} from 'lodash';
+import {getSpans} from '../clinicalInformation/lib/clinicalAttributesUtil.js';
 
 interface ISampleInlineProps {
     sample: ClinicalDataBySampleId;
     sampleNumber: number;
+    showClinical: boolean;
 }
 
 export default class SampleInline extends React.Component<ISampleInlineProps, {}> {
     public render() {
-        const { sample, sampleNumber } = this.props;
+        const { sample, sampleNumber, showClinical } = this.props;
 
-        return (
-            <SampleLabelHTML color={'black'} label={(sampleNumber).toString()} />
-        );
+
+        if (showClinical) {
+            return (
+                <span style={{paddingRight: '10px'}}>
+                    <SampleLabelHTML color={'black'} label={(sampleNumber).toString()} />
+                    {' ' + sample.id}
+                    <span className="clinical-spans" dangerouslySetInnerHTML={{__html:
+                        getSpans(fromPairs(sample.clinicalData.map((x) => [x.clinicalAttributeId, x.value])), 'lgg_ucsf_2014')}}>
+                    </span>
+                </span>
+            );
+        } else {
+            return (
+                <span style={{paddingRight: '10px'}}>
+                    <SampleLabelHTML color={'black'} label={(sampleNumber).toString()} />
+                </span>
+            );
+        }
     }
 }

--- a/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
+++ b/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
@@ -1,0 +1,147 @@
+/* Do not display clinical attributes on default */
+.clinical-spans {
+    display: inline-flex;
+
+    .clinical-attribute {
+        display: none;
+        order: 999;
+    }
+    /* Show only following attributes */
+    .clinical-attribute[attr-id="SEX"],
+    .clinical-attribute[attr-id="GENDER"],
+    .clinical-attribute[attr-id="AGE"],
+    .clinical-attribute[attr-id="OS_STATUS"],
+    .clinical-attribute[attr-id="OS_MONTHS"],
+    .clinical-attribute[attr-id="DFS_STATUS"],
+    .clinical-attribute[attr-id="DFS_MONTHS"],
+    .clinical-attribute[attr-id="CANCER_TYPE"],
+    #patient-attributes .clinical-attribute[attr-id="CANCER_TYPE_DETAILED"],
+    .clinical-attribute[attr-id="KNOWN_MOLECULAR_CLASSIFIER"],
+    .clinical-attribute[attr-id="GLEASON_SCORE"],
+    .clinical-attribute[attr-id="HISTOLOGY"],
+    .clinical-attribute[attr-id="TUMOR_STAGE_2009"],
+    .clinical-attribute[attr-id="TUMOR_GRADE"],
+    .clinical-attribute[attr-id="ETS_RAF_SPINK1_STATUS"],
+    .clinical-attribute[attr-id="TMPRSS2_ERG_FUSION_STATUS"],
+    .clinical-attribute[attr-id="ERG_FUSION_ACGH"],
+    .clinical-attribute[attr-id="SERUM_PSA"],
+    .clinical-attribute[attr-id="DRIVER_MUTATIONS"],
+    .clinical-attribute[attr-id="SAMPLE_CLASS"],
+    .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"],
+    .clinical-attribute[attr-id="DERIVED_SAMPLE_LOCATION"] {
+        display: inline;
+        order: 6;
+    }
+    /* Show comma before clinical attributes */
+    .clinical-attribute:before {
+        content: ", ";
+        color: #428bca;
+    }
+    /* Order patient+sample clinical attributes */
+    .clinical-attribute[attr-id="PATIENT_DISPLAY_NAME"],
+    .clinical-attribute[attr-id="SAMPLE_DISPLAY_NAME"] {
+        order: 0;
+    }
+    /* Order sample clinical attributes (they don't exist for patient) */
+    .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"] {
+        order: 1;
+        text-transform: capitalize;
+    }
+    .clinical-attribute[attr-id="DERIVED_SAMPLE_LOCATION"] {
+        order: 2;
+    }
+    /* attributes with opening parenthesis */
+    .clinical-attribute[attr-id="OS_MONTHS"]:before,
+    .clinical-attribute[attr-id="DFS_MONTHS"]:before,
+    .clinical-attribute[attr-id="CANCER_TYPE_DETAILED"]:before,
+    .clinical-attribute[attr-id="PATIENT_DISPLAY_NAME"]:before,
+    .clinical-attribute[attr-id="DERIVED_SAMPLE_LOCATION"]:before,
+    .clinical-attribute[attr-id="SAMPLE_DISPLAY_NAME"]:before {
+        content: "\00a0(";
+        color: #428bca;
+    }
+    /* attributes with a closing parenthesis */
+    .clinical-attribute[attr-id="CANCER_TYPE_DETAILED"]:after,
+    .clinical-attribute[attr-id="PATIENT_DISPLAY_NAME"]:after,
+    .clinical-attribute[attr-id="DERIVED_SAMPLE_LOCATION"]:after,
+    .clinical-attribute[attr-id="SAMPLE_DISPLAY_NAME"]:after {
+        content: ")";
+    }
+    /* text before an attribute */
+    .clinical-attribute[attr-id="SERUM_PSA"]:before {
+        content: ", Serum PSA: ";
+    }
+    .clinical-attribute[attr-id="ERG_FUSION_ACGH"]:before {
+        content: ", ERG-fusion aCGH: ";
+    }
+    .clinical-attribute[attr-id="TMPRSS2_ERG_FUSION_STATUS"]:before {
+        content: ", TMPRSS2-ERG Fusion: ";
+    }
+    .clinical-attribute[attr-id="GLEASON"]:before {
+        content: ", Gleason: ";
+    }
+    /* text after an attribute */
+    .clinical-attribute[attr-id="OS_MONTHS"]:after,
+    .clinical-attribute[attr-id="DFS_MONTHS"]:after {
+        content: " months)";
+    }
+    .clinical-attribute[attr-id="AGE"]:after {
+        content: " years old";
+    }
+    /* attributes with special colors */
+    .clinical-attribute[attr-id="OS_STATUS"][attr-value="DECEASED"],
+    .clinical-attribute[attr-id="OS_STATUS"][attr-value="DEAD"],
+    .clinical-attribute[attr-id="DFS_STATUS"] {
+        color: #f00;
+    }
+    .clinical-attribute[attr-id="OS_STATUS"][attr-value="LIVING"],
+    .clinical-attribute[attr-id="OS_STATUS"][attr-value="ALIVE"],
+    .clinical-attribute[attr-id="DFS_STATUS"][attr-value="DiseaseFree"],
+    .clinical-attribute[attr-id="DFS_STATUS"][attr-value="Yes"] {
+        color: rgb(0, 128, 0);
+    }
+    .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"][attr-value='Primary'] {
+      color: black;
+    }
+    .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"][attr-value="Progressed"],
+    .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"][attr-value="Recurrence"] {
+      color: orange;
+    }
+    .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"][attr-value="Metastasis"] {
+      color: red;
+    }
+}
+#patient-attributes {
+    /* Order patient clinical attributes */
+    .clinical-attribute[attr-id="SEX"],
+    .clinical-attribute[attr-id="GENDER"] {
+        order: 1;
+    }
+    .clinical-attribute[attr-id="AGE"] {
+        order: 2;
+    }
+    .clinical-attribute[attr-id="CANCER_TYPE"] {
+        order: 3;
+    }
+    .clinical-attribute[attr-id="CANCER_TYPE_DETAILED"] {
+        order: 4;
+    }
+    .clinical-attribute[attr-id="KNOWN_MOLECULAR_CLASSIFIER"] {
+        order: 5;
+    }
+    .clinical-attribute[attr-id="HISTOLOGY"] {
+        order: 6;
+    }
+    .clinical-attribute[attr-id="OS_STATUS"] {
+        order: 7;
+    }
+    .clinical-attribute[attr-id="OS_MONTHS"] {
+        order: 8;
+    }
+    .clinical-attribute[attr-id="DFS_STATUS"] {
+        order: 9;
+    }
+    .clinical-attribute[attr-id="DFS_MONTHS"] {
+        order: 10;
+    }
+}

--- a/src/pages/patientView/patientHeader/styles.module.scss
+++ b/src/pages/patientView/patientHeader/styles.module.scss
@@ -1,6 +1,6 @@
 .patientHeader {
 
-  margin-bottom:20px;
+  margin-bottom: 5px;
 
   :global .genderIcon {
     display:inline-block;

--- a/src/pages/patientView/sampleManager.tsx
+++ b/src/pages/patientView/sampleManager.tsx
@@ -28,46 +28,54 @@ class SampleManager {
         });
     }
 
-    getComponentForSample(sampleId: string, options?: { showText:Boolean }) {
+    getComponentForSample(sampleId: string, showClinical = false) {
 
-        let sample = _.find(this.samples, (sample: ClinicalDataBySampleId)=>{
-            return sample.id === sampleId;
+        let sample = _.find(this.samples, (s: ClinicalDataBySampleId)=> {
+            return s.id === sampleId;
         });
 
-        return sample && this.getOverlayTriggerSample(sample, this.sampleIndex[sample.id]);
+        return sample && this.getOverlayTriggerSample(sample, this.sampleIndex[sample.id], showClinical);
+
     }
 
     getComponentsForSamples() {
         this.samples.map((sample)=>this.getComponentForSample(sample.id));
     }
 
-    getOverlayTriggerSample(sample: ClinicalDataBySampleId, sampleIndex: number) {
+    getOverlayTriggerSample(sample: ClinicalDataBySampleId, sampleIndex: number, showClinical = false) {
 
         const sampleNumberText: number = sampleIndex+1;
 
-        const align = {
-            points: ['tl', 'tr'], // align top left point of sourceNode with top right point of targetNode
-            offset: [0, 20], // the offset sourceNode by 10px in x and 20px in y,
-            targetOffset: ['0','0'], // the offset targetNode by 30% of targetNode width in x and 40% of targetNode height in y,
-        };
+        // const align = {
+        //     points: ['tl', 'tr'], // align top left point of sourceNode with top right point of targetNode
+        //     offset: [0, 20], // the offset sourceNode by 10px in x and 20px in y,
+        //     targetOffset: ['0','0'], // the offset targetNode by 30% of targetNode width in x and 40% of targetNode height in y,
+        // };
 
 
         return (<Tooltip
-            placement='topRight'
+            placement='bottomLeft'
             trigger={['hover', 'focus']}
             overlay={this.getPopoverSample(sample, sampleNumberText)}
             arrowContent={<div className="rc-tooltip-arrow-inner" />}
             destroyTooltipOnHide={false}
             onPopupAlign={placeArrow}
-
             >
-            <svg width="12" height="12">
+            <span>
                 <SampleInline
                              sample={sample}
                              sampleNumber={sampleNumberText}
-                         />
-            </svg>
+                             showClinical={showClinical}
+                         >
+                </SampleInline>
+             </span>
         </Tooltip>);
+
+           // <SampleInline
+           //              sample={sample}
+           //              sampleNumber={sampleNumberText}
+           //              showClinical={showClinical}
+           //          />
 
         // return (
         //     <OverlayTrigger

--- a/src/shared/components/sampleLabel/SampleLabel.tsx
+++ b/src/shared/components/sampleLabel/SampleLabel.tsx
@@ -33,7 +33,7 @@ export class SampleLabelHTML extends React.Component<ISampleLabelHTMLProps, {}> 
     public render() {
         const { label, color } = this.props;
         return (
-            <svg width='12' height='12' className='case-label-header' alt='HCI002T'>
+            <svg width='12' height='12' className='case-label-header'>
                 <g transform='translate(6,6)'>
                     <circle r='6' fill={color} />
                     <text y='4' textAnchor='middle' fontSize='10' fill='white'>{label}</text>


### PR DESCRIPTION
Add old clinical attributes util function to style clinical attributes at the top of page. This is being done using CSS selectors by adding the clinical attribute info to the elements. Reasoning at the time was, that replacing a CSS file is easier for other institutions to replace and less error prone. 

Some data normalization is performed in these functions as well that should preferably happen in the transformation step before import. Not much effort has been made therefore to improve these functions on the frontend.

![screen shot 2017-01-20 at 12 04 05 pm](https://cloud.githubusercontent.com/assets/1334004/22158075/906e0bd0-df08-11e6-92fa-a1d1de09c9d7.png)