### PR TITLE
Improved OncoKB icon status handling

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -25,6 +25,7 @@ import {default as PatientViewMutationTable} from "./mutation/PatientViewMutatio
 import PathologyReport from "./pathologyReport/PathologyReport";
 import { MSKTabs, MSKTab } from "../../shared/components/MSKTabs/MSKTabs";
 import { validateParametersPatientView } from '../../shared/lib/validateParameters';
+import {ONCOKB_ERROR} from "shared/lib/StoreUtils";
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
 import ValidationAlert from "shared/components/ValidationAlert";
 import AjaxErrorModal from "shared/components/AjaxErrorModal";
@@ -335,7 +336,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         myCancerGenomeData={patientViewPageStore.myCancerGenomeData}
                                         hotspots={patientViewPageStore.indexedHotspotData}
                                         cosmicData={patientViewPageStore.cosmicData.result}
-                                        oncoKbData={patientViewPageStore.oncoKbData.result}
+                                        oncoKbData={patientViewPageStore.oncoKbData.error ? ONCOKB_ERROR : patientViewPageStore.oncoKbData.result}
                                         enableOncoKb={AppConfig.showOncoKB}
                                         enableHotspot={AppConfig.showHotspot}
                                         enableMyCancerGenome={AppConfig.showMyCancerGenome}
@@ -351,7 +352,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                             <CopyNumberTableWrapper
                                 sampleIds={sampleManager ? sampleManager.getSampleIdsInOrder() : []}
                                 sampleManager={sampleManager}
-                                cnaOncoKbData={patientViewPageStore.cnaOncoKbData.result}
+                                cnaOncoKbData={patientViewPageStore.cnaOncoKbData.error ? ONCOKB_ERROR : patientViewPageStore.cnaOncoKbData.result}
                                 oncoKbEvidenceCache={patientViewPageStore.oncoKbEvidenceCache}
                                 enableOncoKb={AppConfig.showOncoKB}
                                 pubMedCache={patientViewPageStore.pubMedCache}

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -421,7 +421,10 @@ export class PatientViewPageStore {
             this.uncalledMutationData,
             this.clinicalDataForSamples
         ],
-        invoke: async() => fetchOncoKbData(this.sampleIdToTumorType, this.mutationData, this.uncalledMutationData)
+        invoke: async() => fetchOncoKbData(this.sampleIdToTumorType, this.mutationData, this.uncalledMutationData),
+        onError: (err: Error) => {
+            // fail silently, leave the error handling responsibility to the data consumer
+        }
     }, ONCOKB_DEFAULT);
 
     readonly cnaOncoKbData = remoteData<IOncoKbData>({
@@ -429,7 +432,10 @@ export class PatientViewPageStore {
             this.discreteCNAData,
             this.clinicalDataForSamples
         ],
-        invoke: async() => fetchCnaOncoKbData(this.sampleIdToTumorType, this.discreteCNAData)
+        invoke: async() => fetchCnaOncoKbData(this.sampleIdToTumorType, this.discreteCNAData),
+        onError: (err: Error) => {
+            // fail silently, leave the error handling responsibility to the data consumer
+        }
     }, ONCOKB_DEFAULT);
 
     readonly copyNumberCountData = remoteData<CopyNumberCount[]>({

--- a/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
@@ -19,30 +19,34 @@ export default class AnnotationColumnFormatter
     {
         let value: IAnnotation;
 
-        if (copyNumberData) {
+        if (copyNumberData)
+        {
+            let oncoKbIndicator: IndicatorQueryResp|undefined;
+            let oncoKbStatus = DefaultAnnotationColumnFormatter.getOncoKbStatus(oncoKbData);
+
+            if (oncoKbData && oncoKbStatus === "complete") {
+                oncoKbIndicator = AnnotationColumnFormatter.getIndicatorData(copyNumberData, oncoKbData);
+            }
+
             value = {
-                oncoKbIndicator: oncoKbData ?
-                    AnnotationColumnFormatter.getIndicatorData(copyNumberData, oncoKbData) : undefined,
+                oncoKbStatus,
+                oncoKbIndicator,
                 myCancerGenomeLinks: [],
                 isHotspot: false,
                 is3dHotspot: false
             };
         }
         else {
-            value = {
-                myCancerGenomeLinks: [],
-                isHotspot: false,
-                is3dHotspot: false
-            };
+            value = DefaultAnnotationColumnFormatter.DEFAULT_ANNOTATION_DATA;
         }
 
         return value;
     }
 
-    public static getIndicatorData(copyNumberData:DiscreteCopyNumberData[], oncoKbData:IOncoKbData): IndicatorQueryResp|null
+    public static getIndicatorData(copyNumberData:DiscreteCopyNumberData[], oncoKbData:IOncoKbData): IndicatorQueryResp|undefined
     {
         if (oncoKbData.sampleToTumorMap === null || oncoKbData.indicatorMap === null) {
-            return null;
+            return undefined;
         }
 
         const id = generateQueryVariantId(copyNumberData[0].gene.entrezGeneId,
@@ -52,13 +56,13 @@ export default class AnnotationColumnFormatter
         return oncoKbData.indicatorMap[id];
     }
 
-    public static getEvidenceQuery(copyNumberData:DiscreteCopyNumberData[], oncoKbData:IOncoKbData): Query|null
+    public static getEvidenceQuery(copyNumberData:DiscreteCopyNumberData[], oncoKbData:IOncoKbData): Query|undefined
     {
         // return null in case sampleToTumorMap is null
         return oncoKbData.sampleToTumorMap ? generateQueryVariant(copyNumberData[0].gene.entrezGeneId,
             oncoKbData.sampleToTumorMap[copyNumberData[0].sampleId],
             getAlterationString(copyNumberData[0].alteration)
-        ) : null;
+        ) : undefined;
     }
 
     public static sortValue(data:DiscreteCopyNumberData[],
@@ -75,7 +79,7 @@ export default class AnnotationColumnFormatter
         let evidenceQuery:Query|undefined;
 
         if (columnProps.oncoKbData) {
-            evidenceQuery = this.getEvidenceQuery(data, columnProps.oncoKbData) || undefined;
+            evidenceQuery = this.getEvidenceQuery(data, columnProps.oncoKbData);
         }
 
         return DefaultAnnotationColumnFormatter.mainContent(annotation,

--- a/src/shared/components/annotation/OncoKB.spec.tsx
+++ b/src/shared/components/annotation/OncoKB.spec.tsx
@@ -1,16 +1,18 @@
 import {initQueryIndicator} from "test/OncoKbMockUtils";
+import {lazyMobXTableSort} from "shared/components/lazyMobXTable/LazyMobXTable";
+import {IndicatorQueryResp} from "shared/api/generated/OncoKbAPI";
+import {IOncoKbProps} from "./OncoKB";
 import OncoKB from './OncoKB';
 import React from 'react';
 import { assert } from 'chai';
 import {shallow, mount, ReactWrapper} from 'enzyme';
 import sinon from 'sinon';
-import {lazyMobXTableSort} from "../lazyMobXTable/LazyMobXTable";
-import {IndicatorQueryResp} from "../../api/generated/OncoKbAPI";
 
 describe('OncoKB', () => {
     const props = {
-        indicator: undefined
-    };
+        indicator: undefined,
+        status: "loading"
+    } as IOncoKbProps;
 
     let component: ReactWrapper<any, any>;
 

--- a/src/shared/components/annotation/OncoKB.tsx
+++ b/src/shared/components/annotation/OncoKB.tsx
@@ -19,7 +19,8 @@ import OncokbPubMedCache from "shared/cache/PubMedCache";
 import {default as TableCellStatusIndicator, TableCellStatus} from "shared/components/TableCellStatus";
 
 export interface IOncoKbProps {
-    indicator?: IndicatorQueryResp | null;
+    status: "complete" | "error" | "loading";
+    indicator?: IndicatorQueryResp;
     evidenceCache?: OncoKbEvidenceCache;
     evidenceQuery?: Query;
     pubMedCache?: OncokbPubMedCache;
@@ -78,15 +79,13 @@ export default class OncoKB extends React.Component<IOncoKbProps, {}>
             <span className={`${annotationStyles["annotation-item"]}`} />
         );
 
-        if (this.props.indicator === null) {
-            // null means there is an error...
+        if (this.props.status === "error") {
             oncoKbContent = this.errorIcon();
         }
-        else if (this.props.indicator === undefined) {
-            // undefined means still loading...
+        else if (this.props.status === "loading") {
             oncoKbContent = this.loaderIcon();
         }
-        else
+        else if (this.props.indicator)
         {
             oncoKbContent = (
                 <span className={`${annotationStyles["annotation-item"]}`}>
@@ -109,14 +108,11 @@ export default class OncoKB extends React.Component<IOncoKbProps, {}>
             }
             else if (this.tooltipDataLoadComplete || this.props.evidenceCache && this.props.evidenceQuery)
             {
-                const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
-
                 oncoKbContent = (
                     <DefaultTooltip
                         overlay={this.tooltipContent}
                         placement="right"
                         trigger={['hover', 'focus']}
-                        arrowContent={arrowContent}
                         onPopupAlign={hideArrow}
                         destroyTooltipOnHide={false}
                     >
@@ -143,7 +139,6 @@ export default class OncoKB extends React.Component<IOncoKbProps, {}>
                 overlay={<span>Error fetching OncoKB data</span>}
                 placement="right"
                 trigger={['hover', 'focus']}
-                arrowContent={<div className="rc-tooltip-arrow-inner"/>}
                 destroyTooltipOnHide={true}
             >
                 <span className={`${annotationStyles["annotation-item-error"]}`}>

--- a/src/shared/components/annotation/OncoKbCard.tsx
+++ b/src/shared/components/annotation/OncoKbCard.tsx
@@ -82,8 +82,6 @@ export default class OncoKbCard extends React.Component<IOncoKbCardProps, IOncoK
                         pmids:number[],
                         abstracts:any[])
     {
-        const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
-
         const levelTooltipContent = () => (
             <div style={{maxWidth: "200px"}}>
                 {levelDes}
@@ -109,7 +107,6 @@ export default class OncoKbCard extends React.Component<IOncoKbCardProps, IOncoK
                         overlay={levelTooltipContent}
                         placement="left"
                         trigger={['hover', 'focus']}
-                        arrowContent={arrowContent}
                         destroyTooltipOnHide={true}
                     >
                         <i
@@ -127,7 +124,6 @@ export default class OncoKbCard extends React.Component<IOncoKbCardProps, IOncoK
                             overlay={treatmentTooltipContent}
                             placement="right"
                             trigger={['hover', 'focus']}
-                            arrowContent={arrowContent}
                             destroyTooltipOnHide={true}
                         >
                             <i className="fa fa-book"/>
@@ -499,8 +495,6 @@ export default class OncoKbCard extends React.Component<IOncoKbCardProps, IOncoK
 
         if (componentType === 'tooltip')
         {
-            const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
-
             const tooltipContent = () => (
                 <div style={{maxWidth: "400px", maxHeight: "200px", overflowY: "auto"}}>
                     <ul className="list-group" style={{marginBottom: 0}}>
@@ -516,7 +510,6 @@ export default class OncoKbCard extends React.Component<IOncoKbCardProps, IOncoK
                         overlay={tooltipContent}
                         placement="right"
                         trigger={['hover', 'focus']}
-                        arrowContent={arrowContent}
                         destroyTooltipOnHide={true}
                     >
                         <i className="fa fa-book" style={{color: "black"}}/>

--- a/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
@@ -29,7 +29,8 @@ export interface IAnnotation {
     isHotspot: boolean;
     is3dHotspot: boolean;
     myCancerGenomeLinks: string[];
-    oncoKbIndicator?: IndicatorQueryResp|null;
+    oncoKbIndicator?: IndicatorQueryResp;
+    oncoKbStatus: "error" | "complete" | "loading";
 }
 
 /**
@@ -37,6 +38,37 @@ export interface IAnnotation {
  */
 export default class AnnotationColumnFormatter
 {
+    public static get DEFAULT_ANNOTATION_DATA(): IAnnotation
+    {
+        return {
+            oncoKbStatus: "complete",
+            myCancerGenomeLinks: [],
+            isHotspot: false,
+            is3dHotspot: false
+        };
+    }
+
+    /**
+     * Derives status from data content.
+     * Default (empty) data means loading. Null data means error.
+     */
+    public static getOncoKbStatus(oncoKbData?: IOncoKbData): "complete"|"loading"|"error"
+    {
+        let status: "complete"|"loading"|"error" = "loading";
+
+        if (oncoKbData && oncoKbData.sampleToTumorMap === null && oncoKbData.indicatorMap === null) {
+            status = "error";
+        }
+        else if (oncoKbData && _.isEmpty(oncoKbData.sampleToTumorMap) && _.isEmpty(oncoKbData.indicatorMap)) {
+            status = "loading";
+        }
+        else {
+            status = "complete";
+        }
+
+        return status;
+    }
+
     public static getData(rowData:Mutation[]|undefined,
                           hotspotsData?:IHotspotData,
                           myCancerGenomeData?:IMyCancerGenomeData,
@@ -47,9 +79,16 @@ export default class AnnotationColumnFormatter
         if (rowData) {
             const mutation = rowData[0];
 
+            let oncoKbIndicator: IndicatorQueryResp|undefined;
+            let oncoKbStatus = AnnotationColumnFormatter.getOncoKbStatus(oncoKbData);
+
+            if (oncoKbData && oncoKbStatus === "complete") {
+                oncoKbIndicator = AnnotationColumnFormatter.getIndicatorData(mutation, oncoKbData);
+            }
+
             value = {
-                oncoKbIndicator: oncoKbData ?
-                    AnnotationColumnFormatter.getIndicatorData(mutation, oncoKbData) : undefined,
+                oncoKbStatus,
+                oncoKbIndicator,
                 myCancerGenomeLinks: myCancerGenomeData ?
                     AnnotationColumnFormatter.getMyCancerGenomeLinks(mutation, myCancerGenomeData) : [],
                 isHotspot: hotspotsData ?
@@ -59,20 +98,16 @@ export default class AnnotationColumnFormatter
             };
         }
         else {
-            value = {
-                myCancerGenomeLinks: [],
-                isHotspot: false,
-                is3dHotspot: false
-            };
+            value = AnnotationColumnFormatter.DEFAULT_ANNOTATION_DATA;
         }
 
         return value;
     }
 
-    public static getIndicatorData(mutation:Mutation, oncoKbData:IOncoKbData): IndicatorQueryResp|null
+    public static getIndicatorData(mutation:Mutation, oncoKbData:IOncoKbData): IndicatorQueryResp|undefined
     {
         if (oncoKbData.sampleToTumorMap === null || oncoKbData.indicatorMap === null) {
-            return null;
+            return undefined;
         }
 
         const id = generateQueryVariantId(mutation.gene.entrezGeneId,
@@ -83,7 +118,7 @@ export default class AnnotationColumnFormatter
         return oncoKbData.indicatorMap[id];
     }
 
-    public static getEvidenceQuery(mutation:Mutation, oncoKbData:IOncoKbData): Query|null
+    public static getEvidenceQuery(mutation:Mutation, oncoKbData:IOncoKbData): Query|undefined
     {
         // return null in case sampleToTumorMap is null
         return oncoKbData.sampleToTumorMap ? generateQueryVariant(mutation.gene.entrezGeneId,
@@ -92,7 +127,7 @@ export default class AnnotationColumnFormatter
             mutation.mutationType,
             mutation.proteinPosStart,
             mutation.proteinPosEnd
-        ) : null;
+        ) : undefined;
     }
 
     public static getMyCancerGenomeLinks(mutation:Mutation, myCancerGenomeData: IMyCancerGenomeData):string[] {
@@ -153,7 +188,7 @@ export default class AnnotationColumnFormatter
         let evidenceQuery:Query|undefined;
 
         if (columnProps.oncoKbData) {
-            evidenceQuery = this.getEvidenceQuery(data[0], columnProps.oncoKbData) || undefined;
+            evidenceQuery = this.getEvidenceQuery(data[0], columnProps.oncoKbData);
         }
 
         return AnnotationColumnFormatter.mainContent(annotation,
@@ -173,6 +208,7 @@ export default class AnnotationColumnFormatter
             <span>
                 <If condition={columnProps.enableOncoKb || false}>
                     <OncoKB
+                        status={annotation.oncoKbStatus}
                         indicator={annotation.oncoKbIndicator}
                         evidenceCache={evidenceCache}
                         evidenceQuery={evidenceQuery}

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -295,13 +295,5 @@ describe('StoreUtils', () => {
                 done();
             });
         });
-
-        it("will return null maps if there are mutations but sampleIdToTumorType map is empty", (done) => {
-            fetchOncoKbData({}, mutationDataWithNoKeyword).then((data: any) => {
-                assert.deepEqual(data, {sampleToTumorMap: null, indicatorMap: null});
-                done();
-            });
-        });
-
     });
 });


### PR DESCRIPTION
# Why?
- Addresses remaining issues of PR #424 
- Better handling of missing cancer type value, and OncoKB API error
- Now also fixes https://github.com/cBioPortal/cbioportal/issues/2709

# Changes
- Added a `status` prop for `OncoKB` component
- Removed some redundant `arrowContent`s
- Sending a request to OncoKB API even if cancer type cannot be resolved (OncoKB annotation does not always require the cancer type)
- Not showing the `Something went wrong` popup when there is an OncoKB API error, instead showing the error icon in the Annotation column.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)