### PR TITLE
travis dont install npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 install:
-  - sudo apt-get install npm
   - npm config set registry http://registry.npmjs.org/
   - npm install
   # install codecov.io


### PR DESCRIPTION
Don't install npm on Travis CI. It's already installed in latest Travis images