### PR TITLE
Split timeline on TREATMENT_TYPE and AGENT

### DIFF
--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
@@ -46,8 +46,9 @@ function clean(clinicalData) {
             switch (key) {
                 case 'OS_MONTHS':
                 case 'DFS_MONTHS':
+                case 'AGE':
                     if ($.isNumeric(value)) {
-                        value = Math.round(value);
+                        value = Math.floor(value);
                     }
                     cleanClinicalData[key] = value;
                     break;

--- a/src/pages/patientView/timeline/legacy.js
+++ b/src/pages/patientView/timeline/legacy.js
@@ -101,7 +101,7 @@ export function buildTimeline(params, caseIds, patientInfo, clinicalDataMap, cas
         var prefix = prefixes[i];
         if (patientInfo[prefix + "OS_STATUS"] === "DECEASED" &&
             prefix + "OS_MONTHS" in patientInfo) {
-            var days = parseInt(parseInt(patientInfo[prefix + "OS_MONTHS"]) * 30.4);
+            var days = Math.round(parseFloat(patientInfo[prefix + "OS_MONTHS"]) * 30.4);
             var timePoint = {
                 "starting_time": days,
                 "ending_time": days,
@@ -166,6 +166,7 @@ export function buildTimeline(params, caseIds, patientInfo, clinicalDataMap, cas
     window.pvTimeline =
         window.pvTimeline
             .splitByClinicalAttributes("Treatment", ["SUBTYPE", "AGENT"])
+            .splitByClinicalAttributes("Treatment", ["TREATMENT_TYPE", "AGENT"])
             .collapseAll()
             .toggleTrackCollapse("Specimen")
             .enableTrackTooltips(false)


### PR DESCRIPTION
Before only split occured on SUBTYPE and AGENT. In some cases there is no
SUBTYPE. Therefore better to split on TREATMENT_TYPE. Also floor
AGE/OS_MONTHS/DFS_MONTHS.

Fix https://github.com/cBioPortal/cbioportal/issues/1784