### PR TITLE
adjust width of visualizations on page resize (debounced)

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -22,7 +22,7 @@ body {
 }
 
 .topBanner {
-  width:$portalWidth;
+  @extend .portalWidth;
   margin:0 auto;
 }
 
@@ -65,7 +65,7 @@ th.reactable-header-sort-asc:after {
 .mainTabs {
 
   > .nav {
-    width:$portalWidth;
+    @extend .portalWidth;
     margin:0 auto;
 
     .active a {
@@ -92,7 +92,7 @@ th.reactable-header-sort-asc:after {
     }
 
     > .msk-tab {
-      width:$portalWidth;
+      @extend .portalWidth;
       margin: 0 auto;
     }
 

--- a/src/globalStyles/variables.scss
+++ b/src/globalStyles/variables.scss
@@ -2,4 +2,8 @@
 
 $mutationColor:blue;
 
-$portalWidth: 1240px;
+.portalWidth{
+  padding-left:20px;
+  padding-right:20px;
+  min-width:800px;
+}

--- a/src/pages/patientView/genomicOverview/Tracks.tsx
+++ b/src/pages/patientView/genomicOverview/Tracks.tsx
@@ -10,6 +10,7 @@ interface TracksPropTypes {
     mutations:Array<Mutation>;
     cnaSegments:Array<CopyNumberSeg>;
     sampleManager:SampleManager;
+    width:number;
 }
 
 export default class Tracks extends React.Component<TracksPropTypes, {}> {
@@ -23,7 +24,7 @@ export default class Tracks extends React.Component<TracksPropTypes, {}> {
         // --- construct params ---
         let uniqCnasampleIds = _.uniq(_.map(this.props.cnaSegments, 'sampleId'));
         let uniqMutSampleIds = _.uniq(_.map(this.props.mutations, 'sampleId'));
-        var config = tracksHelper.GenomicOverviewConfig(uniqCnasampleIds.length + uniqMutSampleIds.length, 1145);
+        var config = tracksHelper.GenomicOverviewConfig(uniqCnasampleIds.length + uniqMutSampleIds.length, this.props.width);
         // --- end of params ---
 
         // --- raphael config ---

--- a/src/pages/patientView/timeline/Timeline.tsx
+++ b/src/pages/patientView/timeline/Timeline.tsx
@@ -26,6 +26,16 @@ export default class Timeline extends React.Component<ITimelineProps, {}> {
 
     componentDidMount() {
 
+        this.drawTimeline();
+
+        var debouncedResize =  _.debounce(()=>this.drawTimeline(),500);
+
+        $(window).resize(debouncedResize);
+
+    }
+
+    drawTimeline(){
+
         let clinicalDataMap = this.props.store.patientViewData.result.samples!.reduce((memo:any,item)=>{
             memo[item.id] = item.clinicalData.reduce((innerMemo:any,innerItem)=>{
                 innerMemo[innerItem.clinicalAttributeId] = innerItem.value;
@@ -53,19 +63,20 @@ export default class Timeline extends React.Component<ITimelineProps, {}> {
         };
 
         let timelineData = this.props.store.clinicalEvents.result.map((eventData:ClinicalEvent) => {
-           return {
-               eventType: eventData.eventType,
-               patientId: eventData.patientId,
-               startDate: _.isUndefined(eventData.startNumberOfDaysSinceDiagnosis) ? null : eventData.startNumberOfDaysSinceDiagnosis,
-               stopDate: _.isUndefined(eventData.endNumberOfDaysSinceDiagnosis) ? null : eventData.endNumberOfDaysSinceDiagnosis,
-               eventData: eventData.attributes.reduce((memo:any, evData: ClinicalEventData) => {
-                   memo[evData.key] = evData.value;
-                   return memo;
-               }, {})
-           }
+            return {
+                eventType: eventData.eventType,
+                patientId: eventData.patientId,
+                startDate: _.isUndefined(eventData.startNumberOfDaysSinceDiagnosis) ? null : eventData.startNumberOfDaysSinceDiagnosis,
+                stopDate: _.isUndefined(eventData.endNumberOfDaysSinceDiagnosis) ? null : eventData.endNumberOfDaysSinceDiagnosis,
+                eventData: eventData.attributes.reduce((memo:any, evData: ClinicalEventData) => {
+                    memo[evData.key] = evData.value;
+                    return memo;
+                }, {})
+            }
         });
 
-        buildTimeline(params, caseIds, patientInfo, clinicalDataMap, caseMetaData, timelineData);
+        buildTimeline(params, caseIds, patientInfo, clinicalDataMap, caseMetaData, timelineData, $('.tab-content').width()-40);
+
 
     }
 
@@ -78,20 +89,5 @@ export default class Timeline extends React.Component<ITimelineProps, {}> {
         )
     }
 
-
 }
 
-
-
-
-// let caseMetaData = {
-//     "color": {"P04_Pri": "black", "P04_Rec1": "orange", "P04_Rec2": "orange", "P04_Rec3": "orange"},
-//     "label": {"P04_Pri": 1, "P04_Rec1": 2, "P04_Rec2": 3, "P04_Rec3": 4},
-//     "index": {"P04_Pri": 0, "P04_Rec1": 1, "P04_Rec2": 2, "P04_Rec3": 3},
-//     "tooltip": {
-//         "P04_Pri": "<tr><td><b><u><a href='case.do?cancer_study_id=lgg_ucsf_2014&sample_id=P04_Pri'>P04_Pri</a></b></u><div class='more-sample-info'><span class=\"clinical-attribute\" attr-id=\"IDH1_MUTATION\" attr-value=\"R132C\" study=\"lgg_ucsf_2014\">R132C</span><span class=\"clinical-attribute\" attr-id=\"SAMPLE_TYPE\" attr-value=\"Primary\" study=\"lgg_ucsf_2014\">Primary</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE_DETAILED\" attr-value=\"Astrocytoma\" study=\"lgg_ucsf_2014\">Astrocytoma</span><span class=\"clinical-attribute\" attr-id=\"NON_SILENT_MUTATION\" attr-value=\"TP53\" study=\"lgg_ucsf_2014\">TP53</span><span class=\"clinical-attribute\" attr-id=\"GRADE\" attr-value=\"II\" study=\"lgg_ucsf_2014\">II</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE\" attr-value=\"Glioma\" study=\"lgg_ucsf_2014\">Glioma</span><span class=\"clinical-attribute\" attr-id=\"IDH_1P19Q_SUBTYPE\" attr-value=\"Intact\" study=\"lgg_ucsf_2014\">Intact</span><span class=\"clinical-attribute\" attr-id=\"DERIVED_NORMALIZED_CASE_TYPE\" attr-value=\"primary\" study=\"lgg_ucsf_2014\">primary</span></div>",
-//         "P04_Rec1": "<tr><td><b><u><a href='case.do?cancer_study_id=lgg_ucsf_2014&sample_id=P04_Rec1'>P04_Rec1</a></b></u><div class='more-sample-info'><span class=\"clinical-attribute\" attr-id=\"IDH1_MUTATION\" attr-value=\"R132C\" study=\"lgg_ucsf_2014\">R132C</span><span class=\"clinical-attribute\" attr-id=\"SAMPLE_TYPE\" attr-value=\"Recurrence\" study=\"lgg_ucsf_2014\">Recurrence</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE_DETAILED\" attr-value=\"Anaplastic Astrocytoma\" study=\"lgg_ucsf_2014\">Anaplastic Astrocytoma</span><span class=\"clinical-attribute\" attr-id=\"NON_SILENT_MUTATION\" attr-value=\"TP53\" study=\"lgg_ucsf_2014\">TP53</span><span class=\"clinical-attribute\" attr-id=\"GRADE\" attr-value=\"III\" study=\"lgg_ucsf_2014\">III</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE\" attr-value=\"Glioma\" study=\"lgg_ucsf_2014\">Glioma</span><span class=\"clinical-attribute\" attr-id=\"IDH_1P19Q_SUBTYPE\" attr-value=\"Intact\" study=\"lgg_ucsf_2014\">Intact</span><span class=\"clinical-attribute\" attr-id=\"DERIVED_NORMALIZED_CASE_TYPE\" attr-value=\"recurrence\" study=\"lgg_ucsf_2014\">recurrence</span></div>",
-//         "P04_Rec2": "<tr><td><b><u><a href='case.do?cancer_study_id=lgg_ucsf_2014&sample_id=P04_Rec2'>P04_Rec2</a></b></u><div class='more-sample-info'><span class=\"clinical-attribute\" attr-id=\"IDH1_MUTATION\" attr-value=\"R132C\" study=\"lgg_ucsf_2014\">R132C</span><span class=\"clinical-attribute\" attr-id=\"SAMPLE_TYPE\" attr-value=\"Recurrence\" study=\"lgg_ucsf_2014\">Recurrence</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE_DETAILED\" attr-value=\"Anaplastic Astrocytoma\" study=\"lgg_ucsf_2014\">Anaplastic Astrocytoma</span><span class=\"clinical-attribute\" attr-id=\"NON_SILENT_MUTATION\" attr-value=\"TP53\" study=\"lgg_ucsf_2014\">TP53</span><span class=\"clinical-attribute\" attr-id=\"GRADE\" attr-value=\"III\" study=\"lgg_ucsf_2014\">III</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE\" attr-value=\"Glioma\" study=\"lgg_ucsf_2014\">Glioma</span><span class=\"clinical-attribute\" attr-id=\"IDH_1P19Q_SUBTYPE\" attr-value=\"Intact\" study=\"lgg_ucsf_2014\">Intact</span><span class=\"clinical-attribute\" attr-id=\"DERIVED_NORMALIZED_CASE_TYPE\" attr-value=\"recurrence\" study=\"lgg_ucsf_2014\">recurrence</span></div>",
-//         "P04_Rec3": "<tr><td><b><u><a href='case.do?cancer_study_id=lgg_ucsf_2014&sample_id=P04_Rec3'>P04_Rec3</a></b></u><div class='more-sample-info'><span class=\"clinical-attribute\" attr-id=\"IDH1_MUTATION\" attr-value=\"R132C\" study=\"lgg_ucsf_2014\">R132C</span><span class=\"clinical-attribute\" attr-id=\"SAMPLE_TYPE\" attr-value=\"Recurrence\" study=\"lgg_ucsf_2014\">Recurrence</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE_DETAILED\" attr-value=\"Anaplastic Astrocytoma\" study=\"lgg_ucsf_2014\">Anaplastic Astrocytoma</span><span class=\"clinical-attribute\" attr-id=\"NON_SILENT_MUTATION\" attr-value=\"TP53\" study=\"lgg_ucsf_2014\">TP53</span><span class=\"clinical-attribute\" attr-id=\"GRADE\" attr-value=\"III\" study=\"lgg_ucsf_2014\">III</span><span class=\"clinical-attribute\" attr-id=\"CANCER_TYPE\" attr-value=\"Glioma\" study=\"lgg_ucsf_2014\">Glioma</span><span class=\"clinical-attribute\" attr-id=\"IDH_1P19Q_SUBTYPE\" attr-value=\"Intact\" study=\"lgg_ucsf_2014\">Intact</span><span class=\"clinical-attribute\" attr-id=\"DERIVED_NORMALIZED_CASE_TYPE\" attr-value=\"recurrence\" study=\"lgg_ucsf_2014\">recurrence</span></div>"
-//     }
-// };

--- a/src/pages/patientView/timeline/legacy.js
+++ b/src/pages/patientView/timeline/legacy.js
@@ -55,7 +55,7 @@ function plotCaseLabelsInTimeline(caseIds, clinicalDataMap, caseMetaData) {
     }
 }
 
-export function buildTimeline(params, caseIds, patientInfo, clinicalDataMap, caseMetaData, data) {
+export function buildTimeline(params, caseIds, patientInfo, clinicalDataMap, caseMetaData, data, width) {
 
     if (data.length === 0) return;
 
@@ -132,7 +132,6 @@ export function buildTimeline(params, caseIds, patientInfo, clinicalDataMap, cas
         }
     }
 
-    var width = 1245;
     window.pvTimeline = clinicalTimelineExports.clinicalTimeline()
         .width(width)
         .data(timeData)

--- a/src/pages/patientView/vafPlot/ThumbnailExpandVAFPlot.tsx
+++ b/src/pages/patientView/vafPlot/ThumbnailExpandVAFPlot.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import DefaultTooltip from 'shared/components/DefaultTooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import {VAFPlot, IVAFPlotProps} from './VAFPlot';
+import {MutationFrequenciesBySample} from "../genomicOverview/GenomicOverview";
 
 export type IThumbnailExpandVAFPlotProps = {
-    data: { [s: string]:number[] };
+    data: MutationFrequenciesBySample;
     order?: { [s:string]:number };
     colors?: { [s: string]:string };
     labels?: { [s:string]:string };


### PR DESCRIPTION
We want page to adjust to fill window size.  We also want visualizations to redaw on page resize event

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
