### PR TITLE
Improve cache by supporting metadata

### DIFF
--- a/src/shared/components/annotation/OncoKbTooltip.tsx
+++ b/src/shared/components/annotation/OncoKbTooltip.tsx
@@ -44,18 +44,16 @@ export default class OncoKbTooltip extends React.Component<IOncoKbTooltipProps, 
 
     public get pmidData():ICache<any>
     {
-        let pmidData: ICache<any> = {};
-
         if (this.props.pmidCache && this.evidenceCacheData)
         {
             const refs = extractPmids(this.evidenceCacheData.data);
 
-            if (refs.length > 0) {
-                pmidData = this.props.pmidCache.getData(refs.map((ref:number) => ref.toString()), refs);
+            for (const ref of refs) {
+                this.props.pmidCache.get(ref);
             }
         }
 
-        return pmidData;
+        return (this.props.pmidCache && this.props.pmidCache.cache) || {};
     }
 
     public render()

--- a/src/shared/lib/LazyLoadedTableCell.tsx
+++ b/src/shared/lib/LazyLoadedTableCell.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import {CacheData} from "./LazyMobXCache";
 import {TableCellStatus, default as TableCellStatusIndicator} from "../components/TableCellStatus";
-export default function LazyLoadedTableCell<D,T>(
-    getCacheData:(d:D)=>CacheData<T>|null,
+export default function LazyLoadedTableCell<D,T,M=any>(
+    getCacheData:(d:D)=>CacheData<T,M>|null,
     render:(t:T)=>JSX.Element,
     naAlt?:string
 ):(d:D)=>JSX.Element {
     return (d:D)=>{
-        const cacheData:CacheData<T>|null = getCacheData(d);
+        const cacheData:CacheData<T,M>|null = getCacheData(d);
         if (cacheData === null) {
             return (
                 <TableCellStatusIndicator


### PR DESCRIPTION
Use case: info that you want to use for indexing fetched data is available at fetch time, but not actually in the data itself (e.g. you fetch by study, but then the data doesn't echo 'studyId'). So this allows the fetcher to associate such metadata with the data which can then be used for indexing.

This PR then uses this capability to reimplement PmidCache

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)