### PR TITLE
Improved sample id to tumor type map generating function

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -478,7 +478,9 @@ export class PatientViewPageStore {
     }
 
     @computed get sampleIdToTumorType(): {[sampleId: string]: string} {
-        return generateSampleIdToTumorTypeMap(this.clinicalDataForSamples, this.studyToCancerType[this.studyId]);
+        return generateSampleIdToTumorTypeMap(this.clinicalDataForSamples,
+            this.studyToCancerType[this.studyId],
+            this.samples);
     }
 
     @action("SetSampleId") setSampleId(newId: string) {

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -449,7 +449,8 @@ export function indexHotspotData(hotspotData:MobxPromise<ICancerHotspotData>): I
 }
 
 export function generateSampleIdToTumorTypeMap(clinicalDataForSamples: MobxPromise<ClinicalData[]>,
-                                               defaultCancerType?: string): {[sampleId: string]: string}
+                                               defaultCancerType?: string,
+                                               samples?: MobxPromise<Sample[]>): {[sampleId: string]: string}
 {
     const map: {[sampleId: string]: string} = {};
 
@@ -471,12 +472,22 @@ export function generateSampleIdToTumorTypeMap(clinicalDataForSamples: MobxPromi
 
         // last resort: fall back to the default cancer type
         if (defaultCancerType) {
-            _.each(clinicalDataForSamples.result, (clinicalData:ClinicalData) => {
-                // update map with defaultCancerType value only if it is not already updated
-                if (map[clinicalData.entityId] === undefined) {
-                    map[clinicalData.entityId] = defaultCancerType;
-                }
-            });
+            if (samples && samples.result) {
+                _.each(samples.result, (sample: Sample) => {
+                    if (map[sample.sampleId] === undefined) {
+                        map[sample.sampleId] = defaultCancerType;
+                    }
+                });
+            }
+            // if no sample list is provided, try to get sample ids from clinical data...
+            else {
+                _.each(clinicalDataForSamples.result, (clinicalData:ClinicalData) => {
+                    // update map with defaultCancerType value only if it is not already updated
+                    if (map[clinicalData.entityId] === undefined) {
+                        map[clinicalData.entityId] = defaultCancerType;
+                    }
+                });
+            }
         }
     }
 


### PR DESCRIPTION
# What? Why?
- Current `StoreUtils.generateSampleIdToTumorTypeMap` function may not work if a sample doesn't have any clinical data at all.
- Improved fix for https://github.com/cBioPortal/cbioportal/issues/2709

# Changes proposed in this pull request:
Pass the list of samples to `StoreUtils.generateSampleIdToTumorTypeMap` to make sure that we cover all the samples.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)