### PR TITLE
Incorporate maxTreeDepth of 0 into Download Studies component 

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -234,7 +234,7 @@ export class QueryStore
 	@observable private _maxTreeDepth:number = (window as any).maxTreeDepth;
 	@computed get maxTreeDepth()
 	{
-		return this.forDownloadTab ? 1 : this._maxTreeDepth;
+		return (this.forDownloadTab && this._maxTreeDepth > 0) ? 1 : this._maxTreeDepth;
 	}
 	set maxTreeDepth(value)
 	{


### PR DESCRIPTION
# What? Why?
Made it so download tab of home page preserves maxTreeDepth when it is set to 0.