### PR TITLE
Tooltip orientation fixes for the mutation table

### DIFF
--- a/src/pages/patientView/mutation/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/AnnotationColumnFormatter.tsx
@@ -18,6 +18,11 @@ export interface IAnnotation {
     myCancerGenome: string[];
 }
 
+export function placeArrow(tooltipEl: any) {
+    const arrowEl = tooltipEl.querySelector('.rc-tooltip-arrow');
+    arrowEl.style.left = '10px';
+}
+
 /**
  * @author Selcuk Onur Sumer
  */
@@ -140,9 +145,20 @@ export default class AnnotationColumnFormatter
             const hotspotTooltipContent = AnnotationColumnFormatter.hotspotInfo(isHotspot, is3dHotspot);
 
             hotspotContent = (
-                <Tooltip overlay={hotspotTooltipContent} placement="rightTop" arrowContent={arrowContent}>
+                <Tooltip
+                    overlay={hotspotTooltipContent}
+                    placement="topLeft"
+                    trigger={['hover', 'focus']}
+                    arrowContent={arrowContent}
+                    onPopupAlign={placeArrow}
+                >
                     <span className='annotation-item chang_hotspot'>
-                        <img width={hotspotsImgWidth} height={hotspotsImgHeight} src={hotspotsImgSrc} alt='Recurrent Hotspot Symbol' />
+                        <img
+                            width={hotspotsImgWidth}
+                            height={hotspotsImgHeight}
+                            src={hotspotsImgSrc}
+                            alt='Recurrent Hotspot Symbol'
+                        />
                     </span>
                 </Tooltip>
             );

--- a/src/shared/components/enhancedReactTable/EnhancedReactTable.tsx
+++ b/src/shared/components/enhancedReactTable/EnhancedReactTable.tsx
@@ -358,7 +358,7 @@ export default class EnhancedReactTable<T> extends React.Component<IEnhancedReac
                 const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
 
                 headerContent = (
-                    <Tooltip overlay={columnDef.description} placement="rightTop" arrowContent={arrowContent}>
+                    <Tooltip overlay={columnDef.description} placement="top" arrowContent={arrowContent}>
                         {headerContent}
                     </Tooltip>
                 );

--- a/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.tsx
@@ -256,7 +256,7 @@ export default class MutationTypeColumnFormatter
             const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
 
             content = (
-                <Tooltip overlay={toolTip} placement="rightTop" arrowContent={arrowContent}>
+                <Tooltip overlay={toolTip} placement="left" arrowContent={arrowContent}>
                     {content}
                 </Tooltip>
             );


### PR DESCRIPTION
# What? Why?
Fixes the mutation table column header tooltips.

Changes proposed in this pull request:
Tooltip orientation is changed to `top`

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)