### PR TITLE
Test latest swagger json on Travis for master/rc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ install:
   - npm install codecov.io
 script:
   - echo 'API_ROOT=http://cbioportal-rc.herokuapp.com/api' > .env
+  # make sure json is in sync on master and rc branch (since these are branches
+  # about to be deployed)
+  - |
+      if [ "${TRAVIS_BRANCH}" == "master" ] || [[ "${TRAVIS_BRANCH}" =~ ^rc.* ]]; then
+        (npm run fetchAPI && git diff --quiet src/shared/api/CBioPortalAPI-docs.json ) || (echo 'src/shared/api/CBioPortalAPI-docs.json out of sync' && exit 1);
+        (npm run fetchHotspotsAPI && git diff --quiet src/shared/api/CancerHotspotsAPI-docs.json) || (echo 'src/shared/api/CancerHotspotsAPI-docs.json out of sync' && exit 1);
+      fi
   # Run build
   - npm run build
   # Run test


### PR DESCRIPTION
This is a test to keep the swagger json stored in the repo in sync with whatever API endpoint is being pointed to.

Tested this against master as well to confirm it works. Seems to work: https://github.com/cBioPortal/cbioportal-frontend/pull/165