### PR TITLE
fix width calculation of timeline and genomic overview and move it ou…

### DIFF
--- a/src/pages/pageHeader/styles.scss
+++ b/src/pages/pageHeader/styles.scss
@@ -1,8 +1,6 @@
 .cbioOnePageApp {
 
-
-  padding: 99px 20px 20px 20px;
-
+  padding-top:10px;
 
   header {
     padding: 20px;
@@ -18,6 +16,7 @@
       padding: 0;
       margin: 0;
     }
+    display:none;
 
   }
 

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -284,7 +284,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                     <div>
                                         <FeatureTitle title="Clinical Timeline" isLoading={false} />
 
-                                        <Timeline store={patientViewPageStore} sampleManager={ sampleManager } />
+                                        <Timeline store={patientViewPageStore} getWidth={ ()=>$(window).width()-40 } sampleManager={ sampleManager } />
                                         <hr />
                                     </div>
                                 )
@@ -302,6 +302,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         sampleLabels={sampleManager.sampleLabels}
                                         sampleColors={sampleManager.sampleColors}
                                         sampleManager={sampleManager}
+                                        getWidth={()=>$(window).width()-140}
                                     />
                                 )
                             }

--- a/src/pages/patientView/genomicOverview/GenomicOverview.tsx
+++ b/src/pages/patientView/genomicOverview/GenomicOverview.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import * as _ from 'lodash';
 import $ from 'jquery';
 import Tracks from './Tracks';
@@ -14,6 +15,7 @@ interface IGenomicOverviewProps {
     sampleLabels: {[s:string]:string};
     sampleColors: {[s:string]:string};
     sampleManager: SampleManager;
+    getWidth: ()=>number;
 }
 
 export type MutationFrequencies = number[];
@@ -45,8 +47,6 @@ export default class GenomicOverview extends React.Component<IGenomicOverviewPro
 
     public render() {
 
-        const width = $('.tab-content').width()-140;
-
         const labels = _.reduce(this.props.sampleManager.samples, (result: any, sample: ClinicalDataBySampleId, i: number)=>{
             result[sample.id] = i + 1;
             return result;
@@ -54,7 +54,7 @@ export default class GenomicOverview extends React.Component<IGenomicOverviewPro
 
         return (
             <div style={{ display:'flex', alignItems:'center'  }}>
-                <Tracks mutations={this.props.mutations} key={Math.random()} sampleManager={this.props.sampleManager} width={width} cnaSegments={this.props.cnaSegments} />
+                <Tracks mutations={this.props.mutations} key={Math.random()} sampleManager={this.props.sampleManager} width={this.props.getWidth()} cnaSegments={this.props.cnaSegments} />
                 <ThumbnailExpandVAFPlot
                     data={this.state.frequencies}
                     order={this.props.sampleManager.sampleIndex}

--- a/src/pages/patientView/timeline/Timeline.tsx
+++ b/src/pages/patientView/timeline/Timeline.tsx
@@ -15,7 +15,8 @@ import {ClinicalEvent, ClinicalEventData} from "../../../shared/api/generated/CB
 
 interface ITimelineProps {
     sampleManager:SampleManager;
-    store:PatientViewPageStore
+    store:PatientViewPageStore;
+    getWidth:() => number;
 }
 
 export default class Timeline extends React.Component<ITimelineProps, {}> {
@@ -75,7 +76,7 @@ export default class Timeline extends React.Component<ITimelineProps, {}> {
             }
         });
 
-        buildTimeline(params, caseIds, patientInfo, clinicalDataMap, caseMetaData, timelineData, $('.tab-content').width()-40);
+        buildTimeline(params, caseIds, patientInfo, clinicalDataMap, caseMetaData, timelineData, this.props.getWidth());
 
 
     }


### PR DESCRIPTION
fix width calculation of timeline and genomic overview and move it out to parent page component

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
