### PR TITLE
Corrected local links from directing to public site on DataSetsPage

### DIFF
--- a/src/pages/datasetView/DatasetList.tsx
+++ b/src/pages/datasetView/DatasetList.tsx
@@ -49,7 +49,7 @@ class CancerStudyCell extends React.Component<ICancerStudyCellProps,{}> {
         return (
             <span>
                 <a
-                    href={`http://www.cbioportal.org/study?id=${this.props.studyId}#summary`}
+                    href={`study?id=${this.props.studyId}#summary`}
                     target='_blank'
                 >
                     {this.props.name}


### PR DESCRIPTION
# What? Why?
Change dataset page links to from absolute to relative.

Resolves https://github.com/cBioPortal/cbioportal/issues/2608