### PR TITLE
Exclude invalid position mutations from lollipop plot

### DIFF
--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -221,6 +221,10 @@ export default class LollipopMutationPlot extends React.Component<LollipopMutati
         for (let i=0; i<positionMutations.length; i++) {
             const mutations = positionMutations[i];
             const codon = mutations[0].proteinPosStart;
+            if (isNaN(codon) || codon < 0 || (this.pfamGeneData.isComplete && (codon > this.pfamGeneData.result.length))) {
+                // invalid position
+                continue;
+            }
             let label:string|undefined;
             if (i < numLabelsToShow && mutations.length >= minMutationsToShowLabel) {
                 label = this.lollipopLabel(mutations);


### PR DESCRIPTION
This should catch fusions as well - any mutation without a well defined position.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)