### PR TITLE
Run webdriver-manager on PRs for e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ script:
   then
     npm run buildDLL:dev
   fi
+  # Use browserstack only on runs within repo
 - |
-  if [[ "${TEST}" == end-to-end ]]
+  if [[ "${TEST}" == end-to-end && "${TRAVIS_PULL_REQUEST}" = "false" ]];
   then
     npm run start & \
     export CBIOPORTAL_URL=http://$(grep '__API_ROOT__' my-index.ejs | cut -d= -f2 | tr -d "'" | tr -d [:space:] | tr -d ';') && \
@@ -53,6 +54,24 @@ script:
     cd end-to-end-tests && \
     npm install && \
     npm run test-travis
+  fi
+  # run webdriver-manager on PRs instead of using browserstack
+- |
+  if [[ "${TEST}" == end-to-end && "${TRAVIS_PULL_REQUEST}" = "true" ]];
+  then
+    npm run start & \
+    npm install -g webdriver-manager@10.2.5 && \
+    webdriver-manager start &
+    export CBIOPORTAL_URL=http://$(grep '__API_ROOT__' my-index.ejs | cut -d= -f2 | tr -d "'" | tr -d [:space:] | tr -d ';') && \
+    curl $CBIOPORTAL_URL > /dev/null && \
+    sleep 5s && \
+    curl $CBIOPORTAL_URL > /dev/null && \
+    sleep 5s && \
+    curl $CBIOPORTAL_URL > /dev/null && \
+    curl http://localhost:3000 > /dev/null && \
+    sleep 20s && \
+    cd end-to-end-tests && \
+    npm run test-webdriver-manager
   fi
 after_success:
 - cat test/fixtures/outputs/lcov.info | codecov


### PR DESCRIPTION
Browserstack remote service doesn't work on PRs, because the browserstack key
is not exposed. Use webdriver-manager instead for that.