### PR TITLE
Moved certain shared data model definitions out of the formatter classes

### DIFF
--- a/src/pages/patientView/OncoKbEvidenceCache.ts
+++ b/src/pages/patientView/OncoKbEvidenceCache.ts
@@ -1,7 +1,7 @@
 import {Query} from "shared/api/generated/OncoKbAPI";
 import oncokbClient from "shared/api/oncokbClientInstance";
 import {generateEvidenceQuery, processEvidence} from "shared/lib/OncoKbUtils";
-import {IEvidence} from "./mutation/column/AnnotationColumnFormatter";
+import {IEvidence} from "shared/model/OncoKB";
 import {default as SimpleCache, ICache} from "shared/lib/SimpleCache";
 
 export default class OncoKbEvidenceCache extends SimpleCache<IEvidence, Query[]>

--- a/src/pages/patientView/clinicalInformation/getClinicalInformationData.ts
+++ b/src/pages/patientView/clinicalInformation/getClinicalInformationData.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import CBioPortalAPI from "../../../shared/api/generated/CBioPortalAPI";
 import { ClinicalDataBySampleId } from "../../../shared/api/api-types-extended";
 import {ClinicalData} from "../../../shared/api/generated/CBioPortalAPI";
-import {ClinicalInformationData} from "./PatientViewPageStore";
+import {ClinicalInformationData} from "shared/model/ClinicalInformation";
 import {getCbioPortalApiUrl} from "../../../shared/api/urls";
 //import { getTreeNodesFromClinicalData, PDXNode } from './PDXTree';
 //import sampleQuery from 'shared/api/mock/Samples_query_patient_P04.json';

--- a/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import {DiscreteCopyNumberData} from "shared/api/generated/CBioPortalAPI";
 import {
-    IOncoKbData, IAnnotation, IAnnotationColumnProps, IEvidence, default as DefaultAnnotationColumnFormatter
+    IAnnotation, IAnnotationColumnProps, default as DefaultAnnotationColumnFormatter
 } from "../../mutation/column/AnnotationColumnFormatter";
+import {IOncoKbData} from "shared/model/OncoKB";
 import OncoKB from "shared/components/annotation/OncoKB";
 import {generateQueryVariantId, generateQueryVariant} from "shared/lib/OncoKbUtils";
 import {IndicatorQueryResp, Query} from "shared/api/generated/OncoKbAPI";

--- a/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.spec.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.spec.tsx
@@ -1,4 +1,5 @@
-import {default as CohortColumnFormatter, IGisticData} from './CohortColumnFormatter';
+import CohortColumnFormatter from './CohortColumnFormatter';
+import {IGisticData} from "shared/model/Gistic";
 import {DiscreteCopyNumberData} from "shared/api/generated/CBioPortalAPI";
 import {CopyNumberCount} from "shared/api/generated/CBioPortalAPIInternal";
 import React from 'react';

--- a/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.tsx
@@ -3,16 +3,7 @@ import {DiscreteCopyNumberData} from "shared/api/generated/CBioPortalAPI";
 import {CopyNumberCount} from "shared/api/generated/CBioPortalAPIInternal";
 import FrequencyBar from "shared/components/cohort/FrequencyBar";
 import Icon from "shared/components/cohort/LetterIcon";
-
-export interface IGisticSummary {
-    amp: boolean;
-    qValue:number;
-    peakGeneCount:number;
-}
-
-export interface IGisticData {
-    [entrezGeneId:string]: IGisticSummary[];
-}
+import {IGisticData, IGisticSummary} from "shared/model/Gistic";
 
 export default class CohortColumnFormatter
 {

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -2,8 +2,6 @@ import * as React from "react";
 import {observer} from "mobx-react";
 import {observable, computed} from "mobx";
 import SampleManager from "../sampleManager";
-import PatientHeader from "../patientHeader/PatientHeader";
-import {PatientViewPageStore, MutSigData} from "../clinicalInformation/PatientViewPageStore";
 import {default as MSKTable, Column} from "../../../shared/components/msktable/MSKTable";
 import {Mutation} from "../../../shared/api/generated/CBioPortalAPI";
 import DiscreteCNAColumnFormatter from "./column/DiscreteCNAColumnFormatter";
@@ -17,14 +15,15 @@ import {default as DefaultProteinChangeColumnFormatter} from "../../../shared/co
 import {Protocol} from "_debugger";
 import MutationTypeColumnFormatter from "../../../shared/components/mutationTable/column/MutationTypeColumnFormatter";
 import MutationAssessorColumnFormatter from "../../../shared/components/mutationTable/column/MutationAssessorColumnFormatter";
-import {
-    ICosmicData,
-    default as CosmicColumnFormatter
-} from "../../../shared/components/mutationTable/column/CosmicColumnFormatter";
+import CosmicColumnFormatter from "shared/components/mutationTable/column/CosmicColumnFormatter";
+import {ICosmicData} from "shared/model/Cosmic";
 import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
-import SampleColumnFormatter from "../../../shared/components/mutationTable/column/SampleColumnFormatter";
-import {default as AnnotationColumnFormatter, IMyCancerGenomeData, IHotspotData, IOncoKbData} from "./column/AnnotationColumnFormatter";
+import AnnotationColumnFormatter from "./column/AnnotationColumnFormatter";
+import {IMyCancerGenomeData} from "shared/model/MyCancerGenome";
+import {IHotspotData} from "shared/model/CancerHotspots";
+import {IOncoKbData} from "shared/model/OncoKB";
+import {IMutSigData} from "shared/model/MutSig";
 import DiscreteCNACache from "../clinicalInformation/DiscreteCNACache";
 import MrnaExprRankCache from "../clinicalInformation/MrnaExprRankCache";
 import * as _ from "lodash";
@@ -40,7 +39,7 @@ export type PatientViewMutationTableProps = {
     oncoKbEvidenceCache?:OncoKbEvidenceCache;
     pmidCache?:PmidCache
     variantCountCache?:VariantCountCache;
-    mutSigData?:MutSigData;
+    mutSigData?:IMutSigData;
     myCancerGenomeData?: IMyCancerGenomeData;
     hotspots?: IHotspotData;
     cosmicData?:ICosmicData;

--- a/src/pages/patientView/mutation/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/AnnotationColumnFormatter.tsx
@@ -6,44 +6,13 @@ import OncokbPmidCache from "pages/patientView/PmidCache";
 import CancerHotspots from "shared/components/annotation/CancerHotspots";
 import MyCancerGenome from "shared/components/annotation/MyCancerGenome";
 import OncoKB from "shared/components/annotation/OncoKB";
+import {IOncoKbData} from "shared/model/OncoKB";
+import {IMyCancerGenomeData, IMyCancerGenome} from "shared/model/MyCancerGenome";
+import {IHotspotData} from "shared/model/CancerHotspots";
 import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import {IndicatorQueryResp, Query} from "shared/api/generated/OncoKbAPI";
-import {HotspotMutation} from "shared/api/generated/CancerHotspotsAPI";
 import {generateQueryVariantId, generateQueryVariant} from "shared/lib/OncoKbUtils";
 import {isHotspot, is3dHotspot} from "shared/lib/AnnotationUtils";
-import HotspotSet from "shared/lib/HotspotSet";
-
-export interface IMyCancerGenome {
-    hugoGeneSymbol: string;
-    alteration: string;
-    cancerType: string;
-    linkHTML: string;
-}
-
-export interface IOncoKbData {
-    indicatorMap: {[id:string]: IndicatorQueryResp};
-    sampleToTumorMap: {[sampleId:string]: string};
-}
-
-export interface IHotspotIndex {
-    [gene:string]: {
-        [hotspotType:string]: IHotspotLookup
-    }
-}
-
-export interface IHotspotLookup {
-    hotspotMutations: HotspotMutation[],
-    hotspotSet: HotspotSet;
-}
-
-export interface IHotspotData {
-    single: IHotspotIndex,
-    clustered: IHotspotIndex
-}
-
-export interface IMyCancerGenomeData {
-    [hugoSymbol:string]: IMyCancerGenome[];
-}
 
 export interface IAnnotationColumnProps {
     enableOncoKb: boolean;
@@ -54,30 +23,6 @@ export interface IAnnotationColumnProps {
     oncoKbData?: IOncoKbData;
     oncoKbEvidenceCache?: OncoKbEvidenceCache;
     pmidCache?: OncokbPmidCache;
-}
-
-export interface IEvidence {
-    id: string;
-    gene: any;
-    alteration: any[];
-    prevalence: any[];
-    progImp: any[];
-    treatments: {
-        sensitivity: any[];
-        resistance: any[];
-    }; //separated by level type
-    trials: any[];
-    oncogenic: string;
-    oncogenicRefs: string[];
-    mutationEffect: any;
-    summary: string;
-    drugs: {
-        sensitivity: {
-            current: any[];
-            inOtherTumor: any[];
-        },
-        resistance: any[];
-    };
 }
 
 export interface IAnnotation {

--- a/src/pages/patientView/mutation/column/CohortColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/CohortColumnFormatter.tsx
@@ -4,7 +4,7 @@ import {Mutation} from "../../../../shared/api/generated/CBioPortalAPI";
 import VariantCountCache from "../../clinicalInformation/VariantCountCache";
 import FrequencyBar from "shared/components/cohort/FrequencyBar";
 import Icon from "shared/components/cohort/LetterIcon";
-import {MutSigData} from "../../clinicalInformation/PatientViewPageStore";
+import {IMutSigData as MutSigData} from "shared/model/MutSig";
 import {VariantCount} from "../../../../shared/api/generated/CBioPortalAPIInternal";
 import {CacheData} from "../../../../shared/lib/LazyMobXCache";
 

--- a/src/shared/components/annotation/OncoKbTooltip.tsx
+++ b/src/shared/components/annotation/OncoKbTooltip.tsx
@@ -5,7 +5,7 @@ import OncoKbEvidenceCache from "pages/patientView/OncoKbEvidenceCache";
 import OncokbPmidCache from "pages/patientView/PmidCache";
 import {ICacheData, ICache} from "shared/lib/SimpleCache";
 import {IndicatorQueryResp, Query} from "shared/api/generated/OncoKbAPI";
-import {IEvidence} from "pages/patientView/mutation/column/AnnotationColumnFormatter";
+import {IEvidence} from "shared/model/OncoKB";
 import {
     generateTreatments, generateOncogenicCitations, generateMutationEffectCitations, extractPmids
 } from "shared/lib/OncoKbUtils";

--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.tsx
@@ -1,11 +1,11 @@
 import CosmicColumnFormatter from './CosmicColumnFormatter';
+import {ICosmicData} from "shared/model/Cosmic";
 import {keywordToCosmic} from 'shared/lib/AnnotationUtils';
 import {initMutation} from "test/MutationMockUtils";
 import React from 'react';
 import { assert } from 'chai';
 import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
-import {ICosmicData} from "./CosmicColumnFormatter";
 
 describe('CosmicColumnFormatter', () => {
 

--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
 import DefaultTooltip from 'shared/components/DefaultTooltip';
 import * as _ from 'lodash';
-import {Mutation} from "../../../api/generated/CBioPortalAPI";
-import {CosmicMutation} from "../../../api/generated/CBioPortalAPIInternal";
-import CosmicMutationTable from "../../cosmic/CosmicMutationTable";
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
+import {CosmicMutation} from "shared/api/generated/CBioPortalAPIInternal";
+import CosmicMutationTable from "shared/components/cosmic/CosmicMutationTable";
 import styles from "./cosmic.module.scss";
-
-export interface ICosmicData {
-    [keyword:string]: CosmicMutation[];
-}
+import {ICosmicData} from "shared/model/Cosmic";
 
 export function placeArrow(tooltipEl: any) {
     const arrowEl = tooltipEl.querySelector('.rc-tooltip-arrow');

--- a/src/shared/lib/AnnotationUtils.spec.tsx
+++ b/src/shared/lib/AnnotationUtils.spec.tsx
@@ -1,4 +1,4 @@
-import {IHotspotIndex} from "pages/patientView/mutation/column/AnnotationColumnFormatter";
+import {IHotspotIndex} from "shared/model/CancerHotspots";
 import {isHotspot, indexHotspots, is3dHotspot} from './AnnotationUtils';
 import {initMutation} from "test/MutationMockUtils";
 import React from 'react';

--- a/src/shared/lib/AnnotationUtils.ts
+++ b/src/shared/lib/AnnotationUtils.ts
@@ -1,11 +1,10 @@
 import * as _ from 'lodash';
 import {CosmicMutation} from "shared/api/generated/CBioPortalAPIInternal";
-import {ICosmicData} from "shared/components/mutationTable/column/CosmicColumnFormatter";
-import {
-    IMyCancerGenome, IMyCancerGenomeData, IHotspotIndex, IHotspotLookup
-} from "pages/patientView/mutation/column/AnnotationColumnFormatter";
-import {HotspotMutation} from "../api/generated/CancerHotspotsAPI";
-import {Mutation} from "../api/generated/CBioPortalAPI";
+import {HotspotMutation} from "shared/api/generated/CancerHotspotsAPI";
+import {ICosmicData} from "shared/model/Cosmic";
+import {IMyCancerGenome, IMyCancerGenomeData} from "shared/model/MyCancerGenome";
+import {IHotspotIndex, IHotspotLookup} from "shared/model/CancerHotspots";
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import HotspotSet from "./HotspotSet";
 
 /**

--- a/src/shared/model/CancerHotspots.ts
+++ b/src/shared/model/CancerHotspots.ts
@@ -1,0 +1,18 @@
+import {HotspotMutation} from "shared/api/generated/CancerHotspotsAPI";
+import HotspotSet from "shared/lib/HotspotSet";
+
+export interface IHotspotIndex {
+    [gene:string]: {
+        [hotspotType:string]: IHotspotLookup
+    }
+}
+
+export interface IHotspotLookup {
+    hotspotMutations: HotspotMutation[],
+    hotspotSet: HotspotSet;
+}
+
+export interface IHotspotData {
+    single: IHotspotIndex,
+    clustered: IHotspotIndex
+}

--- a/src/shared/model/ClinicalInformation.ts
+++ b/src/shared/model/ClinicalInformation.ts
@@ -1,0 +1,11 @@
+import {ClinicalData} from "shared/api/generated/CBioPortalAPI";
+import {ClinicalDataBySampleId} from "shared/api/api-types-extended";
+
+export type ClinicalInformationData = {
+    patient?: {
+        id: string,
+        clinicalData: ClinicalData[]
+    },
+    samples?: ClinicalDataBySampleId[],
+    nodes?: any[]//PDXNode[],
+};

--- a/src/shared/model/Cosmic.ts
+++ b/src/shared/model/Cosmic.ts
@@ -1,0 +1,5 @@
+import {CosmicMutation} from "shared/api/generated/CBioPortalAPIInternal";
+
+export interface ICosmicData {
+    [keyword:string]: CosmicMutation[];
+}

--- a/src/shared/model/Gistic.ts
+++ b/src/shared/model/Gistic.ts
@@ -1,0 +1,9 @@
+export interface IGisticSummary {
+    amp: boolean;
+    qValue:number;
+    peakGeneCount:number;
+}
+
+export interface IGisticData {
+    [entrezGeneId:string]: IGisticSummary[];
+}

--- a/src/shared/model/MutSig.ts
+++ b/src/shared/model/MutSig.ts
@@ -1,0 +1,3 @@
+export interface IMutSigData {
+    [entrezGeneId:string]:{ qValue:number }
+}

--- a/src/shared/model/MyCancerGenome.ts
+++ b/src/shared/model/MyCancerGenome.ts
@@ -1,0 +1,10 @@
+export interface IMyCancerGenome {
+    hugoGeneSymbol: string;
+    alteration: string;
+    cancerType: string;
+    linkHTML: string;
+}
+
+export interface IMyCancerGenomeData {
+    [hugoSymbol:string]: IMyCancerGenome[];
+}

--- a/src/shared/model/OncoKB.ts
+++ b/src/shared/model/OncoKB.ts
@@ -1,0 +1,30 @@
+import {IndicatorQueryResp} from "shared/api/generated/OncoKbAPI";
+
+export interface IEvidence {
+    id: string;
+    gene: any;
+    alteration: any[];
+    prevalence: any[];
+    progImp: any[];
+    treatments: {
+        sensitivity: any[];
+        resistance: any[];
+    }; //separated by level type
+    trials: any[];
+    oncogenic: string;
+    oncogenicRefs: string[];
+    mutationEffect: any;
+    summary: string;
+    drugs: {
+        sensitivity: {
+            current: any[];
+            inOtherTumor: any[];
+        },
+        resistance: any[];
+    };
+}
+
+export interface IOncoKbData {
+    indicatorMap: {[id:string]: IndicatorQueryResp};
+    sampleToTumorMap: {[sampleId:string]: string};
+}


### PR DESCRIPTION
# What? Why?
Shared data model should not be defined within the `formatter` classes. It is better to have them in separate designated classes.

This PR also removes some unused import statements.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)