### PR TITLE
Add a tab for MD Anderson heatmaps (where available)

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -543,10 +543,18 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                     </MSKTab>)
                     }
 
+
+                    {  (patientViewPageStore.MDAndersonHeatMapAvailable.isComplete && patientViewPageStore.MDAndersonHeatMapAvailable.result ) &&
+                    (<MSKTab key={4} id="heatMapReportTab" linkText="Heatmap">
+                        <iframe style={{width:'100%', height:700, border:'none'}}
+                                src={ `//bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?participant=${patientViewPageStore.patientId}` }></iframe>
+                    </MSKTab>)
+                    }
+
                     { (patientViewPageStore.hasTissueImageIFrameUrl.isComplete && patientViewPageStore.hasTissueImageIFrameUrl.result) &&
-                        (<MSKTab key={4} id="tissueImageTab" linkText="Tissue Image">
+                        (<MSKTab key={5} id="tissueImageTab" linkText="Tissue Image">
                             <iframe style={{width:'100%', height:700, border:'none'}}
-                                    src="http://cancer.digitalslidearchive.net/index_mskcc.php?slide_name=TCGA-CG-5721"></iframe>
+                                    src={ `http://cancer.digitalslidearchive.net/index_mskcc.php?slide_name=${patientViewPageStore.patientId}` }></iframe>
                         </MSKTab>)
                     }
 

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -245,6 +245,25 @@ export class PatientViewPageStore
 
     }, []);
 
+    readonly MDAndersonHeatMapAvailable = remoteData({
+        await: () => [this.derivedPatientId],
+        invoke: async() => {
+
+            let resp: any = await request.get(`//bioinformatics.mdanderson.org/dyce?app=chmdb&command=participant2maps&participant=${this.patientId}`);
+
+            const parsedResp: any = JSON.parse(resp.text);
+
+            // filecontent array is serialized :(
+            const fileContent: string[] = JSON.parse(parsedResp.fileContent);
+
+            return fileContent.length > 0;
+
+        }
+
+    }, false);
+
+
+    //
     readonly clinicalDataForSamples = remoteData({
         await: () => [
             this.samples


### PR DESCRIPTION
Call service to determine availability of heatmap for given patient id.  Where available, show iframe with heatmap

The following URL will allow you to view:
http://localhost:3000/#/patient?studyId=ucec_tcga_pub&caseId=TCGA-A5-A0G2&tab=tissueImageTab&navCaseIds=TCGA-A5-A0G1%2CTCGA-A5-A0G2%2CTCGA-A5-A0G3%2CTCGA-A5-A0G5

Also, fixed hardcoded patient id in tissue images


