### PR TITLE
move patient/sample radio toggle above textarea for user-defined sets…

### DIFF
--- a/src/shared/components/query/CaseSetSelector.tsx
+++ b/src/shared/components/query/CaseSetSelector.tsx
@@ -74,6 +74,14 @@ export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 
 				{!!(this.store.selectedSampleListId === CUSTOM_CASE_LIST_ID) && (
 					<FlexCol padded>
+
+						<div className={styles.radioRow}>
+							<FlexRow padded>
+								<this.CaseIdsModeRadio label='By sample ID' state='sample'/>
+								<this.CaseIdsModeRadio label='By patient ID' state='patient'/>
+							</FlexRow>
+						</div>
+
 						<span>Enter case IDs below:</span>
 						<textarea
 							title="Enter case IDs"
@@ -82,12 +90,6 @@ export default class CaseSetSelector extends QueryStoreComponent<{}, {}>
 							value={this.store.caseIds}
 							onChange={event => this.store.caseIds = event.currentTarget.value}
 						/>
-						<div className={styles.radioRow}>
-							<FlexCol padded>
-								<this.CaseIdsModeRadio label='By sample ID' state='sample'/>
-								<this.CaseIdsModeRadio label='By patient ID' state='patient'/>
-							</FlexCol>
-						</div>
 					</FlexCol>
 				)}
 				</div>


### PR DESCRIPTION
https://github.com/cBioPortal/cbioportal/issues/2680

Users sometimes copy list of patient ids into textarea without knowing it's in sample mode.  the patient ids are then validated as samples.  they fail.  we move the toggle above the text area to highlight its impact on the text area below.


# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
