### PR TITLE
Cancer type column improvements

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -325,6 +325,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                     <PatientViewMutationTable
                                         sampleManager={sampleManager}
                                         sampleIds={sampleManager ? sampleManager.getSampleIdsInOrder() : []}
+                                        sampleIdToTumorType={patientViewPageStore.sampleIdToTumorType}
                                         variantCountCache={patientViewPageStore.variantCountCache}
                                         discreteCNACache={patientViewPageStore.discreteCNACache}
                                         mrnaExprRankCache={patientViewPageStore.mrnaExprRankCache}

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -118,6 +118,7 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                                     </span>
                                 </div>)
                             }
+                            <LoadingIndicator isLoading={this.props.store.clinicalDataForSamples.isPending} />
                             {!this.props.store.clinicalDataForSamples.isPending && (
                                 <ResultsViewMutationTable
                                     studyId={this.props.studyId}

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -29,7 +29,6 @@ export interface IMutationMapperProps {
     store: MutationMapperStore;
     config: IMutationMapperConfig;
     studyId?: string;
-    studyToCancerType?:{[studyId:string]:string};
     myCancerGenomeData?: IMyCancerGenomeData;
     discreteCNACache?:DiscreteCNACache;
     oncoKbEvidenceCache?:OncoKbEvidenceCache;
@@ -121,11 +120,10 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                             }
                             <ResultsViewMutationTable
                                 studyId={this.props.studyId}
-                                studyToCancerType={this.props.studyToCancerType}
+                                sampleIdToTumorType={this.props.store.sampleIdToTumorType}
                                 discreteCNACache={this.props.discreteCNACache}
                                 oncoKbEvidenceCache={this.props.oncoKbEvidenceCache}
                                 pubMedCache={this.props.pubMedCache}
-                                cancerTypeCache={this.props.cancerTypeCache}
                                 mutationCountCache={this.props.mutationCountCache}
                                 dataStore={this.props.store.dataStore}
                                 myCancerGenomeData={this.props.myCancerGenomeData}

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -118,25 +118,27 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                                     </span>
                                 </div>)
                             }
-                            <ResultsViewMutationTable
-                                studyId={this.props.studyId}
-                                sampleIdToTumorType={this.props.store.sampleIdToTumorType}
-                                discreteCNACache={this.props.discreteCNACache}
-                                oncoKbEvidenceCache={this.props.oncoKbEvidenceCache}
-                                pubMedCache={this.props.pubMedCache}
-                                mutationCountCache={this.props.mutationCountCache}
-                                dataStore={this.props.store.dataStore}
-                                myCancerGenomeData={this.props.myCancerGenomeData}
-                                hotspots={this.props.store.indexedHotspotData}
-                                cosmicData={this.props.store.cosmicData.result}
-                                oncoKbData={this.props.store.oncoKbData}
-                                civicGenes={this.props.store.civicGenes.result}
-                                civicVariants={this.props.store.civicVariants.result}
-                                enableOncoKb={this.props.config.showOncoKB}
-                                enableHotspot={this.props.config.showHotspot}
-                                enableMyCancerGenome={this.props.config.showMyCancerGenome}
-                                enableCivic={this.props.config.showCivic}
-                            />
+                            {!this.props.store.clinicalDataForSamples.isPending && (
+                                <ResultsViewMutationTable
+                                    studyId={this.props.studyId}
+                                    sampleIdToTumorType={this.props.store.sampleIdToTumorType}
+                                    discreteCNACache={this.props.discreteCNACache}
+                                    oncoKbEvidenceCache={this.props.oncoKbEvidenceCache}
+                                    pubMedCache={this.props.pubMedCache}
+                                    mutationCountCache={this.props.mutationCountCache}
+                                    dataStore={this.props.store.dataStore}
+                                    myCancerGenomeData={this.props.myCancerGenomeData}
+                                    hotspots={this.props.store.indexedHotspotData}
+                                    cosmicData={this.props.store.cosmicData.result}
+                                    oncoKbData={this.props.store.oncoKbData}
+                                    civicGenes={this.props.store.civicGenes.result}
+                                    civicVariants={this.props.store.civicVariants.result}
+                                    enableOncoKb={this.props.config.showOncoKB}
+                                    enableHotspot={this.props.config.showHotspot}
+                                    enableMyCancerGenome={this.props.config.showMyCancerGenome}
+                                    enableCivic={this.props.config.showCivic}
+                                />
+                            )}
                     </div>
                     )
                 }

--- a/src/pages/resultsView/mutation/MutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/MutationMapperStore.ts
@@ -45,9 +45,10 @@ export class MutationMapperStore {
     @observable protected hugoGeneSymbol: string;
 
     protected config: IMutationMapperConfig;
-    protected mutationGeneticProfileId: MobxPromise<string>;
-    protected clinicalDataForSamples: MobxPromise<ClinicalData[]>;
-    protected sampleIds: MobxPromise<string[]>;
+
+    mutationGeneticProfileId: MobxPromise<string>;
+    clinicalDataForSamples: MobxPromise<ClinicalData[]>;
+    sampleIds: MobxPromise<string[]>;
 
     readonly cosmicData = remoteData({
         await: () => [

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -65,7 +65,6 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
                     <MSKTab key={gene} id={gene} linkText={gene} anchorStyle={anchorStyle}>
                         <MutationMapper
                             studyId={this.props.store.studyId}
-                            studyToCancerType={this.props.store.studyToCancerType}
                             store={mutationMapperStore}
                             discreteCNACache={this.props.store.discreteCNACache}
                             oncoKbEvidenceCache={this.props.store.oncoKbEvidenceCache}

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -3,6 +3,7 @@ import {observer} from "mobx-react";
 import {
     IMutationTableProps, MutationTableColumnType, default as MutationTable
 } from "shared/components/mutationTable/MutationTable";
+import CancerTypeColumnFormatter from "shared/components/mutationTable/column/CancerTypeColumnFormatter";
 
 export interface IResultsViewMutationTableProps extends IMutationTableProps {
     // add results view specific props here if needed
@@ -50,7 +51,9 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
 
         // override default visibility for some columns
         this._columns[MutationTableColumnType.MUTATION_ASSESSOR].visible = true;
-        this._columns[MutationTableColumnType.CANCER_TYPE].visible = false;
+        this._columns[MutationTableColumnType.CANCER_TYPE].visible = CancerTypeColumnFormatter.isVisible(
+            this.props.dataStore ? this.props.dataStore.allData : this.props.data,
+            this.props.sampleIdToTumorType);
 
         // order columns
         this._columns[MutationTableColumnType.SAMPLE_ID].order = 10;

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -79,7 +79,7 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
 
         // exclude
         this._columns[MutationTableColumnType.CANCER_TYPE].shouldExclude = ()=>{
-            return !this.props.cancerTypeCache;
+            return !this.props.sampleIdToTumorType;
         };
         this._columns[MutationTableColumnType.NUM_MUTATIONS].shouldExclude = ()=>{
             return !this.props.mutationCountCache;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -29,7 +29,6 @@ import OncoKbEvidenceCache from "shared/cache/OncoKbEvidenceCache";
 import MrnaExprRankCache from "shared/cache/MrnaExprRankCache";
 import VariantCountCache from "shared/cache/VariantCountCache";
 import PubMedCache from "shared/cache/PubMedCache";
-import CancerTypeCache from "../../cache/CancerTypeCache";
 import MutationCountCache from "../../cache/MutationCountCache";
 import MutationCountColumnFormatter from "./column/MutationCountColumnFormatter";
 import CancerTypeColumnFormatter from "./column/CancerTypeColumnFormatter";
@@ -37,13 +36,12 @@ import {IMobXApplicationDataStore} from "../../lib/IMobXApplicationDataStore";
 
 export interface IMutationTableProps {
     studyId?:string;
-    studyToCancerType?:{[studyId:string]:string};
+    sampleIdToTumorType?: {[sampleId: string]: string}
     discreteCNACache?:DiscreteCNACache;
     oncoKbEvidenceCache?:OncoKbEvidenceCache;
     mrnaExprRankCache?:MrnaExprRankCache;
     variantCountCache?:VariantCountCache;
     pubMedCache?:PubMedCache
-    cancerTypeCache?:CancerTypeCache;
     mutationCountCache?:MutationCountCache;
     mutSigData?:IMutSigData;
     enableOncoKb?: boolean;
@@ -406,19 +404,10 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
 
         this._columns[MutationTableColumnType.CANCER_TYPE] = {
             name: "Cancer Type",
-            render:CancerTypeColumnFormatter.makeRenderFunction(this),
-            sortBy:(d:Mutation[])=>CancerTypeColumnFormatter.sortBy(d, this.props.studyId, this.props.cancerTypeCache),
-            filter:(d:Mutation[], filterString:string, filterStringUpper:string) => {
-                if (this.props.cancerTypeCache) {
-                    return CancerTypeColumnFormatter.filter(d,
-                        filterStringUpper,
-                        this.props.studyId,
-                        this.props.cancerTypeCache,
-                        this.props.studyToCancerType);
-                } else {
-                    return false;
-                }
-            },
+            render: (d:Mutation[]) => CancerTypeColumnFormatter.render(d, this.props.sampleIdToTumorType),
+            sortBy: (d:Mutation[]) => CancerTypeColumnFormatter.sortBy(d, this.props.sampleIdToTumorType),
+            filter: (d:Mutation[], filterString:string, filterStringUpper:string) =>
+                CancerTypeColumnFormatter.filter(d, filterStringUpper, this.props.sampleIdToTumorType),
             tooltip:(<span>Cancer Type</span>),
         };
 

--- a/src/shared/components/mutationTable/column/CancerTypeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CancerTypeColumnFormatter.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as _ from "lodash";
 import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import TableCellStatusIndicator from "shared/components/TableCellStatus";
 import {TableCellStatus} from "shared/components/TableCellStatus";
@@ -38,6 +39,26 @@ export default class CancerTypeColumnFormatter {
             data !== null &&
             data.toUpperCase().indexOf(filterStringUpper) > -1
         );
+    }
+
+    public static isVisible(mutations?: Mutation[][], sampleIdToTumorType?: {[sampleId: string]: string}): boolean
+    {
+        if (!mutations || !sampleIdToTumorType) {
+            return false;
+        }
+
+        const tumorTypeToSampleId: {[tumorType: string]: string} = {};
+
+        mutations.forEach((d: Mutation[]) => {
+            const tumorType = CancerTypeColumnFormatter.getData(d, sampleIdToTumorType);
+
+            if (tumorType) {
+                tumorTypeToSampleId[tumorType] = d[0].sampleId;
+            }
+        });
+
+        // only visible if number of distinct tumor type values is greater than 1
+        return _.keys(tumorTypeToSampleId).length > 1;
     }
 
     public static render(d: Mutation[], sampleIdToTumorType?: {[sampleId: string]: string})

--- a/src/shared/components/mutationTable/column/CancerTypeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CancerTypeColumnFormatter.tsx
@@ -1,90 +1,59 @@
 import * as React from "react";
-import LazyLoadedTableCell from "shared/lib/LazyLoadedTableCell";
-import {Mutation} from "../../../api/generated/CBioPortalAPI";
-import MutationTable, {IMutationTableProps} from "../MutationTable";
-import CancerTypeCache from "../../../cache/CancerTypeCache";
-import {CacheData} from "../../../lib/LazyMobXCache";
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
+import TableCellStatusIndicator from "shared/components/TableCellStatus";
+import {TableCellStatus} from "shared/components/TableCellStatus";
 
 export default class CancerTypeColumnFormatter {
 
-    public static getData(d: Mutation[],
-                          studyId?: string,
-                          cancerTypeCache?: CancerTypeCache,
-                          studyCancerTypeMap?: {[studyId:string]:string}): CacheData<{value:string}>|null
+    public static getData(d: Mutation[], sampleIdToTumorType?: {[sampleId: string]: string}): string|null
     {
-        if (cancerTypeCache && studyId) {
-            let cacheDatum:CacheData<{value:string}>|null = cancerTypeCache.get({
-                entityId: d[0].sampleId,
-                studyId
-            });
+        let data: string|null = null;
 
-            if (cacheDatum && cacheDatum.status === "complete" && cacheDatum.data === null) {
-                // If no clinical data, use study cancer type if we have it
-                if (studyCancerTypeMap) {
-                    const cancerType = studyCancerTypeMap[studyId];
-                    if (cancerType) {
-                        cacheDatum = {
-                            status: "complete",
-                            data: {
-                                value: cancerType
-                            }
-                        };
-                    }
-                }
-            }
-            return cacheDatum;
-        } else {
-            return {
-                status: "error",
-                data: null
-            };
+        if (sampleIdToTumorType) {
+            data = sampleIdToTumorType[d[0].sampleId] || null;
         }
+
+        return data;
     }
 
-    public static makeRenderFunction<P extends IMutationTableProps>(table:MutationTable<P>) {
-        return LazyLoadedTableCell<Mutation[], {value:string}>(
-            (d:Mutation[])=>{
-                const cancerTypeCache:CancerTypeCache|undefined = table.props.cancerTypeCache;
-                const studyId:string|undefined = table.props.studyId;
-                const studyCancerTypeMap:{[studyId:string]:string} | undefined = table.props.studyToCancerType;
+    public static sortBy(d: Mutation[], sampleIdToTumorType?: {[sampleId: string]: string}): string|null
+    {
+        const data = CancerTypeColumnFormatter.getData(d, sampleIdToTumorType);
 
-                return CancerTypeColumnFormatter.getData(d, studyId, cancerTypeCache, studyCancerTypeMap);
-            },
-            (t:{value:string})=>(<span>{t.value}</span>),
-            "Cancer type not available for this sample."
-        );
-    }
-
-    public static sortBy(d:Mutation[], studyId?:string, cancerTypeCache?:CancerTypeCache) {
-        let ret;
-        if (cancerTypeCache && studyId) {
-            const cacheDatum = cancerTypeCache.get({
-                entityId:d[0].sampleId,
-                studyId: studyId
-            });
-            if (cacheDatum && cacheDatum.data) {
-                ret = cacheDatum.data.value;
-            } else {
-                ret = null;
-            }
-        } else {
-            ret = null;
+        if (data) {
+            return data;
         }
-        return ret;
+        else {
+            return null;
+        }
     }
 
     public static filter(d: Mutation[],
                          filterStringUpper: string,
-                         studyId?: string,
-                         cancerTypeCache?: CancerTypeCache,
-                         studyCancerTypeMap?: {[studyId:string]:string}): boolean
+                         sampleIdToTumorType?: {[sampleId: string]: string}): boolean
     {
-        const cacheDatum = CancerTypeColumnFormatter.getData(d, studyId, cancerTypeCache, studyCancerTypeMap);
+        const data = CancerTypeColumnFormatter.getData(d, sampleIdToTumorType);
 
         return (
-            cacheDatum !== null &&
-            cacheDatum.data !== null &&
-            cacheDatum.data.value.toUpperCase().indexOf(filterStringUpper) > -1
+            data !== null &&
+            data.toUpperCase().indexOf(filterStringUpper) > -1
         );
+    }
+
+    public static render(d: Mutation[], sampleIdToTumorType?: {[sampleId: string]: string})
+    {
+        const data = CancerTypeColumnFormatter.getData(d, sampleIdToTumorType);
+
+        if (data) {
+            return <span>{data}</span>;
+        }
+        else {
+            return (
+                <TableCellStatusIndicator
+                    status={TableCellStatus.NA}
+                    naAlt="Cancer type not available for this sample."
+                />
+            );
+        }
     }
 }

--- a/src/shared/components/mutationTable/column/CancerTypeColumnFormatterLazyLoaded.tsx
+++ b/src/shared/components/mutationTable/column/CancerTypeColumnFormatterLazyLoaded.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import LazyLoadedTableCell from "shared/lib/LazyLoadedTableCell";
+import {Mutation} from "../../../api/generated/CBioPortalAPI";
+import CancerTypeCache from "../../../cache/CancerTypeCache";
+import {CacheData} from "../../../lib/LazyMobXCache";
+
+export default class CancerTypeColumnFormatter {
+
+    public static getData(d: Mutation[],
+                          studyId?: string,
+                          cancerTypeCache?: CancerTypeCache,
+                          studyCancerTypeMap?: {[studyId:string]:string}): CacheData<{value:string}>|null
+    {
+        if (cancerTypeCache && studyId) {
+            let cacheDatum:CacheData<{value:string}>|null = cancerTypeCache.get({
+                entityId: d[0].sampleId,
+                studyId
+            });
+
+            if (cacheDatum && cacheDatum.status === "complete" && cacheDatum.data === null) {
+                // If no clinical data, use study cancer type if we have it
+                if (studyCancerTypeMap) {
+                    const cancerType = studyCancerTypeMap[studyId];
+                    if (cancerType) {
+                        cacheDatum = {
+                            status: "complete",
+                            data: {
+                                value: cancerType
+                            }
+                        };
+                    }
+                }
+            }
+            return cacheDatum;
+        } else {
+            return {
+                status: "error",
+                data: null
+            };
+        }
+    }
+
+    public static makeRenderFunction(studyId?: string,
+                                     cancerTypeCache?: CancerTypeCache,
+                                     studyCancerTypeMap?: {[studyId:string]:string}) {
+        return LazyLoadedTableCell<Mutation[], {value:string}>(
+            (d:Mutation[])=>{
+                return CancerTypeColumnFormatter.getData(d, studyId, cancerTypeCache, studyCancerTypeMap);
+            },
+            (t:{value:string})=>(<span>{t.value}</span>),
+            "Cancer type not available for this sample."
+        );
+    }
+
+    public static sortBy(d:Mutation[], studyId?:string, cancerTypeCache?:CancerTypeCache) {
+        let ret;
+        if (cancerTypeCache && studyId) {
+            const cacheDatum = cancerTypeCache.get({
+                entityId:d[0].sampleId,
+                studyId: studyId
+            });
+            if (cacheDatum && cacheDatum.data) {
+                ret = cacheDatum.data.value;
+            } else {
+                ret = null;
+            }
+        } else {
+            ret = null;
+        }
+        return ret;
+    }
+
+    public static filter(d: Mutation[],
+                         filterStringUpper: string,
+                         studyId?: string,
+                         cancerTypeCache?: CancerTypeCache,
+                         studyCancerTypeMap?: {[studyId:string]:string}): boolean
+    {
+        const cacheDatum = CancerTypeColumnFormatter.getData(d, studyId, cancerTypeCache, studyCancerTypeMap);
+
+        return (
+            cacheDatum !== null &&
+            cacheDatum.data !== null &&
+            cacheDatum.data.value.toUpperCase().indexOf(filterStringUpper) > -1
+        );
+    }
+}


### PR DESCRIPTION
# What? Why?
- Fix https://github.com/cBioPortal/cbioportal/issues/2807
- Fix https://github.com/cBioPortal/cbioportal/issues/2809
- Fix https://github.com/cBioPortal/cbioportal/issues/2811

Changes proposed in this pull request:
- Cancer Type column is not lazily loaded anymore (https://github.com/cBioPortal/cbioportal/issues/2811)
- Cancer Type column is now using the `sampleIdToTumorType` map, which is defined in the store and also used for OncoKB. (https://github.com/cBioPortal/cbioportal/issues/2809)
- Cancer Type column is now conditionally visible (https://github.com/cBioPortal/cbioportal/issues/2807)

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)