### PR TITLE
Fixed broken spinner test for MSKTabs component

### DIFF
--- a/src/shared/components/MSKTabs/MSKTabs.spec.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.spec.tsx
@@ -75,7 +75,7 @@ describe('MSKTabs', () => {
         const tab2 = tabs2.find(MSKTab).at(0);
         span = tab2.find("span").at(0);
         assert.notEqual(span.text(), "One", "the span with the content 'One' does not exist for a loading tab");
-        assert(tab2.find(ThreeBounce).at(0).exists(), "a loading tab contains a spinner element");
+        assert(tab2.find(".default-spinner").at(0).exists(), "a loading tab contains a spinner element");
         assert.deepEqual(tabText(tabs2), ["One", "Two"], "both tabs visible");
 
         tabs2.setProps({ activeTabId: "two" });

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -58,7 +58,7 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
             return React.cloneElement(
                 tab,
                 { inactive } as Partial<IMSKTabProps>,
-                (<ThreeBounce className="center-block text-center" />)
+                (<ThreeBounce className="default-spinner center-block text-center" />)
             );
         } else {
             return React.cloneElement(


### PR DESCRIPTION
# What? Why?
Travis uses the production build for tests, and apparently `find(ThreeBounce)` fails for the production build.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
