### PR TITLE
Put data in the columns "Tumor" and "Allele Frequency" when downloading data

### DIFF
--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -60,6 +60,7 @@ export default class CopyNumberTableWrapper extends React.Component<ICopyNumberT
                 name: "Tumors",
                 render:(d:DiscreteCopyNumberData[])=>TumorColumnFormatter.renderFunction(d, this.props.sampleManager),
                 sortBy:(d:DiscreteCopyNumberData[])=>TumorColumnFormatter.getSortValue(d, this.props.sampleManager),
+                download: (d:DiscreteCopyNumberData[])=>TumorColumnFormatter.getSample(d),
                 order: 20
             });
         }

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -10,7 +10,7 @@ import AlleleCountColumnFormatter from "shared/components/mutationTable/column/A
 import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
 import {isUncalled} from "shared/lib/MutationUtils";
-
+import TumorAlleleFreqColumnFormatter from "shared/components/mutationTable/column/TumorAlleleFreqColumnFormatter";
 
 export interface IPatientViewMutationTableProps extends IMutationTableProps {
     sampleManager:SampleManager | null;
@@ -72,6 +72,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             name: "Allele Freq",
             render: (d:Mutation[])=>AlleleFreqColumnFormatter.renderFunction(d, this.props.sampleManager),
             sortBy:(d:Mutation[])=>AlleleFreqColumnFormatter.getSortValue(d, this.props.sampleManager),
+            download: (d:Mutation[])=>AlleleFreqColumnFormatter.getFrequency(d),
             tooltip:(<span>Variant allele frequency in the tumor sample</span>),
             visible: AlleleFreqColumnFormatter.isVisible(this.props.sampleManager,
                 this.props.dataStore ? this.props.dataStore.allData : this.props.data)
@@ -80,7 +81,8 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         this._columns[MutationTableColumnType.TUMORS] = {
             name: "Tumors",
             render:(d:Mutation[])=>TumorColumnFormatter.renderFunction(d, this.props.sampleManager),
-            sortBy:(d:Mutation[])=>TumorColumnFormatter.getSortValue(d, this.props.sampleManager)
+            sortBy:(d:Mutation[])=>TumorColumnFormatter.getSortValue(d, this.props.sampleManager),
+            download: (d:Mutation[])=>TumorColumnFormatter.getSample(d),
         };
 
         // customization for allele count columns
@@ -88,22 +90,22 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         this._columns[MutationTableColumnType.REF_READS_N].render =
             (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalRefCount");
         this._columns[MutationTableColumnType.REF_READS_N].download =
-            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalRefCount");
+            (d:Mutation[])=>AlleleCountColumnFormatter.getReads(d, "normalRefCount");
 
         this._columns[MutationTableColumnType.VAR_READS_N].render =
             (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "normalAltCount");
         this._columns[MutationTableColumnType.VAR_READS_N].download =
-            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "normalAltCount");
+            (d:Mutation[])=>AlleleCountColumnFormatter.getReads(d, "normalAltCount");
 
         this._columns[MutationTableColumnType.REF_READS].render =
             (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorRefCount");
         this._columns[MutationTableColumnType.REF_READS].download =
-            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorRefCount");
+            (d:Mutation[])=>AlleleCountColumnFormatter.getReads(d, "tumorRefCount");
 
         this._columns[MutationTableColumnType.VAR_READS].render =
             (d:Mutation[])=>AlleleCountColumnFormatter.renderFunction(d, this.getSamples(), "tumorAltCount");
         this._columns[MutationTableColumnType.VAR_READS].download =
-            (d:Mutation[])=>AlleleCountColumnFormatter.getTextValue(d, this.getSamples(), "tumorAltCount");
+            (d:Mutation[])=>AlleleCountColumnFormatter.getReads(d, "tumorAltCount");
 
 
         // order columns

--- a/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.tsx
+++ b/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.tsx
@@ -1,4 +1,7 @@
 import AlleleFreqColumnFormatter from './AlleleFreqColumnFormatter';
+import {GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX, GENETIC_PROFILE_MUTATIONS_SUFFIX} from '../../../../shared/constants';
+import {initMutation} from "test/MutationMockUtils";
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import {MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX, MOLECULAR_PROFILE_MUTATIONS_SUFFIX} from '../../../../shared/constants';
 import React from 'react';
 import { assert } from 'chai';
@@ -51,5 +54,12 @@ describe('AlleleFreqColumnFormatter', () => {
         };
         const res = AlleleFreqColumnFormatter.convertMutationToSampleElement(uncalledMutationWithSupport, 'red', 5, {});
         assert(res && mount(res.text).text().indexOf('(uncalled)') !== -1);
+    });
+    it('calculates the Allele frequency for a mutation', ()=> {
+        const mutation:Mutation[] = [initMutation({
+            tumorAltCount:1,
+            tumorRefCount:10
+        })];
+        assert.equal(AlleleFreqColumnFormatter.getFrequency(mutation), "0.09090909090909091");
     });
 });

--- a/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.tsx
@@ -156,4 +156,21 @@ export default class AlleleFreqColumnFormatter {
 
         return false;
     }
+
+
+    public static getFrequency(data:Mutation[]): string|string[] {
+        let result = [];
+        if (data) {
+            for (let mutation of data) {
+                let frequency = mutation.tumorAltCount/(mutation.tumorAltCount+mutation.tumorRefCount);
+                if (frequency) {
+                    result.push(String(frequency));
+                }
+            }
+        }
+        if (result.length == 1) {
+            return result[0];
+        }
+        return result;
+    }
 }

--- a/src/pages/patientView/mutation/column/TumorColumnFormatter.spec.tsx
+++ b/src/pages/patientView/mutation/column/TumorColumnFormatter.spec.tsx
@@ -6,6 +6,19 @@ import sinon from 'sinon';
 import {MOLECULAR_PROFILE_MUTATIONS_SUFFIX, MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from '../../../../shared/constants';
 
 describe('TumorColumnFormatter', () => {
+    let testData = [
+        {sampleId:'A',
+            molecularProfileId:MOLECULAR_PROFILE_MUTATIONS_SUFFIX
+        },
+        {sampleId:'B',
+            molecularProfileId:MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX,
+            tumorAltCount: 0,
+        },
+        {sampleId:'C',
+            molecularProfileId:MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX,
+            tumorAltCount: 5,
+        },
+    ];
 
     before(()=>{
 
@@ -16,23 +29,14 @@ describe('TumorColumnFormatter', () => {
     });
 
     it('test get present samples', ()=>{
-        let testData = [
-            {sampleId:'A',
-             molecularProfileId:MOLECULAR_PROFILE_MUTATIONS_SUFFIX
-            },
-            {sampleId:'B',
-             molecularProfileId:MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX,
-             tumorAltCount: 0,
-            },
-            {sampleId:'C',
-             molecularProfileId:MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX,
-             tumorAltCount: 5,
-            },
-        ];
         let presentSamples = TumorColumnFormatter.getPresentSamples(testData);
         assert(presentSamples['A'], "sample A is present and is called");
         assert(!('B' in presentSamples), "sample B mutation is not present because it has 0 supporting reads");
         assert(presentSamples['C'] === false, "sample C mutation is present and is uncalled with > 0 supporting reads");
+    });
+
+    it('test get sample ids', ()=>{
+        assert.deepEqual(TumorColumnFormatter.getSample(testData), ["A", "B", "C"]);
     });
 
 });

--- a/src/pages/patientView/mutation/column/TumorColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/TumorColumnFormatter.tsx
@@ -3,7 +3,6 @@ import 'rc-tooltip/assets/bootstrap_white.css';
 import SampleManager from "../../sampleManager";
 import {isUncalled} from 'shared/lib/MutationUtils';
 
-
 export default class TumorColumnFormatter {
 
     public static renderFunction<T extends {sampleId:string}>(data:T[], sampleManager:SampleManager|null) {
@@ -66,5 +65,18 @@ export default class TumorColumnFormatter {
             }
             return map;
         }, {});
+    }
+
+    public static getSample(data:Array<{sampleId:string}>): string|string[] {
+        let result: string[] =[];
+        if (data) {
+            data.forEach((datum:{sampleId:string}) => {
+                result.push(datum.sampleId);
+            })
+        }
+        if (result.length == 1) {
+            return result[0];
+        }
+        return result;
     }
 }

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -151,20 +151,73 @@ describe('LazyMobXTable', ()=>{
         invisibleString:"FILTER4"
     };
     let data = [datum0, datum1, datum2, datum3, datum4];
+    let multiData = [[datum0, datum1], [datum2, datum3], datum4];
     let sortedList:any[];
+    function downloadName(data:{name:string, num:number, str:string, numList:number[], strList:string[],
+        invisibleString:string}|{name:string, num:number, str:string, numList:number[], 
+        strList:string[], invisibleString:string}[]): string|string[] {
+            let result =[];
+            if (data instanceof Array) {
+                for (let datum of data) {
+                    result.push(datum.name);
+                }
+            } else {
+                return data.name;
+            }
+            return result;
+        }
+    function downloadNumber(data:{name:string, num:number, str:string, numList:number[], strList:string[],
+        invisibleString:string}|{name:string, num:number, str:string, numList:number[], 
+        strList:string[], invisibleString:string}[]): string|string[] {
+            let result =[];
+            if (data instanceof Array) {
+                for (let datum of data) {
+                    result.push(datum.num+'');
+                }
+            } else {
+                return data.num+'';
+            }
+            return result;
+        }
+    function downloadString(data:{name:string, num:number, str:string, numList:number[], strList:string[],
+        invisibleString:string}|{name:string, num:number, str:string, numList:number[], 
+        strList:string[], invisibleString:string}[]): string|string[] {
+            let result =[];
+            if (data instanceof Array) {
+                for (let datum of data) {
+                    result.push(datum.str+'');
+                }
+            } else {
+                return data.str+'';
+            }
+            return result;
+        }
+    function downloadInvisible(data:{name:string, num:number, str:string, numList:number[], strList:string[],
+        invisibleString:string}|{name:string, num:number, str:string, numList:number[], 
+        strList:string[], invisibleString:string}[]): string|string[] {
+            let result =[];
+            if (data instanceof Array) {
+                for (let datum of data) {
+                    result.push(datum.name+"HELLO123456");
+                }
+            } else {
+                return data.name+"HELLO123456";
+            }
+            return result;
+        }
     let columns:any[] = [{
         name: "Name",
         filter: (d:any,s:string)=>(d.name.indexOf(s) > -1),
         sortBy: (d:any)=>d.name,
         render:(d:any)=>(<span>{d.name}</span>),
-        download:(d:any)=>d.name,
+        download:(d:any)=>downloadName(d),
         tooltip:(<span>Name of the data.</span>),
         align: "right"
     },{
         name: "Number",
         sortBy: (d:any)=>d.num,
         render:(d:any)=>(<span>{d.num}</span>),
-        download:(d:any)=>d.num+'',
+        download:(d:any)=>downloadNumber(d),
         tooltip:(<span>Number of the data.</span>),
         defaultSortDirection: "desc",
         align: "left"
@@ -173,7 +226,7 @@ describe('LazyMobXTable', ()=>{
         filter: (d:any,s:string)=>(d.str && d.str.indexOf(s) > -1),
         sortBy: (d:any)=>d.str,
         render:(d:any)=>(<span>{d.str}</span>),
-        download:(d:any)=>d.str+'',
+        download:(d:any)=>downloadString(d),
         tooltip:(<span>String of the data</span>),
         defaultSortDirection: "desc",
         align: "center"
@@ -186,7 +239,7 @@ describe('LazyMobXTable', ()=>{
         visible: false,
         sortBy: (d:any)=>d.name,
         render:(d:any)=>(<span>{d.name}</span>),
-        download:(d:any)=>d.name+"HELLO123456",
+        download:(d:any)=>downloadInvisible(d),
     },{
         name: "Initially invisible column with no download",
         render:()=>(<span></span>),
@@ -999,7 +1052,6 @@ describe('LazyMobXTable', ()=>{
                 "3,-1,zijxcpo,,3HELLO123456,,\r\n"+
                 "4,90,zkzxc,,4HELLO123456,,\r\n");
         });
-
         it("gives data back in sorted order according to initially selected sort column and direction", ()=>{
             let table = mount(<Table columns={columns} data={data} initialSortColumn="Number" initialSortDirection="asc"/>);
 
@@ -1010,6 +1062,17 @@ describe('LazyMobXTable', ()=>{
                 "1,6,kdfjpo,,1HELLO123456,,\r\n"+
                 "4,90,zkzxc,,4HELLO123456,,\r\n" +
                 "2,null,null,,2HELLO123456,,\r\n");
+        });
+        
+        it("gives data for data with multiple elements", ()=>{
+            let table = mount(<Table columns={columns} data={multiData}/>)
+            assert.deepEqual((table.instance() as LazyMobXTable<any>).getDownloadData(),
+                "Name,Number,String,Number List,Initially invisible column,Initially invisible column with no download,String without filter function\r\n"+
+                "0,0,asdfj,,0HELLO123456,,\r\n"+
+                "1,6,kdfjpo,,1HELLO123456,,\r\n"+
+                "2,null,null,,2HELLO123456,,\r\n"+
+                "3,-1,zijxcpo,,3HELLO123456,,\r\n"+
+                "4,90,zkzxc,,4HELLO123456,,\r\n");
         });
     });
     describe('pagination', ()=>{

--- a/src/shared/components/mutationTable/column/AlleleCountColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/AlleleCountColumnFormatter.tsx
@@ -49,4 +49,18 @@ export default class AlleleCountColumnFormatter
             </div>
         );
     }
+    
+    public static getReads(mutations:Mutation[], dataField:string): string|string[]
+    {
+        let result = [];
+        if (mutations) {
+            for (let mutation of mutations) {
+                result.push((mutation as any)[dataField]);
+            }
+        }
+        if (result.length == 1) {
+            return result[0];
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
Patients with multiple samples have the column `Tumor` which displays the sample number(s) where the alteration occurs. However, this column, and the column `Allele Frequency`, are empty in the exported tables. This PR fixes that by creating extra rows for those mutations. Also, the "Allele Counts" column have been rearranged. This changes do not alter the visualized tables in the Patient View.

For this table ([link to the Patient View](http://www.cbioportal.org/beta/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04#/patient?caseId=P04&studyId=lgg_ucsf_2014)):
![captura de pantalla 2017-07-21 a les 9 43 13](https://user-images.githubusercontent.com/20278013/28454165-7beceac4-6dfa-11e7-987f-92b851771ccb.png)

This is (part of) the download table:
![captura de pantalla 2017-07-21 a les 9 53 00](https://user-images.githubusercontent.com/20278013/28454173-841a768a-6dfa-11e7-9df4-19a47f9241ca.png) 

