### PR TITLE
MSKTab loading and hide functionality, to solve problem

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -371,26 +371,29 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                     )}
 
 
-                    {  (patientViewPageStore.pathologyReport.isComplete && patientViewPageStore.pathologyReport.result.length > 0 ) &&
-                    (<MSKTab key={3} id="pathologyReportTab" linkText="Pathology Report">
+                    <MSKTab key={3} id="pathologyReportTab" linkText="Pathology Report"
+                            hide={(patientViewPageStore.pathologyReport.isComplete && patientViewPageStore.pathologyReport.result.length === 0)}
+                            loading={patientViewPageStore.pathologyReport.isPending}
+                    >
                         <PathologyReport pdfs={patientViewPageStore.pathologyReport.result} />
-                    </MSKTab>)
-                    }
+                    </MSKTab>
 
 
-                    {  (patientViewPageStore.MDAndersonHeatMapAvailable.isComplete && patientViewPageStore.MDAndersonHeatMapAvailable.result ) &&
-                    (<MSKTab key={4} id="heatMapReportTab" linkText="Heatmap">
+                    <MSKTab key={4} id="heatMapReportTab" linkText="Heatmap"
+                             hide={(patientViewPageStore.MDAndersonHeatMapAvailable.isComplete && !patientViewPageStore.MDAndersonHeatMapAvailable.result)}
+                            loading={patientViewPageStore.MDAndersonHeatMapAvailable.isPending}
+                    >
                         <iframe style={{width:'100%', height:700, border:'none'}}
                                 src={ `//bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?participant=${patientViewPageStore.patientId}` }></iframe>
-                    </MSKTab>)
-                    }
+                    </MSKTab>
 
-                    { (patientViewPageStore.hasTissueImageIFrameUrl.isComplete && patientViewPageStore.hasTissueImageIFrameUrl.result) &&
-                        (<MSKTab key={5} id="tissueImageTab" linkText="Tissue Image">
-                            <iframe style={{width:'100%', height:700, border:'none'}}
-                                    src={ `http://cancer.digitalslidearchive.net/index_mskcc.php?slide_name=${patientViewPageStore.patientId}` }></iframe>
-                        </MSKTab>)
-                    }
+                    <MSKTab key={5} id="tissueImageTab" linkText="Tissue Image"
+                            hide={(patientViewPageStore.hasTissueImageIFrameUrl.isComplete && !patientViewPageStore.hasTissueImageIFrameUrl.result)}
+                            loading={patientViewPageStore.hasTissueImageIFrameUrl.isPending}
+                    >
+                        <iframe style={{width:'100%', height:700, border:'none'}}
+                                src={ `http://cancer.digitalslidearchive.net/index_mskcc.php?slide_name=${patientViewPageStore.patientId}` }></iframe>
+                    </MSKTab>
 
                     </MSKTabs>
 

--- a/src/shared/components/MSKTabs/MSKTabs.spec.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.spec.tsx
@@ -1,22 +1,26 @@
 import { MSKTab, MSKTabs } from './MSKTabs';
 import React from 'react';
 import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
+import Spinner from "react-spinkit";
 
-describe('IMutationTableProps', () => {
+describe('MSKTabs', () => {
 
     let tabs: any;
+
+    function tabText(tabs:ReactWrapper<any,any>):string[] {
+        return tabs.find('ul.nav-tabs').find('li').map(x=>x.text());
+    }
 
     beforeEach(()=>{
 
         tabs = mount(
-          <MSKTabs onTabClick={()=>{}}>
-              <MSKTab id="one" linkText="One">One</MSKTab>
-              <MSKTab linkText="Two" id="two">Two</MSKTab>
+          <MSKTabs>
+              <MSKTab id="one" linkText="One"><span className="content">One</span></MSKTab>
+              <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
           </MSKTabs>
         );
-
     });
 
     after(()=>{
@@ -44,6 +48,39 @@ describe('IMutationTableProps', () => {
         tabs.setProps({ activeTabId:"one" });
         assert.isTrue(tabs.find(MSKTab).at(1).hasClass('hidden'));
         assert.isFalse(tabs.find(MSKTab).at(0).hasClass('hidden'));
+    });
+
+    it('does not display tabs that have hide={true}', ()=>{
+        let tabs2 = mount(<MSKTabs>
+            <MSKTab id="one" linkText="One"><span className="content">One</span></MSKTab>
+            <MSKTab linkText="Two" id="two" hide={true}><span className="content">Two</span></MSKTab>
+        </MSKTabs>);
+        assert.deepEqual(tabText(tabs2), ["One"]);
+    });
+
+    it('does not display the content of tabs that have loading={true}, instead showing a spinner; and ' +
+        'does not show a tab with loading={true} unless it is the active tab', ()=>{
+
+        tabs.setProps({ activeTabId: "one" });
+        const tab = tabs.find(MSKTab).at(0);
+        let span:ReactWrapper<any,any> = tab.find("span").at(0);
+        assert(span.exists(), "the span exists");
+        assert.equal(span.text(), "One");
+
+        let tabs2 = mount(<MSKTabs activeTabId="one">
+            <MSKTab id="one" linkText="One" loading={true}><span className="content">One</span></MSKTab>
+            <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
+        </MSKTabs>);
+
+        const tab2 = tabs2.find(MSKTab).at(0);
+        span = tab2.find("span").at(0);
+        assert(!span.exists(), "the span does not exist for a loading tab");
+        assert(tab2.find(Spinner).at(0).exists(), "a loading tab contains a spinner element");
+        assert.deepEqual(tabText(tabs2), ["One", "Two"], "both tabs visible");
+
+        tabs2.setProps({ activeTabId: "two" });
+        assert.deepEqual(tabText(tabs2), ["Two"], "only one tab visible, since the other is loading");
+
     });
 
 });


### PR DESCRIPTION
Issue is that when URL linking directly to a tab, if that tabs content is pending
so that the tab doesnt exist yet, then it starts at the first tab, then snaps to the
new one when it appears, which is not ideal for a few reasons. Its also causing an SVG bug
in the Genomic Tracks feature which we don't feel like fixing.

So this makes it easy for a tab to be marked as loading, so that it shows a loading spinner
instead of the given content; also, it can be dynamically hidden, using a prop value instead
of ternary logic or <If> or anything like that.

# Checks
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)