### PR TITLE
Lazy loading OncoKB card content from cache

### DIFF
--- a/src/pages/patientView/OncoKbEvidenceCache.ts
+++ b/src/pages/patientView/OncoKbEvidenceCache.ts
@@ -1,0 +1,47 @@
+import {Query} from "shared/api/generated/OncoKbAPI";
+import oncokbClient from "shared/api/oncokbClientInstance";
+import {generateEvidenceQuery, processEvidence} from "shared/lib/OncoKbUtils";
+import {IEvidence} from "./mutation/column/AnnotationColumnFormatter";
+import {default as SimpleCache, ICache} from "shared/lib/SimpleCache";
+
+export default class OncoKbEvidenceCache extends SimpleCache<IEvidence, Query[]>
+{
+    constructor()
+    {
+        super();
+    }
+
+    protected async fetch(queryVariants: Query[])
+    {
+        const cache: ICache<IEvidence> = {};
+
+        try {
+            const evidenceLookup = await oncokbClient.evidencesLookupPostUsingPOST(
+                {body: generateEvidenceQuery(queryVariants)}
+            );
+
+            const evidenceMap = processEvidence((evidenceLookup as any).data);
+
+            for (const id in evidenceMap) {
+                if (evidenceMap.hasOwnProperty(id))
+                {
+                    cache[id] = {
+                        status: "complete",
+                        data: evidenceMap[id]
+                    };
+                }
+            }
+
+            this.putData(cache);
+        }
+        catch (err) {
+            queryVariants.forEach((queryVariant:Query) => {
+                cache[queryVariant.id] = {
+                    status: "error"
+                };
+            });
+
+            this.putData(cache);
+        }
+    }
+}

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -477,6 +477,8 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         variantCountCache={patientViewPageStore.variantCountCache}
                                         discreteCNACache={patientViewPageStore.discreteCNACache}
                                         mrnaExprRankCache={patientViewPageStore.mrnaExprRankCache}
+                                        oncoKbEvidenceCache={patientViewPageStore.oncoKbEvidenceCache}
+                                        pmidCache={patientViewPageStore.pmidCache}
                                         mrnaExprRankGeneticProfileId={patientViewPageStore.mrnaRankGeneticProfileId.result || undefined}
                                         discreteCNAGeneticProfileId={patientViewPageStore.geneticProfileIdDiscrete.result}
                                         data={patientViewPageStore.mergedMutationData}
@@ -485,7 +487,6 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         hotspots={this.state.hotspotsData}
                                         cosmicData={this.state.cosmicData}
                                         oncoKbData={patientViewPageStore.oncoKbData.result}
-                                        pmidData={patientViewPageStore.pmidData.result}
                                         columns={this.mutationTableColumns}
                                     />
                                 )

--- a/src/pages/patientView/PmidCache.ts
+++ b/src/pages/patientView/PmidCache.ts
@@ -1,0 +1,53 @@
+import {default as SimpleCache, ICache} from "shared/lib/SimpleCache";
+
+export default class PmidCache extends SimpleCache<any, number[]>
+{
+    constructor()
+    {
+        super();
+    }
+
+    protected async fetch(pmids: number[])
+    {
+        const cache: ICache<any> = {};
+
+        try {
+            const pmidData:any = await new Promise((resolve, reject) => {
+                // TODO better to separate this call to a configurable client
+                $.post(
+                    'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json',
+                    {id: pmids.join(',')}
+                ).then((data) => {
+                    resolve(data);
+                }).fail((err) => {
+                    reject(err);
+                });
+            });
+
+            pmids.forEach((pmid:number) => {
+                if (pmidData.result[pmid]) {
+                    cache[pmid.toString()] = {
+                        status: "complete",
+                        data: pmidData.result[pmid]
+                    };
+                }
+                else {
+                    cache[pmid.toString()] = {
+                        status: "complete"
+                    };
+                }
+            });
+
+            this.putData(cache);
+        }
+        catch (err) {
+            pmids.forEach((pmid:number) => {
+                cache[pmid.toString()] = {
+                    status: "error"
+                };
+            });
+
+            this.putData(cache);
+        }
+    }
+}

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -27,6 +27,8 @@ import {SampleToEntrezListOrNull} from "./SampleGeneCache";
 import DiscreteCNACache from "./DiscreteCNACache";
 import {getTissueImageCheckUrl} from "../../../shared/api/urls";
 import {getAlterationString} from "shared/lib/CopyNumberUtils";
+import OncoKbEvidenceCache from "../OncoKbEvidenceCache";
+import PmidCache from "../PmidCache";
 
 type PageMode = 'patient' | 'sample';
 
@@ -102,33 +104,9 @@ function transformClinicalInformationToStoreShape(patientId: string, studyId: st
     return rv;
 }
 
-/**
- * Generates <sample id, cancer type> mapping
- *
- * @param data  array of ClinicalData
- * @returns {{[sampleId: string]: string}}
- */
-export function generateSampleToTumorMap(data:ClinicalData[])
-{
-    const map:{[sampleId:string]: string} = {};
-
-    _.each(data, function(clinicalData) {
-        if (clinicalData.clinicalAttributeId === "CANCER_TYPE") {
-            map[clinicalData.entityId] = clinicalData.value;
-        }
-    });
-
-    return map;
-}
-
 export async function fetchOncoKbData(sampleIdToTumorType:{[sampleId:string]: string}, queryVariants: Query[]) {
-    const oncokbSearchPromise = oncokbClient.searchPostUsingPOST(
+    const onkokbSearch = await oncokbClient.searchPostUsingPOST(
         {body: generateEvidenceQuery(queryVariants)});
-
-    const evidenceLookupPromise = oncokbClient.evidencesLookupPostUsingPOST(
-        {body: generateEvidenceQuery(queryVariants)});
-
-    const [onkokbSearch, evidenceLookup] = await Promise.all([oncokbSearchPromise, evidenceLookupPromise]);
 
     // TODO return type is not correct for the auto-generated API!
     // generated return type is Array<IndicatorQueryResp>,
@@ -136,8 +114,7 @@ export async function fetchOncoKbData(sampleIdToTumorType:{[sampleId:string]: st
     // that's why here we need to force data type to be any and get actual data by data.data
     const oncoKbData:IOncoKbData = {
         sampleToTumorMap: sampleIdToTumorType,
-        indicatorMap: generateIdToIndicatorMap((onkokbSearch as any).data),
-        evidenceMap: processEvidence((evidenceLookup as any).data)
+        indicatorMap: generateIdToIndicatorMap((onkokbSearch as any).data)
     };
 
     return oncoKbData;
@@ -426,20 +403,18 @@ export class PatientViewPageStore
             this.clinicalDataForSamples
         ],
         invoke: async () => {
-            const sampleIdToTumorType = generateSampleToTumorMap(this.clinicalDataForSamples.result);
-
-            const queryVariants = _.uniqBy(_.map(this.mutationData.result, function(mutation:Mutation) {
+            const queryVariants = _.uniqBy(_.map(this.mutationData.result, (mutation:Mutation) => {
                 return generateQueryVariant(mutation.gene.hugoGeneSymbol,
-                    sampleIdToTumorType[mutation.sampleId],
+                    this.sampleIdToTumorType[mutation.sampleId],
                     mutation.proteinChange,
                     mutation.mutationType,
                     mutation.proteinPosStart,
                     mutation.proteinPosEnd);
             }), "id");
 
-            return fetchOncoKbData(sampleIdToTumorType, queryVariants);
+            return fetchOncoKbData(this.sampleIdToTumorType, queryVariants);
         }
-    }, {sampleToTumorMap: {}, indicatorMap: {}, evidenceMap: {}});
+    }, {sampleToTumorMap: {}, indicatorMap: {}});
 
     readonly cnaOncoKbData = remoteData<IOncoKbData>({
         await: () => [
@@ -447,89 +422,15 @@ export class PatientViewPageStore
             this.clinicalDataForSamples
         ],
         invoke: async () => {
-            const sampleIdToTumorType = generateSampleToTumorMap(this.clinicalDataForSamples.result);
-
-            const queryVariants = _.uniqBy(_.map(this.discreteCNAData.result, function(copyNumberData:DiscreteCopyNumberData) {
+            const queryVariants = _.uniqBy(_.map(this.discreteCNAData.result, (copyNumberData:DiscreteCopyNumberData) => {
                 return generateQueryVariant(copyNumberData.gene.hugoGeneSymbol,
-                    sampleIdToTumorType[copyNumberData.sampleId],
+                    this.sampleIdToTumorType[copyNumberData.sampleId],
                     getAlterationString(copyNumberData.alteration));
             }), "id");
 
-            return fetchOncoKbData(sampleIdToTumorType, queryVariants);
+            return fetchOncoKbData(this.sampleIdToTumorType, queryVariants);
         }
-    }, {sampleToTumorMap: {}, indicatorMap: {}, evidenceMap: {}});
-
-    readonly pmidData = remoteData({
-        await: () => [
-            this.oncoKbData
-        ],
-        invoke: async () => {
-            let refs:number[] = [];
-
-            _.each(this.oncoKbData.result.evidenceMap, (evidence:IEvidence) => {
-                if (evidence.mutationEffect &&
-                    evidence.mutationEffect.refs &&
-                    evidence.mutationEffect.refs.length > 0)
-                {
-                    refs = refs.concat(evidence.mutationEffect.refs.map((article:any) => {
-                        return Number(article.pmid);
-                    }));
-                }
-
-                if (evidence.oncogenicRefs &&
-                    evidence.oncogenicRefs.length > 0)
-                {
-                    refs = refs.concat(evidence.oncogenicRefs.map((article:any) => {
-                        return Number(article.pmid);
-                    }));
-                }
-
-                if (evidence.treatments &&
-                    _.isArray(evidence.treatments.sensitivity))
-                {
-                    evidence.treatments.sensitivity.forEach((item:any) => {
-                        if (_.isArray(item.articles))
-                        {
-                            refs = refs.concat(item.articles.map((article:any) => {
-                                return Number(article.pmid);
-                            }));
-                        }
-                    });
-                }
-
-                if (evidence.treatments &&
-                    _.isArray(evidence.treatments.resistance))
-                {
-                    evidence.treatments.resistance.forEach((item:any) => {
-                        if (_.isArray(item.articles))
-                        {
-                            refs = refs.concat(item.articles.map((article:any) => {
-                                return Number(article.pmid);
-                            }));
-                        }
-                    });
-                }
-            });
-
-            if (refs.length > 0)
-            {
-                // TODO move this into a properly cached API instance, move the URL into config file
-                return await new Promise((resolve, reject) => {
-                    $.post(
-                        'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json',
-                        {id: refs.join(",")}
-                    ).then((data) => {
-                        resolve(data);
-                    }).fail((err) => {
-                        reject(err);
-                    });
-                });
-            }
-            else {
-                return {};
-            }
-        }
-    }, {});
+    }, {sampleToTumorMap: {}, indicatorMap: {}});
 
     readonly copyNumberCountData = remoteData<CopyNumberCount[]>({
         await: () => [
@@ -571,6 +472,22 @@ export class PatientViewPageStore
         return Object.keys(idToMutations).map(id => idToMutations[id]);
     }
 
+    @computed get sampleIdToTumorType(): {[sampleId:string]: string}
+    {
+        const map:{[sampleId:string]: string} = {};
+
+        if (this.clinicalDataForSamples.result)
+        {
+            _.each(this.clinicalDataForSamples.result, function(clinicalData) {
+                if (clinicalData.clinicalAttributeId === "CANCER_TYPE") {
+                    map[clinicalData.entityId] = clinicalData.value;
+                }
+            });
+        }
+
+        return map;
+    }
+
     @action("SetSampleId") setSampleId(newId: string) {
         if (newId)
             this._patientId = '';
@@ -595,6 +512,16 @@ export class PatientViewPageStore
     @cached get discreteCNACache() {
         return new DiscreteCNACache(this.samples.result.map((s:Sample)=>s.sampleId),
                                     this.geneticProfileIdDiscrete.result);
+    }
+
+    @cached get oncoKbEvidenceCache()
+    {
+        return new OncoKbEvidenceCache();
+    }
+
+    @cached get pmidCache()
+    {
+        return new PmidCache();
     }
 
     @action requestAllVariantCountData() {

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -53,14 +53,15 @@ export default class CopyNumberTableWrapper extends React.Component<{ store:Pati
             name: "Annotation",
             render: (d:DiscreteCopyNumberData) => (AnnotationColumnFormatter.renderFunction(d, {
                 oncoKbData: this.props.store.cnaOncoKbData.result,
-                pmidData: this.props.store.pmidData.result,
+                oncoKbEvidenceCache: this.props.store.oncoKbEvidenceCache,
+                pmidCache: this.props.store.pmidCache,
                 enableOncoKb: true,
                 enableMyCancerGenome: false,
                 enableHotspot: false
             })),
             sortBy:(d:DiscreteCopyNumberData)=>{
                 return AnnotationColumnFormatter.sortValue(d,
-                    this.props.store.cnaOncoKbData.result, this.props.store.pmidData.result);
+                    this.props.store.cnaOncoKbData.result);
             },
             order: 50
         });

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -30,6 +30,8 @@ import DiscreteCNACache from "../clinicalInformation/DiscreteCNACache";
 import MrnaExprRankCache from "../clinicalInformation/MrnaExprRankCache";
 import CohortVariantCountCache from "../clinicalInformation/CohortVariantCountCache";
 import * as _ from "lodash";
+import OncoKbEvidenceCache from "../OncoKbEvidenceCache";
+import PmidCache from "../PmidCache";
 
 export type PatientViewMutationTableProps = {
     sampleManager:SampleManager | null;
@@ -37,12 +39,13 @@ export type PatientViewMutationTableProps = {
     discreteCNACache?:DiscreteCNACache;
     mrnaExprRankCache?:MrnaExprRankCache;
     variantCountCache?:CohortVariantCountCache;
+    oncoKbEvidenceCache?:OncoKbEvidenceCache;
+    pmidCache?:PmidCache
     mutSigData?:MutSigData;
     myCancerGenomeData?: IMyCancerGenomeData;
     hotspots?: IHotspotData;
     cosmicData?:ICosmicData;
     oncoKbData?:IOncoKbData;
-    pmidData?:any;
     mrnaExprRankGeneticProfileId?:string;
     discreteCNAGeneticProfileId?:string;
     columns:MutationTableColumnType[];
@@ -369,14 +372,17 @@ export default class PatientViewMutationTable extends React.Component<PatientVie
                 hotspots: this.props.hotspots,
                 myCancerGenomeData: this.props.myCancerGenomeData,
                 oncoKbData: this.props.oncoKbData,
-                pmidData: this.props.pmidData,
+                oncoKbEvidenceCache: this.props.oncoKbEvidenceCache,
+                pmidCache: this.props.pmidCache,
                 enableOncoKb: true,
                 enableMyCancerGenome: true,
                 enableHotspot: true
             })),
             sortBy:(d:Mutation[])=>{
                 return AnnotationColumnFormatter.sortValue(d,
-                    this.props.hotspots, this.props.myCancerGenomeData, this.props.oncoKbData, this.props.pmidData);
+                    this.props.hotspots,
+                    this.props.myCancerGenomeData,
+                    this.props.oncoKbData);
             },
             order: 35
         };

--- a/src/shared/components/annotation/OncoKbTooltip.tsx
+++ b/src/shared/components/annotation/OncoKbTooltip.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import OncoKbCard from "./OncoKbCard";
+import {observer} from "mobx-react";
+import OncoKbEvidenceCache from "pages/patientView/OncoKbEvidenceCache";
+import OncokbPmidCache from "pages/patientView/PmidCache";
+import {ICacheData, ICache} from "shared/lib/SimpleCache";
+import {IndicatorQueryResp, Query} from "shared/api/generated/OncoKbAPI";
+import {IEvidence} from "pages/patientView/mutation/column/AnnotationColumnFormatter";
+import {
+    generateTreatments, generateOncogenicCitations, generateMutationEffectCitations, extractPmids
+} from "shared/lib/OncoKbUtils";
+import {placeHolder} from "./OncoKB";
+
+export interface IOncoKbTooltipProps {
+    indicator?: IndicatorQueryResp;
+    evidenceCache?: OncoKbEvidenceCache;
+    evidenceQuery?: Query;
+    pmidCache?: OncokbPmidCache;
+    handleFeedbackOpen?: () => void;
+}
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+@observer
+export default class OncoKbTooltip extends React.Component<IOncoKbTooltipProps, {}>
+{
+    public get evidenceCacheData():ICacheData<IEvidence>|undefined
+    {
+        let cacheData:ICacheData<IEvidence>|undefined;
+
+        if (this.props.evidenceCache && this.props.evidenceQuery)
+        {
+            const cache = this.props.evidenceCache.getData([this.props.evidenceQuery.id], [this.props.evidenceQuery]);
+
+            if (cache) {
+                cacheData = cache[this.props.evidenceQuery.id];
+            }
+        }
+
+        return cacheData;
+    }
+
+    public get pmidData():ICache<any>
+    {
+        let pmidData: ICache<any> = {};
+
+        if (this.props.pmidCache && this.evidenceCacheData)
+        {
+            const refs = extractPmids(this.evidenceCacheData.data);
+
+            if (refs.length > 0) {
+                pmidData = this.props.pmidCache.getData(refs.map((ref:number) => ref.toString()), refs);
+            }
+        }
+
+        return pmidData;
+    }
+
+    public render()
+    {
+        let tooltipContent: JSX.Element = <span />;
+        const cacheData:ICacheData<IEvidence>|undefined = this.evidenceCacheData;
+
+        if (!cacheData || !this.props.indicator)
+        {
+            return tooltipContent;
+        }
+
+        if (cacheData.status === 'complete' && cacheData.data)
+        {
+            const evidence = cacheData.data;
+            const pmidData: ICache<any> = this.pmidData;
+
+            tooltipContent = (
+                <OncoKbCard
+                    title={`${this.props.indicator.query.hugoSymbol} ${this.props.indicator.query.alteration} in ${this.props.indicator.query.tumorType}`}
+                    gene={this.props.indicator.geneExist ? this.props.indicator.query.hugoSymbol : ''}
+                    oncogenicity={this.props.indicator.oncogenic}
+                    oncogenicityPmids={generateOncogenicCitations(evidence.oncogenicRefs)}
+                    mutationEffect={evidence.mutationEffect.knownEffect}
+                    mutationEffectPmids={generateMutationEffectCitations(evidence.mutationEffect.refs)}
+                    geneSummary={this.props.indicator.geneSummary}
+                    variantSummary={this.props.indicator.variantSummary}
+                    tumorTypeSummary={this.props.indicator.tumorTypeSummary}
+                    biologicalSummary={evidence.mutationEffect.description}
+                    treatments={generateTreatments(evidence.treatments)}
+                    pmidData={pmidData}
+                    handleFeedbackOpen={this.props.handleFeedbackOpen}
+                />
+            );
+        }
+        else if (cacheData.status === 'pending') {
+            tooltipContent = placeHolder('LOADING');
+        }
+        else if (cacheData.status === 'error') {
+            tooltipContent = placeHolder('ERROR');
+        }
+
+        return tooltipContent;
+    }
+}

--- a/src/shared/lib/OncoKbUtils.ts
+++ b/src/shared/lib/OncoKbUtils.ts
@@ -142,7 +142,58 @@ export function generateQueryVariantId(hugoSymbol:string,
         id = `${id}_${mutationType}`;
     }
 
-    return id;
+    return id.trim().replace(/\s/g, "_");
+}
+
+// TODO evidence:IEvidence
+export function extractPmids(evidence:any)
+{
+    let refs:number[] = [];
+
+    if (evidence.mutationEffect &&
+        evidence.mutationEffect.refs &&
+        evidence.mutationEffect.refs.length > 0)
+    {
+        refs = refs.concat(evidence.mutationEffect.refs.map((article:any) => {
+            return Number(article.pmid);
+        }));
+    }
+
+    if (evidence.oncogenicRefs &&
+        evidence.oncogenicRefs.length > 0)
+    {
+        refs = refs.concat(evidence.oncogenicRefs.map((article:any) => {
+            return Number(article.pmid);
+        }));
+    }
+
+    if (evidence.treatments &&
+        _.isArray(evidence.treatments.sensitivity))
+    {
+        evidence.treatments.sensitivity.forEach((item:any) => {
+            if (_.isArray(item.articles))
+            {
+                refs = refs.concat(item.articles.map((article:any) => {
+                    return Number(article.pmid);
+                }));
+            }
+        });
+    }
+
+    if (evidence.treatments &&
+        _.isArray(evidence.treatments.resistance))
+    {
+        evidence.treatments.resistance.forEach((item:any) => {
+            if (_.isArray(item.articles))
+            {
+                refs = refs.concat(item.articles.map((article:any) => {
+                    return Number(article.pmid);
+                }));
+            }
+        });
+    }
+
+    return refs;
 }
 
 export function normalizeLevel(level:string):string|null

--- a/src/shared/lib/SimpleCache.ts
+++ b/src/shared/lib/SimpleCache.ts
@@ -1,0 +1,97 @@
+import {observable, action} from "mobx";
+import Immutable from "seamless-immutable";
+
+export interface ICacheData<T> {
+    status: "pending" | "complete" | "error";
+    data?: T;
+}
+
+export interface ICache<T> {
+    [queryId:string]: ICacheData<T>;
+}
+
+export type ImmutableCache<T> = ICache<T> & Immutable.ImmutableObject<ICache<T>>;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+export default class SimpleCache<T, Query>
+{
+    @observable.ref protected _cache: ImmutableCache<T>;
+    protected _pendingCache: ICache<T>;
+
+    constructor()
+    {
+        this._cache = Immutable.from<ICache<T>>({});
+        this._pendingCache = {};
+    }
+
+    protected async fetch(query: Query)
+    {
+        // must be implemented by child classes
+    }
+
+    protected filter(ids:string[], query: Query):Query
+    {
+        // should be implemented by the child classes in order to filter certain ids out of the query Q
+        // this might be useful if your query contains already cached ids
+        return query;
+    }
+
+    public getData(ids:string[], query: Query): ICache<T>
+    {
+        const values:ICache<T> = {};
+        const missing:string[] = [];
+
+        ids.forEach((id:string) => {
+            const data = this._cache[id] || this._pendingCache[id];
+
+            if (data === undefined) {
+                missing.push(id);
+            }
+            else {
+                values[id] = data;
+            }
+        });
+
+        // no cache entry for missing ids, we need to fetch
+        if (missing.length > 0) {
+            const pendingData: ICache<T> = {};
+
+            // set status to pending
+            missing.forEach((id: string) => {
+                // update pending data to put in the cache
+                pendingData[id] = {
+                    status: "pending",
+                };
+
+                // putting pending data in the actual cache causes problems,
+                // so putting it in a separate pending cache instead...
+                this._pendingCache[id] = pendingData[id];
+
+                // values to return should contain but completed and pending data
+                values[id] = pendingData[id];
+            });
+
+            // fetch missing data
+            this.fetch(this.filter(missing, query));
+        }
+
+        return values;
+    }
+
+    @action protected putData(data: ICache<T>)
+    {
+        // remove data from the pending cache if it is not pending anymore
+        Object.keys(data).forEach((id:string) => {
+            if (data[id].status !== "pending") {
+                delete this._pendingCache[id];
+            }
+        });
+
+        // put the data into the actual cache
+        if (Object.keys(data).length > 0) {
+            this._cache = this._cache.merge(data, {deep:true}) as ImmutableCache<T>;
+        }
+    }
+}


### PR DESCRIPTION
# What? Why?
- Deferred loading of the OncoKB card data (`Evidence` and `PMID` data) until an actual mouse-over event on a particular OncoKB icon.
- Added a generic `SimpleCache` implementation for Evidence and PMID data caching. We may want to replace these cache implementations with the ones that extend a generic version of `SampleGeneCache`, especially if we need the "accumulating debounce" feature.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
