### PR TITLE
Implement code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       }
 after_success:
  # upload coverage data to codecov.io
- - cat coverage/*/lcov.info | codecov
+ - cat test/fixtures/outputs/lcov.info | codecov
 cache:
   directories:
     - node_modules

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,6 +6,24 @@ process.env.NODE_ENV = 'test';
 
 var webpackConfig = require('./webpack.config');
 
+var path = require('path');
+
+// code which should not impact coverage reports should be listed
+// in exclude
+webpackConfig.module.postLoaders =  [
+    {
+        test: /.tsx?$/,
+        include: path.resolve(__dirname, 'src/'),
+        exclude: [
+            /.spec./,
+            /\/shared\/api\//
+        ],
+        loader: 'istanbul-instrumenter-loader'
+    }
+];
+
+webpackConfig.entry = [];
+
 module.exports = function (config) {
     config.set({
         basePath: '',
@@ -37,20 +55,21 @@ module.exports = function (config) {
             'karma-webpack',
             'karma-phantomjs-launcher',
             'karma-spec-reporter',
-            'karma-sourcemap-loader'
+            'karma-sourcemap-loader',
+            'karma-coverage',
+            'karma-coverage-istanbul-reporter'
         ],
 
-        reporters: ['spec'],
+        coverageIstanbulReporter: {
+            reports: ['text-summary','json-summary','html', 'lcov'],
+            dir: './test/fixtures/outputs'
+        },
+
+        reporters: ['spec','coverage-istanbul'],
         port: 9876,
         colors: true,
         logLevel: config.LOG_INFO,
         browsers: ['PhantomJS'],
         singleRun: !argv.watch,
-        coverageReporter: {
-            reporters: [
-                {type: 'lcov'},
-                {type: 'text-summary'}
-            ],
-        }
     });
 };

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "karma-chai": "^0.1.0",
     "karma-coverage": "^1.1.1",
     "karma-coverage-es6": "^0.2.7",
+    "karma-coverage-istanbul-reporter": "^0.2.0",
     "karma-jasmine": "^1.1.0",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.2",

--- a/scripts/generate_spec_files.sh
+++ b/scripts/generate_spec_files.sh
@@ -1,0 +1,9 @@
+# generate spec files for tsx files w/o them
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+for f in $(cd ${SCRIPT_DIR}/../ && git ls-files | grep -E 'ts(x){0,1}$' | grep -v spec | grep -v api | grep -v redux | grep -v appShell | grep -v typings)
+do 
+        (test -e ${f/.ts*/.spec.js} || test -e ${f/.ts*/.spec.jsx}) || \
+            cat ${SCRIPT_DIR}/spec.template.js | \
+                sed "s:## basename of file here ##:$(basename ${f/.ts*/}):g" > ${f/.ts*/.spec.jsx};
+done

--- a/scripts/spec.template.js
+++ b/scripts/spec.template.js
@@ -1,0 +1,21 @@
+import * as ## basename of file here ## from './## basename of file here ##';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('## basename of file here ##', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/datasetView/Connector.spec.jsx
+++ b/src/pages/datasetView/Connector.spec.jsx
@@ -1,0 +1,21 @@
+import * as Connector from './Connector';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('Connector', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/datasetView/DatasetList.spec.jsx
+++ b/src/pages/datasetView/DatasetList.spec.jsx
@@ -1,0 +1,21 @@
+import * as DatasetList from './DatasetList';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('DatasetList', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/datasetView/DatasetPage.spec.jsx
+++ b/src/pages/datasetView/DatasetPage.spec.jsx
@@ -1,0 +1,21 @@
+import * as DatasetPage from './DatasetPage';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('DatasetPage', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/datasetView/getDatasetsInfo.spec.jsx
+++ b/src/pages/datasetView/getDatasetsInfo.spec.jsx
@@ -1,0 +1,21 @@
+import * as getDatasetsInfo from './getDatasetsInfo';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('getDatasetsInfo', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/home/HomePage.spec.jsx
+++ b/src/pages/home/HomePage.spec.jsx
@@ -1,0 +1,21 @@
+import * as HomePage from './HomePage';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('HomePage', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/pageHeader/PageHeader.spec.jsx
+++ b/src/pages/pageHeader/PageHeader.spec.jsx
@@ -1,0 +1,21 @@
+import * as PageHeader from './PageHeader';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('PageHeader', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/PatientViewPage.spec.jsx
+++ b/src/pages/patientView/PatientViewPage.spec.jsx
@@ -1,0 +1,21 @@
+import * as PatientViewPage from './PatientViewPage';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('PatientViewPage', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/clinicalInformation/ClinicalInformationPatientTable.spec.jsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationPatientTable.spec.jsx
@@ -1,0 +1,21 @@
+import * as ClinicalInformationPatientTable from './ClinicalInformationPatientTable';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('ClinicalInformationPatientTable', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/clinicalInformation/ClinicalInformationSamplesTable.spec.jsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationSamplesTable.spec.jsx
@@ -1,0 +1,21 @@
+import * as ClinicalInformationSamplesTable from './ClinicalInformationSamplesTable';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('ClinicalInformationSamplesTable', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/clinicalInformation/getClinicalInformationData.spec.jsx
+++ b/src/pages/patientView/clinicalInformation/getClinicalInformationData.spec.jsx
@@ -1,0 +1,21 @@
+import * as getClinicalInformationData from './getClinicalInformationData';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('getClinicalInformationData', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/clinicalInformation/lib/convertSamplesData.spec.jsx
+++ b/src/pages/patientView/clinicalInformation/lib/convertSamplesData.spec.jsx
@@ -1,0 +1,21 @@
+import * as convertSamplesData from './convertSamplesData';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('convertSamplesData', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/clinicalInformation/lib/convertSamplesData.ts
+++ b/src/pages/patientView/clinicalInformation/lib/convertSamplesData.ts
@@ -37,3 +37,4 @@ export default function (data?: Array<ClinicalDataBySampleId>):IConvertedSamples
 
     return output;
 }
+

--- a/src/pages/patientView/genomicOverview/GenomicOverview.spec.jsx
+++ b/src/pages/patientView/genomicOverview/GenomicOverview.spec.jsx
@@ -1,0 +1,21 @@
+import * as GenomicOverview from './GenomicOverview';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('GenomicOverview', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/genomicOverview/tracksHelper.spec.jsx
+++ b/src/pages/patientView/genomicOverview/tracksHelper.spec.jsx
@@ -1,0 +1,21 @@
+import * as tracksHelper from './tracksHelper';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('tracksHelper', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/MutationInformationContainer.spec.jsx
+++ b/src/pages/patientView/mutation/MutationInformationContainer.spec.jsx
@@ -1,0 +1,21 @@
+import * as MutationInformationContainer from './MutationInformationContainer';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('MutationInformationContainer', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/column/AlleleCountColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/AlleleCountColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as AlleleCountColumnFormatter from './AlleleCountColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('AlleleCountColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as AlleleFreqColumnFormatter from './AlleleFreqColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('AlleleFreqColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/column/AnnotationColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/AnnotationColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as AnnotationColumnFormatter from './AnnotationColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('AnnotationColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/column/CohortColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/CohortColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as CohortColumnFormatter from './CohortColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('CohortColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/column/MrnaExprColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/MrnaExprColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as MrnaExprColumnFormatter from './MrnaExprColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('MrnaExprColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as ProteinChangeColumnFormatter from './ProteinChangeColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('ProteinChangeColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/mutation/column/TumorColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/TumorColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as TumorColumnFormatter from './TumorColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('TumorColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/patientHeader/ClinicalAttributesInline.spec.jsx
+++ b/src/pages/patientView/patientHeader/ClinicalAttributesInline.spec.jsx
@@ -1,0 +1,21 @@
+import * as ClinicalAttributesInline from './ClinicalAttributesInline';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('ClinicalAttributesInline', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/patientHeader/PatientHeader.spec.jsx
+++ b/src/pages/patientView/patientHeader/PatientHeader.spec.jsx
@@ -1,0 +1,21 @@
+import * as PatientHeader from './PatientHeader';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('PatientHeader', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/patientHeader/SampleInline.spec.jsx
+++ b/src/pages/patientView/patientHeader/SampleInline.spec.jsx
@@ -1,0 +1,21 @@
+import * as SampleInline from './SampleInline';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('SampleInline', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/sampleManager.spec.jsx
+++ b/src/pages/patientView/sampleManager.spec.jsx
@@ -1,0 +1,21 @@
+import * as sampleManager from './sampleManager';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('sampleManager', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/vafPlot/ThumbnailExpandVAFPlot.spec.jsx
+++ b/src/pages/patientView/vafPlot/ThumbnailExpandVAFPlot.spec.jsx
@@ -1,0 +1,21 @@
+import * as ThumbnailExpandVAFPlot from './ThumbnailExpandVAFPlot';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('ThumbnailExpandVAFPlot', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/pages/patientView/vafPlot/VAFPlot.spec.jsx
+++ b/src/pages/patientView/vafPlot/VAFPlot.spec.jsx
@@ -1,0 +1,21 @@
+import * as VAFPlot from './VAFPlot';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('VAFPlot', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/PageDecorator/PageDecorator.spec.jsx
+++ b/src/shared/components/PageDecorator/PageDecorator.spec.jsx
@@ -1,0 +1,21 @@
+import * as PageDecorator from './PageDecorator';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('PageDecorator', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/annotation/CancerHotspots.spec.jsx
+++ b/src/shared/components/annotation/CancerHotspots.spec.jsx
@@ -1,0 +1,21 @@
+import * as CancerHotspots from './CancerHotspots';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('CancerHotspots', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/annotation/MyCancerGenome.spec.jsx
+++ b/src/shared/components/annotation/MyCancerGenome.spec.jsx
@@ -1,0 +1,21 @@
+import * as MyCancerGenome from './MyCancerGenome';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('MyCancerGenome', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/columnVisibilityControls/ColumnVisibilityControls.spec.jsx
+++ b/src/shared/components/columnVisibilityControls/ColumnVisibilityControls.spec.jsx
@@ -1,0 +1,21 @@
+import * as ColumnVisibilityControls from './ColumnVisibilityControls';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('ColumnVisibilityControls', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/cosmic/CosmicMutationTable.spec.jsx
+++ b/src/shared/components/cosmic/CosmicMutationTable.spec.jsx
@@ -1,0 +1,21 @@
+import * as CosmicMutationTable from './CosmicMutationTable';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('CosmicMutationTable', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/enhancedReactTable/EnhancedReactTable.spec.jsx
+++ b/src/shared/components/enhancedReactTable/EnhancedReactTable.spec.jsx
@@ -1,0 +1,21 @@
+import * as EnhancedReactTable from './EnhancedReactTable';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('EnhancedReactTable', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/enhancedReactTable/IColumnFormatter.spec.jsx
+++ b/src/shared/components/enhancedReactTable/IColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as IColumnFormatter from './IColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('IColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/enhancedReactTable/IEnhancedReactTableProps.spec.jsx
+++ b/src/shared/components/enhancedReactTable/IEnhancedReactTableProps.spec.jsx
@@ -1,0 +1,21 @@
+import * as IEnhancedReactTableProps from './IEnhancedReactTableProps';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('IEnhancedReactTableProps', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/featureTitle/FeatureTitle.spec.jsx
+++ b/src/shared/components/featureTitle/FeatureTitle.spec.jsx
@@ -1,0 +1,21 @@
+import * as FeatureTitle from './FeatureTitle';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('FeatureTitle', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/mutationTable/IMutationTableProps.spec.jsx
+++ b/src/shared/components/mutationTable/IMutationTableProps.spec.jsx
@@ -1,0 +1,21 @@
+import * as IMutationTableProps from './IMutationTableProps';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('IMutationTableProps', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/mutationTable/MutationTable.spec.jsx
+++ b/src/shared/components/mutationTable/MutationTable.spec.jsx
@@ -1,0 +1,21 @@
+import * as MutationTable from './MutationTable';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('MutationTable', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as CosmicColumnFormatter from './CosmicColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('CosmicColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as GeneColumnFormatter from './GeneColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('GeneColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as MutationAssessorColumnFormatter from './MutationAssessorColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('MutationAssessorColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as MutationStatusColumnFormatter from './MutationStatusColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('MutationStatusColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.jsx
@@ -1,0 +1,21 @@
+import * as MutationTypeColumnFormatter from './MutationTypeColumnFormatter';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('MutationTypeColumnFormatter', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/sampleLabel/SampleLabel.spec.jsx
+++ b/src/shared/components/sampleLabel/SampleLabel.spec.jsx
@@ -1,0 +1,21 @@
+import * as SampleLabel from './SampleLabel';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('SampleLabel', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/tableHeaderControls/TableHeaderControls.spec.jsx
+++ b/src/shared/components/tableHeaderControls/TableHeaderControls.spec.jsx
@@ -1,0 +1,21 @@
+import * as TableHeaderControls from './TableHeaderControls';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('TableHeaderControls', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/components/tablePaginationControls/TablePaginationControls.spec.jsx
+++ b/src/shared/components/tablePaginationControls/TablePaginationControls.spec.jsx
@@ -1,0 +1,21 @@
+import * as TablePaginationControls from './TablePaginationControls';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('TablePaginationControls', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/lib/ConnectorAPI.spec.jsx
+++ b/src/shared/lib/ConnectorAPI.spec.jsx
@@ -1,0 +1,21 @@
+import * as ConnectorAPI from './ConnectorAPI';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('ConnectorAPI', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/lib/SortUtils.spec.jsx
+++ b/src/shared/lib/SortUtils.spec.jsx
@@ -1,0 +1,21 @@
+import * as SortUtils from './SortUtils';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('SortUtils', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/lib/classNames.spec.jsx
+++ b/src/shared/lib/classNames.spec.jsx
@@ -1,0 +1,21 @@
+import * as classNames from './classNames';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('classNames', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/lib/handleReady.spec.jsx
+++ b/src/shared/lib/handleReady.spec.jsx
@@ -1,0 +1,21 @@
+import * as handleReady from './handleReady';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('handleReady', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});


### PR DESCRIPTION
Add code coverage reporting

- Use istanbul instrumenter loader and coverageIstanbulReporter
- Output lcov for codecov.io, update Travis to upload lcov file
- Exclude API clients from testing
- Since source files are not included in coverage report if they are not
  imported in a spec files, a bash script for generating spec files was made.
  The script uses a template to generate them.
- Add the generated spec files for ts/tsx source files w/o one.