### PR TITLE
Add test for TS swagger client generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4.4.7"
+  - "v6.11.0"
 env:
   - CXX=g++-4.8
 addons:
@@ -17,16 +17,8 @@ install:
   # install codecov.io
   - npm install codecov.io
 script:
-  - echo 'API_ROOT=http://cbioportal-rc.herokuapp.com/api' > .env
-  # make sure json is in sync on master and rc branch (since these are branches
-  # about to be deployed)
-  - |
-      if [ "${TRAVIS_BRANCH}" == "master" ] || [[ "${TRAVIS_BRANCH}" =~ ^rc.* ]]; then
-        (npm run fetchAPI && git diff --quiet src/shared/api/generated/CBioPortalAPI-docs.json) || (echo 'src/shared/api/generated/CBioPortalAPI-docs.json out of sync' && exit 1);
-        (git diff --quiet src/shared/api/generated/CBioPortalAPIInternal-docs.json) || (echo 'src/shared/api/generated/CBioPortalAPIInternal-docs.json out of sync' && exit 1);
-        (npm run fetchHotspotsAPI && git diff --quiet src/shared/api/generated/CancerHotspotsAPI-docs.json) || (echo 'src/shared/api/generated/CancerHotspotsAPI-docs.json out of sync' && exit 1);
-        (npm run fetchOncoKbAPI && git diff --quiet src/shared/api/generated/OncoKbAPI-docs.json) || (echo 'src/shared/api/generated/OncoKbAPI-docs.json out of sync' && exit 1);
-      fi
+  # make sure json/ts client is in sync
+  - bash src/test/check_api_sync.sh
   # Run build
   - npm run build
   # Run test

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # cbioportal-frontend
 ## Live demo
 Development: http://cbioportal-frontend-demo.herokuapp.com/#/patient?studyId=prad_fhcrc&caseId=00-090
-Master: http://cbioportal-frontend.herokuapp.com/?cancer_study_id=lgg_ucsf_2014&case_id=P04
+Master: http://cbioportal-frontend.herokuapp.com/#/patient?studyId=prad_fhcrc&caseId=00-090
 ## Test status & Code Quality
-| Branch | master | integration |
-| --- | --- | --- |
-| Status | [![Build Status](https://travis-ci.org/cBioPortal/cbioportal-frontend.svg?branch=master)](https://travis-ci.org/cBioPortal/cbioportal-frontend) | [![Build Status](https://travis-ci.org/cBioPortal/cbioportal-frontend.svg?branch=integration)](https://travis-ci.org/cBioPortal/cbioportal-frontend)
+| Branch | master | integration | rc |
+| --- | --- | --- | --- |
+| Status | [![Build Status](https://travis-ci.org/cBioPortal/cbioportal-frontend.svg?branch=master)](https://travis-ci.org/cBioPortal/cbioportal-frontend) | [![Build Status](https://travis-ci.org/cBioPortal/cbioportal-frontend.svg?branch=integration)](https://travis-ci.org/cBioPortal/cbioportal-frontend) | [![Build Status](https://travis-ci.org/cBioPortal/cbioportal-frontend.svg?branch=rc)](https://travis-ci.org/cBioPortal/cbioportal-frontend) |
 
 [![codecov](https://codecov.io/gh/cbioportal/cbioportal-frontend/branch/master/graph/badge.svg)](https://codecov.io/gh/cbioportal/cbioportal-frontend)
 
@@ -14,7 +14,8 @@ Master: http://cbioportal-frontend.herokuapp.com/?cancer_study_id=lgg_ucsf_2014&
 ## Deployment
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-This is the new React frontend for cBioPortal, currently under development.
+This is the frontend code for cBioPortal using React, MobX and TypeScript. The
+frontend for the new patient view is now completely in this repo. The 
 
 Make sure you have the latest stable node version installed:
 
@@ -59,12 +60,14 @@ git commit -n
 ```
 
 ## Changing the URL of API
-Add .env file in root of project. Put the following in that file:  (The host
-can be set to whatever instance of the api you want to use as a backend.)  
-
-The default is:
+If the version of the desired API URL is the same as the one used to generate
+the typescipt client, one can hange the `API_ROOT` variable for development in
+[my-index.ejs](my-index.ejs). If the version is different, make sure the API
+endpoint works with the checked in client by changing the API URL in
+[package.json](package.json) and running:
 ```
-API_ROOT=www.cbioportal.org/api
+npm run updateAPI
+npm run test
 ```
 
 ## Check in cBioPortal context

--- a/my-index.ejs
+++ b/my-index.ejs
@@ -11,7 +11,7 @@
         // window.enableDarwin = true;
 
         // Set default API in case none is specified in .env
-        __API_ROOT__ = 'cbioportal-rc.herokuapp.com';
+        __API_ROOT__ = 'cbioportal-release-1.7.0.herokuapp.com';
 //        __HOTSPOTS_API_ROOT__ = 'cbioportal-rc.herokuapp.com/proxy/cancerhotspots.org';
 //        __3D_HOTSPOTS_API_ROOT__ = 'cbioportal-rc.herokuapp.com/proxy/3dhotspots.org/3d';
 //        __ONCOKB_API_ROOT__ = 'cbioportal-rc.herokuapp.com/proxy/oncokb.org/api/v1';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "buildBootstrap": "sass --style :compressed src/globalStyles/bootstrap-entry.scss src/globalStyles/prefixed-bootstrap.min.css",
     "heroku-postbuild": "npm run build && npm install http-server -g",
     "updateAPI": "npm run fetchAPI && npm run buildAPI && npm run updateHotspotsAPI && npm run updateOncoKbAPI",
-    "fetchAPI": "curl http://cbioportal-rc.herokuapp.com/api/api-docs > src/shared/api/generated/CBioPortalAPI-docs.json && curl http://cbioportal-rc.herokuapp.com/api/api-docs?group=internal > src/shared/api/generated/CBioPortalAPIInternal-docs.json",
+    "fetchAPI": "curl http://cbioportal-release-1-7-0.herokuapp.com/api/api-docs > src/shared/api/generated/CBioPortalAPI-docs.json && curl http://cbioportal-release-1-7-0.herokuapp.com/api/api-docs?group=internal > src/shared/api/generated/CBioPortalAPIInternal-docs.json",
     "buildAPI": "node scripts/generate-api.js src/shared/api/generated CBioPortalAPI CBioPortalAPIInternal",
     "updateHotspotsAPI": "npm run fetchHotspotsAPI && npm run buildHotspotsAPI",
     "fetchHotspotsAPI": "curl http://cancerhotspots.org/v2/api-docs?group=cancer_hotspots > src/shared/api/generated/CancerHotspotsAPI-docs.json",

--- a/src/test/check_api_sync.sh
+++ b/src/test/check_api_sync.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+run_and_check_diff() {
+    local cmd="$1"
+    local files="$2"
+    local msg="$3"
+
+    eval "$cmd"
+    for f in $files; do
+        git diff --quiet $f || (git checkout -- $files && echo -e "${RED}$f $msg${NC}" && exit 1)
+    done
+}
+# dir of bash script http://stackoverflow.com/questions/59895
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# move to root dir
+cd ${DIR}/../..
+
+echo "Test if docs used to generate API are same as those in repo (don't fail, just error message)"
+OUT_OF_SYNC_MSG="out of sync"
+run_and_check_diff 'npm run fetchAPI' 'src/shared/api/generated/CBioPortalAPI-docs.json src/shared/api/generated/CBioPortalAPIInternal-docs.json' "${OUT_OF_SYNC_MSG}"
+run_and_check_diff 'npm run fetchHotspotsAPI' src/shared/api/generated/CancerHotspotsAPI-docs.json "${OUT_OF_SYNC_MSG}"
+run_and_check_diff 'npm run fetchOncoKbAPI' src/shared/api/generated/OncoKbAPI-docs.json "${OUT_OF_SYNC_MSG}"
+TS_GEN_MSG="generation of typescript client differs compared to checked in version"
+echo "Test if docs generate the same TS client as the one stored in the repo (fail with exit code > 0)"
+generation_error_count=0
+run_and_check_diff 'npm run buildAPI' 'src/shared/api/generated/CBioPortalAPI.ts src/shared/api/generated/CBioPortalAPIInternal.ts' "${TS_GEN_MSG}"
+if [[ $? -gt 0 ]]; then
+    generation_error_count=$(($generation_error_count + 1))
+fi
+run_and_check_diff 'npm run buildHotspotsAPI' src/shared/api/generated/CancerHotspotsAPI.ts "${TS_GEN_MSG}"
+if [[ $? -gt 0 ]]; then
+    generation_error_count=$(($generation_error_count + 1))
+fi
+run_and_check_diff 'npm run buildOncoKbAPI' src/shared/api/generated/OncoKbAPI.ts "${TS_GEN_MSG}"
+if [[ $? -gt 0 ]]; then
+    generation_error_count=$(($generation_error_count + 1))
+fi
+exit $generation_error_count


### PR DESCRIPTION
Add test for TS client generation. We had an issue where the TS swagger client was not up to date with the checked in docs. This test should prevent that. Updated the README as well in terms of how we're setting the `API_ROOT`