### PR TITLE
Fix CIViC filtering problem in the Result's Mutation tab

### DIFF
--- a/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
@@ -102,12 +102,14 @@ export default class AnnotationColumnFormatter
     public static getCivicEntry(mutation:Mutation, civicGenes:ICivicGene, civicVariants:ICivicVariant): ICivicEntry | null
     {
         let geneSymbol: string = mutation.gene.hugoGeneSymbol;
-        let geneVariants: {[name: string]: ICivicVariantData} = civicVariants[geneSymbol];
-        let geneEntry: ICivicGeneData = civicGenes[geneSymbol];
         let civicEntry = null;
-        //Only search for matching Civic variants if the gene exists in the Civic API
-        if (geneVariants) {
-            civicEntry = buildCivicEntry(geneEntry, geneVariants);
+        //Only search for matching Civic variants if the gene mutation exists in the Civic API
+        if (civicVariants[geneSymbol]) {
+            let geneVariants: {[name: string]: ICivicVariantData} = {[mutation.proteinChange]: civicVariants[geneSymbol][mutation.proteinChange]};
+            let geneEntry: ICivicGeneData = civicGenes[geneSymbol];
+            if (civicVariants) {
+                civicEntry = buildCivicEntry(geneEntry, geneVariants);
+            }
         }
 
         return civicEntry;


### PR DESCRIPTION
# What? Why?
Fix cbioportal/cbioportal#2734 .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
