### PR TITLE
Case set selector should filter on plain text of options.

### DIFF
--- a/src/shared/components/query/CaseSetSelector.spec.tsx
+++ b/src/shared/components/query/CaseSetSelector.spec.tsx
@@ -1,0 +1,24 @@
+import {filterCaseSetOptions, ReactSelectOptionWithName} from './CaseSetSelector';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+describe('CaseSetSelector', () => {
+
+    describe('filterCaseSetOptions', ()=>{
+
+        it('lambda filters without case sensitivity', ()=>{
+
+            let opt = ({ textLabel:'this is the Haystack' } as ReactSelectOptionWithName);
+
+            assert.isTrue( filterCaseSetOptions(opt, 'haystack') );
+            assert.isTrue( filterCaseSetOptions(opt, 'Haystack') );
+            assert.isFalse( filterCaseSetOptions(opt, 'Maystack') );
+
+        });
+
+
+    });
+
+});

--- a/src/shared/components/query/CaseSetSelector.tsx
+++ b/src/shared/components/query/CaseSetSelector.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as styles_any from './styles.module.scss';
+import * as _ from 'lodash';
 import ReactSelect from 'react-select';
 import {observer} from "mobx-react";
 import {computed} from 'mobx';
@@ -8,6 +9,7 @@ import {QueryStore, QueryStoreComponent, CUSTOM_CASE_LIST_ID} from "./QueryStore
 import {getStudyViewUrl} from "../../api/urls";
 import DefaultTooltip from "../DefaultTooltip";
 import SectionHeader from "../sectionHeader/SectionHeader";
+import {ReactSelectOption} from "react-select";
 
 const styles = styles_any as {
 	CaseSetSelector: string,
@@ -15,10 +17,18 @@ const styles = styles_any as {
 	radioRow: string,
 };
 
+export interface ReactSelectOptionWithName extends ReactSelectOption<any> {
+	textLabel:string;
+}
+
+export function filterCaseSetOptions(opt: ReactSelectOptionWithName, filter: string) {
+	return _.includes(opt.textLabel.toLowerCase(), filter.toLowerCase());
+}
+
 @observer
 export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 {
-	@computed get caseSetOptions()
+	@computed get caseSetOptions() : ReactSelectOptionWithName[]
 	{
 		return [
 			...this.store.sampleLists.result.map(sampleList => {
@@ -32,7 +42,8 @@ export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 							<span>{`${sampleList.name} (${sampleList.sampleCount})`}</span>
 						</DefaultTooltip>
 					),
-					value: sampleList.sampleListId
+					value: sampleList.sampleListId,
+					textLabel:sampleList.name
 				};
 			}),
 			{
@@ -45,7 +56,8 @@ export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 						<span>User-defined Case List</span>
 					</DefaultTooltip>
 				),
-				value: CUSTOM_CASE_LIST_ID
+				value: CUSTOM_CASE_LIST_ID,
+				textLabel:'User-defined Case List'
 			}
 		];
 	}
@@ -54,7 +66,6 @@ export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 	{
 		if (!this.store.singleSelectedStudyId)
 			return null;
-
 		return (
 			<FlexRow padded overflow className={styles.CaseSetSelector}>
 				<div>
@@ -68,7 +79,7 @@ export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 				<ReactSelect
 					value={this.store.selectedSampleListId}
 					options={this.caseSetOptions}
-					clearable={this.store.selectedSampleListId != this.store.defaultSelectedSampleListId}
+					filterOption={filterCaseSetOptions}
 					onChange={option => this.store.selectedSampleListId = option ? option.value : undefined}
 				/>
 


### PR DESCRIPTION
https://github.com/cBioPortal/cbioportal/issues/2679

Case Set selector in study view should filter on plain text of the set name (was filtering ID)

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
