### PR TITLE
Removed DataSets table row limit

### DIFF
--- a/src/pages/datasetView/DatasetList.tsx
+++ b/src/pages/datasetView/DatasetList.tsx
@@ -154,6 +154,7 @@ export default class DataSetsPageTable extends React.Component <IDataSetsTablePr
                         showColumnVisibility={true}
                         showFilter={true}
                         showCopyDownload={false}
+                        initialItemsPerPage={this.props.datasets.length}
                     />
                 </div>
             );


### PR DESCRIPTION
# What? Why?
Fix issue where DataSets table was limiting number of studies to 50. DataSets table now shows all studies.

Resolved https://github.com/cBioPortal/cbioportal/issues/2550

