### PR TITLE
improved query selector style to reduce cross browser inconsistencies

### DIFF
--- a/src/shared/components/query/CaseSetSelector.tsx
+++ b/src/shared/components/query/CaseSetSelector.tsx
@@ -64,7 +64,7 @@ export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 					Select Patient/Case Set:
 				</SectionHeader>
 				</div>
-				<div>
+				<div className="sectionContent">
 				<ReactSelect
 					value={this.store.selectedSampleListId}
 					options={this.caseSetOptions}

--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -77,7 +77,7 @@ export default class GeneSetSelector extends QueryStoreComponent<GeneSetSelector
 					Enter Gene Set:
 				</SectionHeader>
 
-				<FlexCol overflow>
+				<FlexCol overflow className="sectionContent">
 				<ReactSelect
 					value={this.selectedGeneListOption}
 					options={this.geneListOptions}

--- a/src/shared/components/query/styles.module.scss
+++ b/src/shared/components/query/styles.module.scss
@@ -61,7 +61,11 @@
   }
 
   :global(.sectionLabel) {
-    width:246px;
+    width:236px;
+  }
+
+  :global(.sectionContent) {
+    margin-left: 0 !important;
   }
 
   label {
@@ -192,7 +196,8 @@ div.SelectedStudiesWindow {
   }
 
   div.cancerTypeListContainer {
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   div.cancerStudyListContainer {
@@ -219,7 +224,7 @@ div.SelectedStudiesWindow {
       color: #043852;
       border-bottom: 1px solid rgb(222, 233, 241);
       border-top: 1px solid rgb(243, 248, 251);
-      padding: 8px 10px;
+      padding: 8px 16px 8px 10px;
 
       span {
         &.cancerTypeListItemLabel {
@@ -344,7 +349,8 @@ div.SelectedStudiesWindow {
     width: 555px;
     resize: vertical;
     padding: 5px;
-    border-color:$borderColor;
+    border: 1px solid $borderColor;
+    border-radius: 2px;
   }
   .radioRow {
     div {


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/2625.
Also fixes inconsistency between gene set text area and case set text area.

Chrome:
![queryselector_chrome](https://user-images.githubusercontent.com/3604198/27454761-0cac3efa-5769-11e7-89cc-6a1c8ed49457.png)

IE 11:
![queryselector_ie](https://user-images.githubusercontent.com/3604198/27454742-f89431fc-5768-11e7-97bf-21ae5b6a8e38.png)

Firefox:
![queryselector_firefox](https://user-images.githubusercontent.com/3604198/27454750-0208278e-5769-11e7-8d1a-ade9f138ace7.png)

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
