### PR TITLE
Add extra visual indicators for uncalled mutations

### DIFF
--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -10,7 +10,7 @@ import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
 import {Column} from "shared/components/lazyMobXTable/LazyMobXTable";
 import ProteinChangeColumnFormatter from "./column/ProteinChangeColumnFormatter";
-import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "../../../shared/constants";
+import {isUncalled} from "../../../shared/lib/mutationUtils";
 
 export interface IPatientViewMutationTableProps extends IMutationTableProps {
     sampleManager:SampleManager | null;
@@ -117,7 +117,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
     @computed private get hasUncalledMutations():boolean {
         return this.props.data.some((row:Mutation[]) => {
             return row.some((m:Mutation) => {
-                return Boolean(m.geneticProfileId && m.geneticProfileId.endsWith(GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX));
+                return isUncalled(m.geneticProfileId);
             });
         });
     }

--- a/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.tsx
+++ b/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.tsx
@@ -1,21 +1,55 @@
-import * as AlleleFreqColumnFormatter from './AlleleFreqColumnFormatter';
+import AlleleFreqColumnFormatter from './AlleleFreqColumnFormatter';
+import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX, GENETIC_PROFILE_MUTATIONS_SUFFIX} from '../../../../shared/constants';
 import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
-describe('AlleleFreqColumnFormatter', () => {
+describe.only('AlleleFreqColumnFormatter', () => {
 
-    before(()=>{
-
-    });
-
-    after(()=>{
+    before(()=> {
 
     });
 
-    it('what does it do?', ()=>{
+    after(()=> {
 
     });
 
+    it('uncalled mutations component w/o reads should have 0 opacity', ()=> {
+        const uncalledMutationWithoutSupport = {
+            geneticProfileId:`study_${GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX}`,
+            tumorAltCount:0,
+            tumorRefCount:10
+        };
+        const res = AlleleFreqColumnFormatter.getComponentForSampleArgs(uncalledMutationWithoutSupport);
+        assert(res.opacity === 0);
+    });
+    it('uncalled mutations component w supporting reads should have >0 and <1 opacity', ()=> {
+        const uncalledMutationWithSupport = {
+            geneticProfileId:`study_${GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX}`,
+            tumorAltCount:1,
+            tumorRefCount:10
+        };
+        const res = AlleleFreqColumnFormatter.getComponentForSampleArgs(uncalledMutationWithSupport);
+        assert(res.opacity > 0 && res.opacity < 1);
+    });
+    it('called mutations component w supporting reads should have 1 opacity', ()=> {
+        const calledMutation = {
+            geneticProfileId:`study_${GENETIC_PROFILE_MUTATIONS_SUFFIX}`,
+            tumorAltCount:1,
+            tumorRefCount:10
+        };
+        const res = AlleleFreqColumnFormatter.getComponentForSampleArgs(calledMutation);
+        assert(res.opacity === 1);
+    });
+    it('sampleElement should have the text (uncalled)', ()=> {
+        const uncalledMutationWithSupport = {
+            sampleId:'1',
+            geneticProfileId:`study_${GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX}`,
+            tumorAltCount:1,
+            tumorRefCount:10
+        };
+        const res = AlleleFreqColumnFormatter.convertMutationToSampleElement(uncalledMutationWithSupport, 'red', 5, {});
+        assert(res && mount(res.text).text().indexOf('(uncalled)') !== -1);
+    });
 });

--- a/src/pages/patientView/mutation/column/TumorColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/TumorColumnFormatter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import SampleManager from "../../sampleManager";
-import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from '../../../../shared/constants';
+import {isUncalled} from '../../../../shared/lib/mutationUtils';
 
 
 export default class TumorColumnFormatter {
@@ -20,7 +20,10 @@ export default class TumorColumnFormatter {
                 return (
                     <li className={(sample.id in presentSamples) ? '' : 'invisible'}>
                         {
-                        sampleManager.getComponentForSample(sample.id, (presentSamples[sample.id]) ? 1 : 0.1)
+                        sampleManager.getComponentForSample(sample.id,
+                                                            (presentSamples[sample.id]) ? 1 : 0.1,
+                                                            (presentSamples[sample.id]) ? '' : "Mutation has supporting reads, but wasn't called"
+                                                            )
                         }
                     </li>
                 );
@@ -54,7 +57,7 @@ export default class TumorColumnFormatter {
             // Indicate called mutations with true,
             // uncalled mutations with supporting reads as false
             // exclude uncalled mutations without supporting reads completely
-            if (next.geneticProfileId && next.geneticProfileId.endsWith(GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX)) {
+            if (next.geneticProfileId && isUncalled(next.geneticProfileId)) {
                 if (next.tumorAltCount && next.tumorAltCount > 0) {
                     map[next.sampleId] = false;
                 }

--- a/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
+++ b/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
@@ -62,7 +62,6 @@ $sample-color-xenograft: pink;
     /* Order sample clinical attributes (they don't exist for patient) */
     .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"] {
         order: 1;
-        text-transform: capitalize;
     }
     .clinical-attribute[attr-id="DERIVED_SAMPLE_LOCATION"] {
         order: 2;

--- a/src/pages/patientView/sampleManager.tsx
+++ b/src/pages/patientView/sampleManager.tsx
@@ -132,13 +132,13 @@ class SampleManager {
         this.sampleOrder = _.sortBy(Object.keys(this.sampleIndex), (k) => this.sampleIndex[k]);
     }
 
-    getComponentForSample(sampleId: string, fillOpacity: number = 1) {
+    getComponentForSample(sampleId: string, fillOpacity: number = 1, extraText: string = '') {
 
         let sample = _.find(this.samples, (s: ClinicalDataBySampleId)=> {
             return s.id === sampleId;
         });
 
-        return sample && this.getOverlayTriggerSample(sample, this.sampleIndex[sample.id], this.sampleColors[sample.id], fillOpacity=fillOpacity);
+        return sample && this.getOverlayTriggerSample(sample, this.sampleIndex[sample.id], this.sampleColors[sample.id], fillOpacity=fillOpacity, extraText=extraText);
 
     }
 
@@ -154,36 +154,47 @@ class SampleManager {
         this.samples.map((sample)=>this.getComponentForSample(sample.id));
     }
 
-    getOverlayTriggerSample(sample: ClinicalDataBySampleId, sampleIndex: number, sampleColor: string, fillOpacity: number = 1) {
+    getOverlayTriggerSample(sample: ClinicalDataBySampleId, sampleIndex: number, sampleColor: string, fillOpacity: number = 1, extraText: string = '') {
 
         const sampleNumberText: number = sampleIndex+1;
 
         return (<DefaultTooltip
             placement='bottomLeft'
             trigger={['hover', 'focus']}
-            overlay={this.getPopoverSample(sample, sampleNumberText)}
+            overlay={this.getPopoverSample(sample, sampleNumberText, sampleColor, fillOpacity, extraText)}
             arrowContent={<div className="rc-tooltip-arrow-inner" />}
             destroyTooltipOnHide={false}
             onPopupAlign={placeArrow}
             >
                 <svg height="12" width="12">
                 <SampleInline
-                             sample={sample}
-                             sampleNumber={sampleNumberText}
-                             sampleColor={sampleColor}
-                             fillOpacity={fillOpacity}
-                         >
-                </SampleInline>
+                    sample={sample}
+                    sampleNumber={sampleNumberText}
+                    sampleColor={sampleColor}
+                    fillOpacity={fillOpacity}
+                />
                 </svg>
 
         </DefaultTooltip>);
 
     }
 
-    getPopoverSample(sample: ClinicalDataBySampleId, sampleNumber: number) {
+    getPopoverSample(sample: ClinicalDataBySampleId, sampleNumber: number, sampleColor:string, fillOpacity: number, extraText: string) {
+
         return (
             <div style={{ maxHeight:400, overflow:'auto' }}>
-                <h5>{ sample.id }</h5>
+                <h5 style={{ marginBottom: 1 }}>
+                    <svg height="12" width="12" style={{ marginRight: 5}}>
+                        <SampleInline
+                            sample={sample}
+                            sampleNumber={sampleNumber}
+                            sampleColor={sampleColor}
+                            fillOpacity={fillOpacity}
+                        />
+                    </svg>
+                    { sample.id }
+                </h5>
+                <span style={{ marginBottom: 4}}>{ extraText }</span>
                 <ClinicalInformationPatientTable showTitleBar={false} data={sample.clinicalData} />
             </div>
         );

--- a/src/shared/lib/mutationUtils.ts
+++ b/src/shared/lib/mutationUtils.ts
@@ -1,0 +1,6 @@
+import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "../constants";
+
+export function isUncalled(geneticProfileId:string) {
+    const r = new RegExp(GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX + "$");
+    return r.test(geneticProfileId);
+}


### PR DESCRIPTION
- On mouseover of label in mutation table indicate the mutation wasn't called

![screen shot 2017-05-23 at 3 28 11 pm](https://cloud.githubusercontent.com/assets/1334004/26372595/7b7bf99c-3fcc-11e7-9ebe-b984d5cf74f4.png)

- In allele freq mouseover indicate which mutations were not called
![screen shot 2017-05-24 at 6 36 23 pm](https://cloud.githubusercontent.com/assets/1334004/26428483/eee04756-40af-11e7-8083-b75f30aef15b.png)

