### PR TITLE
Restored routing functionality for Mutations component

### DIFF
--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -14,7 +14,6 @@ export interface IMutationsPageProps {
 @observer
 export default class Mutations extends React.Component<IMutationsPageProps, {}>
 {
-
     @observable mutationsGeneTab:string;
 
     constructor(props: IMutationsPageProps) {
@@ -24,11 +23,14 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
     }
 
     public render() {
-        //activeTabId={this.props.routing.location.query.mutationsGeneTab}
+        // use routing if available, if not fall back to the observable variable
+        const activeTabId = this.props.routing ?
+            this.props.routing.location.query.mutationsGeneTab : this.mutationsGeneTab;
+
         return (
             <MSKTabs
                 id="mutationsPageTabs"
-                activeTabId={this.mutationsGeneTab}
+                activeTabId={activeTabId}
                 onTabClick={(id:string) => this.handleTabChange(id)}
                 className="mainTabs"
             >
@@ -69,7 +71,13 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
     }
     
     protected handleTabChange(id: string) {
-        //this.props.routing.updateRoute({ mutationsGeneTab: id });
-        this.mutationsGeneTab = id;
+        // update the hash if routing exits
+        if (this.props.routing) {
+            this.props.routing.updateRoute({ mutationsGeneTab: id });
+        }
+        // update the observable if no routing
+        else {
+            this.mutationsGeneTab = id;
+        }
     }
 }


### PR DESCRIPTION
# What? Why?
If the `routing` is not available then falling back to `observable`.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
