### PR TITLE
when samples are clicked with mod keys, sample should open in new tab…

### DIFF
--- a/src/pages/patientView/PatientViewPage.spec.tsx
+++ b/src/pages/patientView/PatientViewPage.spec.tsx
@@ -1,9 +1,66 @@
-//import {  } from './PatientViewPage';
+import  PatientViewPage from './PatientViewPage';
 import React from 'react';
-import { assert } from 'chai';
-import { shallow, mount } from 'enzyme';
+import {assert} from 'chai';
+import {shallow, mount} from 'enzyme';
 import sinon from 'sinon';
 
+const componentUnderTest: PatientViewPage = (PatientViewPage as any).wrappedComponent;
+
+
 describe('PatientViewPage', () => {
+
+    describe('handleSampleClick', () => {
+
+        const handleSampleClick = (componentUnderTest as any).prototype.handleSampleClick;
+
+        let updateRouteStub: sinon.SinonStub, preventDefaultStub: sinon.SinonStub, mock: any, ev: Partial<React.MouseEvent<HTMLAnchorElement>>;
+
+        beforeEach(() => {
+            updateRouteStub = sinon.stub();
+            preventDefaultStub = sinon.stub();
+
+            mock = {
+                props: {
+                    routing: {
+                        updateRoute: updateRouteStub
+                    }
+                }
+            };
+
+            ev = {
+                preventDefault: preventDefaultStub,
+                altKey: false,
+            };
+        })
+
+        it('calls update route when no modifier keys are pressed', () => {
+            handleSampleClick.call(mock, 1, ev);
+            assert.isTrue(updateRouteStub.calledOnce);
+            assert.isTrue(preventDefaultStub.called);
+        });
+
+        it('does not call updateRoute or preventDefault if altKey is true', () => {
+            ev.altKey = true;
+            handleSampleClick.call(mock, 1, ev);
+            assert.isFalse(updateRouteStub.called);
+            assert.isFalse(preventDefaultStub.called);
+        });
+
+
+        it('does not call updateRoute or preventDefault if metaKey is true', () => {
+            ev.metaKey = true;
+            handleSampleClick.call(mock, 1, ev);
+            assert.isFalse(updateRouteStub.called);
+            assert.isFalse(preventDefaultStub.called);
+        });
+
+        it('does not call updateRoute or preventDefault if shiftKey is true', () => {
+            ev.shiftKey = true;
+            handleSampleClick.call(mock, 1, ev);
+            assert.isFalse(updateRouteStub.called);
+            assert.isFalse(preventDefaultStub.called);
+        });
+
+    })
 
 });

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -120,10 +120,13 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
 
     }
 
-    private handleSampleClick(id: string) {
-
-        this.props.routing.updateRoute({ caseId:undefined, sampleId:id });
-
+    public handleSampleClick(id: string, e: React.MouseEvent<HTMLAnchorElement>) {
+        if (!e.shiftKey && !e.altKey && !e.metaKey) {
+            e.preventDefault();
+            this.props.routing.updateRoute({ caseId:undefined, sampleId:id });
+        }
+        // otherwise do nothing, we want default behavior of link
+        // namely that href will open in a new window/tab
     }
 
     private handleTabChange(id: string) {
@@ -168,8 +171,8 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
             studyName = <a href={`study.do?cancer_study_id=${study.studyId}`} className="studyMetaBar_studyName">{study.name}</a>;
         }
 
-        if (patientViewPageStore.patientViewData.isComplete) {
-            let patientData = patientViewPageStore.patientViewData.result!;
+        if (patientViewPageStore.patientViewData.isComplete && patientViewPageStore.studyMetaData.isComplete) {
+            let patientData = patientViewPageStore.patientViewData.result;
             if (patientViewPageStore.clinicalEvents.isComplete && patientViewPageStore.clinicalEvents.result.length > 0) {
                 sampleManager = new SampleManager(patientData.samples!, patientViewPageStore.clinicalEvents.result);
             } else {
@@ -186,8 +189,9 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                     <span style={{display:'inline-flex'}}>
                                         {'\u00A0'}
                                         <a
-                                            href="javascript:void(0)"
-                                            onClick={() => this.handleSampleClick(sample.id)}
+                                            href={`case.do?#/patient?sampleId=${sample.id}&studyId=${patientViewPageStore.studyMetaData.result!.studyId}`}
+                                            target="_blank"
+                                            onClick={(e: React.MouseEvent<HTMLAnchorElement>) => this.handleSampleClick(sample.id, e)}
                                         >
                                             {sample.id}
                                         </a>


### PR DESCRIPTION
NOTE: probably we will merge this to 1.7.1, not 1.7.0.  No reason to destabilize.

![image](https://user-images.githubusercontent.com/186521/27202202-a4d44d88-51ee-11e7-9957-417939bcc98f.png)

When user is in a cohort, they want to be able to open specific samples in a new tab for future reference in isolation. We've changed that behavior, but we can restore it on conditional basis -> when user holds down modifier keys.