### PR TITLE
Using TableCellStatusIndicator as a placeholder for OncoKB tooltip

### DIFF
--- a/src/shared/components/annotation/OncoKB.tsx
+++ b/src/shared/components/annotation/OncoKB.tsx
@@ -13,6 +13,7 @@ import {observable} from "mobx";
 import OncoKbEvidenceCache from "pages/patientView/OncoKbEvidenceCache";
 import OncoKbTooltip from "./OncoKbTooltip";
 import OncokbPmidCache from "pages/patientView/PmidCache";
+import {default as TableCellStatusIndicator, TableCellStatus} from "shared/components/TableCellStatus";
 
 export interface IOncoKbProps {
     indicator?: IndicatorQueryResp;
@@ -24,19 +25,6 @@ export interface IOncoKbProps {
 export function hideArrow(tooltipEl: any) {
     const arrowEl = tooltipEl.querySelector('.rc-tooltip-arrow');
     arrowEl.style.display = 'none';
-}
-
-// TODO duplicate code: replace this with the actual PlaceHolder component when ready
-export function placeHolder(text:string)
-{
-    return (
-        <span
-            style={{color: "gray", fontSize:"xx-small", textAlign:"center"}}
-            alt="Querying server for data."
-        >
-            {text}
-        </span>
-    );
 }
 
 /**
@@ -166,7 +154,7 @@ export default class OncoKB extends React.Component<IOncoKbProps, {}>
                         marginHeight={0}
                         marginWidth={0}
                     >
-                        {placeHolder('LOADING')}
+                        <TableCellStatusIndicator status={TableCellStatus.LOADING} />
                     </iframe>
                 </Modal.Body>
             </Modal>

--- a/src/shared/components/annotation/OncoKbTooltip.tsx
+++ b/src/shared/components/annotation/OncoKbTooltip.tsx
@@ -9,7 +9,7 @@ import {IEvidence} from "shared/model/OncoKB";
 import {
     generateTreatments, generateOncogenicCitations, generateMutationEffectCitations, extractPmids
 } from "shared/lib/OncoKbUtils";
-import {placeHolder} from "./OncoKB";
+import {default as TableCellStatusIndicator, TableCellStatus} from "shared/components/TableCellStatus";
 
 export interface IOncoKbTooltipProps {
     indicator?: IndicatorQueryResp;
@@ -92,10 +92,10 @@ export default class OncoKbTooltip extends React.Component<IOncoKbTooltipProps, 
             );
         }
         else if (cacheData.status === 'pending') {
-            tooltipContent = placeHolder('LOADING');
+            tooltipContent = <TableCellStatusIndicator status={TableCellStatus.LOADING} />;
         }
         else if (cacheData.status === 'error') {
-            tooltipContent = placeHolder('ERROR');
+            tooltipContent = <TableCellStatusIndicator status={TableCellStatus.ERROR} />;
         }
 
         return tooltipContent;


### PR DESCRIPTION
Replaced the `placeHolder` function with `TableCellStatusIndicator`

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
