### PR TITLE
Fix #2388 clinical data wrapping

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -18,7 +18,7 @@ import { PatientViewPageStore } from './clinicalInformation/PatientViewPageStore
 import ClinicalInformationPatientTable from "./clinicalInformation/ClinicalInformationPatientTable";
 import ClinicalInformationSamples from "./clinicalInformation/ClinicalInformationSamplesTable";
 import {observer, inject } from "mobx-react";
-import {getSpans} from './clinicalInformation/lib/clinicalAttributesUtil.js';
+import {getSpanElements} from './clinicalInformation/lib/clinicalAttributesUtil.js';
 import CopyNumberTableWrapper from "./copyNumberAlterations/CopyNumberTableWrapper";
 import {reaction, computed} from "mobx";
 import Timeline from "./timeline/Timeline";
@@ -199,11 +199,12 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                 const clinicalDataLegacy: any = _.fromPairs(sample.clinicalData.map((x) => [x.clinicalAttributeId, x.value]));
                 return (
                     <div className="patientSample">
-                        {  sampleManager!.getComponentForSample(sample.id, true) }
-                        {'\u00A0'}
-                        <a href="javascript:void(0)" onClick={()=>{ this.handleSampleClick(sample.id) }}>{sample.id}</a>
-                        <span className='clinical-spans'
-                              dangerouslySetInnerHTML={{__html:getSpans(clinicalDataLegacy, 'lgg_ucsf_2014')}}></span>
+                        <span className='clinical-spans'>
+                            {  sampleManager!.getComponentForSample(sample.id, true) }
+                            {'\u00A0'}
+                            <a href="javascript:void(0)" onClick={()=>{ this.handleSampleClick(sample.id) }}>{sample.id}</a>
+                            {getSpanElements(clinicalDataLegacy, 'lgg_ucsf_2014')}
+                        </span>
                     </div>
 
                 )

--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
@@ -1,5 +1,6 @@
 import * as $ from 'jquery';
 import _ from 'underscore';
+import * as React from 'react';
 
 /**
  * Functions for dealing with clinical attributes.
@@ -167,18 +168,14 @@ function cleanAndDerive(clinicalData) {
  * @param {object} clinicalData     - key/value pairs of clinical data
  * @param {string} cancerStudyId    - short name of cancer study
  */
-function getSpans(clinicalData, cancerStudyId) {
-    let spans = '';
+function getSpanElements(clinicalData, cancerStudyId) {
+    let spans = [];
     const clinicalAttributesCleanDerived = cleanAndDerive(clinicalData);
 
-    const keys = Object.keys(clinicalAttributesCleanDerived);
-    for (let i = 0; i < keys.length; i += 1) {
-        const key = keys[i];
-        const value = clinicalAttributesCleanDerived[key];
-        spans += `<span class="clinical-attribute" attr-id="${key}" attr-value="${value}" study="${cancerStudyId}">${value}</span>`;
-    }
-
-    return spans;
+    return Object.keys(clinicalAttributesCleanDerived).map((key) => {
+        let value = clinicalAttributesCleanDerived[key];
+        return <span is class="clinical-attribute" attr-id={key} attr-value={value} study={cancerStudyId}>{value}</span>
+    });
 }
 
 /*
@@ -201,4 +198,4 @@ function addFirstOrderClass() {
     });
 }
 
-export { cleanAndDerive, getSpans, addFirstOrderClass };
+export { cleanAndDerive, getSpanElements, addFirstOrderClass };

--- a/src/pages/patientView/patientHeader/PatientHeader.tsx
+++ b/src/pages/patientView/patientHeader/PatientHeader.tsx
@@ -3,7 +3,7 @@ import {fromPairs} from 'lodash';
 import {OverlayTrigger, Popover} from 'react-bootstrap';
 
 import ClinicalInformationPatientTable from '../clinicalInformation/ClinicalInformationPatientTable';
-import {getSpans} from '../clinicalInformation/lib/clinicalAttributesUtil.js';
+import {getSpanElements} from '../clinicalInformation/lib/clinicalAttributesUtil.js';
 
 import styles from './styles.module.scss';
 import DefaultTooltip from "../../../shared/components/DefaultTooltip";
@@ -56,11 +56,9 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
                 arrowContent={<div className="rc-tooltip-arrow-inner" />}
                 destroyTooltipOnHide={true}
             >
-                 <span>
+                <span className='clinical-spans' id='patient-attributes'>
                     <a href="javascript:void(0)" onClick={()=>this.props.handlePatientClick(patient.id)}>{patient.id}</a>
-                    <span className='clinical-spans' id='patient-attributes' dangerouslySetInnerHTML={{__html:
-                        getSpans(fromPairs(patient.clinicalData.map((x: any) => [x.clinicalAttributeId, x.value])), 'lgg_ucsf_2014')}}>
-                    </span>
+                    {getSpanElements(fromPairs(patient.clinicalData.map((x: any) => [x.clinicalAttributeId, x.value])), 'lgg_ucsf_2014')}
                 </span>
             </DefaultTooltip>
         );

--- a/src/pages/patientView/patientHeader/SampleInline.tsx
+++ b/src/pages/patientView/patientHeader/SampleInline.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {SampleLabelHTML} from "../../../shared/components/sampleLabel/SampleLabel";
 import { ClinicalDataBySampleId } from "../../../shared/api/api-types-extended";
 import {fromPairs} from 'lodash';
-import {getSpans} from '../clinicalInformation/lib/clinicalAttributesUtil.js';
 
 
 interface ISampleInlineProps {
@@ -14,27 +13,11 @@ interface ISampleInlineProps {
 
 export default class SampleInline extends React.Component<ISampleInlineProps, {}> {
     public render() {
-        const { sample, sampleNumber, sampleColor, showClinical } = this.props;
+        const { sample, sampleNumber, sampleColor } = this.props;
 
 
         return (
             <SampleLabelHTML color={sampleColor} label={(sampleNumber).toString()} />
         );
-
-        // if (showClinical) {
-        //     const clinicalDataLegacy: any = fromPairs(sample.clinicalData.map((x) => [x.clinicalAttributeId, x.value]));
-        //
-        //     return (
-        //         <span style={{paddingRight: '10px'}}>
-        //             <SampleLabelHTML color={sampleColor} label={(sampleNumber).toString()} />
-        //             {' ' + sample.id}
-        //             <span className='clinical-spans' dangerouslySetInnerHTML={{__html:
-        //                 getSpans(clinicalDataLegacy, 'lgg_ucsf_2014')}}>
-        //             </span>
-        //         </span>
-        //     );
-        // } else {
-        //
-        // }
     }
 }

--- a/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
+++ b/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
@@ -16,6 +16,7 @@ $sample-color-xenograft: pink;
 /* Do not display clinical attributes on default */
 .clinical-spans {
     display: inline-flex;
+    flex-wrap: wrap;
 
     .clinical-attribute {
         display: none;


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/2388. Puts clinical data and link in same span with flex-wrap set to wrap. So the clinical data in the patient view header wraps as expected.

![screen shot 2017-04-26 at 8 35 07 pm](https://cloud.githubusercontent.com/assets/1334004/25462869/04d87098-2ac0-11e7-927d-5b0012cf1888.png)
