### PR TITLE
Removed a duplicate line that fetches the hotspot data twice

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -399,9 +399,6 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                 });
 
                 this.fetchMutationData(sampleIds).then((_result) => {
-                    this.fetchHotspotsData(_result).then((hotspotsData:IHotspotData) => {
-                        this.setState(({ hotspotsData } as IPatientViewState));
-                    });
                     this.fetchVariantCountData(_result).then((variantCountData:IVariantCountData) => {
                         this.setState(({ variantCountData } as IPatientViewState));
                     });


### PR DESCRIPTION
# What? Why?
Seems like we are fetching the hotspot data twice.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
