### PR TITLE
Fix PmidCache bug - not wrapping AugmentedData correctly

### DIFF
--- a/src/shared/cache/PmidCache.ts
+++ b/src/shared/cache/PmidCache.ts
@@ -2,26 +2,83 @@ import LazyMobXCache from "../lib/LazyMobXCache";
 import {AugmentedData} from "../lib/LazyMobXCache";
 import request from "superagent";
 
-async function fetch(pmids: number[])
+export type PmidData = {
+        [pmid:string]:PmidDatum;
+};
+
+export type PmidDatum = {
+    uid: string,
+    pubdate: string,
+    epubdate: string,
+    source: string,
+    authors: { name: string, authtype: string, clusterid: string}[],
+    lastauthor: string,
+    title: string,
+    sorttitle: string,
+    volume: string,
+    issue: string,
+    pages: string,
+    lang: string[],
+    nlmuniqueid: string,
+    issn: string,
+    essn: string,
+    pubtype: string,
+    recordstatus: string,
+    pubstatus:string,
+    articleids: { idtype: string, idtypen: number, value: string}[],
+    history: { pubstatus:string, date:string }[],
+    references: { refsource: string, reftype: string, pmid: number, note: string }[],
+    attributes: string[],
+    pmcrefcount: number,
+    fulljournalname: string,
+    elocationid: string,
+    doctype: string,
+    srccontriblist:any[],
+    booktitle: string,
+    medium: string,
+    edition: string,
+    publisherlocation: string,
+    publishername: string,
+    srcdate: string,
+    reportnumber: string,
+    availablefromurl:string,
+    locationlabel: string,
+    doccontriblist:any[],
+    docdate: string,
+    bookname: string,
+    chapter: string,
+    sortpubdate: string,
+    sortfirstauthor: string,
+    vernaculartitle:string
+};
+
+async function fetch(pmids: number[]):Promise<AugmentedData<PmidDatum, string>[]>
 {
-        const pmidData:any = await new Promise((resolve, reject) => {
+        const pmidData:PmidData = await new Promise<PmidData>((resolve, reject) => {
             // TODO better to separate this call to a configurable client
             request.post('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json')
                 .type("form")
                 .send({id: pmids.join(',')})
                 .end((err, res)=>{
                     if (!err && res.ok) {
-                        resolve(JSON.parse(res.text));
+                        const response = JSON.parse(res.text);
+                        const result = response.result;
+                        const uids = result.uids;
+                        const ret:PmidData = {};
+                        for (let uid of uids) {
+                            ret[uid] = result[uid];
+                        }
+                        resolve(ret);
                     } else {
                         reject(err);
                     }
                 });
         });
 
-        const ret:AugmentedData<any, string>[] = [];
+        const ret:AugmentedData<PmidDatum, string>[] = [];
         for (const pmidStr of Object.keys(pmidData)) {
             ret.push({
-                data: pmidData[pmidStr],
+                data: [pmidData[pmidStr]],
                 meta: pmidStr
             });
         }
@@ -29,7 +86,7 @@ async function fetch(pmids: number[])
         return ret;
 }
 
-export default class PmidCache extends LazyMobXCache<number, any, string>
+export default class PmidCache extends LazyMobXCache<PmidDatum, number, string>
 {
     constructor()
     {


### PR DESCRIPTION
Typescript didnt catch it because of `any` typing the server response.

As a way of adding what testing should have caught this, I've added a type for the pmid result, which catches this.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)