### PR TITLE
move cosmic data to store.  don't fetch cosmic or onkobk when no muta…

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -67,7 +67,6 @@ interface IPatientViewState {
     mutationData: any;
     myCancerGenomeData?: IMyCancerGenomeData;
     hotspotsData?: IHotspotData;
-    cosmicData?: ICosmicData;
     oncoKbData?: IOncoKbData;
     mutSigData?: MutSigData;
     activeTabKey: number;
@@ -101,7 +100,6 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
         this.state = {
             mutationData: undefined,
             hotspotsData: undefined,
-            cosmicData: undefined,
             oncoKbData: undefined,
             mutSigData: undefined,
             activeTabKey:1
@@ -278,13 +276,6 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                         this.setState(({hotspotsData} as IPatientViewState)));
                     hotspotDataPromise.catch(() => {
                     });
-
-                    const cosmicDataPromise = this.fetchCosmicData(patientViewPageStore.mutationData.result).then((cosmicData: ICosmicData) =>
-                        this.setState(({cosmicData} as IPatientViewState)));
-                    cosmicDataPromise.catch(() => {
-                    });
-
-                    this.setState(({mutationData: patientViewPageStore.mutationData.result} as IPatientViewState));
 
                     this.fetchMutSigData().then((_result) => {
                         const data = _result.reduce((map:MutSigData, next:MutSig) => {
@@ -499,9 +490,9 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
 
                             <hr />
 
-                            <FeatureTitle title="Mutations" isLoading={ !this.state.mutationData }/>
+                            <FeatureTitle title="Mutations" isLoading={ patientViewPageStore.mutationData.isPending }/>
                             {
-                                (this.state.mutationData && !!sampleManager) && (
+                                (patientViewPageStore.mutationData.isComplete && !!sampleManager) && (
                                     <PatientViewMutationTable
                                         sampleManager={sampleManager}
                                         sampleIds={sampleManager ? sampleManager.getSampleIdsInOrder() : []}
@@ -516,7 +507,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         mutSigData={this.state.mutSigData}
                                         myCancerGenomeData={this.state.myCancerGenomeData}
                                         hotspots={this.state.hotspotsData}
-                                        cosmicData={this.state.cosmicData}
+                                        cosmicData={patientViewPageStore.cosmicData.result}
                                         oncoKbData={patientViewPageStore.oncoKbData.result}
                                         columns={this.mutationTableColumns}
                                     />

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.spec.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.spec.ts
@@ -2,18 +2,20 @@
  * Created by aaronlisman on 3/2/17.
  */
 
-import { handlePathologyReportCheckResponse } from './PatientViewPageStore';
+import { handlePathologyReportCheckResponse, PatientViewPageStore } from './PatientViewPageStore';
 // import React from 'react';
 import { assert } from 'chai';
 // import { shallow, mount } from 'enzyme';
-// import sinon from 'sinon';
+import sinon from 'sinon';
 // //import AppConfig from 'appConfig';
 // import request from 'superagent';
 
 describe('ClinicalInformationSamplesTable', () => {
 
-    before(()=>{
+    let store: PatientViewPageStore;
 
+    before(()=>{
+        store = new PatientViewPageStore();
     });
 
     after(()=>{
@@ -31,6 +33,38 @@ describe('ClinicalInformationSamplesTable', () => {
             total_count:0,
         });
         assert.deepEqual(result,[]);
+    });
+
+    it('won\'t fetch cosmic data if there are no mutations', ()=>{
+
+        const fetchStub = sinon.stub();
+
+        let mockInstance = {
+            mutationData: { result:[] },
+            internalClient: {
+                fetchCosmicCountsUsingPOST: fetchStub
+            }
+        };
+
+        store.cosmicDataInvoke.apply(mockInstance).then((data: any)=>{
+           assert.isUndefined(data);
+           assert.isFalse(fetchStub.called);
+        });
+
+    });
+
+    it('won\'t fetch onkokb data if there are no mutations', ()=>{
+
+        const fetchStub = sinon.stub();
+
+        let mockInstance = {
+            mutationData: { result:[] }
+        };
+
+        store.oncoKbDataInvoke.apply(mockInstance).then((data: any)=>{
+            assert.deepEqual(data,{sampleToTumorMap: {}, indicatorMap: {}});
+        });
+
     });
 
 });


### PR DESCRIPTION
We were getting errors on patients where mutations service returned empty.  this work prevents cosmic data and onko kb services from being called when there are no mutations present.

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
