### PR TITLE
LazyMobXTable data store, and row highlighting

### DIFF
--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {assert} from 'chai';
 import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
-import {lazyMobXTableSort, default as LazyMobXTable, Column} from "./LazyMobXTable";
+import {lazyMobXTableSort, default as LazyMobXTable, Column, LazyMobXTableDataStore} from "./LazyMobXTable";
 import SimpleTable from "../simpleTable/SimpleTable";
 import DefaultTooltip from "../DefaultTooltip";
 import expect from 'expect';
@@ -68,6 +68,10 @@ function getCurrentPage(table:ReactWrapper<any, any>):number|undefined {
 
 function getVisibleRows(table:ReactWrapper<any, any>) {
     return table.find(SimpleTable).props().rows;
+}
+
+function getSimpleTableRows(table:ReactWrapper<any, any>) {
+    return table.find(SimpleTable).find("tbody").find("tr");
 }
 
 function getNumVisibleRows(table:ReactWrapper<any, any>):number {
@@ -787,6 +791,17 @@ describe('LazyMobXTable', ()=>{
             table.setProps({data:[]});
             rows = getVisibleRows(table);
             assert.equal(rows.length, 0);
+        });
+        it("highlights rows properly, according to highlight function in data store", ()=>{
+            const store:LazyMobXTableDataStore<any> = new LazyMobXTableDataStore(data);
+            store.highlight = (d:any)=>(d.numList[1] === null);
+            let table = mount(<Table columns={columns} dataStore={store}/>);
+            let rows = getSimpleTableRows(table);
+            assert.isFalse(rows.at(0).hasClass("highlight"), "row 0 not highlighted");
+            assert.isTrue(rows.at(1).hasClass("highlight"), "row 1 highlighted");
+            assert.isFalse(rows.at(2).hasClass("highlight"), "row 2 not highlighted");
+            assert.isTrue(rows.at(3).hasClass("highlight"), "row 3 highlighted");
+            assert.isTrue(rows.at(4).hasClass("highlight"), "row 4 highlighted");
         });
     });
     describe('column visibility', ()=>{

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -14,8 +14,11 @@ import {serializeData} from "shared/lib/Serializer";
 import DefaultTooltip from "../DefaultTooltip";
 import {ButtonToolbar} from "react-bootstrap";
 import { If } from 'react-if';
+import {SortMetric} from "../../lib/ISortMetric";
+import {IMobXApplicationDataStore} from "../../lib/IMobXApplicationDataStore";
 
 type SortDirection = 'asc' | 'desc';
+
 export type Column<T> = {
     name: string;
     filter?:(data:T, filterString:string, filterStringUpper?:string, filterStringLower?:string)=>boolean;
@@ -29,7 +32,8 @@ export type Column<T> = {
 
 type LazyMobXTableProps<T> = {
     columns:Column<T>[];
-    data:T[];
+    data?:T[];
+    dataStore?:IMobXApplicationDataStore<T>;
     initialSortColumn?: string;
     initialSortDirection?:SortDirection;
     initialItemsPerPage?:number;
@@ -90,7 +94,6 @@ function compareLists<U extends number|string>(a:(U|null)[], b:(U|null)[], asc:b
     return ret;
 }
 
-type SortMetric<T> = ((d:T)=>number|null) | ((d:T)=>(number|null)[]) | ((d:T)=>string|null) | ((d:T)=>(string|null)[]);
 export function lazyMobXTableSort<T>(data:T[], metric:SortMetric<T>, ascending:boolean = true):T[] {
     // Separating this for testing, so that classes can test their comparators
     //  against how the table will sort.
@@ -124,6 +127,38 @@ export function lazyMobXTableSort<T>(data:T[], metric:SortMetric<T>, ascending:b
     return dataAndValue.map(x=>x.data);
 }
 
+export class LazyMobXTableDataStore<T> implements IMobXApplicationDataStore<T> {
+    @observable.ref private data:T[];
+    @observable private dataFilter:(d:T)=>boolean;
+
+    @observable public sortMetric:SortMetric<T>;
+    @observable public sortAscending:boolean;
+    @observable public highlight:(d:T)=>boolean;
+
+    @computed get allData() {
+        return this.data;
+    }
+    @computed get sortedData() {
+        return lazyMobXTableSort(this.allData, this.sortMetric, this.sortAscending);
+    }
+    @computed get sortedFilteredData() {
+        return this.sortedData.filter(this.dataFilter);
+    }
+
+    public setFilter(dataFilter:(d:T)=>boolean) {
+        this.dataFilter = dataFilter;
+    }
+
+
+    constructor(data:T[]) {
+        this.data = data;
+        this.highlight = ()=>false;
+        this.dataFilter = ()=>true;
+        this.sortMetric = ()=>0;
+        this.sortAscending = true;
+    }
+}
+
 class LazyMobXTableStore<T> {
     @observable public filterString:string;
     @observable private _page:number;
@@ -134,7 +169,7 @@ class LazyMobXTableStore<T> {
     @observable public sortAscending:boolean;
     @observable.ref public columns:Column<T>[];
     @observable private _columnVisibility:{[columnId: string]: boolean};
-    @observable.ref public data:T[];
+    @observable private dataStore:IMobXApplicationDataStore<T>;
 
     @computed public get itemsPerPage() {
         return this._itemsPerPage;
@@ -146,7 +181,7 @@ class LazyMobXTableStore<T> {
     }
 
     @computed get showingAllRows(): boolean {
-        return this.sortedFilteredData.length <= this.itemsPerPage || this.itemsPerPage === -1
+        return this.dataStore.sortedFilteredData.length <= this.itemsPerPage || this.itemsPerPage === -1
     }
 
     @computed public get page() {
@@ -166,7 +201,7 @@ class LazyMobXTableStore<T> {
         if (this.itemsPerPage === PAGINATION_SHOW_ALL) {
             return 0;
         } else {
-            return Math.floor(this.sortedFilteredData.length / this.itemsPerPage);
+            return Math.floor(this.dataStore.sortedFilteredData.length / this.itemsPerPage);
         }
     }
 
@@ -193,7 +228,7 @@ class LazyMobXTableStore<T> {
         });
 
         // add rows (including hidden columns)
-        this.sortedData.forEach((rowData:T) => {
+        this.dataStore.sortedData.forEach((rowData:T) => {
             const rowDownloadData:string[] = [];
 
             this.columns.forEach((column:Column<T>) => {
@@ -215,36 +250,11 @@ class LazyMobXTableStore<T> {
         return this.columns.find((col:Column<T>)=>this.isVisible(col) && (col.name === this.sortColumn));
     }
 
-    @computed get sortedData():T[] {
-        let ret = this.data;
-        const column = this.sortColumnObject;
-        if (column && column.sortBy) {
-            ret = lazyMobXTableSort(ret, column.sortBy, this.sortAscending);
-        }
-        return ret;
-    }
-
-    @computed get sortedFilteredData():T[] {
-        let filtered:T[] = this.sortedData;
-        if (this.filterString) {
-            filtered = filtered.filter((datum:T)=>{
-                let match = false;
-                for (const column of this.visibleColumns) {
-                    match = (column.filter && column.filter(datum, this.filterString, this.filterStringUpper, this.filterStringLower)) || false;
-                    if (match) {
-                        break;
-                    }
-                }
-                return match;
-            });
-        }
-        return filtered;
-    }
     @computed get visibleData():T[] {
         if (this.itemsPerPage === PAGINATION_SHOW_ALL) {
-            return this.sortedFilteredData;
+            return this.dataStore.sortedFilteredData;
         } else {
-            return this.sortedFilteredData.slice(this.page*this.itemsPerPage, (this.page+1)*this.itemsPerPage);
+            return this.dataStore.sortedFilteredData.slice(this.page*this.itemsPerPage, (this.page+1)*this.itemsPerPage);
         }
     }
 
@@ -259,6 +269,15 @@ class LazyMobXTableStore<T> {
         }
     }
 
+    @computed get sortMetric():SortMetric<T> {
+        const sortColumnObject = this.sortColumnObject;
+        if (sortColumnObject && sortColumnObject.sortBy) {
+            return sortColumnObject.sortBy;
+        } else {
+            return ()=>0;
+        }
+    }
+
     @computed get headers():JSX.Element[] {
         return this.visibleColumns.map((column:Column<T>)=>{
             const headerProps:{role?:"button",
@@ -268,7 +287,11 @@ class LazyMobXTableStore<T> {
                 headerProps.role = "button";
                 headerProps.onClick = ()=>{
                     this.sortAscending = this.getNextSortAscending(column);
+                    this.dataStore.sortAscending = this.sortAscending;
+
                     this.sortColumn = column.name;
+                    this.dataStore.sortMetric = this.sortMetric;
+
                     this.page = 0;
                 };
             }
@@ -334,7 +357,7 @@ class LazyMobXTableStore<T> {
 
         if (this._itemsLabel) {
             // use itemsLabel for plural in case no itemsLabelPlural provided
-            if (!this._itemsLabelPlural || this.sortedFilteredData.length === 1) {
+            if (!this._itemsLabelPlural || this.dataStore.sortedFilteredData.length === 1) {
                 itemsLabel = this._itemsLabel;
             }
             else {
@@ -346,30 +369,59 @@ class LazyMobXTableStore<T> {
             itemsLabel = ` ${itemsLabel}`;
         }
 
-        return `${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${this.sortedFilteredData.length}${itemsLabel}`;
+        return `${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${this.dataStore.sortedFilteredData.length}${itemsLabel}`;
     }
 
     public get rows():JSX.Element[] {
         return this.visibleData.map((datum:T)=>{
-            const tds = this.visibleColumns.map((column:Column<T>)=>{
-                return (<td key={column.name}>
-                    {column.render(datum)}
-                </td>);
-            });
-            return (
-                <tr>
-                    {tds}
-                </tr>
-            );
+                const tds = this.visibleColumns.map((column:Column<T>)=>{
+                    return (<td key={column.name}>
+                        {column.render(datum)}
+                    </td>);
+                });
+                const rowProps:any = {};
+                if (this.dataStore.highlight(datum)) {
+                    rowProps.className = "highlight";
+                }
+                return (
+                    <tr {...rowProps}>
+                        {tds}
+                    </tr>
+                );
+        });
+    }
+
+    @action setFilterString(str:string) {
+        this.filterString = str;
+        this.page = 0;
+        this.dataStore.setFilter((d:T)=>{
+            let match = false;
+            for (const column of this.visibleColumns) {
+                match = (column.filter && column.filter(d, this.filterString, this.filterStringUpper, this.filterStringLower)) || false;
+                if (match) {
+                    break;
+                }
+            }
+            return match;
         });
     }
 
     @action setProps(props:LazyMobXTableProps<T>) {
         this.columns = props.columns;
-        this.data = props.data;
         this._itemsLabel = props.itemsLabel;
         this._itemsLabelPlural = props.itemsLabelPlural;
         this._columnVisibility = this.resolveColumnVisibility(props.columns);
+
+        if (props.dataStore) {
+            // if dataStore passed in, inherit its current state
+            this.dataStore = props.dataStore;
+            this.sortAscending = this.dataStore.sortAscending;
+        } else {
+            // else, initialize it to the tables state
+            this.dataStore = new LazyMobXTableDataStore<T>(props.data || []);
+            this.dataStore.sortAscending = this.sortAscending;
+            this.dataStore.sortMetric = this.sortMetric;
+        }
     }
 
     @action public updateColumnVisibility(id:string, visible:boolean)
@@ -403,10 +455,11 @@ class LazyMobXTableStore<T> {
     }
 
     constructor(lazyMobXTableProps:LazyMobXTableProps<T>) {
-        this.setProps(lazyMobXTableProps);
         this.filterString = "";
         this.sortColumn = lazyMobXTableProps.initialSortColumn || "";
         this.sortAscending = (lazyMobXTableProps.initialSortDirection !== "desc"); // default ascending
+        this.setProps(lazyMobXTableProps);
+
         this._page = 0;
         this.itemsPerPage = lazyMobXTableProps.initialItemsPerPage || 50;
     }
@@ -444,7 +497,7 @@ export default class LazyMobXTable<T> extends React.Component<LazyMobXTableProps
 
                     const filterValue = evt.currentTarget.value;
                     searchTimeout = window.setTimeout(()=>{
-                        this.store.filterString = filterValue;
+                        this.store.setFilterString(filterValue);
                     }, 400);
                 };
             })(),

--- a/src/shared/components/simpleTable/styles.scss
+++ b/src/shared/components/simpleTable/styles.scss
@@ -5,6 +5,14 @@ th {
   background-color: rgb(255,255,255); // solid background
 }
 
+tbody>tr:nth-of-type(odd).highlight {
+  background-color: #E0E000 !important;
+}
+
 tbody>tr:nth-of-type(even) { // solid background - hard coded hack, react-bootstrap .table-striped makes ODD # rows grey
   background-color: rgb(255,255,255);
+}
+
+tbody>tr:nth-of-type(even).highlight {
+  background-color: #E9E900;
 }

--- a/src/shared/lib/IMobXApplicationDataStore.ts
+++ b/src/shared/lib/IMobXApplicationDataStore.ts
@@ -1,0 +1,15 @@
+import {SortMetric} from "./ISortMetric";
+export interface IMobXApplicationDataStore<T> {
+    // Setters
+    setFilter:(filterFn:(d:T)=>boolean)=>void;
+
+    // mobX computed getters
+    allData:T[];
+    sortedData:T[];
+    sortedFilteredData:T[];
+
+    // mobX observable public properties (note you can still implement with getter and setter)
+    highlight:(d:T)=>boolean;
+    sortAscending:boolean;
+    sortMetric:SortMetric<T>;
+};

--- a/src/shared/lib/ISortMetric.ts
+++ b/src/shared/lib/ISortMetric.ts
@@ -1,0 +1,1 @@
+export type SortMetric<T> = ((d:T)=>number|null) | ((d:T)=>(number|null)[]) | ((d:T)=>string|null) | ((d:T)=>(string|null)[]);


### PR DESCRIPTION
Allow passing in a data store to LazyMobXTable, and implement row highlighting in LazyMobXTable, which is used according to `store.highlight`

# Checks
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)