### PR TITLE
We need to be able to hide download tab in study selector

### DIFF
--- a/my-index.ejs
+++ b/my-index.ejs
@@ -11,7 +11,7 @@
         // window.enableDarwin = true;
 
         // Set default API in case none is specified in .env
-        __API_ROOT__ = 'cbioportal-release-1.7.0.herokuapp.com';
+        __API_ROOT__ = 'cbioportal-rc.herokuapp.com';
 //        __HOTSPOTS_API_ROOT__ = 'cbioportal-rc.herokuapp.com/proxy/cancerhotspots.org';
 //        __3D_HOTSPOTS_API_ROOT__ = 'cbioportal-rc.herokuapp.com/proxy/3dhotspots.org/3d';
 //        __ONCOKB_API_ROOT__ = 'cbioportal-rc.herokuapp.com/proxy/oncokb.org/api/v1';

--- a/src/globalComponents.tsx
+++ b/src/globalComponents.tsx
@@ -13,4 +13,6 @@ exposeComponentRenderer('renderRightBar', ()=>{
 
 exposeComponentRenderer('renderQuerySelectorInModal', ()=><QueryModal store={queryStore} />);
 
-exposeComponentRenderer('renderQuerySelector', ()=>{ return <QueryAndDownloadTabs store={queryStore} />  });
+exposeComponentRenderer('renderQuerySelector', (props:{[k:string]:string|boolean|number})=>{
+    return <QueryAndDownloadTabs {...props} store={queryStore} />
+});

--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -195,26 +195,6 @@ export default class CancerStudySelector extends QueryStoreComponent<ICancerStud
 								}}
 							/>);
 
-
-							{/*return (*/}
-								{/*<ReactSelect*/}
-									{/*className={styles.searchTextInput}*/}
-									{/*value={this.store.searchText}*/}
-									{/*autofocus={true}*/}
-									{/*options={searchTextOptions.map(str => ({label: str, value: str}))}*/}
-									{/*placeholder='Search...'*/}
-									{/*noResultsText={false}*/}
-									{/*onCloseResetsInput={false}*/}
-									{/*onInputChange={(searchText:string) => {*/}
-										{/*this.store.searchText = searchText;*/}
-										{/*this.store.selectedCancerTypeIds = [];*/}
-									{/*}}*/}
-									{/*onChange={option => {*/}
-										{/*this.store.searchText = option ? option.value || '' : '';*/}
-										{/*this.store.selectedCancerTypeIds = [];*/}
-									{/*}}*/}
-								{/*/>*/}
-							{/*);*/}
 						}}
 					</Observer>
 

--- a/src/shared/components/query/QueryAndDownloadTab.spec.tsx
+++ b/src/shared/components/query/QueryAndDownloadTab.spec.tsx
@@ -1,0 +1,18 @@
+import QueryAndDownloadTabs from './QueryAndDownloadTabs';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+import { Tab } from 'react-bootstrap';
+import {QueryStore} from "./QueryStore";
+
+describe('QueryAndDownloadTabs', () => {
+
+    it('Hides download tab if prop showDownloadTab is false', ()=>{
+        const comp = shallow(<QueryAndDownloadTabs store={({} as QueryStore)} />);
+        assert.equal(comp.find(Tab).length, 2);
+        comp.setProps({ showDownloadTab:false });
+        assert.equal(comp.find(Tab).length, 1);
+    });
+
+});

--- a/src/shared/components/query/QueryAndDownloadTabs.tsx
+++ b/src/shared/components/query/QueryAndDownloadTabs.tsx
@@ -3,7 +3,7 @@ import {Tabs, Tab, default as ReactBootstrap} from 'react-bootstrap';
 import * as styles_any from './styles.module.scss';
 import {observer} from 'mobx-react';
 import QueryContainer from "./QueryContainer";
-import {QueryStoreComponent, QueryStore} from "./QueryStore";
+import { QueryStore} from "./QueryStore";
 
 const styles = styles_any as {
 	QueryAndDownloadTabs: string,
@@ -16,12 +16,14 @@ interface IQueryAndDownloadTabsProps
 {
 	store:QueryStore;
 	onSubmit?:()=>void;
+	showDownloadTab?:boolean;
 }
 
 
 @observer
 export default class QueryAndDownloadTabs extends React.Component<IQueryAndDownloadTabsProps, {}>
 {
+
 	get store()
 	{
 		return this.props.store;
@@ -42,8 +44,13 @@ export default class QueryAndDownloadTabs extends React.Component<IQueryAndDownl
 					activeKey={this.store.forDownloadTab ? DOWNLOAD : QUERY}
 					onSelect={this.onSelectTab as ReactBootstrap.SelectCallback}
 				>
+
 					<Tab eventKey='query' title="Query"/>
-					<Tab eventKey='download' title="Download Data"/>
+
+					{
+						(this.props.showDownloadTab !== false) && (<Tab eventKey='download' title="Download Data"/>)
+					}
+
 				</Tabs>
 				<QueryContainer onSubmit={this.props.onSubmit} store={this.props.store}/>
 			</div>

--- a/src/shared/lib/exposeComponentRenderer.ts
+++ b/src/shared/lib/exposeComponentRenderer.ts
@@ -6,8 +6,7 @@ export default function(name: string, Comp: React.ComponentClass<any> | React.St
     const win = (window as any);
 
     if(win) {
-        win[name] = (mountNode: HTMLElement): void => {
-
+        win[name] = (mountNode: HTMLElement, props:{[k:string]:string|boolean|number}): void => {
             let el = React.createElement(
                 Comp as any,
                 props


### PR DESCRIPTION
NOTE: this will not be merged to 1.7.0, but to hotfix or 1.7.1 after release.

Download tab should not show when study selector is used on results pages.  First we add property to hide it.  We will then need to modify parent project to provide this property as appropriate.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
