### PR TITLE
Fix genomic overview rendering

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -129,3 +129,9 @@ th.reactable-header-sort-asc:after {
 .table {
   margin-bottom: 5px;
 }
+
+.hiddenByPosition {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+}

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -25,7 +25,7 @@ export class MSKTab extends React.Component<IMSKTabProps,{}> {
     render(){
         return (
             <div
-                className={classnames({ 'msk-tab':true, 'hidden':!!this.props.inactive  }, this.props.className )}
+                className={classnames({ 'msk-tab':true, 'hiddenByPosition':!!this.props.inactive  }, this.props.className )}
             >
                 {this.props.children}
             </div>


### PR DESCRIPTION
# What? Why?
https://github.com/cBioPortal/cbioportal/issues/2370

There was a problem with genomic overview chromosome numbers when the GO rendered in a hidden tab.  This has to do with some deep SVG box measuring bug.  Seemed to me the best way to fix and avoid issues like this going forward was to hide the tabs by position instead of display:none.  Can anyone think of a drawback?

![image](https://cloud.githubusercontent.com/assets/186521/25139977/d55b1a76-242c-11e7-8d67-fe1459b882ae.png)

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
