### PR TITLE
Minor changes related to rc-tooltip

### DIFF
--- a/src/pages/patientView/vafPlot/ThumbnailExpandVAFPlot.tsx
+++ b/src/pages/patientView/vafPlot/ThumbnailExpandVAFPlot.tsx
@@ -3,13 +3,14 @@ import DefaultTooltip from 'shared/components/DefaultTooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import {VAFPlot, IVAFPlotProps} from './VAFPlot';
 import {MutationFrequenciesBySample} from "../genomicOverview/GenomicOverview";
+import Tooltip from "rc-tooltip";
 
 export type IThumbnailExpandVAFPlotProps = {
     data: MutationFrequenciesBySample;
     order?: { [s:string]:number };
     colors?: { [s: string]:string };
     labels?: { [s:string]:string };
-    overlayPlacement?: string;
+    overlayPlacement?: Tooltip.Placement;
     cssClass?: string;
 };
 

--- a/src/shared/components/DefaultTooltip.tsx
+++ b/src/shared/components/DefaultTooltip.tsx
@@ -3,16 +3,14 @@ import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
 
 export default class DefaultTooltip extends React.Component<Tooltip.Props, {}> {
+    static readonly defaultProps = {
+        mouseEnterDelay: 0.5,
+        mouseLeaveDelay: 0.05,
+        arrowContent: <div className="rc-tooltip-arrow-inner"/>,
+    };
     render() {
-        const defaultProps = {
-            mouseEnterDelay:0.5,
-            mouseLeaveDelay:0.05,
-            arrowContent:(<div className="rc-tooltip-arrow-inner"/>)
-        };
         return (
-            <Tooltip {...Object.assign({}, defaultProps, this.props)}>
-                {this.props.children}
-            </Tooltip>
+            <Tooltip {...this.props}/>
         );
     }
 }

--- a/typings/missing.d.ts
+++ b/typings/missing.d.ts
@@ -3,7 +3,6 @@ declare module '*.scss';
 declare module '*.json';
 
 // these packages are missing typings
-declare module 'rc-tooltip';
 declare module 'react-file-download';
 declare module 'react-zeroclipboard';
 declare module 'reactableMSK';


### PR DESCRIPTION
# What? Why?
Minor improvements

Changes proposed in this pull request:
- Use static defaultProps in DefaultTooltip
- Remove rc-tooltip from missing.d.ts
- Use Tooltip.Placement instead of string in IThumbnailExpandVAFPlotProps.overlayPlacement

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
