### PR TITLE
Reduced the width of some mutation table columns

### DIFF
--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -21,6 +21,7 @@ export type SortDirection = 'asc' | 'desc';
 
 export type Column<T> = {
     name: string;
+    headerRender?:(name:string)=>JSX.Element;
     filter?:(data:T, filterString:string, filterStringUpper?:string, filterStringLower?:string)=>boolean;
     visible?:boolean;
     sortBy?:((data:T)=>(number|null)) | ((data:T)=>(string|null)) | ((data:T)=>(number|null)[]) | ((data:T)=>(string|null)[]);
@@ -286,12 +287,16 @@ class LazyMobXTableStore<T> {
             if (this.sortColumn === column.name) {
                 headerProps.className = (this.sortAscending ? "sort-asc" : "sort-des");
             }
-            const label = (<span>{column.name}</span>);
+
+            const label = column.headerRender ? column.headerRender(column.name) : (<span>{column.name}</span>);
             let thContents;
+
             if (column.tooltip) {
-                thContents = (<DefaultTooltip placement="top" overlay={column.tooltip}>
-                    {label}
-                </DefaultTooltip>);
+                thContents = (
+                    <DefaultTooltip placement="top" overlay={column.tooltip}>
+                        {label}
+                    </DefaultTooltip>
+                );
             } else {
                 thContents = label;
             }

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -168,6 +168,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
         this._columns[MutationTableColumnType.TUMOR_ALLELE_FREQ] = {
             name: "Allele Freq (T)",
             render: TumorAlleleFreqColumnFormatter.renderFunction,
+            headerRender: (name: string) => <span style={{display:'inline-block', maxWidth:55}}>{name}</span>,
             sortBy: TumorAlleleFreqColumnFormatter.getSortValue,
             tooltip:(<span>Variant allele frequency in the tumor sample</span>),
             visible: true
@@ -176,6 +177,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
         this._columns[MutationTableColumnType.NORMAL_ALLELE_FREQ] = {
             name: "Allele Freq (N)",
             render: NormalAlleleFreqColumnFormatter.renderFunction,
+            headerRender: (name: string) => <span style={{display:'inline-block', maxWidth:55}}>{name}</span>,
             sortBy: NormalAlleleFreqColumnFormatter.getSortValue,
             tooltip:(<span>Variant allele frequency in the normal sample</span>),
             visible: false
@@ -360,6 +362,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
 
         this._columns[MutationTableColumnType.MUTATION_ASSESSOR] = {
             name: "Mutation Assessor",
+            headerRender: (name: string) => <span style={{display:'inline-block', maxWidth:60}}>{name}</span>,
             render:MutationAssessorColumnFormatter.renderFunction,
             download:MutationAssessorColumnFormatter.getTextValue,
             sortBy:(d:Mutation[])=>MutationAssessorColumnFormatter.getSortValue(d),
@@ -414,6 +417,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
         this._columns[MutationTableColumnType.NUM_MUTATIONS] = {
             name: "# Mut in Sample",
             render: MutationCountColumnFormatter.makeRenderFunction(this),
+            headerRender: (name: string) => <span style={{display:'inline-block', maxWidth:55}}>{name}</span>,
             sortBy: (d:Mutation[]) => MutationCountColumnFormatter.sortBy(d, this.props.mutationCountCache),
             tooltip:(<span>Total number of nonsynonymous mutations in the sample</span>)
         };


### PR DESCRIPTION
![selection_072](https://user-images.githubusercontent.com/3604198/28637676-5f2dd910-7210-11e7-842c-7df38f09c9a5.png)

# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/2849.

Changes proposed in this pull request:
- Reduced the max width of `Allele Frequency`, `Mutation Assessor`,  and `# Mut in Sample` columns
- Needed to add another column option to customize the column header rendering

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)