### PR TITLE
Run spec file generation on Travis for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ script:
       echo 'WARNING: mock data out of sync with API return calls';
     }
   fi
+  # first generate spec files for all source files (to show coverage for each) then run tests
 - |
   if [[ "${TEST}" == unit ]]
   then
+      bash scripts/generate_spec_files.sh && \  
       npm run build && \
       npm test
   fi

--- a/scripts/generate_spec_files.sh
+++ b/scripts/generate_spec_files.sh
@@ -1,7 +1,7 @@
 # generate spec files for tsx files w/o them
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-for f in $(cd ${SCRIPT_DIR}/../ && git ls-files | grep -E 'ts(x){0,1}$' | grep -v spec | grep -v api | grep -v redux | grep -v appShell | grep -v typings)
+for f in $(cd ${SCRIPT_DIR}/../ && git ls-files | grep -E 'ts(x){0,1}$' | grep -v spec | grep -v api | grep -v redux | grep -v appShell | grep -v typings | grep -v config | grep -v oql-parser.d)
 do 
         (test -e ${f/.ts*/.spec.ts} || test -e ${f/.ts*/.spec.tsx}) || \
             cat ${SCRIPT_DIR}/spec.tsx.template | \


### PR DESCRIPTION
The code coverage only works on source files that are imported in a spec file.
This generates spec files for each source file before running the tests.