### PR TITLE
Table download improvements

### DIFF
--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -335,7 +335,8 @@ export default class PatientViewMutationTable extends React.Component<PatientVie
         this._columns[MutationTableColumnType.COSMIC] = {
             name: "COSMIC",
             render: (d:Mutation[])=>CosmicColumnFormatter.renderFunction(d, this.props.cosmicData),
-            sortBy:(d:Mutation[])=>CosmicColumnFormatter.getSortValue(d, this.props.cosmicData),
+            sortBy: (d:Mutation[])=>CosmicColumnFormatter.getSortValue(d, this.props.cosmicData),
+            download: (d:Mutation[])=>CosmicColumnFormatter.getDownloadValue(d, this.props.cosmicData),
             tooltip: (<span>COSMIC occurrences</span>),
             defaultSortDirection: "desc",
             order: 184

--- a/src/shared/components/msktable/MSKTable.spec.tsx
+++ b/src/shared/components/msktable/MSKTable.spec.tsx
@@ -951,6 +951,18 @@ describe('MSKTable', ()=>{
                 "3,-1,zijxcpo,,3HELLO123456,,\r\n"+
                 "4,90,zkzxc,,4HELLO123456,,\r\n");
         });
+
+        it("gives data back in sorted order according to initially selected sort column and direction", ()=>{
+            let table = mount(<Table columns={columns} data={data} initialSortColumn="Number" initialSortDirection="asc"/>);
+
+            assert.deepEqual((table.instance() as MSKTable<any>).getDownloadData(),
+                "Name,Number,String,Number List,Initially invisible column,Initially invisible column with no download,String without filter function\r\n"+
+                "3,-1,zijxcpo,,3HELLO123456,,\r\n"+
+                "0,0,asdfj,,0HELLO123456,,\r\n"+
+                "1,6,kdfjpo,,1HELLO123456,,\r\n"+
+                "4,90,zkzxc,,4HELLO123456,,\r\n" +
+                "2,null,null,,2HELLO123456,,\r\n");
+        });
     });
     describe('pagination', ()=>{
         it("starts with 50 items per page", ()=>{

--- a/src/shared/components/msktable/MSKTable.tsx
+++ b/src/shared/components/msktable/MSKTable.tsx
@@ -193,7 +193,7 @@ class MSKTableStore<T> {
         });
 
         // add rows (including hidden columns)
-        this.data.forEach((rowData:T) => {
+        this.sortedData.forEach((rowData:T) => {
             const rowDownloadData:string[] = [];
 
             this.columns.forEach((column:Column<T>) => {

--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
@@ -80,6 +80,17 @@ export default class CosmicColumnFormatter
         return value;
     }
 
+    public static getDownloadValue(data:Mutation[], cosmicData?:ICosmicData):string {
+        let value = CosmicColumnFormatter.getSortValue(data, cosmicData);
+
+        if (value) {
+            return `${value}`;
+        }
+        else {
+            return "";
+        }
+    }
+
     public static renderFunction(data:Mutation[], cosmicData?:ICosmicData)
     {
         const cosmic:CosmicMutation[]|null = CosmicColumnFormatter.getData(data, cosmicData);


### PR DESCRIPTION
- Table download file is now sorted
- Mutation table download file now contains cosmic count

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)