### PR TITLE
Test and lint cleaning for mutation table column formatters

### DIFF
--- a/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.spec.jsx
+++ b/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.spec.jsx
@@ -1,21 +1,72 @@
-import * as ProteinChangeColumnFormatter from './ProteinChangeColumnFormatter';
+import ProteinChangeColumnFormatter from './ProteinChangeColumnFormatter';
+import styles from './style/proteinChange.module.scss';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
-describe('ProteinChangeColumnFormatter', () => {
+describe('ProteinChangeColumnFormatter (customized for patient view)', () => {
+    const germlineMutation = {
+        proteinChange: "Q616K",
+        mutationStatus: "Germline"
+    };
 
-    before(()=>{
+    const somaticMutation = {
+        proteinChange: "Q616L",
+        mutationStatus: "Somatic"
+    };
 
+    const tableData = [[germlineMutation], [somaticMutation]];
+
+    let germlineComponent, somaticComponent;
+
+    before(() => {
+
+        let data = {
+            name:"Protein Change",
+            tableData: tableData,
+            rowData: [germlineMutation]
+        };
+
+        // mount a single cell component (Td) for a germline mutation
+        germlineComponent = mount(ProteinChangeColumnFormatter.renderFunction(data));
+
+        data = {
+            name:"Protein Change",
+            tableData: tableData,
+            rowData: [somaticMutation]
+        };
+
+        // mount a single cell component (Td) for a somatic mutation
+        somaticComponent = mount(ProteinChangeColumnFormatter.renderFunction(data));
+    });
+
+    it('component protein change display value', () => {
+        assert.isTrue(germlineComponent.find(`.${styles.proteinChange}`).exists(),
+            'Germline mutation should have the protein change value');
+        assert.isTrue(germlineComponent.find(`.${styles.proteinChange}`).text().indexOf("Q616K") > -1,
+            'Protein change value for germline mutation is correct');
+        assert.isTrue(somaticComponent.find(`.${styles.proteinChange}`).exists(),
+            'Somatic mutation should have the protein change value');
+        assert.isTrue(somaticComponent.find(`.${styles.proteinChange}`).text().indexOf("Q616L") > -1,
+            'Protein change value for somatic mutation is correct');
+    });
+
+    it('component germline indicator', () => {
+        assert.isTrue(germlineComponent.find(`.${styles.germline}`).exists(),
+            'Germline mutation should have the additional germline indicator');
+        assert.isFalse(somaticComponent.find(`.${styles.germline}`).exists(),
+            'Somatic mutation should not have the additional germline indicator');
+    });
+
+    it('component cell value property', () => {
+        assert.equal(germlineComponent.prop("value"), "Q616K",
+            'Cell (Td) value property for germline mutation is correct');
+        assert.equal(somaticComponent.prop("value"), "Q616L",
+            'Cell (Td) value property for somatic mutation is correct');
     });
 
     after(()=>{
-
+        
     });
-
-    it('what does it do?', ()=>{
-
-    });
-
 });

--- a/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.spec.tsx
+++ b/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.spec.tsx
@@ -1,31 +1,36 @@
 import ProteinChangeColumnFormatter from './ProteinChangeColumnFormatter';
 import styles from './style/proteinChange.module.scss';
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
+import {MutationTableRowData} from "shared/components/mutationTable/IMutationTableProps";
+import {initMutation} from "test/MutationMockUtils";
+import {Mutation} from "shared/api/CBioPortalAPI";
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
 
 describe('ProteinChangeColumnFormatter (customized for patient view)', () => {
-    const germlineMutation = {
+    const germlineMutation:Mutation = initMutation({
         proteinChange: "Q616K",
         mutationStatus: "Germline"
-    };
+    });
 
-    const somaticMutation = {
+    const somaticMutation:Mutation = initMutation({
         proteinChange: "Q616L",
         mutationStatus: "Somatic"
-    };
+    });
 
     const tableData = [[germlineMutation], [somaticMutation]];
 
-    let germlineComponent, somaticComponent;
+    let germlineComponent: ReactWrapper<any, any>;
+    let somaticComponent:ReactWrapper<any, any>;
 
     before(() => {
-
-        let data = {
+        let data:IColumnFormatterData<MutationTableRowData> = {
             name:"Protein Change",
-            tableData: tableData,
-            rowData: [germlineMutation]
+            tableData,
+            rowData: [germlineMutation],
+            columnData: null
         };
 
         // mount a single cell component (Td) for a germline mutation
@@ -33,7 +38,7 @@ describe('ProteinChangeColumnFormatter (customized for patient view)', () => {
 
         data = {
             name:"Protein Change",
-            tableData: tableData,
+            tableData,
             rowData: [somaticMutation]
         };
 
@@ -41,7 +46,7 @@ describe('ProteinChangeColumnFormatter (customized for patient view)', () => {
         somaticComponent = mount(ProteinChangeColumnFormatter.renderFunction(data));
     });
 
-    it('component protein change display value', () => {
+    it('renders protein change display value', () => {
         assert.isTrue(germlineComponent.find(`.${styles.proteinChange}`).exists(),
             'Germline mutation should have the protein change value');
         assert.isTrue(germlineComponent.find(`.${styles.proteinChange}`).text().indexOf("Q616K") > -1,
@@ -52,21 +57,21 @@ describe('ProteinChangeColumnFormatter (customized for patient view)', () => {
             'Protein change value for somatic mutation is correct');
     });
 
-    it('component germline indicator', () => {
+    it('renders germline indicator', () => {
         assert.isTrue(germlineComponent.find(`.${styles.germline}`).exists(),
             'Germline mutation should have the additional germline indicator');
         assert.isFalse(somaticComponent.find(`.${styles.germline}`).exists(),
             'Somatic mutation should not have the additional germline indicator');
     });
 
-    it('component cell value property', () => {
+    it('sets component cell value property', () => {
         assert.equal(germlineComponent.prop("value"), "Q616K",
             'Cell (Td) value property for germline mutation is correct');
         assert.equal(somaticComponent.prop("value"), "Q616L",
             'Cell (Td) value property for somatic mutation is correct');
     });
 
-    after(()=>{
+    after(() => {
         
     });
 });

--- a/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/ProteinChangeColumnFormatter.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {Td} from 'reactable';
-import {IColumnFormatterData}
-    from "../../../../shared/components/enhancedReactTable/IColumnFormatter";
-import {default as DefaultProteinChangeColumnFormatter} from
-    "../../../../shared/components/mutationTable/column/ProteinChangeColumnFormatter";
-import MutationStatusColumnFormatter from "../../../../shared/components/mutationTable/column/MutationStatusColumnFormatter";
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
+import {
+    default as DefaultProteinChangeColumnFormatter
+} from "shared/components/mutationTable/column/ProteinChangeColumnFormatter";
+import MutationStatusColumnFormatter from "shared/components/mutationTable/column/MutationStatusColumnFormatter";
 import styles from './style/proteinChange.module.scss';
-import {MutationTableRowData} from "../../../../shared/components/mutationTable/IMutationTableProps";
+import {MutationTableRowData} from "shared/components/mutationTable/IMutationTableProps";
 
 /**
  * Designed to customize protein change column content for patient view page.
@@ -23,7 +23,7 @@ export default class ProteinChangeColumnFormatter
         // use value as sort & filter value
         const value:string = DefaultProteinChangeColumnFormatter.getTextValue(data);
 
-        let mutationStatus:string|null = MutationStatusColumnFormatter.getDataFromRow(data.rowData);
+        const mutationStatus:string|null = MutationStatusColumnFormatter.getDataFromRow(data.rowData);
 
         let content = <span className={styles.proteinChange}>{text}</span>;
 

--- a/src/shared/components/annotation/CancerHotspots.spec.jsx
+++ b/src/shared/components/annotation/CancerHotspots.spec.jsx
@@ -1,4 +1,4 @@
-import * as CancerHotspots from './CancerHotspots';
+import CancerHotspots from './CancerHotspots';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
@@ -6,15 +6,54 @@ import sinon from 'sinon';
 
 describe('CancerHotspots', () => {
 
+    const hotspotMutation1 = {
+        gene: {
+            hugoGeneSymbol: "TP53"
+        },
+        proteinPosStart: 273,
+        proteinPosEnd: 273,
+        proteinChange: "R273C"
+    };
+
+    const hotspotMutation2 = {
+        gene: {
+            hugoGeneSymbol: "PIK3CA"
+        },
+        proteinPosStart: 38,
+        proteinPosEnd: 40,
+        proteinChange: "R38H"
+    };
+
+    const notHotspotMutation = {
+        gene: {
+            hugoGeneSymbol: "SMURF1"
+        },
+        proteinPosStart: 101,
+        proteinPosEnd: 101,
+        proteinChange: "R101N"
+    };
+
+    const map = {
+        "TP53_273": true,
+        "PIK3CA_38_40": true
+    };
+
     before(()=>{
 
     });
 
-    after(()=>{
+    it('isHotspots function', () => {
+        assert.isTrue(CancerHotspots.isHotspot(hotspotMutation1, map),
+            "TP53 R273C should be a hotspot mutation.");
 
+        assert.isTrue(CancerHotspots.isHotspot(hotspotMutation2, map),
+            "PIK3CA R38H should be a hotspot mutation.");
+
+        assert.isFalse(CancerHotspots.isHotspot(notHotspotMutation, map),
+            "SMURF1 R101N should not be a hotspot mutation.");
     });
 
-    it('what does it do?', ()=>{
+    after(()=>{
 
     });
 

--- a/src/shared/components/annotation/CancerHotspots.spec.tsx
+++ b/src/shared/components/annotation/CancerHotspots.spec.tsx
@@ -1,4 +1,5 @@
 import CancerHotspots from './CancerHotspots';
+import {initMutation} from "test/MutationMockUtils";
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
@@ -6,43 +7,43 @@ import sinon from 'sinon';
 
 describe('CancerHotspots', () => {
 
-    const hotspotMutation1 = {
+    const hotspotMutation1 = initMutation({
         gene: {
             hugoGeneSymbol: "TP53"
         },
         proteinPosStart: 273,
         proteinPosEnd: 273,
         proteinChange: "R273C"
-    };
+    });
 
-    const hotspotMutation2 = {
+    const hotspotMutation2 = initMutation({
         gene: {
             hugoGeneSymbol: "PIK3CA"
         },
         proteinPosStart: 38,
         proteinPosEnd: 40,
         proteinChange: "R38H"
-    };
+    });
 
-    const notHotspotMutation = {
+    const notHotspotMutation = initMutation({
         gene: {
             hugoGeneSymbol: "SMURF1"
         },
         proteinPosStart: 101,
         proteinPosEnd: 101,
         proteinChange: "R101N"
-    };
+    });
 
     const map = {
         "TP53_273": true,
         "PIK3CA_38_40": true
     };
 
-    before(()=>{
+    before(() => {
 
     });
 
-    it('isHotspots function', () => {
+    it('checks if a mutation is a hotspot mutation', () => {
         assert.isTrue(CancerHotspots.isHotspot(hotspotMutation1, map),
             "TP53 R273C should be a hotspot mutation.");
 
@@ -53,7 +54,7 @@ describe('CancerHotspots', () => {
             "SMURF1 R101N should not be a hotspot mutation.");
     });
 
-    after(()=>{
+    after(() => {
 
     });
 

--- a/src/shared/components/annotation/MyCancerGenome.spec.jsx
+++ b/src/shared/components/annotation/MyCancerGenome.spec.jsx
@@ -1,4 +1,4 @@
-import * as MyCancerGenome from './MyCancerGenome';
+import MyCancerGenome from './MyCancerGenome';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
@@ -6,16 +6,31 @@ import sinon from 'sinon';
 
 describe('MyCancerGenome', () => {
 
-    before(()=>{
+    let component, emptyListComponent, tooltip, emptyListTooltip;
 
+    before(()=>{
+        component = mount(<MyCancerGenome linksHTML={["link1, link2"]}/>);
+        emptyListComponent = mount(<MyCancerGenome linksHTML={[]}/>);
+        tooltip = mount(MyCancerGenome.myCancerGenomeLinks(["link1, link2"]));
+        emptyListTooltip = mount(MyCancerGenome.myCancerGenomeLinks([]));
+
+    });
+
+    it('component icon', () => {
+        assert.isTrue(component.find("img").exists(),
+            "There should be an image icon for a valid list of links");
+        assert.isFalse(emptyListComponent.find("img").exists(),
+            "There should not be an image icon for an invalid list of links");
+    });
+
+    it('tooltip content', () => {
+        assert.isTrue(tooltip.find("li").exists(),
+            "There should be a list element for a valid list of links");
+        assert.isFalse(emptyListTooltip.find("li").exists(),
+            "There should not be a list element for an invalid list of links");
     });
 
     after(()=>{
 
     });
-
-    it('what does it do?', ()=>{
-
-    });
-
 });

--- a/src/shared/components/annotation/MyCancerGenome.spec.tsx
+++ b/src/shared/components/annotation/MyCancerGenome.spec.tsx
@@ -1,14 +1,16 @@
 import MyCancerGenome from './MyCancerGenome';
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
 
 describe('MyCancerGenome', () => {
+    let component: ReactWrapper<any, any>;
+    let emptyListComponent: ReactWrapper<any, any>;
+    let tooltip: ReactWrapper<any, any>;
+    let emptyListTooltip: ReactWrapper<any, any>;
 
-    let component, emptyListComponent, tooltip, emptyListTooltip;
-
-    before(()=>{
+    before(() => {
         component = mount(<MyCancerGenome linksHTML={["link1, link2"]}/>);
         emptyListComponent = mount(<MyCancerGenome linksHTML={[]}/>);
         tooltip = mount(MyCancerGenome.myCancerGenomeLinks(["link1, link2"]));
@@ -30,7 +32,7 @@ describe('MyCancerGenome', () => {
             "There should not be a list element for an invalid list of links");
     });
 
-    after(()=>{
+    after(() => {
 
     });
 });

--- a/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.spec.js
+++ b/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.spec.js
@@ -12,7 +12,7 @@ describe('ChromosomeColumnFormatter functions', () => {
     let e = "Y";
     let f = "chrY";
 
-    it('chromosome integer values are properly extracted', () => {
+    it('extractSortValue function', () => {
         assert.isAbove(ChromosomeColumnFormatter.extractSortValue(b),
             ChromosomeColumnFormatter.extractSortValue(a));
 

--- a/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.spec.tsx
@@ -4,15 +4,15 @@ import ChromosomeColumnFormatter from "./ChromosomeColumnFormatter";
 /**
  * @author Selcuk Onur Sumer
  */
-describe('ChromosomeColumnFormatter functions', () => {
-    let a = "1";
-    let b = "chr2";
-    let c = "22";
-    let d = "chrX";
-    let e = "Y";
-    let f = "chrY";
+describe('ChromosomeColumnFormatter', () => {
+    const a = "1";
+    const b = "chr2";
+    const c = "22";
+    const d = "chrX";
+    const e = "Y";
+    const f = "chrY";
 
-    it('extractSortValue function', () => {
+    it('properly extracts sort value from a chromosome string value', () => {
         assert.isAbove(ChromosomeColumnFormatter.extractSortValue(b),
             ChromosomeColumnFormatter.extractSortValue(a));
 

--- a/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.tsx
@@ -1,5 +1,4 @@
-import {IColumnFormatterData}
-    from "../../../../shared/components/enhancedReactTable/IColumnFormatter";
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
 import GeneColumnFormatter from "./GeneColumnFormatter";
 import {MutationTableRowData} from "../IMutationTableProps";
 
@@ -10,7 +9,7 @@ export default class ChromosomeColumnFormatter
 {
     public static getDataFromRow(rowData:MutationTableRowData|undefined)
     {
-        let geneData = GeneColumnFormatter.getDataFromRow(rowData);
+        const geneData = GeneColumnFormatter.getDataFromRow(rowData);
 
         if (geneData) {
             return geneData.chromosome;
@@ -22,8 +21,8 @@ export default class ChromosomeColumnFormatter
 
     public static sortFunction(a:string, b:string):number
     {
-        let aValue = ChromosomeColumnFormatter.extractSortValue(a);
-        let bValue = ChromosomeColumnFormatter.extractSortValue(b);
+        const aValue = ChromosomeColumnFormatter.extractSortValue(a);
+        const bValue = ChromosomeColumnFormatter.extractSortValue(b);
 
         return aValue > bValue ? 1 : -1;
     }
@@ -32,7 +31,7 @@ export default class ChromosomeColumnFormatter
     {
         const numerical:RegExp = /[0-9]+/g;
 
-        let matched:RegExpMatchArray|null = chromosome.match(numerical);
+        const matched:RegExpMatchArray|null = chromosome.match(numerical);
         let value:number = -1;
 
         // if no match, then search for X or Y

--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.jsx
@@ -1,4 +1,5 @@
-import * as CosmicColumnFormatter from './CosmicColumnFormatter';
+import CosmicColumnFormatter from './CosmicColumnFormatter';
+import {keywordToCosmic} from 'shared/lib/AnnotationUtils';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
@@ -6,16 +7,126 @@ import sinon from 'sinon';
 
 describe('CosmicColumnFormatter', () => {
 
-    before(()=>{
+    const cosmicMutations = [
+        {
+            count: 2,
+            keyword: "TP53 R273 missense",
+            proteinChange: "R273H"
+        },
+        {
+            count: 3,
+            keyword: "TP53 R273 missense",
+            proteinChange: "R273C"
+        },
+        {
+            count: 5,
+            keyword: "TP53 R273 missense",
+            proteinChange: "R273L"
+        },
+        {
+            count: 7,
+            keyword: "PIK3CA R38 missense",
+            proteinChange: "R38H"
+        },
+        {
+            count: 11,
+            keyword: "PIK3CA R38 missense",
+            proteinChange: "R38C"
+        },
+        {
+            count: 13,
+            keyword: "PIK3CA R38 missense",
+            proteinChange: "R38S"
+        }
+    ];
 
+    const mutation273 = {
+        gene: {
+            hugoGeneSymbol: "TP53"
+        },
+        proteinChange: "R273S",
+        keyword: "TP53 R273 missense"
+    };
+
+    const mutation38 = {
+        gene: {
+            hugoGeneSymbol: "PIK3CA"
+        },
+        proteinChange: "R38S",
+        keyword: "PIK3CA R38 missense"
+    };
+
+    const mutation666 = {
+        gene: {
+            hugoGeneSymbol: "DIABLO"
+        },
+        proteinChange: "V666E",
+        keyword: "DIABLO"
+    };
+
+    const tableData = [[mutation273], [mutation38], [mutation666]];
+
+    let component273, component38, component666;
+
+    before(() => {
+        const columnProps = {
+            cosmicData: keywordToCosmic(cosmicMutations)
+        };
+
+        let data = {
+            name: "Cosmic",
+            tableData: tableData,
+            rowData: [mutation273]
+        };
+
+        // mount a single cell component (Td)
+        component273 = mount(CosmicColumnFormatter.renderFunction(data, columnProps));
+
+        data = {
+            name: "Cosmic",
+            tableData: tableData,
+            rowData: [mutation38]
+        };
+
+        // mount a single cell component (Td)
+        component38 = mount(CosmicColumnFormatter.renderFunction(data, columnProps));
+
+        data = {
+            name: "Cosmic",
+            tableData: tableData,
+            rowData: [mutation666]
+        };
+
+        // mount a single cell component (Td)
+        component666 = mount(CosmicColumnFormatter.renderFunction(data, columnProps));
+    });
+
+    it('component tooltip', () => {
+        assert.isTrue(component273.find('DefaultTooltip').exists(),
+            'Tooltip should exists for TP53 R273 missense mutation');
+        assert.isTrue(component38.find('DefaultTooltip').exists(),
+            'Tooltip should exists for PIK3CA R38 missense mutation');
+        assert.isFalse(component666.find('DefaultTooltip').exists(),
+            'Tooltip should not exist for DIABLO mutation');
+    });
+
+    it('component display value', () => {
+        assert.isTrue(component273.find(`span`).text().indexOf((2 + 3 + 5).toString()) > -1,
+            'Cosmic count total for TP53 R273 missense mutation is correct');
+        assert.isTrue(component38.find(`span`).text().indexOf((7 + 11 + 13).toString()) > -1,
+            'Cosmic count total for PIK3CA R38 missense mutation is correct');
+    });
+
+    it('component cell value property', () => {
+        assert.equal(component273.prop("value"), (2 + 3 + 5),
+            'Cell (Td) value property for TP53 R273 missense mutation is correct');
+        assert.equal(component38.prop("value"), (7 + 11 + 13),
+            'Cell (Td) value property for PIK3CA R38 missense mutation is correct');
+        assert.isAtMost(component666.prop("value"), 0,
+            'Cell (Td) value property for DIABLO mutation should not be greater than zero');
     });
 
     after(()=>{
 
     });
-
-    it('what does it do?', ()=>{
-
-    });
-
 });

--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.tsx
@@ -1,72 +1,81 @@
 import CosmicColumnFormatter from './CosmicColumnFormatter';
 import {keywordToCosmic} from 'shared/lib/AnnotationUtils';
+import {initMutation} from "test/MutationMockUtils";
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
 
 describe('CosmicColumnFormatter', () => {
 
     const cosmicMutations = [
         {
+            cosmicMutationId: "",
             count: 2,
             keyword: "TP53 R273 missense",
             proteinChange: "R273H"
         },
         {
+            cosmicMutationId: "",
             count: 3,
             keyword: "TP53 R273 missense",
             proteinChange: "R273C"
         },
         {
+            cosmicMutationId: "",
             count: 5,
             keyword: "TP53 R273 missense",
             proteinChange: "R273L"
         },
         {
+            cosmicMutationId: "",
             count: 7,
             keyword: "PIK3CA R38 missense",
             proteinChange: "R38H"
         },
         {
+            cosmicMutationId: "",
             count: 11,
             keyword: "PIK3CA R38 missense",
             proteinChange: "R38C"
         },
         {
+            cosmicMutationId: "",
             count: 13,
             keyword: "PIK3CA R38 missense",
             proteinChange: "R38S"
         }
     ];
 
-    const mutation273 = {
+    const mutation273 = initMutation({
         gene: {
             hugoGeneSymbol: "TP53"
         },
         proteinChange: "R273S",
         keyword: "TP53 R273 missense"
-    };
+    });
 
-    const mutation38 = {
+    const mutation38 = initMutation({
         gene: {
             hugoGeneSymbol: "PIK3CA"
         },
         proteinChange: "R38S",
         keyword: "PIK3CA R38 missense"
-    };
+    });
 
-    const mutation666 = {
+    const mutation666 = initMutation({
         gene: {
             hugoGeneSymbol: "DIABLO"
         },
         proteinChange: "V666E",
         keyword: "DIABLO"
-    };
+    });
 
     const tableData = [[mutation273], [mutation38], [mutation666]];
 
-    let component273, component38, component666;
+    let component273: ReactWrapper<any, any>;
+    let component38: ReactWrapper<any, any>;
+    let component666: ReactWrapper<any, any>;
 
     before(() => {
         const columnProps = {
@@ -75,7 +84,7 @@ describe('CosmicColumnFormatter', () => {
 
         let data = {
             name: "Cosmic",
-            tableData: tableData,
+            tableData,
             rowData: [mutation273]
         };
 
@@ -84,7 +93,7 @@ describe('CosmicColumnFormatter', () => {
 
         data = {
             name: "Cosmic",
-            tableData: tableData,
+            tableData,
             rowData: [mutation38]
         };
 
@@ -93,7 +102,7 @@ describe('CosmicColumnFormatter', () => {
 
         data = {
             name: "Cosmic",
-            tableData: tableData,
+            tableData,
             rowData: [mutation666]
         };
 
@@ -101,7 +110,7 @@ describe('CosmicColumnFormatter', () => {
         component666 = mount(CosmicColumnFormatter.renderFunction(data, columnProps));
     });
 
-    it('component tooltip', () => {
+    it('generates component tooltip', () => {
         assert.isTrue(component273.find('DefaultTooltip').exists(),
             'Tooltip should exists for TP53 R273 missense mutation');
         assert.isTrue(component38.find('DefaultTooltip').exists(),
@@ -110,14 +119,14 @@ describe('CosmicColumnFormatter', () => {
             'Tooltip should not exist for DIABLO mutation');
     });
 
-    it('component display value', () => {
+    it('renders display value', () => {
         assert.isTrue(component273.find(`span`).text().indexOf((2 + 3 + 5).toString()) > -1,
             'Cosmic count total for TP53 R273 missense mutation is correct');
         assert.isTrue(component38.find(`span`).text().indexOf((7 + 11 + 13).toString()) > -1,
             'Cosmic count total for PIK3CA R38 missense mutation is correct');
     });
 
-    it('component cell value property', () => {
+    it('sets component cell value property', () => {
         assert.equal(component273.prop("value"), (2 + 3 + 5),
             'Cell (Td) value property for TP53 R273 missense mutation is correct');
         assert.equal(component38.prop("value"), (7 + 11 + 13),
@@ -126,7 +135,7 @@ describe('CosmicColumnFormatter', () => {
             'Cell (Td) value property for DIABLO mutation should not be greater than zero');
     });
 
-    after(()=>{
+    after(() => {
 
     });
 });

--- a/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.jsx
@@ -1,4 +1,4 @@
-import * as GeneColumnFormatter from './GeneColumnFormatter';
+import GeneColumnFormatter from './GeneColumnFormatter';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
@@ -6,15 +6,37 @@ import sinon from 'sinon';
 
 describe('GeneColumnFormatter', () => {
 
-    before(()=>{
+    const mutation = {
+        gene: {
+            hugoGeneSymbol: "DIABLO"
+        }
+    };
 
+    const tableData = [[mutation]];
+    let component;
+
+    before(() => {
+        let data = {
+            name: "Gene",
+            tableData: tableData,
+            rowData: [mutation]
+        };
+
+        // mount a single cell component (Td)
+        component = mount(GeneColumnFormatter.renderFunction(data));
+    });
+
+    it('component display value', () => {
+        assert.isTrue(component.find(`span`).text().indexOf("DIABLO") > -1,
+            'Gene symbol display value is correct');
+    });
+
+    it('component cell value property', () => {
+        assert.equal(component.prop("value"), "DIABLO",
+            'Cell (Td) value property is correct');
     });
 
     after(()=>{
-
-    });
-
-    it('what does it do?', ()=>{
 
     });
 

--- a/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.tsx
@@ -1,24 +1,25 @@
 import GeneColumnFormatter from './GeneColumnFormatter';
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
+import {initMutation} from "test/MutationMockUtils";
 
 describe('GeneColumnFormatter', () => {
 
-    const mutation = {
+    const mutation = initMutation({
         gene: {
             hugoGeneSymbol: "DIABLO"
         }
-    };
+    });
 
     const tableData = [[mutation]];
-    let component;
+    let component: ReactWrapper<any, any>;
 
     before(() => {
-        let data = {
+        const data = {
             name: "Gene",
-            tableData: tableData,
+            tableData,
             rowData: [mutation]
         };
 
@@ -26,18 +27,17 @@ describe('GeneColumnFormatter', () => {
         component = mount(GeneColumnFormatter.renderFunction(data));
     });
 
-    it('component display value', () => {
+    it('renders display value', () => {
         assert.isTrue(component.find(`span`).text().indexOf("DIABLO") > -1,
             'Gene symbol display value is correct');
     });
 
-    it('component cell value property', () => {
+    it('sets component cell value property', () => {
         assert.equal(component.prop("value"), "DIABLO",
             'Cell (Td) value property is correct');
     });
 
-    after(()=>{
+    after(() => {
 
     });
-
 });

--- a/src/shared/components/mutationTable/column/GeneColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/GeneColumnFormatter.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import {Td} from 'reactable';
-import {IColumnFormatterData}
-    from "../../enhancedReactTable/IColumnFormatter";
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
 import {MutationTableRowData} from "../IMutationTableProps";
-import {Mutation, Gene} from "../../../api/CBioPortalAPI";
+import {Mutation, Gene} from "shared/api/CBioPortalAPI";
 
 /**
  * @author Selcuk Onur Sumer
@@ -39,7 +38,7 @@ export default class GeneColumnFormatter
         let value: Gene|null;
 
         if (rowData) {
-            const mutations:Array<Mutation> = rowData;
+            const mutations:Mutation[] = rowData;
             value = (mutations.length > 0 ? mutations[0].gene : null);
         }
         else {

--- a/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.jsx
@@ -1,20 +1,161 @@
-import * as MutationAssessorColumnFormatter from './MutationAssessorColumnFormatter';
+import MutationAssessorColumnFormatter from './MutationAssessorColumnFormatter';
+import styles from "./mutationAssessor.module.scss";
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
 describe('MutationAssessorColumnFormatter', () => {
+    const mutations = [
+        {
+            functionalImpactScore: "H",
+            fisValue: 3.5,
+            linkPdb: "http://mutationassessor.org/r2/pdb.php?var=Q616K",
+            linkMsa: "http://mutationassessor.org/r2/?cm=msa&var=Q616K",
+            linkXvar: "http://mutationassessor.org/r2/?cm=var&var=hg19,0,0,X,X"
+        },
+        {
+
+            functionalImpactScore: "H",
+            fisValue: 3.8,
+            linkPdb: null,
+            linkMsa: null,
+            linkXvar: "http://mutationassessor.org/r2/?cm=var&var=hg19,0,0,Y,Y"
+        },
+        {
+            functionalImpactScore: "M",
+            fisValue: null,
+            linkPdb: null,
+            linkMsa: "http://mutationassessor.org/r2/?cm=msa&var=Q1429R",
+            linkXvar: "http://mutationassessor.org/r2/?cm=var&var=hg19,0,0,Z,Z"
+        },
+        {
+            functionalImpactScore: "M",
+            fisValue: 2.2,
+            linkPdb: null,
+            linkMsa: "http://mutationassessor.org/r2/?cm=msa&var=Q1429R",
+            linkXvar: null
+        },
+        {
+            functionalImpactScore: "L",
+            fisValue: 0.7,
+            linkPdb: null,
+            linkMsa: null,
+            linkXvar: null
+        },
+        {
+            functionalImpactScore: "Unknown",
+            fisValue: null,
+            linkPdb: null,
+            linkMsa: null,
+            linkXvar: null
+        }
+    ];
+
+    const tableData = [
+        [mutations[0]],
+        [mutations[1]],
+        [mutations[2]],
+        [mutations[3]],
+        [mutations[4]],
+        [mutations[5]]
+    ];
+
+    let components = [];
+    let tooltips = [];
+    let formatterData = [];
 
     before(()=>{
+        // prepare the data and component arrays for test
+        mutations.forEach((mutation) => {
+            const data = {
+                name: "Mutation Assessor",
+                tableData: tableData,
+                rowData: [mutation]
+            };
 
+            formatterData.push(data);
+            components.push(mount(MutationAssessorColumnFormatter.renderFunction(data)));
+            tooltips.push(mount(MutationAssessorColumnFormatter.getTooltipContent(data)))
+        });
+    });
+
+    it('component class name', () => {
+        assert.isTrue(components[0].find(`span.${styles['oma-high']}`).exists(),
+            `Span has the correct class name for impact score H(3.5)`);
+        assert.isTrue(components[1].find(`span.${styles['oma-high']}`).exists(),
+            `Span has the correct class name for impact score H(3.8)`);
+        assert.isTrue(components[2].find(`span.${styles['oma-medium']}`).exists(),
+            `Span has the correct class name for impact score M(null)`);
+        assert.isTrue(components[3].find(`span.${styles['oma-medium']}`).exists(),
+            `Span has the correct class name for impact score M(2.2)`);
+        assert.isTrue(components[4].find(`span.${styles['oma-low']}`).exists(),
+            `Span has the correct class name for impact score L(0.7)`);
+        assert.isFalse(components[5].find(`span.${styles['oma-link']}`).exists(),
+            `Span has the correct class name for impact score Unknown(null)`);
+    });
+
+    it('mutation assessor main link for the tooltip', () => {
+        assert.isTrue(tooltips[0].find(`.${styles['mutation-assessor-main-img']}`).exists(),
+            `Main mutation assessor link exists for impact score H(3.5)`);
+        assert.isTrue(tooltips[1].find(`.${styles['mutation-assessor-main-img']}`).exists(),
+            `Main mutation assessor link exists for impact score H(3.8)`);
+        assert.isTrue(tooltips[2].find(`.${styles['mutation-assessor-main-img']}`).exists(),
+            `Main mutation assessor link exists for impact score M(null)`);
+        assert.isFalse(tooltips[3].find(`.${styles['mutation-assessor-main-img']}`).exists(),
+            `Main mutation assessor link should not exist for impact score M(2.2)`);
+        assert.isFalse(tooltips[4].find(`.${styles['mutation-assessor-main-img']}`).exists(),
+            `Main mutation assessor link should not exist for impact score L(0.7)`);
+        assert.isFalse(tooltips[5].find(`.${styles['mutation-assessor-main-img']}`).exists(),
+            `Main mutation assessor link should not exist for impact score Unknown(null)`);
+    });
+
+    it('MSA link for the tooltip', () => {
+        assert.isTrue(tooltips[0].find(`.${styles['ma-msa-icon']}`).exists(),
+            `MSA link exists for impact score H(3.5)`);
+        assert.isFalse(tooltips[1].find(`.${styles['ma-msa-icon']}`).exists(),
+            `MSA link should not exist for impact score H(3.8)`);
+        assert.isTrue(tooltips[2].find(`.${styles['ma-msa-icon']}`).exists(),
+            `MSA link exists for impact score M(null)`);
+        assert.isTrue(tooltips[3].find(`.${styles['ma-msa-icon']}`).exists(),
+            `MSA link exists for impact score M(2.2)`);
+        assert.isFalse(tooltips[4].find(`.${styles['ma-msa-icon']}`).exists(),
+            `MSA link should not exist for impact score L(0.7)`);
+        assert.isFalse(tooltips[5].find(`.${styles['ma-msa-icon']}`).exists(),
+            `MSA link should not exist for impact score Unknown(null)`);
+    });
+
+    it('PDB link for the tooltip', () => {
+        assert.isTrue(tooltips[0].find(`.${styles['ma-3d-icon']}`).exists(),
+            `PDB link exists for impact score H(3.5)`);
+        assert.isFalse(tooltips[1].find(`.${styles['ma-3d-icon']}`).exists(),
+            `PDB link should not exist for impact score H(3.8)`);
+        assert.isFalse(tooltips[2].find(`.${styles['ma-3d-icon']}`).exists(),
+            `PDB link should not exist for impact score M(null)`);
+        assert.isFalse(tooltips[3].find(`.${styles['ma-3d-icon']}`).exists(),
+            `PDB link should not exist for impact score M(2.2)`);
+        assert.isFalse(tooltips[4].find(`.${styles['ma-3d-icon']}`).exists(),
+            `PDB link should not exist for impact score L(0.7)`);
+        assert.isFalse(tooltips[5].find(`.${styles['ma-3d-icon']}`).exists(),
+            `PDB link should not exist for impact score Unknown(null)`);
+    });
+
+    it('sortFunction', ()=>{
+        assert.isAbove(MutationAssessorColumnFormatter.sortFunction(formatterData[0], formatterData[2]), 0,
+            "H(3.5) should rank higher than M(null)");
+        assert.isBelow(MutationAssessorColumnFormatter.sortFunction(formatterData[0], formatterData[1]), 0,
+            "H(3.5) should rank lower than H(3.8)");
+        assert.isAbove(MutationAssessorColumnFormatter.sortFunction(formatterData[1], formatterData[3]), 0,
+            "H(3.8) should rank higher than M(2.2)");
+        assert.isBelow(MutationAssessorColumnFormatter.sortFunction(formatterData[2], formatterData[3]), 0,
+            "M(null) should rank lower than M(2.2)");
+        assert.isAbove(MutationAssessorColumnFormatter.sortFunction(formatterData[2], formatterData[4]), 0,
+            "M(null) should rank higher than L(0.7)");
+        assert.isAbove(MutationAssessorColumnFormatter.sortFunction(formatterData[4], formatterData[5]), 0,
+            "L(0.7) should rank higher than Unknown(null)");
     });
 
     after(()=>{
-
-    });
-
-    it('what does it do?', ()=>{
 
     });
 

--- a/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.tsx
@@ -1,55 +1,58 @@
 import MutationAssessorColumnFormatter from './MutationAssessorColumnFormatter';
 import styles from "./mutationAssessor.module.scss";
+import {initMutation} from "test/MutationMockUtils";
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
+import {MutationTableRowData} from "../IMutationTableProps";
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
 
 describe('MutationAssessorColumnFormatter', () => {
     const mutations = [
-        {
+        initMutation({
             functionalImpactScore: "H",
             fisValue: 3.5,
             linkPdb: "http://mutationassessor.org/r2/pdb.php?var=Q616K",
             linkMsa: "http://mutationassessor.org/r2/?cm=msa&var=Q616K",
             linkXvar: "http://mutationassessor.org/r2/?cm=var&var=hg19,0,0,X,X"
-        },
-        {
+        }),
+        initMutation({
 
             functionalImpactScore: "H",
             fisValue: 3.8,
             linkPdb: null,
             linkMsa: null,
             linkXvar: "http://mutationassessor.org/r2/?cm=var&var=hg19,0,0,Y,Y"
-        },
-        {
+        }),
+        initMutation({
             functionalImpactScore: "M",
             fisValue: null,
             linkPdb: null,
             linkMsa: "http://mutationassessor.org/r2/?cm=msa&var=Q1429R",
             linkXvar: "http://mutationassessor.org/r2/?cm=var&var=hg19,0,0,Z,Z"
-        },
-        {
+        }),
+        initMutation({
             functionalImpactScore: "M",
             fisValue: 2.2,
             linkPdb: null,
             linkMsa: "http://mutationassessor.org/r2/?cm=msa&var=Q1429R",
             linkXvar: null
-        },
-        {
+        }),
+        initMutation({
             functionalImpactScore: "L",
             fisValue: 0.7,
             linkPdb: null,
             linkMsa: null,
             linkXvar: null
-        },
-        {
+        }),
+        initMutation({
             functionalImpactScore: "Unknown",
             fisValue: null,
             linkPdb: null,
             linkMsa: null,
             linkXvar: null
-        }
+        })
     ];
 
     const tableData = [
@@ -61,26 +64,26 @@ describe('MutationAssessorColumnFormatter', () => {
         [mutations[5]]
     ];
 
-    let components = [];
-    let tooltips = [];
-    let formatterData = [];
+    const components: Array<ReactWrapper<any, any>> = [];
+    const tooltips: Array<ReactWrapper<any, any>> = [];
+    const formatterData: Array<IColumnFormatterData<MutationTableRowData>> = [];
 
-    before(()=>{
+    before(() => {
         // prepare the data and component arrays for test
         mutations.forEach((mutation) => {
             const data = {
                 name: "Mutation Assessor",
-                tableData: tableData,
+                tableData,
                 rowData: [mutation]
             };
 
             formatterData.push(data);
             components.push(mount(MutationAssessorColumnFormatter.renderFunction(data)));
-            tooltips.push(mount(MutationAssessorColumnFormatter.getTooltipContent(data)))
+            tooltips.push(mount(MutationAssessorColumnFormatter.getTooltipContent(data)));
         });
     });
 
-    it('component class name', () => {
+    it('sets component class name', () => {
         assert.isTrue(components[0].find(`span.${styles['oma-high']}`).exists(),
             `Span has the correct class name for impact score H(3.5)`);
         assert.isTrue(components[1].find(`span.${styles['oma-high']}`).exists(),
@@ -95,7 +98,7 @@ describe('MutationAssessorColumnFormatter', () => {
             `Span has the correct class name for impact score Unknown(null)`);
     });
 
-    it('mutation assessor main link for the tooltip', () => {
+    it('renders mutation assessor main link for the tooltip', () => {
         assert.isTrue(tooltips[0].find(`.${styles['mutation-assessor-main-img']}`).exists(),
             `Main mutation assessor link exists for impact score H(3.5)`);
         assert.isTrue(tooltips[1].find(`.${styles['mutation-assessor-main-img']}`).exists(),
@@ -110,7 +113,7 @@ describe('MutationAssessorColumnFormatter', () => {
             `Main mutation assessor link should not exist for impact score Unknown(null)`);
     });
 
-    it('MSA link for the tooltip', () => {
+    it('renders MSA link for the tooltip', () => {
         assert.isTrue(tooltips[0].find(`.${styles['ma-msa-icon']}`).exists(),
             `MSA link exists for impact score H(3.5)`);
         assert.isFalse(tooltips[1].find(`.${styles['ma-msa-icon']}`).exists(),
@@ -125,7 +128,7 @@ describe('MutationAssessorColumnFormatter', () => {
             `MSA link should not exist for impact score Unknown(null)`);
     });
 
-    it('PDB link for the tooltip', () => {
+    it('renders PDB link for the tooltip', () => {
         assert.isTrue(tooltips[0].find(`.${styles['ma-3d-icon']}`).exists(),
             `PDB link exists for impact score H(3.5)`);
         assert.isFalse(tooltips[1].find(`.${styles['ma-3d-icon']}`).exists(),
@@ -140,7 +143,7 @@ describe('MutationAssessorColumnFormatter', () => {
             `PDB link should not exist for impact score Unknown(null)`);
     });
 
-    it('sortFunction', ()=>{
+    it('properly sorts by Mutation Assessor column', () => {
         assert.isAbove(MutationAssessorColumnFormatter.sortFunction(formatterData[0], formatterData[2]), 0,
             "H(3.5) should rank higher than M(null)");
         assert.isBelow(MutationAssessorColumnFormatter.sortFunction(formatterData[0], formatterData[1]), 0,
@@ -155,7 +158,7 @@ describe('MutationAssessorColumnFormatter', () => {
             "L(0.7) should rank higher than Unknown(null)");
     });
 
-    after(()=>{
+    after(() => {
 
     });
 

--- a/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import DefaultTooltip from 'shared/components/DefaultTooltip';
 import {Td} from 'reactable';
-import {IColumnFormatterData} from "../../enhancedReactTable/IColumnFormatter";
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
 import 'rc-tooltip/assets/bootstrap_white.css';
 import styles from "./mutationAssessor.module.scss";
 import {MutationTableRowData} from "../IMutationTableProps";
-import {Mutation} from "../../../api/CBioPortalAPI";
+import {Mutation} from "shared/api/CBioPortalAPI";
+import {compareNumberLists} from "shared/lib/SortUtils";
 
 type MA_CLASS_NAME = 'oma-high' | 'oma-medium' | 'oma-low' | 'oma-neutral' | 'oma-na';
 
@@ -37,8 +38,6 @@ export default class MutationAssessorColumnFormatter
 
     public static sortFunction(a:IColumnFormatterData<MutationTableRowData>, b:IColumnFormatterData<MutationTableRowData>):number
     {
-        const NA:string = MutationAssessorColumnFormatter.MA_SCORE_MAP["na"].label;
-
         const aScore:number = MutationAssessorColumnFormatter.getData(a).score;
         const bScore:number = MutationAssessorColumnFormatter.getData(b).score;
 
@@ -48,20 +47,8 @@ export default class MutationAssessorColumnFormatter
         const aPriority:number = aFormat ? aFormat.priority : -1;
         const bPriority:number = bFormat ? bFormat.priority : -1;
 
-        const hasNa = (aFormat && aFormat.label === NA) || (bFormat && bFormat.label === NA);
-
-        // use actual score values to compare (if exist)
-        // score for NA values are zero, but negative scores are also valid,
-        // so comparing scores when there is an NA value is not always accurate!
-        if (aScore && bScore && !hasNa)
-        {
-            return aScore > bScore ? 1 : -1;
-        }
-        // if no score available sort by impact priority
-        else
-        {
-            return aPriority > bPriority ? 1 : -1;
-        }
+        // first sort by priority, then sort by score
+        return compareNumberLists([aPriority, aScore], [bPriority, bScore]);
     }
 
     public static filterValue(data:IColumnFormatterData<MutationTableRowData>):string

--- a/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.jsx
@@ -1,10 +1,18 @@
-import * as MutationStatusColumnFormatter from './MutationStatusColumnFormatter';
+import MutationStatusColumnFormatter from './MutationStatusColumnFormatter';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
 describe('MutationStatusColumnFormatter', () => {
+    const mutation = {
+        mutationStatus: "Germline"
+    };
+
+    const data = {
+        tableData: [[mutation]],
+        rowData: [mutation]
+    };
 
     before(()=>{
 
@@ -14,8 +22,9 @@ describe('MutationStatusColumnFormatter', () => {
 
     });
 
-    it('what does it do?', ()=>{
-
+    it('data process functions', ()=>{
+        assert.equal(MutationStatusColumnFormatter.getData(data), "Germline",
+            "Mutation status data is properly extracted");
     });
 
 });

--- a/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.tsx
@@ -1,28 +1,30 @@
 import MutationStatusColumnFormatter from './MutationStatusColumnFormatter';
+import {initMutation} from "test/MutationMockUtils";
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
 describe('MutationStatusColumnFormatter', () => {
-    const mutation = {
+    const mutation = initMutation({
         mutationStatus: "Germline"
-    };
+    });
 
     const data = {
+        name: "Mutation Status",
         tableData: [[mutation]],
         rowData: [mutation]
     };
 
-    before(()=>{
+    before(() => {
 
     });
 
-    after(()=>{
+    after(() => {
 
     });
 
-    it('data process functions', ()=>{
+    it('gets mutation status data', () => {
         assert.equal(MutationStatusColumnFormatter.getData(data), "Germline",
             "Mutation status data is properly extracted");
     });

--- a/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.tsx
@@ -1,7 +1,6 @@
-import {IColumnFormatterData}
-    from "../../../../shared/components/enhancedReactTable/IColumnFormatter";
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
 import {MutationTableRowData} from "../IMutationTableProps";
-import {Mutation} from "../../../api/CBioPortalAPI";
+import {Mutation} from "shared/api/CBioPortalAPI";
 
 /**
  * @author Selcuk Onur Sumer
@@ -13,7 +12,7 @@ export default class MutationStatusColumnFormatter
         let value;
 
         if (rowData) {
-            let mutations:Array<Mutation> = rowData;
+            const mutations:Mutation[] = rowData;
             value = mutations[0].mutationStatus;
         }
         else {

--- a/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.jsx
+++ b/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.jsx
@@ -1,20 +1,110 @@
-import * as MutationTypeColumnFormatter from './MutationTypeColumnFormatter';
+import MutationTypeColumnFormatter from './MutationTypeColumnFormatter';
+import styles from './mutationType.module.scss';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
 describe('MutationTypeColumnFormatter', () => {
+    const missenseVariant = {
+        mutationType: "Missense_Variant"
+    };
 
-    before(()=>{
+    const missenseMutation = {
+        mutationType: "Missense_mutation"
+    };
 
+    const stopgainSnv = {
+        mutationType: "stopgain_SNV"
+    };
+
+    const nonFrameShiftDeletion = {
+        mutationType: "NonFrameShift_deletion"
+    };
+
+    const spliceSite = {
+        mutationType: "Splice Site"
+    };
+
+    const frameshiftDeletion = {
+        mutationType: "FrameShift_Deletion"
+    };
+
+    const otherMutation = {
+        mutationType: "other"
+    };
+
+    const unknownMutation = {
+        mutationType: "a_strange_type_of_mutation"
+    };
+
+    const tableData = [
+        [missenseVariant],
+        [missenseMutation],
+        [stopgainSnv],
+        [nonFrameShiftDeletion],
+        [spliceSite],
+        [frameshiftDeletion],
+        [otherMutation],
+        [unknownMutation]
+    ];
+
+    let msVarComponent, msMutComponent, stopgainSnvComponent,
+        nonFsDelComponent, unknownMutComponent, fsDelComponent,
+        otherMutComponent, spliceComponent;
+
+    before(() => {
+        let data = {
+            name: "Mutation Type",
+            tableData: tableData,
+            rowData: [missenseVariant]
+        };
+        msVarComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+
+        data.rowData = [missenseMutation];
+        msMutComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+
+        data.rowData = [stopgainSnv];
+        stopgainSnvComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+
+        data.rowData = [nonFrameShiftDeletion];
+        nonFsDelComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+
+        data.rowData = [spliceSite];
+        spliceComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+
+        data.rowData = [frameshiftDeletion];
+        fsDelComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+
+        data.rowData = [unknownMutation];
+        unknownMutComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+
+        data.rowData = [otherMutation];
+        otherMutComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
+    });
+
+    function testRenderedValues(component, mutationType, className, value)
+    {
+        assert.isTrue(component.find(`span.${styles[className]}`).exists(),
+            `Span has the correct class name for ${mutationType}`);
+        assert.isTrue(component.find(`span.${styles[className]}`).text().indexOf(value) > -1,
+            `Display value is correct for ${mutationType}`);
+        assert.equal(component.prop("value"), value,
+            `Cell (Td) value property is correct for ${mutationType}`);
+    }
+
+    it('component display value, class name, and cell value property', () => {
+        testRenderedValues(msVarComponent, "Missense_Variant", "missense-mutation", "Missense");
+        testRenderedValues(msMutComponent, "Missense_mutation", "missense-mutation", "Missense");
+        testRenderedValues(stopgainSnvComponent, "stopgain_SNV", "trunc-mutation", "Nonsense");
+        testRenderedValues(nonFsDelComponent, "NonFrameShift_deletion", "inframe-mutation", "IF");
+        testRenderedValues(spliceComponent, "Splice Site", "trunc-mutation", "Splice");
+        testRenderedValues(fsDelComponent, "FrameShift_Deletion", "trunc-mutation", "FS del");
+        testRenderedValues(unknownMutComponent, "a_strange_type_of_mutation", "other-mutation", "a_strange_type_of_mutation");
+        testRenderedValues(otherMutComponent, "other", "other-mutation", "Other");
     });
 
     after(()=>{
-
-    });
-
-    it('what does it do?', ()=>{
 
     });
 

--- a/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.tsx
@@ -1,42 +1,43 @@
 import MutationTypeColumnFormatter from './MutationTypeColumnFormatter';
 import styles from './mutationType.module.scss';
+import {initMutation} from "test/MutationMockUtils";
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
 
 describe('MutationTypeColumnFormatter', () => {
-    const missenseVariant = {
+    const missenseVariant = initMutation({
         mutationType: "Missense_Variant"
-    };
+    });
 
-    const missenseMutation = {
+    const missenseMutation = initMutation({
         mutationType: "Missense_mutation"
-    };
+    });
 
-    const stopgainSnv = {
+    const stopgainSnv = initMutation({
         mutationType: "stopgain_SNV"
-    };
+    });
 
-    const nonFrameShiftDeletion = {
+    const nonFrameShiftDeletion = initMutation({
         mutationType: "NonFrameShift_deletion"
-    };
+    });
 
-    const spliceSite = {
+    const spliceSite = initMutation({
         mutationType: "Splice Site"
-    };
+    });
 
-    const frameshiftDeletion = {
+    const frameshiftDeletion = initMutation({
         mutationType: "FrameShift_Deletion"
-    };
+    });
 
-    const otherMutation = {
+    const otherMutation = initMutation({
         mutationType: "other"
-    };
+    });
 
-    const unknownMutation = {
+    const unknownMutation = initMutation({
         mutationType: "a_strange_type_of_mutation"
-    };
+    });
 
     const tableData = [
         [missenseVariant],
@@ -49,14 +50,19 @@ describe('MutationTypeColumnFormatter', () => {
         [unknownMutation]
     ];
 
-    let msVarComponent, msMutComponent, stopgainSnvComponent,
-        nonFsDelComponent, unknownMutComponent, fsDelComponent,
-        otherMutComponent, spliceComponent;
+    let msVarComponent: ReactWrapper<any, any>;
+    let msMutComponent: ReactWrapper<any, any>;
+    let stopgainSnvComponent: ReactWrapper<any, any>;
+    let nonFsDelComponent: ReactWrapper<any, any>;
+    let unknownMutComponent: ReactWrapper<any, any>;
+    let fsDelComponent: ReactWrapper<any, any>;
+    let otherMutComponent: ReactWrapper<any, any>;
+    let spliceComponent: ReactWrapper<any, any>;
 
     before(() => {
-        let data = {
+        const data = {
             name: "Mutation Type",
-            tableData: tableData,
+            tableData,
             rowData: [missenseVariant]
         };
         msVarComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
@@ -83,7 +89,10 @@ describe('MutationTypeColumnFormatter', () => {
         otherMutComponent = mount(MutationTypeColumnFormatter.renderFunction(data));
     });
 
-    function testRenderedValues(component, mutationType, className, value)
+    function testRenderedValues(component: ReactWrapper<any, any>,
+                                mutationType: string,
+                                className: string,
+                                value: string)
     {
         assert.isTrue(component.find(`span.${styles[className]}`).exists(),
             `Span has the correct class name for ${mutationType}`);
@@ -93,7 +102,7 @@ describe('MutationTypeColumnFormatter', () => {
             `Cell (Td) value property is correct for ${mutationType}`);
     }
 
-    it('component display value, class name, and cell value property', () => {
+    it('renders component display value, class name, and cell value property', () => {
         testRenderedValues(msVarComponent, "Missense_Variant", "missense-mutation", "Missense");
         testRenderedValues(msMutComponent, "Missense_mutation", "missense-mutation", "Missense");
         testRenderedValues(stopgainSnvComponent, "stopgain_SNV", "trunc-mutation", "Nonsense");
@@ -104,7 +113,7 @@ describe('MutationTypeColumnFormatter', () => {
         testRenderedValues(otherMutComponent, "other", "other-mutation", "Other");
     });
 
-    after(()=>{
+    after(() => {
 
     });
 

--- a/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.tsx
@@ -1,19 +1,18 @@
 import * as React from 'react';
 import DefaultTooltip from 'shared/components/DefaultTooltip';
 import {Td} from 'reactable';
-import {IColumnFormatterData}
-    from "../../enhancedReactTable/IColumnFormatter";
+import {IColumnFormatterData} from "../../enhancedReactTable/IColumnFormatter";
 import styles from "./mutationType.module.scss";
 import {MutationTableRowData} from "../IMutationTableProps";
 import {Mutation} from "../../../api/CBioPortalAPI";
 
-type IMutationTypeFormat = {
-    label?: string,
-    longName?: string,
-    className: string,
-    mainType: string,
-    priority?: number
-};
+interface IMutationTypeFormat {
+    label?: string;
+    longName?: string;
+    className: string;
+    mainType: string;
+    priority?: number;
+}
 
 /**
  * @author Selcuk Onur Sumer
@@ -108,55 +107,55 @@ export default class MutationTypeColumnFormatter
     }
 
     public static get MUTATION_TYPE_MAP():{[key:string]: IMutationTypeFormat} {
-        let mainMap = MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP;
+        const mainMap = MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP;
         
         return {
-            missense_mutation: mainMap["missense"],
-            missense: mainMap["missense"],
-            missense_variant: mainMap["missense"],
-            frame_shift_ins: mainMap["frame_shift_ins"],
-            frame_shift_del: mainMap["frame_shift_del"],
-            frameshift: mainMap["frameshift"],
-            frameshift_deletion: mainMap["frame_shift_del"],
-            frameshift_insertion: mainMap["frame_shift_ins"],
-            de_novo_start_outofframe: mainMap["frameshift"],
-            frameshift_variant: mainMap["frameshift"],
-            nonsense_mutation: mainMap["nonsense"],
-            nonsense: mainMap["nonsense"],
-            stopgain_snv: mainMap["nonsense"],
-            stop_gained: mainMap["nonsense"],
-            splice_site: mainMap["splice_site"],
-            splice: mainMap["splice_site"],
+            "missense_mutation": mainMap["missense"],
+            "missense": mainMap["missense"],
+            "missense_variant": mainMap["missense"],
+            "frame_shift_ins": mainMap["frame_shift_ins"],
+            "frame_shift_del": mainMap["frame_shift_del"],
+            "frameshift": mainMap["frameshift"],
+            "frameshift_deletion": mainMap["frame_shift_del"],
+            "frameshift_insertion": mainMap["frame_shift_ins"],
+            "de_novo_start_outofframe": mainMap["frameshift"],
+            "frameshift_variant": mainMap["frameshift"],
+            "nonsense_mutation": mainMap["nonsense"],
+            "nonsense": mainMap["nonsense"],
+            "stopgain_snv": mainMap["nonsense"],
+            "stop_gained": mainMap["nonsense"],
+            "splice_site": mainMap["splice_site"],
+            "splice": mainMap["splice_site"],
             "splice site": mainMap["splice_site"],
-            splicing: mainMap["splice_site"],
-            splice_site_snp: mainMap["splice_site"],
-            splice_site_del: mainMap["splice_site"],
-            splice_site_indel: mainMap["splice_site"],
-            splice_region_variant: mainMap["splice_site"],
-            translation_start_site:  mainMap["nonstart"],
-            initiator_codon_variant: mainMap["nonstart"],
-            start_codon_snp: mainMap["nonstart"],
-            start_codon_del: mainMap["nonstart"],
-            nonstop_mutation: mainMap["nonstop"],
-            stop_lost: mainMap["nonstop"],
-            in_frame_del: mainMap["in_frame_del"],
-            in_frame_deletion: mainMap["in_frame_del"],
-            in_frame_ins: mainMap["in_frame_ins"],
-            in_frame_insertion: mainMap["in_frame_ins"],
-            indel: mainMap["in_frame_del"],
-            nonframeshift_deletion: mainMap["inframe"],
-            nonframeshift: mainMap["inframe"],
+            "splicing": mainMap["splice_site"],
+            "splice_site_snp": mainMap["splice_site"],
+            "splice_site_del": mainMap["splice_site"],
+            "splice_site_indel": mainMap["splice_site"],
+            "splice_region_variant": mainMap["splice_site"],
+            "translation_start_site":  mainMap["nonstart"],
+            "initiator_codon_variant": mainMap["nonstart"],
+            "start_codon_snp": mainMap["nonstart"],
+            "start_codon_del": mainMap["nonstart"],
+            "nonstop_mutation": mainMap["nonstop"],
+            "stop_lost": mainMap["nonstop"],
+            "in_frame_del": mainMap["in_frame_del"],
+            "in_frame_deletion": mainMap["in_frame_del"],
+            "in_frame_ins": mainMap["in_frame_ins"],
+            "in_frame_insertion": mainMap["in_frame_ins"],
+            "indel": mainMap["in_frame_del"],
+            "nonframeshift_deletion": mainMap["inframe"],
+            "nonframeshift": mainMap["inframe"],
             "nonframeshift insertion": mainMap["inframe"],
-            nonframeshift_insertion: mainMap["inframe"],
-            targeted_region: mainMap["inframe"],
-            inframe: mainMap["inframe"],
-            truncating: mainMap["truncating"],
-            feature_truncation: mainMap["truncating"],
-            fusion: mainMap["fusion"],
-            silent: mainMap["silent"],
-            synonymous_variant: mainMap["silent"],
-            any: mainMap["default"],
-            other: mainMap["default"]
+            "nonframeshift_insertion": mainMap["inframe"],
+            "targeted_region": mainMap["inframe"],
+            "inframe": mainMap["inframe"],
+            "truncating": mainMap["truncating"],
+            "feature_truncation": mainMap["truncating"],
+            "fusion": mainMap["fusion"],
+            "silent": mainMap["silent"],
+            "synonymous_variant": mainMap["silent"],
+            "any": mainMap["default"],
+            "other": mainMap["default"]
         };
     }
 
@@ -229,7 +228,7 @@ export default class MutationTypeColumnFormatter
         }
         else if (data.rowData)
         {
-            const mutations:Array<Mutation> = data.rowData;
+            const mutations:Mutation[] = data.rowData;
             mutationType = (mutations.length > 0 ? mutations[0].mutationType : null);
         }
         else {

--- a/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.spec.js
+++ b/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.spec.js
@@ -4,13 +4,13 @@ import ProteinChangeColumnFormatter from "./ProteinChangeColumnFormatter";
 /**
  * @author Selcuk Onur Sumer
  */
-describe('ProteinChangeColumnFormatter functions', () => {
+describe('ProteinChangeColumnFormatter', () => {
     let a = "E746_A750del";
     let b = "E747_T749del";
     let c = "K754E";
     let d = "K754I";
 
-    it('protein change sort values are properly extracted', () => {
+    it('extractSortValue function', () => {
         assert.isAbove(ProteinChangeColumnFormatter.extractSortValue(b),
                        ProteinChangeColumnFormatter.extractSortValue(a));
 

--- a/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.spec.tsx
@@ -5,12 +5,12 @@ import ProteinChangeColumnFormatter from "./ProteinChangeColumnFormatter";
  * @author Selcuk Onur Sumer
  */
 describe('ProteinChangeColumnFormatter', () => {
-    let a = "E746_A750del";
-    let b = "E747_T749del";
-    let c = "K754E";
-    let d = "K754I";
+    const a = "E746_A750del";
+    const b = "E747_T749del";
+    const c = "K754E";
+    const d = "K754I";
 
-    it('extractSortValue function', () => {
+    it('properly extracts sort value from a protein change string value', () => {
         assert.isAbove(ProteinChangeColumnFormatter.extractSortValue(b),
                        ProteinChangeColumnFormatter.extractSortValue(a));
 

--- a/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import {Td} from 'reactable';
-import {IColumnFormatterData}
-    from "../../enhancedReactTable/IColumnFormatter";
+import {IColumnFormatterData} from "shared/components/enhancedReactTable/IColumnFormatter";
 import {MutationTableRowData} from "../IMutationTableProps";
-import {Mutation} from "../../../api/CBioPortalAPI";
+import {Mutation} from "shared/api/CBioPortalAPI";
 
 /**
  * @author Selcuk Onur Sumer
@@ -20,15 +19,15 @@ export default class ProteinChangeColumnFormatter
 
     // this is to sort alphabetically
     // in case the protein position values are the same
-    public static extractNonNumerical(matched:RegExpMatchArray):Array<number>
+    public static extractNonNumerical(matched:RegExpMatchArray):number[]
     {
         const nonNumerical:RegExp = /[^0-9]+/g;
-        let buffer:RegExpMatchArray|null = matched[0].match(nonNumerical);
-        let value:Array<number> = [];
+        const buffer:RegExpMatchArray|null = matched[0].match(nonNumerical);
+        const value:number[] = [];
 
         if (buffer && buffer.length > 0)
         {
-            let str:string = buffer.join("");
+            const str:string = buffer.join("");
 
             // since we are returning a float value
             // assigning numerical value for each character.
@@ -57,7 +56,7 @@ export default class ProteinChangeColumnFormatter
 
         // first priority is to match values like V600E , V600, E747G, E747, X37_, X37, etc.
         let matched:RegExpMatchArray|null = proteinChange.match(alleleAndPosition);
-        let buffer:Array<number> = [];
+        let buffer:number[] = [];
 
         // if no match, then search for numerical (position) match only
         if (!matched || matched.length === 0)
@@ -121,7 +120,7 @@ export default class ProteinChangeColumnFormatter
             value = data.columnData;
         }
         else if (data.rowData) {
-            const mutations:Array<Mutation> = data.rowData;
+            const mutations:Mutation[] = data.rowData;
             value = (mutations.length > 0 ? mutations[0].proteinChange : null);
         }
         else {

--- a/src/shared/components/mutationTable/column/SampleColumnFormatter.spec.js
+++ b/src/shared/components/mutationTable/column/SampleColumnFormatter.spec.js
@@ -1,12 +1,46 @@
-import {assert} from "chai";
 import SampleColumnFormatter from "./SampleColumnFormatter";
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
 
 /**
  * @author Selcuk Onur Sumer
  */
-describe('SampleColumnFormatter functions', () => {
-    const shortSampleId = {columnData: "Short_Id"};
-    const longSampleId = {columnData: "This_is_a_quite_long_Sample_Id_in_my_opinion!"};
+describe('SampleColumnFormatter', () => {
+    const mutationShort = {
+        sampleId: "Short_Id"
+    };
+
+    const mutationLong = {
+        sampleId: "This_is_a_quite_long_Sample_Id_in_my_opinion!"
+    };
+
+    const shortSampleId = {columnData: mutationShort.sampleId};
+    const longSampleId = {columnData: mutationLong.sampleId};
+
+    let componentShort, componentLong;
+    const tableData = [[mutationShort], [mutationLong]];
+
+    before(() => {
+        let data = {
+            name: "Sample",
+            tableData: tableData,
+            rowData: [mutationShort]
+        };
+
+        // mount a single cell component (Td) for the mutation with short sample id
+        componentShort = mount(SampleColumnFormatter.renderFunction(data));
+
+        data = {
+            name: "Sample",
+            tableData: tableData,
+            rowData: [mutationLong]
+        };
+
+        // mount a single cell component (Td) for the mutation with long sample id
+        componentLong = mount(SampleColumnFormatter.renderFunction(data));
+    });
 
     it('sample id text is properly formatted', () => {
         // text and display should be the same for short sample ids
@@ -32,5 +66,30 @@ describe('SampleColumnFormatter functions', () => {
         // tooltip value should be the same as text value for long ids
         assert.equal(SampleColumnFormatter.getTooltipValue(longSampleId.columnData),
                      SampleColumnFormatter.getTextValue(longSampleId));
+    });
+
+    it('component display value', () => {
+        assert.isTrue(componentShort.find(`span`).text().indexOf("Short_Id") > -1,
+            'Display value is correct for short sample id');
+        assert.isFalse(componentLong.find(`span`).text().indexOf("This_is_a_quite_long_Sample_Id_in_my_opinion!") > -1,
+            'Display value for long sample id should not be equal to the actual value');
+    });
+
+    it('component cell value property', () => {
+        assert.equal(componentShort.prop("value"), "Short_Id",
+            'Cell (Td) value property is correct for short sample id');
+        assert.equal(componentLong.prop("value"), "This_is_a_quite_long_Sample_Id_in_my_opinion!",
+            'Cell (Td) value property is correct for long sample id');
+    });
+
+    it('component tooltip', () => {
+        assert.isFalse(componentShort.find('DefaultTooltip').exists(),
+            'Tooltip should not exists for short sample id');
+        assert.isTrue(componentLong.find('DefaultTooltip').exists(),
+            'Tooltip should exists for long sample id');
+    });
+
+    after(()=>{
+
     });
 });

--- a/src/shared/components/mutationTable/column/SampleColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/SampleColumnFormatter.spec.tsx
@@ -1,31 +1,41 @@
 import SampleColumnFormatter from "./SampleColumnFormatter";
+import {initMutation} from "test/MutationMockUtils";
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
 
 /**
  * @author Selcuk Onur Sumer
  */
 describe('SampleColumnFormatter', () => {
-    const mutationShort = {
+    const mutationShort = initMutation({
         sampleId: "Short_Id"
-    };
+    });
 
-    const mutationLong = {
+    const mutationLong = initMutation({
         sampleId: "This_is_a_quite_long_Sample_Id_in_my_opinion!"
+    });
+
+    const shortSampleId = {
+        name: "Sample",
+        columnData: mutationShort.sampleId
     };
 
-    const shortSampleId = {columnData: mutationShort.sampleId};
-    const longSampleId = {columnData: mutationLong.sampleId};
+    const longSampleId = {
+        name: "Sample",
+        columnData: mutationLong.sampleId
+    };
 
-    let componentShort, componentLong;
+    let componentShort:ReactWrapper<any, any>;
+    let componentLong:ReactWrapper<any, any>;
+
     const tableData = [[mutationShort], [mutationLong]];
 
     before(() => {
         let data = {
             name: "Sample",
-            tableData: tableData,
+            tableData,
             rowData: [mutationShort]
         };
 
@@ -34,7 +44,7 @@ describe('SampleColumnFormatter', () => {
 
         data = {
             name: "Sample",
-            tableData: tableData,
+            tableData,
             rowData: [mutationLong]
         };
 
@@ -68,28 +78,28 @@ describe('SampleColumnFormatter', () => {
                      SampleColumnFormatter.getTextValue(longSampleId));
     });
 
-    it('component display value', () => {
+    it('renders sample display value', () => {
         assert.isTrue(componentShort.find(`span`).text().indexOf("Short_Id") > -1,
             'Display value is correct for short sample id');
         assert.isFalse(componentLong.find(`span`).text().indexOf("This_is_a_quite_long_Sample_Id_in_my_opinion!") > -1,
             'Display value for long sample id should not be equal to the actual value');
     });
 
-    it('component cell value property', () => {
+    it('sets component cell value property', () => {
         assert.equal(componentShort.prop("value"), "Short_Id",
             'Cell (Td) value property is correct for short sample id');
         assert.equal(componentLong.prop("value"), "This_is_a_quite_long_Sample_Id_in_my_opinion!",
             'Cell (Td) value property is correct for long sample id');
     });
 
-    it('component tooltip', () => {
+    it('generates component tooltip', () => {
         assert.isFalse(componentShort.find('DefaultTooltip').exists(),
             'Tooltip should not exists for short sample id');
         assert.isTrue(componentLong.find('DefaultTooltip').exists(),
             'Tooltip should exists for long sample id');
     });
 
-    after(()=>{
+    after(() => {
 
     });
 });

--- a/src/shared/components/mutationTable/column/SampleColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/SampleColumnFormatter.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import DefaultTooltip from 'shared/components/DefaultTooltip';
 import {Td} from 'reactable';
-import {IColumnFormatterData}
-    from "../../enhancedReactTable/IColumnFormatter";
+import {IColumnFormatterData} from "../../enhancedReactTable/IColumnFormatter";
 import styles from "./sample.module.scss";
 import {MutationTableRowData} from "../IMutationTableProps";
 import {Mutation} from "../../../api/CBioPortalAPI";
@@ -79,7 +78,7 @@ export default class SampleColumnFormatter
             value = data.columnData;
         }
         else if (data.rowData) {
-            const mutations:Array<Mutation> = data.rowData;
+            const mutations:Mutation[] = data.rowData;
             value = (mutations.length > 0 ? mutations[0].sampleId : null);
         }
         else {

--- a/src/shared/lib/AnnotationUtils.spec.jsx
+++ b/src/shared/lib/AnnotationUtils.spec.jsx
@@ -1,0 +1,21 @@
+import * as AnnotationUtils from './AnnotationUtils';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('AnnotationUtils', () => {
+
+    before(()=>{
+
+    });
+
+    after(()=>{
+
+    });
+
+    it('what does it do?', ()=>{
+
+    });
+
+});

--- a/src/shared/lib/AnnotationUtils.ts
+++ b/src/shared/lib/AnnotationUtils.ts
@@ -1,0 +1,62 @@
+import {CosmicMutation} from "shared/api/CBioPortalAPIInternal";
+import {ICosmicData} from "shared/components/mutationTable/column/CosmicColumnFormatter";
+import {IMyCancerGenome, IMyCancerGenomeData} from "pages/patientView/mutation/column/AnnotationColumnFormatter";
+import {HotspotMutation} from "../api/CancerHotspotsAPI";
+
+/**
+ * Utility functions related to annotation data.
+ *
+ * @author Selcuk Onur Sumer
+ */
+
+
+export function keywordToCosmic(cosmicMutations:CosmicMutation[]):ICosmicData
+{
+    // key: keyword
+    // value: CosmicMutation[]
+    const map: ICosmicData = {};
+
+    // create a map for a faster lookup
+    cosmicMutations.forEach(function(cosmic:CosmicMutation) {
+        if (!(cosmic.keyword in map)) {
+            map[cosmic.keyword] = [];
+        }
+
+        map[cosmic.keyword].push(cosmic);
+    });
+
+    return map;
+}
+
+export function geneToMyCancerGenome(myCancerGenomes:IMyCancerGenome[]):IMyCancerGenomeData
+{
+    // key: hugo gene symbol
+    // value: IMyCancerGenome[]
+    const map:IMyCancerGenomeData = {};
+
+    myCancerGenomes.forEach(function (myCancerGenome) {
+        if (!(myCancerGenome.hugoGeneSymbol in map)) {
+            map[myCancerGenome.hugoGeneSymbol] = [];
+        }
+
+        map[myCancerGenome.hugoGeneSymbol].push(myCancerGenome);
+    });
+
+    return map;
+}
+
+export function geneAndProteinPosToHotspots(hotspots:HotspotMutation[]):{[key:string]: boolean}
+{
+    // key: geneSymbol_proteinPosition
+    // (protienPosition: start[_end])
+    const map: {[key:string]: boolean} = {};
+
+    // create a map for a faster lookup
+    hotspots.forEach(function(hotspot:HotspotMutation) {
+        const positions = hotspot.residue.match(/[0-9]+/g) || []; // start (and optionally end) positions
+        const key = [hotspot.hugoSymbol.toUpperCase()].concat(positions).join("_");
+        map[key] = true;
+    });
+
+    return map;
+}

--- a/src/test/MutationMockUtils.ts
+++ b/src/test/MutationMockUtils.ts
@@ -1,0 +1,67 @@
+import * as _ from 'lodash';
+import {Mutation} from "shared/api/CBioPortalAPI";
+
+/**
+ * Utility functions to generate mock data.
+ *
+ * @author Selcuk Onur Sumer
+ */
+
+
+export function emptyMutation(): Mutation
+{
+    return {
+        aminoAcidChange: "",
+        center: "",
+        endPosition: -1,
+        entrezGeneId: -1,
+        fisValue: -1,
+        functionalImpactScore: "",
+        gene: {
+            chromosome: "",
+            cytoband: "",
+            entrezGeneId: -1,
+            hugoGeneSymbol: "",
+            length: -1,
+            type: ""
+        },
+        geneticProfileId: "",
+        keyword: "",
+        linkMsa: "",
+        linkPdb: "",
+        linkXvar: "",
+        mutationStatus: "",
+        mutationType: "",
+        ncbiBuild: "",
+        normalAltCount: -1,
+        normalRefCount: -1,
+        proteinChange: "",
+        proteinPosEnd: -1,
+        proteinPosStart: -1,
+        referenceAllele: "",
+        refseqMrnaId: "",
+        sampleId: "",
+        startPosition: -1,
+        tumorAltCount: -1,
+        tumorRefCount: -1,
+        validationStatus: "",
+        variantAllele: "",
+        variantType: ""
+    };
+}
+
+/**
+ * Initializes an empty mutation and overrides the values with the given props.
+ *
+ * @param props
+ * @returns {Mutation}
+ */
+export function initMutation(props:{[key:string]: any}): Mutation
+{
+    const mutation = emptyMutation();
+
+    // TODO this is not a type safe operation since the property values can be anything
+    _.merge(mutation, props);
+
+    return mutation;
+}


### PR DESCRIPTION
# What? Why?
Added tests for most of the default mutation table column formatters, and for some of the patient view mutation table column formatters.

Changes proposed in this pull request:

- added tests for the patient view protein change column formatter
- lint cleaning for the protein change column formatters
- added tests for the cosmic column formatter
- added tests for gene column formatter
- added rendering tests for sample column formatter
- lint cleaning for sample column formatter
- added tests for mutation type column formatter
- lint cleaning for mutation type column formatter
- added tests for Mutation Assessor column formatter
- tests and lint cleaning for mutation status column formatter
- lint cleaning for gene and chromosome column formatters
- added tests for CancerHotspots component
- added tests for MyCancerGenome component

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)