### PR TITLE
sorting copy number table by annotation column by default

### DIFF
--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -124,6 +124,8 @@ export default class CopyNumberTableWrapper extends React.Component<{ store:Pati
                     <CNATableComponent
                         columns={orderedColumns}
                         data={this.props.store.discreteCNAData.result}
+                        initialSortColumn="Annotation"
+                        initialSortDirection="desc"
                         initialItemsPerPage={25}
                     />
                 )


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/2279

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)