### PR TITLE
tighten padding in bootstrap tables

### DIFF
--- a/src/appShell/App/Container.tsx
+++ b/src/appShell/App/Container.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import PageHeader from '../../pages/pageHeader/PageHeader';
 
-import '../../globalStyles/global.scss';
+import '../../globalStyles/prefixed-global.scss';
 
 interface IContainerProps {
     location: Location;

--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -120,5 +120,10 @@ th.reactable-header-sort-asc:after {
   }
 }
 
+.table tbody tr td {
+  padding:6px 10px !important;
+  border-top:none;
+}
+
 
 

--- a/src/globalStyles/prefixed-global.scss
+++ b/src/globalStyles/prefixed-global.scss
@@ -1,0 +1,5 @@
+.cbioportal-frontend {
+
+  @import './global.scss';
+
+}


### PR DESCRIPTION
@jjgao requested that cell padding be the same as in legacy portal. 

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
