### PR TITLE
Updated Mutation Assessor column formatter

### DIFF
--- a/src/shared/components/mutationTable/column/mutationAssessor.module.scss
+++ b/src/shared/components/mutationTable/column/mutationAssessor.module.scss
@@ -1,5 +1,5 @@
 .oma-link {
-  font-weight:bold;
+  font-weight:normal;
 }
 
 .oma-high {
@@ -20,6 +20,12 @@
 .oma-neutral {
   color: #909090;
   font-weight:bold;
+}
+
+.oma-na {
+  color: #808080;
+  font-size: xx-small;
+  text-align: center;
 }
 
 .mutation-assessor-link {


### PR DESCRIPTION
# What? Why?
Updated the Mutation Assessor column formatter to use the mutation model values (legacy DB values).
This is needed until we switch to an external service for Mutation Assessor.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
