### PR TITLE
Use Darwin servlet

### DIFF
--- a/my-index.ejs
+++ b/my-index.ejs
@@ -6,11 +6,9 @@
     <script>
         window.devContext = true;
         window.defaultRoute = "/patient";
-        // TODO: this is patient view link injected through JSP, connecting to
-        // another system (DARWIN) at MSKCC. This prolly be a service further
-        // down the line.
-        // Uncomment to test
-        // window.darwinAccessUrl = "https://en.wikipedia.org/wiki/Charles_Darwin";
+        // uncomment to enable Darwin internal MSKCC service patient view link
+        // uses checkDarwinAccess.do service from cbioportal/cbioportal
+        // window.enableDarwin = true;
 
         // Set default API in case none is specified in .env
         __API_ROOT__ = 'cbioportal-rc.herokuapp.com';

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -441,7 +441,8 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                 <td>Patient:</td>
                                 <td><PatientHeader
                                     handlePatientClick={(id: string)=>this.handlePatientClick(id)}
-                                    patient={patientViewPageStore.patientViewData.result.patient}/></td>
+                                    patient={patientViewPageStore.patientViewData.result.patient}
+                                    darwinUrl={patientViewPageStore.darwinUrl.result}/></td>
                             </tr>
                             <tr>
                                 <td>Samples:</td>

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -25,7 +25,7 @@ import CohortVariantCountCache from "./CohortVariantCountCache";
 import {EntrezToKeywordList} from "./CohortVariantCountCache";
 import {SampleToEntrezListOrNull} from "./SampleGeneCache";
 import DiscreteCNACache from "./DiscreteCNACache";
-import {getTissueImageCheckUrl} from "../../../shared/api/urls";
+import {getTissueImageCheckUrl, getDarwinUrl} from "../../../shared/api/urls";
 import {getAlterationString} from "shared/lib/CopyNumberUtils";
 import OncoKbEvidenceCache from "../OncoKbEvidenceCache";
 import PmidCache from "../PmidCache";
@@ -423,6 +423,25 @@ export class PatientViewPageStore {
             return profile ? profile.geneticProfileId : undefined;
         }
 
+    });
+
+    readonly darwinUrl = remoteData({
+        await: () => [
+            this.derivedPatientId
+        ],
+        invoke: async() => {
+            let enableDarwin: boolean | null | undefined = ((window as any).enableDarwin);
+
+            if (enableDarwin === true) {
+                let resp = await request.get(getDarwinUrl(this.samples.result.map((sample: Sample) => sample.sampleId).join(','), this.patientId));
+                return resp.text;
+            } else {
+                return '';
+            }
+        },
+        onError: () => {
+            // fail silently
+        }
     });
 
 

--- a/src/pages/patientView/patientHeader/PatientHeader.tsx
+++ b/src/pages/patientView/patientHeader/PatientHeader.tsx
@@ -11,6 +11,7 @@ import DefaultTooltip from "../../../shared/components/DefaultTooltip";
 export type IPatientHeaderProps = {
     patient:any;
     handlePatientClick:any;
+    darwinUrl?: string;
 }
 export default class PatientHeader extends React.Component<IPatientHeaderProps, {}> {
     public render() {
@@ -18,21 +19,19 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
         return (
             <div className={styles.patientHeader}>
                 {this.props.patient && this.getOverlayTriggerPatient(this.props.patient)}
-                {this.getDarwinAccessUrl()}
+                {this.getDarwinUrl(this.props.darwinUrl)}
             </div>
         );
 
     }
 
-    private getDarwinAccessUrl() {
+    private getDarwinUrl(darwinUrl: string | null | undefined) {
         // use JSP injected Darwin URL window.darwinAccessUrl
         // TODO: use internal API service instead, once this exists
-        let darwinAccessUrl: string | null | undefined = ((window as any).darwinAccessUrl);
-
-        if (darwinAccessUrl !== undefined && darwinAccessUrl !== null && darwinAccessUrl !== '') {
+        if (darwinUrl !== undefined && darwinUrl !== null && darwinUrl !== '') {
             // add link to darwin
             let darwinImgSrc = require("./images/darwin_logo.png");
-            return (<a target='_blank' href={darwinAccessUrl}><img style={{paddingLeft:'5px'}} src={darwinImgSrc} /></a>);
+            return (<a target='_blank' href={darwinUrl}><img style={{paddingLeft:'5px'}} src={darwinImgSrc} /></a>);
         } else {
             return null;
         }

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -32,3 +32,8 @@ export function getOncoKbApiUrl() {
 export function getTissueImageCheckUrl(filter:string) {
     return `//${getHost()}/proxy/cancer.digitalslidearchive.net/local_php/get_slide_list_from_db_groupid_not_needed.php?slide_name_filter=${filter}`;
 }
+
+// Comma separated list of sample ids and the case id
+export function getDarwinUrl(sampleIds:string, caseId:string) {
+    return `//${getHost()}/checkDarwinAccess.do?sample_id=${sampleIds}&case_id=${caseId}`;
+}


### PR DESCRIPTION
Use `checkDarwinAcces.do` servlet from parent cBioPortal to determine Darwin URL for patient. Only show in case this is enabled. Previously this variable was passed through JSP, but now that we have the routing on frontend after `#` symbol, we had to use a servlet instead.

Requires https://github.com/cBioPortal/cbioportal/pull/2289 to be merged