### PR TITLE
Fix infinite pulling of source code

### DIFF
--- a/src/shared/components/lollipopMutationPlot/Domain.tsx
+++ b/src/shared/components/lollipopMutationPlot/Domain.tsx
@@ -93,7 +93,7 @@ export default class Domain extends React.Component<DomainProps, {}> {
         };
         const text = (reference ? (this.props.label || "") : this.displayText);
         if (reference) {
-            props.ref=this.handlers.textRef;
+            //props.ref=this.handlers.textRef;
             props.visibility="hidden";
             props.className=this.props.hitzoneClassName;
         }


### PR DESCRIPTION
Possibly related to this: https://github.com/facebook/react/issues/5591

When using `localDev = true` trick on the mutation mapper integration https://github.com/cBioPortal/cbioportal/pull/2713 branch. It infinitely pulls the source code. Seems to be related to the issue of setting state in `render`? Not 100% sure why everything works when uncommenting this line. I guess when the props of the component change they initiate a new call to render, causing the infinite loop. Things seem to work with this change, I'm not entirely sure what this component is supposed to do other than displaying the text of the protein domain or why there are two text elements created, one with reference and one without. Hope @onursumer or @adamabeshouse can clarify? Thanks!