### PR TITLE
Results View Mutation Page & Store Cleanup

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -29,6 +29,7 @@ import validateParameters from '../../shared/lib/validateParameters';
 
 import './patient.scss';
 import LoadingIndicator from "../../shared/components/loadingIndicator/LoadingIndicator";
+import ValidationAlert from "shared/components/ValidationAlert";
 
 const patientViewPageStore = new PatientViewPageStore();
 
@@ -142,17 +143,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
         let studyName: JSX.Element | null = null;
 
         if (patientViewPageStore.urlValidationError) {
-            return (
-                <div className="alert alert-danger urlError" role="alert">
-                    <i className="fa fa-warning" aria-hidden="true"></i>
-                    <h3>The URL is invalid</h3>
-                    <ul>
-                        { patientViewPageStore.urlValidationError
-                            .split(".").map((message:string)=>(message.length > 0) ? <li>{message}</li> : null)
-                        }
-                    </ul>
-                </div>
-            )
+            return <ValidationAlert urlValidationError={patientViewPageStore.urlValidationError} />;
         }
 
         if (patientViewPageStore.studyMetaData.isComplete) {

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.spec.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.spec.ts
@@ -6,11 +6,11 @@ import { handlePathologyReportCheckResponse, PatientViewPageStore } from './Pati
 // import React from 'react';
 import { assert } from 'chai';
 // import { shallow, mount } from 'enzyme';
-import sinon from 'sinon';
-// //import AppConfig from 'appConfig';
+// import sinon from 'sinon';
+// import AppConfig from 'appConfig';
 // import request from 'superagent';
 
-describe('ClinicalInformationSamplesTable', () => {
+describe('PatientViewPageStore', () => {
 
     let store: PatientViewPageStore;
 
@@ -33,38 +33,6 @@ describe('ClinicalInformationSamplesTable', () => {
             total_count:0,
         });
         assert.deepEqual(result,[]);
-    });
-
-    it('won\'t fetch cosmic data if there are no mutations', ()=>{
-
-        const fetchStub = sinon.stub();
-
-        let mockInstance = {
-            mutationData: { result:[] },
-            internalClient: {
-                fetchCosmicCountsUsingPOST: fetchStub
-            }
-        };
-
-        store.cosmicDataInvoke.apply(mockInstance).then((data: any)=>{
-           assert.isUndefined(data);
-           assert.isFalse(fetchStub.called);
-        });
-
-    });
-
-    it('won\'t fetch onkokb data if there are no mutations', ()=>{
-
-        const fetchStub = sinon.stub();
-
-        let mockInstance = {
-            mutationData: { result:[] }
-        };
-
-        store.oncoKbDataInvoke.apply(mockInstance).then((data: any)=>{
-            assert.deepEqual(data,{sampleToTumorMap: {}, indicatorMap: {}});
-        });
-
     });
 
 });

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -5,31 +5,20 @@ import {
 } from "../../../shared/api/generated/CBioPortalAPI";
 import client from "../../../shared/api/cbioportalClientInstance";
 import internalClient from "../../../shared/api/cbioportalInternalClientInstance";
-import hotspot3DClient from '../../../shared/api/3DhotspotClientInstance';
-import hotspotClient from '../../../shared/api/hotspotClientInstance';
 import {
-    CopyNumberCount, CopyNumberCountIdentifier, Gistic, GisticToGene, CosmicMutation, default as CBioPortalAPIInternal,
-    MutSig
+    CopyNumberCount, CopyNumberCountIdentifier, Gistic, GisticToGene, default as CBioPortalAPIInternal, MutSig
 } from "shared/api/generated/CBioPortalAPIInternal";
 import {computed, observable, action} from "mobx";
-import oncokbClient from "../../../shared/api/oncokbClientInstance";
 import {remoteData, addErrorHandler} from "../../../shared/api/remoteData";
 import {IGisticData} from "shared/model/Gistic";
-import {
-    generateIdToIndicatorMap, generateQueryVariant, generateEvidenceQuery
-} from "shared/lib/OncoKbUtils";
-import {Query} from "shared/api/generated/OncoKbAPI";
 import {labelMobxPromises, cached} from "mobxpromise";
 import MrnaExprRankCache from 'shared/cache/MrnaExprRankCache';
 import request from 'superagent';
 import DiscreteCNACache from "shared/cache/DiscreteCNACache";
 import {getTissueImageCheckUrl, getDarwinUrl} from "../../../shared/api/urls";
-import {getAlterationString} from "shared/lib/CopyNumberUtils";
 import OncoKbEvidenceCache from "shared/cache/OncoKbEvidenceCache";
 import PmidCache from "shared/cache/PmidCache";
-import {keywordToCosmic, indexHotspots, geneToMyCancerGenome} from "shared/lib/AnnotationUtils";
 import {IOncoKbData} from "shared/model/OncoKB";
-import {IMyCancerGenomeData, IMyCancerGenome} from "shared/model/MyCancerGenome";
 import {IHotspotData} from "shared/model/CancerHotspots";
 import {IMutSigData} from "shared/model/MutSig";
 import {ClinicalInformationData} from "shared/model/ClinicalInformation";
@@ -38,13 +27,13 @@ import VariantCountCache from "shared/cache/VariantCountCache";
 import CopyNumberCountCache from "./CopyNumberCountCache";
 import CancerTypeCache from "shared/cache/CancerTypeCache";
 import MutationCountCache from "shared/cache/MutationCountCache";
+import {
+    findGeneticProfileIdDiscrete, ONCOKB_DEFAULT, fetchOncoKbData, fetchCnaOncoKbData,
+    indexHotspotData, mergeMutations, fetchHotspotsData, fetchMyCancerGenomeData, fetchCosmicData,
+    fetchMutationData, fetchDiscreteCNAData, generateSampleIdToTumorTypeMap
+} from "shared/lib/StoreUtils";
 
 type PageMode = 'patient' | 'sample';
-
-const ONCOKB_DEFAULT: IOncoKbData = {
-    sampleToTumorMap : {},
-    indicatorMap : {}
-};
 
 export function groupByEntityId(clinicalDataArray: Array<ClinicalData>) {
     return _.map(
@@ -105,18 +94,6 @@ function transformClinicalInformationToStoreShape(patientId: string, studyId: st
     };
 
     return rv;
-}
-
-export async function fetchOncoKbData(sampleIdToTumorType: {[sampleId: string]: string}, queryVariants: Query[]) {
-    const onkokbSearch = await oncokbClient.searchPostUsingPOST(
-        {body: generateEvidenceQuery(queryVariants)});
-
-    const oncoKbData: IOncoKbData = {
-        sampleToTumorMap: sampleIdToTumorType,
-        indicatorMap: generateIdToIndicatorMap(onkokbSearch)
-    };
-
-    return oncoKbData;
 }
 
 export class PatientViewPageStore {
@@ -185,9 +162,8 @@ export class PatientViewPageStore {
 
     @observable patientIdsInCohort: string[] = [];
 
-    get myCancerGenomeData() : IMyCancerGenomeData {
-        const data:IMyCancerGenome[] = require('../../../../resources/mycancergenome.json');
-        return geneToMyCancerGenome(data);
+    @computed get myCancerGenomeData() {
+        return fetchMyCancerGenomeData();
     }
 
     readonly derivedPatientId = remoteData<string>({
@@ -261,28 +237,12 @@ export class PatientViewPageStore {
 
     }, []);
 
-    async cosmicDataInvoke() {
-        if (this.mutationData.result.length === 0 && this.uncalledMutationData.result.length === 0) {
-            return undefined;
-        }
-
-        const queryKeywords: string[] = _.uniq(_.map(this.mutationData.result.concat(this.uncalledMutationData.result), (mutation: Mutation) => mutation.keyword));
-
-        const cosmicData: CosmicMutation[] = await this.internalClient.fetchCosmicCountsUsingPOST({
-            keywords: _.filter(queryKeywords, (query) => {
-                return query != null;
-            })
-        });
-
-        return keywordToCosmic(cosmicData);
-    }
-
     readonly cosmicData = remoteData({
         await: () => [
             this.mutationData,
             this.uncalledMutationData
         ],
-        invoke: () => this.cosmicDataInvoke()
+        invoke: () => fetchCosmicData(this.mutationData)
     });
 
     readonly mutSigData = remoteData({
@@ -296,36 +256,13 @@ export class PatientViewPageStore {
         }
     });
 
-
     readonly hotspotData = remoteData({
         await: ()=> [
             this.mutationData,
             this.uncalledMutationData,
         ],
         invoke: async () => {
-            const queryGenes:string[] = _.uniq(_.map(this.mutationData.result.concat(this.uncalledMutationData.result),
-                                                     function(mutation:Mutation) {
-                if (mutation && mutation.gene) {
-                    return mutation.gene.hugoGeneSymbol;
-                }
-                else {
-                    return "";
-                }
-            }));
-
-            const [dataSingle, data3d] = await Promise.all([
-                hotspotClient.fetchSingleResidueHotspotMutationsByGenePOST({
-                    hugoSymbols: queryGenes
-                }),
-                hotspot3DClient.fetch3dHotspotMutationsByGenePOST({
-                    hugoSymbols: queryGenes
-                })
-            ]);
-
-            return {
-                single: dataSingle,
-                clustered: data3d
-            };
+            return fetchHotspotsData(this.mutationData);
         },
         onError: () => {
             // fail silently
@@ -424,19 +361,9 @@ export class PatientViewPageStore {
             this.samples
         ],
         invoke: async() => {
-
             const sampleIds = this.samples.result.map((sample) => sample.sampleId);
-
-            if (this.geneticProfileIdDiscrete.isComplete && this.geneticProfileIdDiscrete.result) {
-                return await client.fetchDiscreteCopyNumbersInGeneticProfileUsingPOST({
-                    projection: 'DETAILED',
-                    discreteCopyNumberFilter: {sampleIds: sampleIds} as DiscreteCopyNumberFilter,
-                    geneticProfileId: this.geneticProfileIdDiscrete.result
-                });
-            } else {
-                return [];
-            }
-
+            const filter = {sampleIds: sampleIds} as DiscreteCopyNumberFilter;
+            return fetchDiscreteCNAData(filter, this.geneticProfileIdDiscrete);
         },
         onResult: (result:DiscreteCopyNumberData[])=>{
             // We want to take advantage of this loaded data, and not redownload the same data
@@ -504,17 +431,12 @@ export class PatientViewPageStore {
     }, []);
 
     readonly geneticProfileIdDiscrete = remoteData({
-
         await: () => [
             this.geneticProfilesInStudy
         ],
         invoke: async() => {
-            const profile = this.geneticProfilesInStudy.result.find((p: GeneticProfile) => {
-                return p.datatype === 'DISCRETE';
-            });
-            return profile ? profile.geneticProfileId : undefined;
+            return findGeneticProfileIdDiscrete(this.geneticProfilesInStudy);
         }
-
     });
 
     readonly darwinUrl = remoteData({
@@ -578,39 +500,14 @@ export class PatientViewPageStore {
             this.mutationGeneticProfileId
         ],
         invoke: async() => {
-            const geneticProfileId = this.mutationGeneticProfileId.result;
-            if (geneticProfileId) {
-                return await client.fetchMutationsInGeneticProfileUsingPOST({
-                    geneticProfileId,
-                    mutationFilter: {
-                        sampleIds: this.samples.result.map((sample: Sample) => sample.sampleId)
-                    } as MutationFilter,
-                    projection: "DETAILED"
-                });
-            } else {
-                return [];
-            }
+            let mutationFilter = {
+                sampleIds: this.samples.result.map((sample: Sample) => sample.sampleId)
+            } as MutationFilter;
+
+            return fetchMutationData(mutationFilter, this.mutationGeneticProfileId.result);
         }
     }, []);
 
-
-    async oncoKbDataInvoke(){
-
-        if (this.mutationData.result.length === 0 && this.uncalledMutationData.result.length === 0) {
-            return ONCOKB_DEFAULT;
-        }
-
-        const queryVariants = _.uniqBy(_.map(this.mutationData.result.concat(this.uncalledMutationData.result), (mutation: Mutation) => {
-            return generateQueryVariant(mutation.gene.hugoGeneSymbol,
-                this.sampleIdToTumorType[mutation.sampleId],
-                mutation.proteinChange,
-                mutation.mutationType,
-                mutation.proteinPosStart,
-                mutation.proteinPosEnd);
-        }), "id");
-
-        return fetchOncoKbData(this.sampleIdToTumorType, queryVariants);
-    }
 
     readonly oncoKbData = remoteData<IOncoKbData>({
         await: () => [
@@ -618,7 +515,7 @@ export class PatientViewPageStore {
             this.uncalledMutationData,
             this.clinicalDataForSamples
         ],
-        invoke: async() => this.oncoKbDataInvoke()
+        invoke: async() => fetchOncoKbData(this.mutationData, this.sampleIdToTumorType)
     }, ONCOKB_DEFAULT);
 
     readonly cnaOncoKbData = remoteData<IOncoKbData>({
@@ -626,18 +523,7 @@ export class PatientViewPageStore {
             this.discreteCNAData,
             this.clinicalDataForSamples
         ],
-        invoke: async() => {
-            if (this.discreteCNAData.result.length > 0) {
-                const queryVariants = _.uniqBy(_.map(this.discreteCNAData.result, (copyNumberData: DiscreteCopyNumberData) => {
-                    return generateQueryVariant(copyNumberData.gene.hugoGeneSymbol,
-                        this.sampleIdToTumorType[copyNumberData.sampleId],
-                        getAlterationString(copyNumberData.alteration));
-                }), "id");
-                return fetchOncoKbData(this.sampleIdToTumorType, queryVariants);
-            } else {
-                return ONCOKB_DEFAULT;
-            }
-        }
+        invoke: async() => fetchCnaOncoKbData(this.discreteCNAData, this.sampleIdToTumorType)
     }, ONCOKB_DEFAULT);
 
     readonly copyNumberCountData = remoteData<CopyNumberCount[]>({
@@ -666,33 +552,11 @@ export class PatientViewPageStore {
 
     @computed get indexedHotspotData(): IHotspotData|undefined
     {
-        const data = this.hotspotData.result;
-
-        if (data) {
-            return {
-                single: indexHotspots(data.single),
-                clustered: indexHotspots(data.clustered)
-            }
-        }
-        else {
-            return undefined;
-        }
+        return indexHotspotData(this.hotspotData);
     }
 
     @computed get mergedMutationData(): Mutation[][] {
-        let idToMutations: {[key: string]: Array<Mutation>} = {};
-        let mutationId: string;
-        let MutationId: (m: Mutation) => string = (m: Mutation) => {
-            return [m.gene.chromosome, m.startPosition, m.endPosition, m.referenceAllele, m.variantAllele].join("_");
-        };
-
-        for (const mutation of this.mutationData.result) {
-            mutationId = MutationId(mutation);
-            idToMutations[mutationId] = idToMutations[mutationId] || [];
-            idToMutations[mutationId].push(mutation);
-        }
-
-        return Object.keys(idToMutations).map(id => idToMutations[id]);
+        return mergeMutations(this.mutationData);
     }
 
     static getMutationId(m: any): string {
@@ -720,17 +584,7 @@ export class PatientViewPageStore {
 
 
     @computed get sampleIdToTumorType(): {[sampleId: string]: string} {
-        const map: {[sampleId: string]: string} = {};
-
-        if (this.clinicalDataForSamples.result) {
-            _.each(this.clinicalDataForSamples.result, function (clinicalData) {
-                if (clinicalData.clinicalAttributeId === "CANCER_TYPE") {
-                    map[clinicalData.entityId] = clinicalData.value;
-                }
-            });
-        }
-
-        return map;
+        return generateSampleIdToTumorTypeMap(this.clinicalDataForSamples);
     }
 
     @action("SetSampleId") setSampleId(newId: string) {

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
 import {observer} from "mobx-react";
-import {computed} from "mobx";
 import MutationTable from "shared/components/mutationTable/MutationTable";
 import {IMutationTableProps} from "shared/components/mutationTable/MutationTable";
 import SampleManager from "../sampleManager";
 import {MutationTableColumnType} from "shared/components/mutationTable/MutationTable";
 import {Mutation} from "shared/api/generated/CBioPortalAPI";
+import AlleleCountColumnFormatter from "shared/components/mutationTable/column/AlleleCountColumnFormatter";
 import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
-import {Column} from "shared/components/lazyMobXTable/LazyMobXTable";
 import ProteinChangeColumnFormatter from "./column/ProteinChangeColumnFormatter";
 import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "../../../shared/constants";
 
 export interface IPatientViewMutationTableProps extends IMutationTableProps {
     sampleManager:SampleManager | null;
+    sampleIds?:string[];
 }
 
 @observer
@@ -54,6 +54,15 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         ]
     };
 
+    protected getSamples():string[] {
+        if (this.props.sampleIds) {
+            return this.props.sampleIds;
+        }
+        else {
+            return [];
+        }
+    }
+
     protected generateColumns() {
         super.generateColumns();
 
@@ -72,6 +81,32 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
 
         // patient view has a custom renderer for protein change column, so we need to override render function
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].render = ProteinChangeColumnFormatter.renderFunction;
+
+        // customization for allele count columns
+
+        this._columns[MutationTableColumnType.REF_READS_N] = {
+            ...this._columns[MutationTableColumnType.REF_READS_N],
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalRefCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalRefCount")
+        };
+
+        this._columns[MutationTableColumnType.VAR_READS_N] = {
+            ...this._columns[MutationTableColumnType.VAR_READS_N],
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalAltCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalAltCount")
+        };
+
+        this._columns[MutationTableColumnType.REF_READS] = {
+            ...this._columns[MutationTableColumnType.REF_READS],
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorRefCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorRefCount")
+        };
+
+        this._columns[MutationTableColumnType.VAR_READS] = {
+            ...this._columns[MutationTableColumnType.VAR_READS],
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorAltCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorAltCount")
+        };
 
 
         // order columns

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -1,15 +1,16 @@
 import * as React from "react";
+import {computed} from "mobx";
 import {observer} from "mobx-react";
-import MutationTable from "shared/components/mutationTable/MutationTable";
-import {IMutationTableProps} from "shared/components/mutationTable/MutationTable";
+import {
+    IMutationTableProps, MutationTableColumnType, default as MutationTable
+} from "shared/components/mutationTable/MutationTable";
 import SampleManager from "../sampleManager";
-import {MutationTableColumnType} from "shared/components/mutationTable/MutationTable";
 import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import AlleleCountColumnFormatter from "shared/components/mutationTable/column/AlleleCountColumnFormatter";
 import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
 import ProteinChangeColumnFormatter from "./column/ProteinChangeColumnFormatter";
-import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "../../../shared/constants";
+import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "shared/constants";
 
 export interface IPatientViewMutationTableProps extends IMutationTableProps {
     sampleManager:SampleManager | null;
@@ -84,29 +85,25 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
 
         // customization for allele count columns
 
-        this._columns[MutationTableColumnType.REF_READS_N] = {
-            ...this._columns[MutationTableColumnType.REF_READS_N],
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalRefCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalRefCount")
-        };
+        this._columns[MutationTableColumnType.REF_READS_N].render =
+            (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalRefCount");
+        this._columns[MutationTableColumnType.REF_READS_N].download =
+            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalRefCount");
 
-        this._columns[MutationTableColumnType.VAR_READS_N] = {
-            ...this._columns[MutationTableColumnType.VAR_READS_N],
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalAltCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalAltCount")
-        };
+        this._columns[MutationTableColumnType.VAR_READS_N].render =
+            (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalAltCount");
+        this._columns[MutationTableColumnType.VAR_READS_N].download =
+            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalAltCount");
 
-        this._columns[MutationTableColumnType.REF_READS] = {
-            ...this._columns[MutationTableColumnType.REF_READS],
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorRefCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorRefCount")
-        };
+        this._columns[MutationTableColumnType.REF_READS].render =
+            (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorRefCount");
+        this._columns[MutationTableColumnType.REF_READS].download =
+            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorRefCount");
 
-        this._columns[MutationTableColumnType.VAR_READS] = {
-            ...this._columns[MutationTableColumnType.VAR_READS],
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorAltCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorAltCount")
-        };
+        this._columns[MutationTableColumnType.VAR_READS].render =
+            (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorAltCount");
+        this._columns[MutationTableColumnType.VAR_READS].download =
+            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorAltCount");
 
 
         // order columns

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import {observer, inject } from "mobx-react";
+import {reaction, computed} from "mobx";
+import validateParameters from 'shared/lib/validateParameters';
+import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
+import ValidationAlert from "shared/components/ValidationAlert";
+import ResultsViewMutationTable from "./mutation/ResultsViewMutationTable";
+import {ResultsViewPageStore} from "./ResultsViewPageStore";
+
+const resultsViewPageStore = new ResultsViewPageStore();
+
+(window as any).resultsViewPageStore = resultsViewPageStore;
+
+export interface IResultsViewPageProps {
+    routing: any;
+}
+
+@inject('routing')
+@observer
+export default class ResultsViewPage extends React.Component<IResultsViewPageProps, {}> {
+
+    constructor(props: IResultsViewPageProps) {
+        super();
+
+        const reaction1 = reaction(
+            () => props.routing.location.query,
+            query => {
+
+                const validationResult = validateParameters(query, ['studyId']);
+
+                if (validationResult.isValid) {
+                    resultsViewPageStore.urlValidationError = null;
+
+                    resultsViewPageStore.studyId = query.studyId;
+
+                    if ('sampleListId' in query) {
+                        resultsViewPageStore.sampleListId = query.sampleListId as string;
+                    }
+
+                    // TODO we may want to split by ","
+
+                    if ('sampleList' in query) {
+                        resultsViewPageStore.sampleList = (query.sampleList as string).split(" ");
+                    }
+
+                    if ('geneList' in query) {
+                        resultsViewPageStore.hugoGeneSymbols = (query.geneList as string).split(" ");
+                    }
+                }
+                else {
+                    resultsViewPageStore.urlValidationError = validationResult.message;
+                }
+
+            },
+            { fireImmediately:true }
+        );
+    }
+
+    public render() {
+
+        if (resultsViewPageStore.urlValidationError) {
+            return <ValidationAlert urlValidationError={resultsViewPageStore.urlValidationError} />;
+        }
+
+        return (
+            <div className="resultsViewPage">
+                <LoadingIndicator isLoading={resultsViewPageStore.mutationData.isPending} />
+
+                {
+                    (resultsViewPageStore.mutationData.isComplete) && (
+                        <ResultsViewMutationTable
+                            studyId={resultsViewPageStore.studyId}
+                            discreteCNACache={resultsViewPageStore.discreteCNACache}
+                            oncoKbEvidenceCache={resultsViewPageStore.oncoKbEvidenceCache}
+                            pmidCache={resultsViewPageStore.pmidCache}
+                            cancerTypeCache={resultsViewPageStore.cancerTypeCache}
+                            mutationCountCache={resultsViewPageStore.mutationCountCache}
+                            data={resultsViewPageStore.mergedMutationData}
+                            myCancerGenomeData={resultsViewPageStore.myCancerGenomeData}
+                            hotspots={resultsViewPageStore.indexedHotspotData}
+                            cosmicData={resultsViewPageStore.cosmicData.result}
+                            oncoKbData={resultsViewPageStore.oncoKbData.result}
+                        />
+                    )
+                }
+            </div>
+        );
+    }
+}

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -42,7 +42,7 @@ export class ResultsViewPageStore {
         await: () => [
             this.geneticProfilesInStudy
         ],
-        invoke: async() => findMutationGeneticProfileId(this.geneticProfilesInStudy, this.studyId)
+        invoke: async () => findMutationGeneticProfileId(this.geneticProfilesInStudy, this.studyId)
     });
 
     @computed get myCancerGenomeData() {
@@ -69,7 +69,7 @@ export class ResultsViewPageStore {
         }
     });
 
-    readonly sampleIds = remoteData(async() => {
+    readonly sampleIds = remoteData(async () => {
         // first priority: user provided custom sample list
         if (this.sampleList) {
             return this.sampleList;
@@ -95,10 +95,10 @@ export class ResultsViewPageStore {
         await: () => [
             this.sampleIds
         ],
-        invoke: async() => fetchSamples(this.sampleIds, this.studyId)
+        invoke: async () => fetchSamples(this.sampleIds, this.studyId)
     }, []);
 
-    readonly genes = remoteData(async() => {
+    readonly genes = remoteData(async () => {
         if (this.hugoGeneSymbols) {
             return await client.fetchGenesUsingPOST({
                 // an observable array (hugoGeneSymbols) is incompatible with an API call,
@@ -116,7 +116,7 @@ export class ResultsViewPageStore {
             this.sampleIds,
             this.genes
         ],
-        invoke: async() => {
+        invoke: async () => {
             const mutationFilter = {
                 ...this.apiDataFilter,
                 entrezGeneIds: this.genes.result.map((gene: Gene) => gene.entrezGeneId)
@@ -130,20 +130,20 @@ export class ResultsViewPageStore {
         await: () => [
             this.mutationData
         ],
-        invoke: async() => fetchOncoKbData(this.sampleIdToTumorType, this.mutationData)
+        invoke: async () => fetchOncoKbData(this.sampleIdToTumorType, this.mutationData)
     }, ONCOKB_DEFAULT);
 
     readonly geneticProfilesInStudy = remoteData(() => {
         return client.getAllGeneticProfilesInStudyUsingGET({
             studyId: this.studyId
-        })
+        });
     }, []);
 
     readonly geneticProfileIdDiscrete = remoteData({
         await: () => [
             this.geneticProfilesInStudy
         ],
-        invoke: async() => {
+        invoke: async () => {
             return findGeneticProfileIdDiscrete(this.geneticProfilesInStudy);
         }
     });
@@ -153,11 +153,11 @@ export class ResultsViewPageStore {
             this.geneticProfileIdDiscrete,
             this.sampleIds
         ],
-        invoke: async() => {
+        invoke: async () => {
             const filter = this.apiDataFilter as DiscreteCopyNumberFilter;
             return fetchDiscreteCNAData(filter, this.geneticProfileIdDiscrete);
         },
-        onResult: (result:DiscreteCopyNumberData[])=>{
+        onResult: (result:DiscreteCopyNumberData[]) => {
             // We want to take advantage of this loaded data, and not redownload the same data
             //  for users of the cache
             this.discreteCNACache.addData(result);

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1,0 +1,242 @@
+import {
+    Mutation, DiscreteCopyNumberFilter, DiscreteCopyNumberData, MutationFilter, Gene
+} from "shared/api/generated/CBioPortalAPI";
+import client from "shared/api/cbioportalClientInstance";
+import {computed, observable, action} from "mobx";
+import {remoteData, addErrorHandler} from "shared/api/remoteData";
+import {labelMobxPromises, cached} from "mobxpromise";
+import OncoKbEvidenceCache from "shared/cache/OncoKbEvidenceCache";
+import PmidCache from "shared/cache/PmidCache";
+import {IOncoKbData} from "shared/model/OncoKB";
+import {IHotspotData} from "shared/model/CancerHotspots";
+import CancerTypeCache from "shared/cache/CancerTypeCache";
+import MutationCountCache from "shared/cache/MutationCountCache";
+import DiscreteCNACache from "shared/cache/DiscreteCNACache";
+import {
+    indexHotspotData, fetchHotspotsData, mergeMutations, ONCOKB_DEFAULT,
+    fetchCosmicData, fetchOncoKbData, findGeneticProfileIdDiscrete, fetchMyCancerGenomeData, fetchMutationData,
+    fetchDiscreteCNAData, generateSampleIdToTumorTypeMap
+} from "shared/lib/StoreUtils";
+
+export class ResultsViewPageStore {
+
+    constructor() {
+        labelMobxPromises(this);
+
+        addErrorHandler((error:any) => {
+            this.ajaxErrors.push(error);
+        });
+    }
+
+    @observable public urlValidationError: string | null = null;
+
+    @observable ajaxErrors: Error[] = [];
+
+    @observable studyId: string = '';
+    @observable sampleListId: string|null = null;
+    @observable hugoGeneSymbols: string[]|null = null;
+    @observable sampleList: string[]|null = null;
+
+    @computed get mutationGeneticProfileId() {
+        return `${this.studyId}_mutations`;
+    }
+
+    @computed get myCancerGenomeData() {
+        return fetchMyCancerGenomeData();
+    }
+
+    readonly cosmicData = remoteData({
+        await: () => [
+            this.mutationData
+        ],
+        invoke: () => fetchCosmicData(this.mutationData)
+    });
+
+
+    readonly hotspotData = remoteData({
+        await: ()=> [
+            this.mutationData
+        ],
+        invoke: async () => {
+            return fetchHotspotsData(this.mutationData);
+        },
+        onError: () => {
+            // fail silently
+        }
+    });
+
+    readonly sampleIds = remoteData(async() => {
+        // first priority: user provided custom sample list
+        if (this.sampleList) {
+            return this.sampleList;
+        }
+        // if no custom sample list try to fetch sample ids from the API
+        else if (this.sampleListId) {
+            return await client.getAllSampleIdsInSampleListUsingGET({
+                sampleListId: this.sampleListId
+            });
+        }
+
+        return [];
+    }, []);
+
+    readonly clinicalDataForSamples = remoteData({
+        await: () => [
+            this.sampleIds
+        ],
+        invoke: () => client.fetchClinicalDataUsingPOST({
+            clinicalDataType: 'SAMPLE',
+            identifiers: this.sampleIds.result.map((sampleId: string) => ({
+                entityId: sampleId,
+                studyId: this.studyId
+            })),
+            projection: 'DETAILED',
+        })
+    }, []);
+
+    readonly samples = remoteData({
+        await: () => [
+            this.sampleIds
+        ],
+        invoke: async() => {
+            if (this.sampleIds.result &&
+                this.sampleIds.result.length > 0 &&
+                this.studyId)
+            {
+                const sampleIdentifiers = this.sampleIds.result.map(
+                    (sampleId: string) => ({sampleId: sampleId, studyId: this.studyId})
+                );
+
+                return await client.fetchSamplesUsingPOST({
+                    sampleIdentifiers,
+                    projection: "DETAILED"
+                });
+            }
+
+            return [];
+        }
+    }, []);
+
+    readonly genes = remoteData(async() => {
+        if (this.hugoGeneSymbols) {
+            return await client.fetchGenesUsingPOST({
+                // an observable array (hugoGeneSymbols) is incompatible with an API call,
+                // we need to convert it to a regular array before the request
+                geneIds: this.hugoGeneSymbols.slice(0),
+                geneIdType: "HUGO_GENE_SYMBOL"
+            });
+        }
+
+        return [];
+    }, []);
+
+    readonly mutationData = remoteData({
+        await: () => [
+            this.sampleIds,
+            this.genes
+        ],
+        invoke: async() => {
+            let mutationFilter = {
+                ...this.apiDataFilter,
+                entrezGeneIds: this.genes.result.map((gene: Gene) => gene.entrezGeneId)
+            } as MutationFilter;
+
+            return fetchMutationData(mutationFilter, this.mutationGeneticProfileId);
+        }
+    }, []);
+
+    readonly oncoKbData = remoteData<IOncoKbData>({
+        await: () => [
+            this.mutationData
+        ],
+        invoke: async() => fetchOncoKbData(this.mutationData, this.sampleIdToTumorType)
+    }, ONCOKB_DEFAULT);
+
+    readonly geneticProfilesInStudy = remoteData(() => {
+        return client.getAllGeneticProfilesInStudyUsingGET({
+            studyId: this.studyId
+        })
+    }, []);
+
+    readonly geneticProfileIdDiscrete = remoteData({
+        await: () => [
+            this.geneticProfilesInStudy
+        ],
+        invoke: async() => {
+            return findGeneticProfileIdDiscrete(this.geneticProfilesInStudy);
+        }
+    });
+
+    readonly discreteCNAData = remoteData({
+        await: () => [
+            this.sampleIds
+        ],
+        invoke: async() => {
+            const filter = this.apiDataFilter as DiscreteCopyNumberFilter;
+            return fetchDiscreteCNAData(filter, this.geneticProfileIdDiscrete);
+        },
+        onResult: (result:DiscreteCopyNumberData[])=>{
+            // We want to take advantage of this loaded data, and not redownload the same data
+            //  for users of the cache
+            this.discreteCNACache.addData(result);
+        }
+
+    }, []);
+
+    @computed get apiDataFilter() {
+        let filter: {
+            sampleIds?: string[],
+            sampleListId?: string
+        } = {};
+
+        if (this.sampleListId) {
+            filter = {
+                sampleListId: this.sampleListId
+            };
+        }
+        else if (this.sampleIds.result) {
+            filter = {
+                sampleIds: this.sampleIds.result
+            };
+        }
+
+        return filter;
+    }
+
+    @computed get mergedMutationData(): Mutation[][] {
+        return mergeMutations(this.mutationData);
+    }
+
+    @computed get indexedHotspotData(): IHotspotData|undefined
+    {
+        return indexHotspotData(this.hotspotData);
+    }
+
+    @computed get sampleIdToTumorType(): {[sampleId: string]: string} {
+        return generateSampleIdToTumorTypeMap(this.clinicalDataForSamples);
+    }
+
+    @cached get oncoKbEvidenceCache() {
+        return new OncoKbEvidenceCache();
+    }
+
+    @cached get pmidCache() {
+        return new PmidCache();
+    }
+
+    @cached get discreteCNACache() {
+        return new DiscreteCNACache(this.geneticProfileIdDiscrete.result);
+    }
+
+    @cached get cancerTypeCache() {
+        return new CancerTypeCache(this.studyId);
+    }
+
+    @cached get mutationCountCache() {
+        return new MutationCountCache(this.mutationGeneticProfileId);
+    }
+
+    @action clearErrors() {
+        this.ajaxErrors = [];
+    }
+}

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -1,17 +1,11 @@
 import * as React from "react";
 import {observer} from "mobx-react";
-import {computed} from "mobx";
-import MutationTable from "shared/components/mutationTable/MutationTable";
-import {IMutationTableProps} from "shared/components/mutationTable/MutationTable";
-import LazyLoadedTableCell from "shared/lib/LazyLoadedTableCell";
-import {MutationTableColumnType} from "shared/components/mutationTable/MutationTable";
-import CancerTypeCache from "../../../shared/cache/CancerTypeCache";
-import MutationCountCache from "../../../shared/cache/MutationCountCache";
-import {Mutation, ClinicalData, MutationCount} from "../../../shared/api/generated/CBioPortalAPI";
-import {Column} from "../../../shared/components/lazyMobXTable/LazyMobXTable";
+import {
+    IMutationTableProps, MutationTableColumnType, default as MutationTable
+} from "shared/components/mutationTable/MutationTable";
 
 export interface IResultsViewMutationTableProps extends IMutationTableProps {
-    // TODO add results view specific props
+    // add results view specific props here if needed
 }
 
 @observer

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -15,6 +15,7 @@ import { restoreRouteAfterRedirect } from './shared/lib/redirectHelpers';
 // webpack knows to 'split' the code into seperate bundles accordingly
 // see article http://henleyedition.com/implicit-code-splitting-with-react-router-and-webpack/
 import PatientViewPage from 'bundle?lazy!babel!./pages/patientView/PatientViewPage';
+import ResultsViewPage from 'bundle?lazy!babel!./pages/resultsView/ResultsViewPage';
 import HomePage from 'bundle?lazy!babel!./pages/home/HomePage';
 //import DatasetPage from 'bundle?lazy!babel!./pages/datasetView/DatasetPage';
 // accepts bundle-loader's deferred loader function and defers execution of route's render
@@ -42,7 +43,8 @@ export const makeRoutes = (routing) => {
         <Route path="/home" getComponent={lazyLoadComponent(HomePage)}/>
         <Route path="/patient" getComponent={lazyLoadComponent(PatientViewPage)}/>
         <Route path="/restore" component={restoreRoute}/>
-        <Redirect from="*" to={defaultRoute}/>
+        <Route path="/query" getComponent={lazyLoadComponent(ResultsViewPage)} />
+            <Redirect from="*" to={defaultRoute}/>
         <IndexRedirect to={defaultRoute}/>
     </Route>)
 };

--- a/src/shared/components/ValidationAlert.tsx
+++ b/src/shared/components/ValidationAlert.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+export interface IValidationAlertProps {
+    urlValidationError: string;
+}
+
+export default class ValidationAlert extends React.Component<IValidationAlertProps, {}> {
+
+    public render() {
+        return (
+            <div className="alert alert-danger urlError" role="alert">
+                <i className="fa fa-warning" aria-hidden="true"></i>
+                <h3>The URL is invalid</h3>
+                <ul>
+                    { this.props.urlValidationError.split(".").map(
+                        (message: string) => (message.length > 0) ? <li>{message}</li> : null)
+                    }
+                </ul>
+            </div>
+        );
+    }
+
+}

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -34,7 +34,6 @@ import LazyLoadedTableCell from "shared/lib/LazyLoadedTableCell";
 
 export interface IMutationTableProps {
     studyId?:string;
-    sampleIds?:string[];
     discreteCNACache?:DiscreteCNACache;
     oncoKbEvidenceCache?:OncoKbEvidenceCache;
     mrnaExprRankCache?:MrnaExprRankCache;
@@ -140,15 +139,6 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
         this.generateColumns();
     }
 
-    protected getSamples():string[] {
-        if (this.props.sampleIds) {
-            return this.props.sampleIds as string[];
-        }
-        else {
-            return [];
-        }
-    }
-
     protected generateColumns() {
         this._columns = {};
 
@@ -223,32 +213,32 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
 
         this._columns[MutationTableColumnType.REF_READS_N] = {
             name: "Ref Reads (N)",
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalRefCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalRefCount"),
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, [d[0].sampleId], "normalRefCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, [d[0].sampleId], "normalRefCount"),
             sortBy:(d:Mutation[])=>d.map(m=>m.normalRefCount),
             visible: false
         };
 
         this._columns[MutationTableColumnType.VAR_READS_N] = {
             name: "Variant Reads (N)",
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalAltCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalAltCount"),
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, [d[0].sampleId], "normalAltCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, [d[0].sampleId], "normalAltCount"),
             sortBy:(d:Mutation[])=>d.map(m=>m.normalAltCount),
             visible: false
         };
 
         this._columns[MutationTableColumnType.REF_READS] = {
             name: "Ref Reads",
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorRefCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorRefCount"),
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, [d[0].sampleId], "tumorRefCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, [d[0].sampleId], "tumorRefCount"),
             sortBy:(d:Mutation[])=>d.map(m=>m.tumorRefCount),
             visible: false
         };
 
         this._columns[MutationTableColumnType.VAR_READS] = {
             name: "Variant Reads",
-            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorAltCount"),
-            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorAltCount"),
+            render: (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, [d[0].sampleId], "tumorAltCount"),
+            download: (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, [d[0].sampleId], "tumorAltCount"),
             sortBy:(d:Mutation[])=>d.map(m=>m.tumorAltCount),
             visible: false
         };

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -1,0 +1,44 @@
+import {fetchCosmicData, fetchOncoKbData} from "./StoreUtils";
+import { assert } from 'chai';
+import sinon from 'sinon';
+import {MobxPromise} from "mobxpromise";
+import {Mutation} from "../api/generated/CBioPortalAPI";
+
+describe('StoreUtils', () => {
+
+    let mutationData: MobxPromise<Mutation[]>
+
+    before(()=>{
+        mutationData =  {
+            result: [],
+            status: 'complete' as 'complete',
+            isPending: false,
+            isError: false,
+            isComplete: true,
+            error: undefined
+        };
+    });
+
+    after(()=>{
+
+    });
+
+    it('won\'t fetch cosmic data if there are no mutations', () => {
+        const fetchStub = sinon.stub();
+        let internalClient = {
+            fetchCosmicCountsUsingPOST: fetchStub
+        };
+
+        fetchCosmicData(mutationData, internalClient as any).then((data: any) => {
+            assert.isUndefined(data);
+            assert.isFalse(fetchStub.called);
+        });
+    });
+
+    it('won\'t fetch onkokb data if there are no mutations', () => {
+        fetchOncoKbData(mutationData, {}).then((data: any)=>{
+            assert.deepEqual(data, {sampleToTumorMap: {}, indicatorMap: {}});
+        });
+    });
+
+});

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -6,10 +6,40 @@ import {Mutation} from "../api/generated/CBioPortalAPI";
 
 describe('StoreUtils', () => {
 
-    let mutationData: MobxPromise<Mutation[]>;
+    let emptyMutationData: MobxPromise<Mutation[]>;
+    let emptyUncalledMutationData: MobxPromise<Mutation[]>;
+    let mutationDataWithNoKeyword: MobxPromise<Mutation[]>;
+    let mutationDataWithKeywords: MobxPromise<Mutation[]>;
 
     before(() => {
-        mutationData =  {
+        emptyMutationData =  {
+            result: [],
+            status: 'complete' as 'complete',
+            isPending: false,
+            isError: false,
+            isComplete: true,
+            error: undefined
+        };
+
+        mutationDataWithNoKeyword =  {
+            result: [{}, {}] as Mutation[],
+            status: 'complete' as 'complete',
+            isPending: false,
+            isError: false,
+            isComplete: true,
+            error: undefined
+        };
+
+        mutationDataWithKeywords =  {
+            result: [{keyword:"one"}] as Mutation[],
+            status: 'complete' as 'complete',
+            isPending: false,
+            isError: false,
+            isComplete: true,
+            error: undefined
+        };
+
+        emptyUncalledMutationData =  {
             result: [],
             status: 'complete' as 'complete',
             isPending: false,
@@ -23,22 +53,54 @@ describe('StoreUtils', () => {
 
     });
 
-    it('won\'t fetch cosmic data if there are no mutations', () => {
-        const fetchStub = sinon.stub();
-        const internalClient = {
-            fetchCosmicCountsUsingPOST: fetchStub
-        };
+    describe('fetchCosmicCount', () => {
 
-        fetchCosmicData(mutationData, undefined, internalClient as any).then((data: any) => {
-            assert.isUndefined(data);
-            assert.isFalse(fetchStub.called);
+        it("won't fetch cosmic data if there are no mutations", (done) => {
+            const fetchStub = sinon.stub();
+            const internalClient = {
+                fetchCosmicCountsUsingPOST: fetchStub
+            };
+
+            fetchCosmicData(emptyMutationData, emptyUncalledMutationData, internalClient as any).then((data: any) => {
+                assert.isUndefined(data);
+                assert.isFalse(fetchStub.called);
+                done();
+            });
+        });
+
+        it("won't fetch cosmic data if there ARE mutations, but none with keywords", (done) => {
+            const fetchStub = sinon.stub();
+            const internalClient = {
+                fetchCosmicCountsUsingPOST: fetchStub
+            };
+
+            fetchCosmicData(mutationDataWithNoKeyword, emptyUncalledMutationData, internalClient as any).then((data: any) => {
+                assert.isUndefined(data);
+                assert.isFalse(fetchStub.called);
+                done();
+            });
+        });
+
+        it('will fetch cosmic data if there are mutations with keywords', (done) => {
+            const fetchStub = sinon.stub();
+            fetchStub.returns(Promise.resolve([]));
+
+            const internalClient = {
+                fetchCosmicCountsUsingPOST: fetchStub
+            };
+
+            fetchCosmicData(mutationDataWithKeywords, emptyUncalledMutationData, internalClient as any).then((data: any) => {
+                //assert.isUndefined(data);
+                assert.isTrue(fetchStub.called);
+                done();
+            });
         });
     });
 
-    it('won\'t fetch onkokb data if there are no mutations', () => {
-        fetchOncoKbData({}, mutationData).then((data: any) => {
+    it("won't fetch onkokb data if there are no mutations", (done) => {
+        fetchOncoKbData({}, emptyMutationData).then((data: any) => {
             assert.deepEqual(data, {sampleToTumorMap: {}, indicatorMap: {}});
+            done();
         });
     });
-
 });

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -6,9 +6,9 @@ import {Mutation} from "../api/generated/CBioPortalAPI";
 
 describe('StoreUtils', () => {
 
-    let mutationData: MobxPromise<Mutation[]>
+    let mutationData: MobxPromise<Mutation[]>;
 
-    before(()=>{
+    before(() => {
         mutationData =  {
             result: [],
             status: 'complete' as 'complete',
@@ -19,24 +19,24 @@ describe('StoreUtils', () => {
         };
     });
 
-    after(()=>{
+    after(() => {
 
     });
 
     it('won\'t fetch cosmic data if there are no mutations', () => {
         const fetchStub = sinon.stub();
-        let internalClient = {
+        const internalClient = {
             fetchCosmicCountsUsingPOST: fetchStub
         };
 
-        fetchCosmicData(mutationData, internalClient as any).then((data: any) => {
+        fetchCosmicData(mutationData, undefined, internalClient as any).then((data: any) => {
             assert.isUndefined(data);
             assert.isFalse(fetchStub.called);
         });
     });
 
     it('won\'t fetch onkokb data if there are no mutations', () => {
-        fetchOncoKbData(mutationData, {}).then((data: any)=>{
+        fetchOncoKbData({}, mutationData).then((data: any) => {
             assert.deepEqual(data, {sampleToTumorMap: {}, indicatorMap: {}});
         });
     });

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1,13 +1,16 @@
 import * as _ from 'lodash';
 import {
     GeneticProfile, Mutation, MutationFilter, default as CBioPortalAPI, DiscreteCopyNumberData,
-    DiscreteCopyNumberFilter, ClinicalData
+    DiscreteCopyNumberFilter, ClinicalData, Sample
 } from "shared/api/generated/CBioPortalAPI";
 import defaultClient from "shared/api/cbioportalClientInstance";
 import internalClient from "shared/api/cbioportalInternalClientInstance";
 import hotspot3DClient from 'shared/api/3DhotspotClientInstance';
 import hotspotClient from 'shared/api/hotspotClientInstance';
-import {CosmicMutation, default as CBioPortalAPIInternal} from "shared/api/generated/CBioPortalAPIInternal";
+import {
+    CosmicMutation, default as CBioPortalAPIInternal,
+    GisticToGene, Gistic, CopyNumberCountIdentifier, MutSig
+} from "shared/api/generated/CBioPortalAPIInternal";
 import oncokbClient from "shared/api/oncokbClientInstance";
 import {
     generateIdToIndicatorMap, generateQueryVariant, generateEvidenceQuery
@@ -17,9 +20,12 @@ import {getAlterationString} from "shared/lib/CopyNumberUtils";
 import {MobxPromise} from "mobxpromise";
 import {keywordToCosmic, indexHotspots, geneToMyCancerGenome} from "shared/lib/AnnotationUtils";
 import {IOncoKbData} from "shared/model/OncoKB";
+import {IGisticData} from "shared/model/Gistic";
+import {IMutSigData} from "shared/model/MutSig";
 import {IMyCancerGenomeData, IMyCancerGenome} from "shared/model/MyCancerGenome";
 import {IHotspotData, ICancerHotspotData} from "shared/model/CancerHotspots";
-import CancerHotspotsAPI from "../api/generated/CancerHotspotsAPI";
+import CancerHotspotsAPI from "shared/api/generated/CancerHotspotsAPI";
+import {GENETIC_PROFILE_MUTATIONS_SUFFIX, GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "shared/constants";
 
 export const ONCOKB_DEFAULT: IOncoKbData = {
     sampleToTumorMap : {},
@@ -30,6 +36,8 @@ export const HOTSPOTS_DEFAULT = {
     single: [],
     clustered: []
 };
+
+export type MutationIdGenerator = (mutation:Mutation) => string;
 
 export async function fetchMutationData(mutationFilter:MutationFilter,
                                         geneticProfileId?:string,
@@ -46,14 +54,119 @@ export async function fetchMutationData(mutationFilter:MutationFilter,
     }
 }
 
+export async function fetchClinicalData(studyId:string,
+                                        sampleIds:string[],
+                                        client:CBioPortalAPI = defaultClient)
+{
+    if (studyId && sampleIds.length > 0)
+    {
+        return await client.fetchClinicalDataUsingPOST({
+            clinicalDataType: 'SAMPLE',
+            identifiers: sampleIds.map((sampleId: string) => ({
+                entityId: sampleId,
+                studyId
+            })),
+            projection: 'DETAILED',
+        });
+    }
+    else {
+        return [];
+    }
+}
+
+export async function fetchClinicalDataForPatient(studyId:string,
+                                                  patientId:string,
+                                                  client:CBioPortalAPI = defaultClient)
+{
+    if (studyId && patientId)
+    {
+        return await client.getAllClinicalDataOfPatientInStudyUsingGET({
+            projection: 'DETAILED',
+            studyId,
+            patientId
+        });
+    }
+    else {
+        return [];
+    }
+}
+
+export async function fetchCopyNumberSegments(studyId:string,
+                                              sampleIds:string[],
+                                              client:CBioPortalAPI = defaultClient)
+{
+    if (studyId && sampleIds.length > 0)
+    {
+        return await client.fetchCopyNumberSegmentsUsingPOST({
+            sampleIdentifiers: sampleIds.map((sampleId: string) => ({
+                sampleId,
+                studyId
+            })),
+            projection: 'DETAILED',
+        });
+    }
+    else {
+        return [];
+    }
+}
+
+export async function fetchSamplesForPatient(studyId:string,
+                                             patientId?:string,
+                                             sampleId?:string,
+                                             client:CBioPortalAPI = defaultClient)
+{
+    if (studyId && patientId)
+    {
+        return await client.getAllSamplesOfPatientInStudyUsingGET({
+            studyId,
+            patientId
+        });
+    }
+    else if (studyId && sampleId)
+    {
+        return await client.getSampleInStudyUsingGET({
+            studyId,
+            sampleId
+        }).then((data:Sample) => [data]);
+    }
+    else {
+        return [];
+    }
+}
+
+export async function fetchSamples(sampleIds:MobxPromise<string[]>,
+                                   studyId:string,
+                                   client:CBioPortalAPI = defaultClient)
+{
+    if (sampleIds.result &&
+        sampleIds.result.length > 0 &&
+        studyId)
+    {
+        const sampleIdentifiers = sampleIds.result.map(
+            (sampleId: string) => ({sampleId, studyId})
+        );
+
+        return await client.fetchSamplesUsingPOST({
+            sampleIdentifiers,
+            projection: "DETAILED"
+        });
+    }
+    else {
+        return [];
+    }
+}
+
 export async function fetchCosmicData(mutationData:MobxPromise<Mutation[]>,
+                                      uncalledMutationData?:MobxPromise<Mutation[]>,
                                       client:CBioPortalAPIInternal = internalClient)
 {
-    if (!mutationData.result || mutationData.result.length === 0) {
+    const mutationDataResult = concatMutationData(mutationData, uncalledMutationData);
+
+    if (mutationDataResult.length === 0) {
         return undefined;
     }
 
-    const queryKeywords: string[] = _.uniq(_.map(mutationData.result, (mutation: Mutation) => mutation.keyword));
+    const queryKeywords: string[] = _.uniq(_.map(mutationDataResult, (mutation: Mutation) => mutation.keyword));
 
     const cosmicData: CosmicMutation[] = await client.fetchCosmicCountsUsingPOST({
         keywords: _.filter(queryKeywords, (query) => {
@@ -64,20 +177,85 @@ export async function fetchCosmicData(mutationData:MobxPromise<Mutation[]>,
     return keywordToCosmic(cosmicData);
 }
 
+export async function fetchMutSigData(studyId: string, client:CBioPortalAPIInternal = internalClient)
+{
+    const mutSigdata = await client.getSignificantlyMutatedGenesUsingGET({studyId});
+
+    const byEntrezGeneId: IMutSigData = mutSigdata.reduce((map:IMutSigData, next:MutSig) => {
+        map[next.entrezGeneId] = { qValue: next.qValue };
+        return map;
+    }, {});
+
+    return byEntrezGeneId;
+}
+
+export async function fetchGisticData(studyId: string, client:CBioPortalAPIInternal = internalClient)
+{
+    if (studyId) {
+        const gisticData = await client.getSignificantCopyNumberRegionsUsingGET({studyId});
+
+        // generate a map of <entrezGeneId, IGisticSummary[]> pairs
+        return gisticData.reduce((map: IGisticData, gistic: Gistic) => {
+            gistic.genes.forEach((gene: GisticToGene) => {
+                if (map[gene.entrezGeneId] === undefined) {
+                    map[gene.entrezGeneId] = [];
+                }
+
+                // we may have more than one entry for a gene, so using array
+                map[gene.entrezGeneId].push({
+                    amp: gistic.amp,
+                    qValue: gistic.qValue,
+                    peakGeneCount: gistic.genes.length
+                });
+            });
+
+            return map;
+        }, {});
+    }
+    else {
+        return {};
+    }
+}
+
+export async function fetchCopyNumberData(discreteCNAData:MobxPromise<DiscreteCopyNumberData[]>,
+                                          geneticProfileIdDiscrete:MobxPromise<string>,
+                                          client:CBioPortalAPIInternal = internalClient)
+{
+    const copyNumberCountIdentifiers: CopyNumberCountIdentifier[] = discreteCNAData.result ?
+        discreteCNAData.result.map((cnData: DiscreteCopyNumberData) => {
+            return {
+                alteration: cnData.alteration,
+                entrezGeneId: cnData.entrezGeneId
+            };
+        }) : [];
+
+    if (geneticProfileIdDiscrete.result && copyNumberCountIdentifiers.length > 0) {
+        return await client.fetchCopyNumberCountsUsingPOST({
+            geneticProfileId: geneticProfileIdDiscrete.result,
+            copyNumberCountIdentifiers
+        });
+    } else {
+        return [];
+    }
+}
+
 export function fetchMyCancerGenomeData(): IMyCancerGenomeData
 {
     const data:IMyCancerGenome[] = require('../../../resources/mycancergenome.json');
     return geneToMyCancerGenome(data);
 }
 
-export async function fetchOncoKbData(mutationData:MobxPromise<Mutation[]>,
-                                      sampleIdToTumorType:{[sampleId: string]: string})
+export async function fetchOncoKbData(sampleIdToTumorType:{[sampleId: string]: string},
+                                      mutationData:MobxPromise<Mutation[]>,
+                                      uncalledMutationData?:MobxPromise<Mutation[]>)
 {
-    if (!mutationData.result || mutationData.result.length === 0) {
+    const mutationDataResult = concatMutationData(mutationData, uncalledMutationData);
+
+    if (mutationDataResult.length === 0) {
         return ONCOKB_DEFAULT;
     }
 
-    const queryVariants = _.uniqBy(_.map(mutationData.result, (mutation: Mutation) => {
+    const queryVariants = _.uniqBy(_.map(mutationDataResult, (mutation: Mutation) => {
         return generateQueryVariant(mutation.gene.hugoGeneSymbol,
             sampleIdToTumorType[mutation.sampleId],
             mutation.proteinChange,
@@ -89,8 +267,8 @@ export async function fetchOncoKbData(mutationData:MobxPromise<Mutation[]>,
     return queryOncoKbData(queryVariants, sampleIdToTumorType);
 }
 
-export async function fetchCnaOncoKbData(discreteCNAData:MobxPromise<DiscreteCopyNumberData[]>,
-                                         sampleIdToTumorType:{[sampleId: string]: string},
+export async function fetchCnaOncoKbData(sampleIdToTumorType:{[sampleId: string]: string},
+                                         discreteCNAData:MobxPromise<DiscreteCopyNumberData[]>,
                                          client: OncoKbAPI = oncokbClient)
 {
     if (discreteCNAData.result && discreteCNAData.result.length > 0) {
@@ -141,22 +319,68 @@ export function findGeneticProfileIdDiscrete(geneticProfilesInStudy:MobxPromise<
         return undefined;
     }
 
-    const profile = geneticProfilesInStudy.result.find((profile: GeneticProfile) => {
-        return profile.datatype === 'DISCRETE';
+    const profile = geneticProfilesInStudy.result.find((p: GeneticProfile) => {
+        return p.datatype === 'DISCRETE';
     });
 
     return profile ? profile.geneticProfileId : undefined;
 }
 
+export function findMutationGeneticProfileId(geneticProfilesInStudy: MobxPromise<GeneticProfile[]>,
+                                             studyId:string,
+                                             suffix:string = GENETIC_PROFILE_MUTATIONS_SUFFIX)
+{
+    if (!geneticProfilesInStudy.result) {
+        return undefined;
+    }
+
+    const profile = geneticProfilesInStudy.result.find((p: GeneticProfile) => {
+        return p.geneticProfileId === `${studyId}${suffix}`;
+    });
+
+    return profile ? profile.geneticProfileId : undefined;
+}
+
+export function findUncalledMutationGeneticProfileId(geneticProfilesInStudy: MobxPromise<GeneticProfile[]>,
+                                                     studyId:string,
+                                                     suffix:string = GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX)
+{
+    return findMutationGeneticProfileId(geneticProfilesInStudy, studyId, suffix);
+}
+
+export function findMrnaRankGeneticProfileId(geneticProfilesInStudy: MobxPromise<GeneticProfile[]>)
+{
+    if (!geneticProfilesInStudy.result) {
+        return null;
+    }
+
+    const regex1 = /^.+rna_seq.*_zscores$/; // We prefer profiles that look like this
+    const regex2 = /^.*_zscores$/; // If none of the above are available, we'll look for ones like this
+    const preferredProfile: (GeneticProfile | undefined) = geneticProfilesInStudy.result.find(
+        (gp: GeneticProfile) => regex1.test(gp.geneticProfileId.toLowerCase()));
+
+    if (preferredProfile) {
+        return preferredProfile.geneticProfileId;
+    } else {
+        const fallbackProfile: (GeneticProfile | undefined) = geneticProfilesInStudy.result.find(
+            (gp: GeneticProfile) => regex2.test(gp.geneticProfileId.toLowerCase()));
+
+        return fallbackProfile ? fallbackProfile.geneticProfileId : null;
+    }
+}
+
 export async function fetchHotspotsData(mutationData:MobxPromise<Mutation[]>,
+                                        uncalledMutationData?:MobxPromise<Mutation[]>,
                                         clientSingle:CancerHotspotsAPI = hotspotClient,
                                         client3d:CancerHotspotsAPI = hotspot3DClient)
 {
-    if (!mutationData.result) {
+    const mutationDataResult = concatMutationData(mutationData, uncalledMutationData);
+
+    if (mutationDataResult.length === 0) {
         return HOTSPOTS_DEFAULT;
     }
 
-    const queryGenes:string[] = _.uniq(_.map(mutationData.result, function(mutation:Mutation) {
+    const queryGenes:string[] = _.uniq(_.map(mutationDataResult, function(mutation:Mutation) {
         if (mutation && mutation.gene) {
             return mutation.gene.hugoGeneSymbol;
         }
@@ -186,7 +410,7 @@ export function indexHotspotData(hotspotData:MobxPromise<ICancerHotspotData>): I
         return {
             single: indexHotspots(hotspotData.result.single),
             clustered: indexHotspots(hotspotData.result.clustered)
-        }
+        };
     }
     else {
         return undefined;
@@ -208,24 +432,68 @@ export function generateSampleIdToTumorTypeMap(clinicalDataForSamples: MobxPromi
     return map;
 }
 
-export function mergeMutations(mutationData:MobxPromise<Mutation[]>)
+export function mergeDiscreteCNAData(discreteCNAData:MobxPromise<DiscreteCopyNumberData[]>)
 {
-    let idToMutations: {[key: string]: Array<Mutation>} = {};
+    const idToCNAs: {[key: string]: DiscreteCopyNumberData[]} = {};
 
-    if (mutationData.result)
-    {
-        let mutationId: string;
+    if (discreteCNAData.result) {
+        for (const d of discreteCNAData.result) {
+            const cnaId: string = `${d.entrezGeneId}_${d.alteration}`;
+            idToCNAs[cnaId] = idToCNAs[cnaId] || [];
+            idToCNAs[cnaId].push(d);
+        }
+    }
 
-        let MutationId: (m: Mutation) => string = (m: Mutation) => {
-            return [m.gene.chromosome, m.startPosition, m.endPosition, m.referenceAllele, m.variantAllele].join("_");
-        };
+    return Object.keys(idToCNAs).map((id:string) => idToCNAs[id]);
+}
 
+export function mergeMutations(mutationData:MobxPromise<Mutation[]>,
+                               generateMutationId:MutationIdGenerator = generateMutationIdByEvent)
+{
+    const idToMutations: {[key: string]: Mutation[]} = {};
+
+    updateIdToMutationsMap(idToMutations, mutationData, generateMutationId);
+
+    return Object.keys(idToMutations).map((id:string) => idToMutations[id]);
+}
+
+export function mergeMutationsIncludingUncalled(mutationData:MobxPromise<Mutation[]>,
+                                                uncalledMutationData:MobxPromise<Mutation[]>,
+                                                generateMutationId:MutationIdGenerator = generateMutationIdByEvent)
+{
+    const idToMutations: {[key: string]: Mutation[]} = {};
+
+    updateIdToMutationsMap(idToMutations, mutationData, generateMutationId);
+    updateIdToMutationsMap(idToMutations, uncalledMutationData, generateMutationId);
+
+    return Object.keys(idToMutations).map((id:string) => idToMutations[id]);
+}
+
+function updateIdToMutationsMap(idToMutations: {[key: string]: Mutation[]},
+                                mutationData:MobxPromise<Mutation[]>,
+                                generateMutationId:MutationIdGenerator = generateMutationIdByEvent)
+{
+    if (mutationData.result) {
         for (const mutation of mutationData.result) {
-            mutationId = MutationId(mutation);
+            const mutationId = generateMutationId(mutation);
             idToMutations[mutationId] = idToMutations[mutationId] || [];
             idToMutations[mutationId].push(mutation);
         }
     }
+}
 
-    return Object.keys(idToMutations).map(id => idToMutations[id]);
+export function concatMutationData(mutationData?:MobxPromise<Mutation[]>,
+                                   uncalledMutationData?:MobxPromise<Mutation[]>): Mutation[]
+{
+    const mutationDataResult:Mutation[] = mutationData && mutationData.result ?
+        mutationData.result : [];
+
+    const uncalledMutationDataResult:Mutation[] = uncalledMutationData && uncalledMutationData.result ?
+        uncalledMutationData.result : [];
+
+    return mutationDataResult.concat(uncalledMutationDataResult);
+}
+
+export function generateMutationIdByEvent(m: Mutation): string {
+    return [m.gene.chromosome, m.startPosition, m.endPosition, m.referenceAllele, m.variantAllele].join("_");
 }

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -166,15 +166,25 @@ export async function fetchCosmicData(mutationData:MobxPromise<Mutation[]>,
         return undefined;
     }
 
-    const queryKeywords: string[] = _.uniq(_.map(mutationDataResult, (mutation: Mutation) => mutation.keyword));
+    // we have to check and see if keyword property is present
+    // it is NOT present sometimes
+    const queryKeywords: string[] =
+        _.chain(mutationDataResult)
+            .filter((mutation: Mutation) => mutation.hasOwnProperty('keyword'))
+            .map((mutation: Mutation) => mutation.keyword)
+            .uniq().value();
 
-    const cosmicData: CosmicMutation[] = await client.fetchCosmicCountsUsingPOST({
-        keywords: _.filter(queryKeywords, (query) => {
-            return query != null;
-        })
-    });
+    if (queryKeywords.length > 0)
+    {
+        const cosmicData: CosmicMutation[] = await client.fetchCosmicCountsUsingPOST({
+            keywords: _.filter(queryKeywords, (query: string) => query != null)
+        });
 
-    return keywordToCosmic(cosmicData);
+        return keywordToCosmic(cosmicData);
+    }
+    else {
+        return undefined;
+    }
 }
 
 export async function fetchMutSigData(studyId: string, client:CBioPortalAPIInternal = internalClient)

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1,0 +1,231 @@
+import * as _ from 'lodash';
+import {
+    GeneticProfile, Mutation, MutationFilter, default as CBioPortalAPI, DiscreteCopyNumberData,
+    DiscreteCopyNumberFilter, ClinicalData
+} from "shared/api/generated/CBioPortalAPI";
+import defaultClient from "shared/api/cbioportalClientInstance";
+import internalClient from "shared/api/cbioportalInternalClientInstance";
+import hotspot3DClient from 'shared/api/3DhotspotClientInstance';
+import hotspotClient from 'shared/api/hotspotClientInstance';
+import {CosmicMutation, default as CBioPortalAPIInternal} from "shared/api/generated/CBioPortalAPIInternal";
+import oncokbClient from "shared/api/oncokbClientInstance";
+import {
+    generateIdToIndicatorMap, generateQueryVariant, generateEvidenceQuery
+} from "shared/lib/OncoKbUtils";
+import {Query, default as OncoKbAPI} from "shared/api/generated/OncoKbAPI";
+import {getAlterationString} from "shared/lib/CopyNumberUtils";
+import {MobxPromise} from "mobxpromise";
+import {keywordToCosmic, indexHotspots, geneToMyCancerGenome} from "shared/lib/AnnotationUtils";
+import {IOncoKbData} from "shared/model/OncoKB";
+import {IMyCancerGenomeData, IMyCancerGenome} from "shared/model/MyCancerGenome";
+import {IHotspotData, ICancerHotspotData} from "shared/model/CancerHotspots";
+import CancerHotspotsAPI from "../api/generated/CancerHotspotsAPI";
+
+export const ONCOKB_DEFAULT: IOncoKbData = {
+    sampleToTumorMap : {},
+    indicatorMap : {}
+};
+
+export const HOTSPOTS_DEFAULT = {
+    single: [],
+    clustered: []
+};
+
+export async function fetchMutationData(mutationFilter:MutationFilter,
+                                        geneticProfileId?:string,
+                                        client:CBioPortalAPI = defaultClient)
+{
+    if (geneticProfileId) {
+        return await client.fetchMutationsInGeneticProfileUsingPOST({
+            geneticProfileId,
+            mutationFilter,
+            projection: "DETAILED"
+        });
+    } else {
+        return [];
+    }
+}
+
+export async function fetchCosmicData(mutationData:MobxPromise<Mutation[]>,
+                                      client:CBioPortalAPIInternal = internalClient)
+{
+    if (!mutationData.result || mutationData.result.length === 0) {
+        return undefined;
+    }
+
+    const queryKeywords: string[] = _.uniq(_.map(mutationData.result, (mutation: Mutation) => mutation.keyword));
+
+    const cosmicData: CosmicMutation[] = await client.fetchCosmicCountsUsingPOST({
+        keywords: _.filter(queryKeywords, (query) => {
+            return query != null;
+        })
+    });
+
+    return keywordToCosmic(cosmicData);
+}
+
+export function fetchMyCancerGenomeData(): IMyCancerGenomeData
+{
+    const data:IMyCancerGenome[] = require('../../../resources/mycancergenome.json');
+    return geneToMyCancerGenome(data);
+}
+
+export async function fetchOncoKbData(mutationData:MobxPromise<Mutation[]>,
+                                      sampleIdToTumorType:{[sampleId: string]: string})
+{
+    if (!mutationData.result || mutationData.result.length === 0) {
+        return ONCOKB_DEFAULT;
+    }
+
+    const queryVariants = _.uniqBy(_.map(mutationData.result, (mutation: Mutation) => {
+        return generateQueryVariant(mutation.gene.hugoGeneSymbol,
+            sampleIdToTumorType[mutation.sampleId],
+            mutation.proteinChange,
+            mutation.mutationType,
+            mutation.proteinPosStart,
+            mutation.proteinPosEnd);
+    }), "id");
+
+    return queryOncoKbData(queryVariants, sampleIdToTumorType);
+}
+
+export async function fetchCnaOncoKbData(discreteCNAData:MobxPromise<DiscreteCopyNumberData[]>,
+                                         sampleIdToTumorType:{[sampleId: string]: string},
+                                         client: OncoKbAPI = oncokbClient)
+{
+    if (discreteCNAData.result && discreteCNAData.result.length > 0) {
+        const queryVariants = _.uniqBy(_.map(discreteCNAData.result, (copyNumberData: DiscreteCopyNumberData) => {
+            return generateQueryVariant(copyNumberData.gene.hugoGeneSymbol,
+                sampleIdToTumorType[copyNumberData.sampleId],
+                getAlterationString(copyNumberData.alteration));
+        }), "id");
+        return queryOncoKbData(queryVariants, sampleIdToTumorType, client);
+    } else {
+        return ONCOKB_DEFAULT;
+    }
+}
+
+export async function queryOncoKbData(queryVariants: Query[],
+                                      sampleIdToTumorType: {[sampleId: string]: string},
+                                      client: OncoKbAPI = oncokbClient)
+{
+    const onkokbSearch = await client.searchPostUsingPOST(
+        {body: generateEvidenceQuery(queryVariants)});
+
+    const oncoKbData: IOncoKbData = {
+        sampleToTumorMap: sampleIdToTumorType,
+        indicatorMap: generateIdToIndicatorMap(onkokbSearch)
+    };
+
+    return oncoKbData;
+}
+
+export async function fetchDiscreteCNAData(discreteCopyNumberFilter:DiscreteCopyNumberFilter,
+                                           geneticProfileIdDiscrete:MobxPromise<string>,
+                                           client:CBioPortalAPI = defaultClient)
+{
+    if (geneticProfileIdDiscrete.isComplete && geneticProfileIdDiscrete.result) {
+        return await client.fetchDiscreteCopyNumbersInGeneticProfileUsingPOST({
+            projection: 'DETAILED',
+            discreteCopyNumberFilter,
+            geneticProfileId: geneticProfileIdDiscrete.result
+        });
+    } else {
+        return [];
+    }
+}
+
+export function findGeneticProfileIdDiscrete(geneticProfilesInStudy:MobxPromise<GeneticProfile[]>)
+{
+    if (!geneticProfilesInStudy.result) {
+        return undefined;
+    }
+
+    const profile = geneticProfilesInStudy.result.find((profile: GeneticProfile) => {
+        return profile.datatype === 'DISCRETE';
+    });
+
+    return profile ? profile.geneticProfileId : undefined;
+}
+
+export async function fetchHotspotsData(mutationData:MobxPromise<Mutation[]>,
+                                        clientSingle:CancerHotspotsAPI = hotspotClient,
+                                        client3d:CancerHotspotsAPI = hotspot3DClient)
+{
+    if (!mutationData.result) {
+        return HOTSPOTS_DEFAULT;
+    }
+
+    const queryGenes:string[] = _.uniq(_.map(mutationData.result, function(mutation:Mutation) {
+        if (mutation && mutation.gene) {
+            return mutation.gene.hugoGeneSymbol;
+        }
+        else {
+            return "";
+        }
+    }));
+
+    const [dataSingle, data3d] = await Promise.all([
+        clientSingle.fetchSingleResidueHotspotMutationsByGenePOST({
+            hugoSymbols: queryGenes
+        }),
+        client3d.fetch3dHotspotMutationsByGenePOST({
+            hugoSymbols: queryGenes
+        })
+    ]);
+
+    return {
+        single: dataSingle,
+        clustered: data3d
+    };
+}
+
+export function indexHotspotData(hotspotData:MobxPromise<ICancerHotspotData>): IHotspotData|undefined
+{
+    if (hotspotData.result) {
+        return {
+            single: indexHotspots(hotspotData.result.single),
+            clustered: indexHotspots(hotspotData.result.clustered)
+        }
+    }
+    else {
+        return undefined;
+    }
+}
+
+export function generateSampleIdToTumorTypeMap(clinicalDataForSamples: MobxPromise<ClinicalData[]>): {[sampleId: string]: string}
+{
+    const map: {[sampleId: string]: string} = {};
+
+    if (clinicalDataForSamples.result) {
+        _.each(clinicalDataForSamples.result, (clinicalData:ClinicalData) => {
+            if (clinicalData.clinicalAttributeId === "CANCER_TYPE") {
+                map[clinicalData.entityId] = clinicalData.value;
+            }
+        });
+    }
+
+    return map;
+}
+
+export function mergeMutations(mutationData:MobxPromise<Mutation[]>)
+{
+    let idToMutations: {[key: string]: Array<Mutation>} = {};
+
+    if (mutationData.result)
+    {
+        let mutationId: string;
+
+        let MutationId: (m: Mutation) => string = (m: Mutation) => {
+            return [m.gene.chromosome, m.startPosition, m.endPosition, m.referenceAllele, m.variantAllele].join("_");
+        };
+
+        for (const mutation of mutationData.result) {
+            mutationId = MutationId(mutation);
+            idToMutations[mutationId] = idToMutations[mutationId] || [];
+            idToMutations[mutationId].push(mutation);
+        }
+    }
+
+    return Object.keys(idToMutations).map(id => idToMutations[id]);
+}

--- a/src/shared/model/CancerHotspots.ts
+++ b/src/shared/model/CancerHotspots.ts
@@ -16,3 +16,8 @@ export interface IHotspotData {
     single: IHotspotIndex,
     clustered: IHotspotIndex
 }
+
+export interface ICancerHotspotData {
+    single: HotspotMutation[],
+    clustered: HotspotMutation[]
+}


### PR DESCRIPTION
- added a new `ResultsViewPage` with a separate `ResultsViewPageStore`: Currently we have a single table with all mutations
- added a new route for results page -- example:  http://localhost:3000/#/query?geneList=BRCA1%20BRCA2&sampleListId=ov_tcga_pub_3way_complete&studyId=ov_tcga_pub
- extracted some of the store's `invoke` functions into `StoreUtils` for reuse purposes
- made results view page specific table columns fully functional

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)