### PR TITLE
configure webpack to emit sourcemaps in build

### DIFF
--- a/vendor-bundles.webpack.config.js
+++ b/vendor-bundles.webpack.config.js
@@ -29,6 +29,8 @@ let config = {
     plugins: [
 
     ],
+
+    devtool : 'source-map'
 };
 
 config.plugins = [
@@ -59,7 +61,7 @@ if (process.env.NODE_ENV !== 'development') {
             compress: {
                 warnings: false
             },
-            sourceMap:false,
+            sourceMap:true,
             comments:false
         })
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -311,7 +311,7 @@ if (isDev || isTest) {
             compress: {
                 warnings: false
             },
-            sourceMap:false,
+            sourceMap:true,
             comments:false
         })
     );


### PR DESCRIPTION
Turn on sourcemap emission in production build.