### PR TITLE
Issue 167 cosmic overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/react-spinkit": "^1.1.29",
     "@types/reselect": "^2.0.27",
     "@types/seamless-immutable": "^6.1.2",
+    "@types/sinon": "^1.16.35",
     "@types/superagent": "^2.0.36",
     "autoprefixer": "^6.7.0",
     "babel-core": "^6.22.1",

--- a/src/shared/components/tableHeaderControls/TableHeaderControls.spec.tsx
+++ b/src/shared/components/tableHeaderControls/TableHeaderControls.spec.tsx
@@ -1,0 +1,37 @@
+import {assert} from "chai";
+import TableHeaderControls from "./TableHeaderControls";
+import sinon from 'sinon';
+
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+describe('TableHeaderControls', () => {
+
+    it('bindCopyButton is called only when there is a copy button and props flag is true', ()=>{
+
+        const mockInstance = {
+            bindCopyButton: sinon.stub(),
+            props: { showCopyAndDownload: true },
+            _copyButton: {}
+        };
+
+        TableHeaderControls.prototype.componentDidMount.apply(mockInstance);
+
+        assert.isTrue(mockInstance.bindCopyButton.calledOnce);
+    });
+
+    it('bindCopyButton is called only when there is a copy button and props flag is true', ()=>{
+
+        const mockInstance = {
+            bindCopyButton: sinon.stub(),
+            props: { showCopyAndDownload: false },
+            _copyButton: {}
+        };
+
+        TableHeaderControls.prototype.componentDidMount.apply(mockInstance);
+
+        assert.isFalse(mockInstance.bindCopyButton.called);
+    });
+
+});

--- a/src/shared/components/tableHeaderControls/TableHeaderControls.tsx
+++ b/src/shared/components/tableHeaderControls/TableHeaderControls.tsx
@@ -80,6 +80,14 @@ export default class TableExportButtons extends React.Component<ITableExportButt
 
         // this is necessary because the clipboard wrapper library
         // doesn't work with tooltips :(
+        if (this.props.showCopyAndDownload && this._copyButton) {
+            this.bindCopyButton();
+        }
+
+    }
+
+    public bindCopyButton(){
+
         new Clipboard(this._copyButton, {
             text: function() {
                 return this.getText();


### PR DESCRIPTION
# What? Why?
Fix issue #167 .
The Cosmic overlay uses enhanced reactable, which uses table header controls.  There was a bug in table header controls where it was trying to bind clipboard.js to a non-existant copy button


Changes proposed in this pull request:
- If there's no copy button, don't try to bind clipboard.js to it

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
