### PR TITLE
Percentage display value fix for cohort tooltip

### DIFF
--- a/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.tsx
@@ -3,6 +3,7 @@ import {DiscreteCopyNumberData, CopyNumberCount} from "shared/api/generated/CBio
 import FrequencyBar from "shared/components/cohort/FrequencyBar";
 import Icon from "shared/components/cohort/LetterIcon";
 import {IGisticData, IGisticSummary} from "shared/model/Gistic";
+import {getPercentage} from "shared/lib/FormatUtils";
 
 import CopyNumberCountCache from "../../clinicalInformation/CopyNumberCountCache";
 import {CacheData} from "../../../../shared/lib/LazyMobXCache";
@@ -103,8 +104,8 @@ export default class CohortColumnFormatter
     public static tooltipContent(data:DiscreteCopyNumberData[], copyNumberCount:CopyNumberCount)
     {
         const count = copyNumberCount.numberOfSamplesWithAlterationInGene;
-        const percent = 100 * (copyNumberCount.numberOfSamplesWithAlterationInGene / copyNumberCount.numberOfSamples);
-        const boldPercentage = <b>{`${percent.toFixed(1)}%`}</b>;
+        const proportion = copyNumberCount.numberOfSamplesWithAlterationInGene / copyNumberCount.numberOfSamples;
+        const boldPercentage = <b>{getPercentage(proportion)}</b>;
         const gene = data[0].gene.hugoGeneSymbol;
         const cna = data[0].alteration === -2 ? "deleted" : "amplified";
         const samples = count === 1 ? "sample" : "samples";

--- a/src/shared/components/cohort/FrequencyBar.tsx
+++ b/src/shared/components/cohort/FrequencyBar.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import DefaultTooltip from 'shared/components/DefaultTooltip';
+import {getPercentage} from "shared/lib/FormatUtils";
 
 export interface IFrequencyBarProps
 {
     totalCount: number;
     counts: number[];
+    mainCountIndex?: number;
     freqColors?: string[];
     barColor?: string;
     barWidth?: number;
@@ -41,7 +43,16 @@ export default class FrequencyBar extends React.Component<IFrequencyBarProps, {}
         } = this.props;
 
         const freqColors = this.props.freqColors || FrequencyBar.defaultProps.freqColors;
-        const mainProportion = counts[0] / totalCount; // assuming the first count in the list is the main
+
+        // if no mainCountIndex is provided or it is not a valid index, then use the first count in the list
+        // (main count is used to calculate the percentage to display)
+        const mainCountIndex = (
+            this.props.mainCountIndex &&
+            this.props.mainCountIndex >= 0 &&
+            this.props.mainCountIndex < counts.length
+        ) ? this.props.mainCountIndex : 0;
+
+        const mainProportion = counts[mainCountIndex] / totalCount;
         const textPos = (barWidth || 0) + (textMargin || 0);
         const totalWidth = textPos + FrequencyBar.TEXT_WIDTH;
 
@@ -63,7 +74,7 @@ export default class FrequencyBar extends React.Component<IFrequencyBarProps, {}
                     textAnchor="start"
                     fontSize="10"
                 >
-                    {`${(100 * mainProportion).toFixed(1)}%`}
+                    {getPercentage(mainProportion)}
                 </text>
                 <rect
                     y="2"

--- a/src/shared/components/mutationTable/column/CohortColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CohortColumnFormatter.tsx
@@ -7,6 +7,7 @@ import Icon from "shared/components/cohort/LetterIcon";
 import {IMutSigData as MutSigData} from "shared/model/MutSig";
 import {VariantCount} from "shared/api/generated/CBioPortalAPIInternal";
 import {CacheData} from "shared/lib/LazyMobXCache";
+import {getPercentage} from "shared/lib/FormatUtils";
 import {default as TableCellStatusIndicator, TableCellStatus} from "shared/components/TableCellStatus";
 
 type AugVariantCountOutput = (CacheData<VariantCount> & {hugoGeneSymbol:string});
@@ -104,11 +105,10 @@ export default class CohortColumnFormatter {
         );
     }
 
-    private static getBoldPercentage(proportion:number) {
+    private static getBoldPercentage(proportion: number)
+    {
         return (
-            <b>
-                {(100*proportion).toFixed(1) + "%"}
-            </b>
+            <b>{getPercentage(proportion)}</b>
         );
     }
 

--- a/src/shared/lib/FormatUtils.spec.ts
+++ b/src/shared/lib/FormatUtils.spec.ts
@@ -1,0 +1,33 @@
+import { assert } from 'chai';
+import {toFixedWithThreshold} from "./FormatUtils";
+
+describe('toFixedWithThreshold', ()=>{
+    it("has the same behavior with regular toFixed function when the result is not expected to be a zero value", () => {
+        assert.equal(toFixedWithThreshold(0.324, 2), "0.32");
+        assert.equal(toFixedWithThreshold(0.0032, 3), "0.003");
+        assert.equal(toFixedWithThreshold(0.006, 2), "0.01");
+    });
+
+    it("returns zero value string only if the actual value is zero", () => {
+        assert.equal(toFixedWithThreshold(0, 1), "0.0");
+        assert.equal(toFixedWithThreshold(0, 2), "0.00");
+        assert.equal(toFixedWithThreshold(0, 3), "0.000");
+    });
+
+    it("converts zero value results into an inequality if the actual value is not zero", () => {
+        assert.equal(toFixedWithThreshold(0.000333, 3), "<0.001");
+        assert.equal(toFixedWithThreshold(0.000666, 2), "<0.01");
+        assert.equal(toFixedWithThreshold(0.00666, 1), "<0.1");
+        assert.equal(toFixedWithThreshold(0.0333, 1), "<0.1");
+    });
+
+    it("works for negative numbers too", () => {
+        assert.equal(toFixedWithThreshold(-0.324, 2), "-0.32");
+        assert.equal(toFixedWithThreshold(-0.0032, 3), "-0.003");
+        assert.equal(toFixedWithThreshold(-0.006, 2), "-0.01");
+        assert.equal(toFixedWithThreshold(-0.000333, 3), ">-0.001");
+        assert.equal(toFixedWithThreshold(-0.000666, 2), ">-0.01");
+        assert.equal(toFixedWithThreshold(-0.00666, 1), ">-0.1");
+        assert.equal(toFixedWithThreshold(-0.0333, 1), ">-0.1");
+    });
+});

--- a/src/shared/lib/FormatUtils.ts
+++ b/src/shared/lib/FormatUtils.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 export function toPrecision(value:number, precision:number, threshold:number)
 {
     // round to precision significant figures
@@ -12,4 +14,34 @@ export function toPrecision(value:number, precision:number, threshold:number)
     //    ret = ret.replace(/\.?0+$/,'');
 
     return ret;
+}
+
+/**
+ * Works the same as the default toFixed() function when the result string is not expected to be a zero value
+ * such as 0.0, 0.00, 0.000, etc.
+ *
+ * If the default toFixed() function returns a zero value, then converts it to an inequality such as
+ * <0.1, <0.01, <0.001, etc.
+ */
+export function toFixedWithThreshold(value: number, digits: number): string
+{
+    let fixed = value.toFixed(digits);
+
+    // if we end up with 0.0...0, returns <0.0...1 instead
+    if (value !== 0 && parseFloat(fixed) === 0) {
+        const floatingZeros = digits > 1 ? _.fill(Array(digits - 1), "0") : [];
+
+        // in case the value is negative, direction of the inequality changes
+        // (because, for example, 0.02 < 0.1 but, -0.02 > -0.1)
+        // we need to add the minus sign as well...
+        const prefix = value > 0 ? "<" : ">-";
+
+        fixed = `${prefix}0.${floatingZeros.join('')}1`;
+    }
+
+    return fixed;
+}
+
+export function getPercentage(proportion: number, digits: number = 1) {
+    return `${toFixedWithThreshold(100 * proportion, digits)}%`;
 }


### PR DESCRIPTION
![cohort_tooltip](https://user-images.githubusercontent.com/3604198/27890949-5806d904-61c4-11e7-8e59-dd5da471ea85.png)

# What? Why?
Fixes cBioPortal/cbioportal/issues/2691

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)