### PR TITLE
Handle non-existent genetic profiles for mutations

### DIFF
--- a/src/shared/cache/MutationCountCache.ts
+++ b/src/shared/cache/MutationCountCache.ts
@@ -2,14 +2,18 @@ import client from "../api/cbioportalClientInstance";
 import LazyMobXCache from "../lib/LazyMobXCache";
 import {MutationCount} from "../api/generated/CBioPortalAPI";
 
-function fetch(sampleIds:string[], geneticProfileId:string):Promise<MutationCount[]> {
-    return client.fetchMutationCountsInGeneticProfileUsingPOST({
-        geneticProfileId,
-        sampleIds
-    });
+function fetch(sampleIds:string[], geneticProfileId:string|undefined):Promise<MutationCount[]> {
+    if (!geneticProfileId) {
+        return Promise.reject("No mutation genetic profile id given");
+    } else {
+        return client.fetchMutationCountsInGeneticProfileUsingPOST({
+            geneticProfileId,
+            sampleIds
+        });
+    }
 }
 export default class MutationCountCache extends LazyMobXCache<MutationCount, string> {
-    constructor(geneticProfileId:string) {
+    constructor(geneticProfileId:string|undefined) {
         super(q=>q, (d:MutationCount)=>d.sampleId, fetch, geneticProfileId);
     }
 }

--- a/src/shared/cache/VariantCountCache.ts
+++ b/src/shared/cache/VariantCountCache.ts
@@ -10,8 +10,10 @@ function getKey<T extends { entrezGeneId:number, keyword?:string}>(obj:T):string
     }
 }
 
-function fetch(queries:VariantCountIdentifier[], mutationGeneticProfileId:string):Promise<VariantCount[]> {
-    if (queries.length > 0) {
+function fetch(queries:VariantCountIdentifier[], mutationGeneticProfileId:string|undefined):Promise<VariantCount[]> {
+    if (!mutationGeneticProfileId) {
+        return Promise.reject("No mutation genetic profile id given");
+    } else if (queries.length > 0) {
         return client.fetchVariantCountsUsingPOST({
             geneticProfileId: mutationGeneticProfileId,
             variantCountIdentifiers: queries
@@ -22,7 +24,7 @@ function fetch(queries:VariantCountIdentifier[], mutationGeneticProfileId:string
 }
 
 export default class VariantCountCache extends LazyMobXCache<VariantCount, VariantCountIdentifier> {
-    constructor(mutationGeneticProfileId:string) {
+    constructor(mutationGeneticProfileId:string|undefined) {
         super(getKey, getKey,
             fetch, mutationGeneticProfileId);
     }


### PR DESCRIPTION
If a mutation profile did not exist, you would get a 404 on patient view. This
instead first checks what genetic profiles are available for the patient.