### PR TITLE
put pagination controls below MSKtable when nec

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -419,19 +419,12 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
         }
 
         return (
-            <div>
+            <div className="patientViewPage">
 
                 <div className="studyMetaBar">
                     <div>
-                    <If condition={(cohortNav != null)}>
-
-                            <div>
-                                {cohortNav}
-                            </div>
-
-                    </If>
+                        <If condition={(cohortNav != null)}>{cohortNav}</If>
                     </div>
-
                     <div>{ studyName }</div>
                 </div>
 

--- a/src/shared/components/paginationControls/PaginationControls.tsx
+++ b/src/shared/components/paginationControls/PaginationControls.tsx
@@ -27,7 +27,7 @@ export interface IPaginationControlsProps {
     onLastPageClick?:()=>void;
     onChangeCurrentPage?:(newPage:number)=>void;
     className?:string;
-    marginLeft?: number;
+    style?:{ [k: string]: string | number },
     firstPageDisabled?:boolean;
     previousPageDisabled?:boolean;
     nextPageDisabled?:boolean;
@@ -50,7 +50,7 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
         showFirstPage:false,
         showLastPage:false,
         className: "",
-        marginLeft: 0,
+        style:{},
         previousPageDisabled:false,
         nextPageDisabled:false,
         pageNumberEditable: false
@@ -118,7 +118,7 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
         }
 
         return (
-            <div className={this.props.className} style={{marginLeft: this.props.marginLeft}}>
+            <div className={this.props.className} style={this.props.style}>
                 <ButtonGroup bsSize="sm">
                     <If condition={!!this.props.showFirstPage}>
                         <Button key="firstPageBtn" disabled={!!this.props.firstPageDisabled} onClick={this.props.onFirstPageClick}>


### PR DESCRIPTION
Put pagination control at bottom of table, but only show it when there is pagination. 

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
