### PR TITLE
Improved patient header tooltip

### DIFF
--- a/src/pages/patientView/clinicalInformation/style/patientTable.module.scss
+++ b/src/pages/patientView/clinicalInformation/style/patientTable.module.scss
@@ -1,9 +1,8 @@
 .patientTable {
+    table-layout: fixed;
+    word-wrap: break-word;
 
     td:first-child {
-
         width:300px;
-
     }
-
 }

--- a/src/pages/patientView/patientHeader/PatientHeader.tsx
+++ b/src/pages/patientView/patientHeader/PatientHeader.tsx
@@ -4,6 +4,7 @@ import {OverlayTrigger, Popover} from 'react-bootstrap';
 
 import ClinicalInformationPatientTable from '../clinicalInformation/ClinicalInformationPatientTable';
 import {getSpanElements} from '../clinicalInformation/lib/clinicalAttributesUtil.js';
+import {placeArrowBottomLeft} from "shared/components/DefaultTooltip";
 
 import styles from './styles.module.scss';
 import DefaultTooltip from "../../../shared/components/DefaultTooltip";
@@ -39,7 +40,7 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
 
     private getPopoverPatient(patient: any) {
         return patient && (
-            <div key={patient.id} style={{ maxHeight:400, overflow:'auto' }}>
+            <div key={patient.id} style={{ maxHeight:400, maxWidth:600, overflow:'auto' }}>
                 <h5>{ patient.id }</h5>
                 <ClinicalInformationPatientTable showFilter={false} showCopyDownload={false} showTitleBar={false} data={patient.clinicalData} />
             </div>
@@ -50,11 +51,12 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
         return patient &&
         (
             <DefaultTooltip
-                placement='bottom'
+                placement='bottomLeft'
                 trigger={['hover', 'focus']}
                 overlay={this.getPopoverPatient(patient)}
                 arrowContent={<div className="rc-tooltip-arrow-inner" />}
                 destroyTooltipOnHide={true}
+                onPopupAlign={placeArrowBottomLeft}
             >
                 <span className='clinical-spans' id='patient-attributes'>
                     <a href="javascript:void(0)" onClick={()=>this.props.handlePatientClick(patient.id)}>{patient.id}</a>

--- a/src/pages/patientView/patientHeader/SampleInline.tsx
+++ b/src/pages/patientView/patientHeader/SampleInline.tsx
@@ -4,6 +4,7 @@ import {SampleLabelHTML} from "shared/components/sampleLabel/SampleLabel";
 import {ClinicalDataBySampleId} from "shared/api/api-types-extended";
 import ClinicalInformationPatientTable from "../clinicalInformation/ClinicalInformationPatientTable";
 import DefaultTooltip from "shared/components/DefaultTooltip";
+import {placeArrowBottomLeft} from "shared/components/DefaultTooltip";
 
 interface ISampleInlineProps {
     sample: ClinicalDataBySampleId;
@@ -13,13 +14,6 @@ interface ISampleInlineProps {
     tooltipEnabled?: boolean;
     extraTooltipText?: string;
     additionalContent?: JSX.Element|null;
-}
-
-// we need this to account for issue with rc-tooltip when dealing with large tooltip overlay content
-export function placeArrow(tooltipEl: any) {
-    const arrowEl = tooltipEl.querySelector('.rc-tooltip-arrow');
-    const targetEl = this.getRootDomNode();  // eslint-disable-line no-invalid-this
-    arrowEl.style.left = '10px';
 }
 
 export default class SampleInline extends React.Component<ISampleInlineProps, {}> {
@@ -59,7 +53,7 @@ export default class SampleInline extends React.Component<ISampleInlineProps, {}
         const {sample, extraTooltipText} = this.props;
 
         return (
-            <div style={{ maxHeight:400, overflow:'auto' }}>
+            <div style={{ maxHeight:400, maxWidth:600, overflow:'auto' }}>
                 <h5 style={{ marginBottom: 1 }}>
                     <svg height="12" width="12" style={{ marginRight: 5}}>
                         {this.sampleLabelHTML()}
@@ -108,7 +102,7 @@ export default class SampleInline extends React.Component<ISampleInlineProps, {}
                 overlay={this.tooltipContent()}
                 arrowContent={<div className="rc-tooltip-arrow-inner" />}
                 destroyTooltipOnHide={false}
-                onPopupAlign={placeArrow}
+                onPopupAlign={placeArrowBottomLeft}
             >
                 {this.mainContent()}
             </DefaultTooltip>

--- a/src/shared/components/DefaultTooltip.tsx
+++ b/src/shared/components/DefaultTooltip.tsx
@@ -33,3 +33,10 @@ function setArrowLeft(tooltipEl:Element, align:any) {
         arrowEl.style.left = `${arrowLeftOffset + width/2}px`;
     }
 }
+
+// we need this to account for issue with rc-tooltip when dealing with large tooltip overlay content
+export function placeArrowBottomLeft(tooltipEl: any) {
+    const arrowEl = tooltipEl.querySelector('.rc-tooltip-arrow');
+    const targetEl = this.getRootDomNode();  // eslint-disable-line no-invalid-this
+    arrowEl.style.left = '10px';
+}


### PR DESCRIPTION
- Tooltip placement for both patient and the sample tooltip is now the same: `bottomLeft`
- Added max width and word wrap for the tooltip table (solution for word break: https://stackoverflow.com/questions/12195469/bootstrap-tables-overflowing-with-long-unspaced-text)

# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/2601.

![patientheadertooltip](https://user-images.githubusercontent.com/3604198/27350341-114d782c-55c8-11e7-85bb-f51807eedd26.png)

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)