### PR TITLE
Only override hash params if none exist

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -24,7 +24,7 @@ import Timeline from "./timeline/Timeline";
 import {default as PatientViewMutationTable} from "./mutation/PatientViewMutationTable";
 import PathologyReport from "./pathologyReport/PathologyReport";
 import { MSKTabs, MSKTab } from "../../shared/components/MSKTabs/MSKTabs";
-import validateParameters from '../../shared/lib/validateParameters';
+import { validateParametersPatientView } from '../../shared/lib/validateParameters';
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
 import ValidationAlert from "shared/components/ValidationAlert";
 import AjaxErrorModal from "shared/components/AjaxErrorModal";
@@ -60,7 +60,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
             () => props.routing.location.query,
             query => {
 
-                const validationResult = validateParameters(query, [ 'studyId', ['sampleId', 'caseId']]);
+                const validationResult = validateParametersPatientView(query);
 
                 if (validationResult.isValid) {
 

--- a/src/shared/lib/validateParameters.ts
+++ b/src/shared/lib/validateParameters.ts
@@ -6,7 +6,11 @@ export interface URLValidationResult {
     message:string | null
 }
 
-export default function(params: { [k:string]: string }, rules:(string | string[])[]): URLValidationResult {
+export function validateParametersPatientView(params: { [k:string]: string} ): URLValidationResult {
+    return validateParameters(params, ['studyId', ['sampleId', 'caseId']]);
+}
+
+export default function validateParameters(params: { [k:string]: string }, rules:(string | string[])[]): URLValidationResult {
 
     // we want to interpret empty string as missing
     let cleanedParams = _.reduce(params,(memo: { [k:string]: string }, paramVal, paramKey)=>{


### PR DESCRIPTION
e.g. use sampleId in this case instead of `case_id`

http://localhost:3000/?cancer_study_id=lgg_ucsf_2014&case_id=P04#/patient?sampleId=P04_Pri&studyId=lgg_ucsf_2014

No checking is done whether the hash is actually valid, which might be better