### PR TITLE
Displaying empty string for all unknown Mutation Assessor values

### DIFF
--- a/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/MutationAssessorColumnFormatter.spec.tsx
@@ -18,7 +18,6 @@ describe('MutationAssessorColumnFormatter', () => {
             linkXvar: "http://mutationassessor.org/r2/?cm=var&var=hg19,0,0,X,X"
         }),
         initMutation({
-
             functionalImpactScore: "H",
             fisValue: 3.8,
             linkPdb: null,
@@ -149,8 +148,8 @@ describe('MutationAssessorColumnFormatter', () => {
             "M(null) should rank higher than M(2.2)");
         assert.isAbove(sortedMutations.indexOf(mutations[2]), sortedMutations.indexOf(mutations[4]),
             "M(null) should rank higher than L(0.7)");
-        assert.isAbove(sortedMutations.indexOf(mutations[4]), sortedMutations.indexOf(mutations[5]),
-            "L(0.7) should rank higher than Unknown(null)");
+        assert.isBelow(sortedMutations.indexOf(mutations[4]), sortedMutations.indexOf(mutations[5]),
+            "L(0.7) should rank lower than Unknown(null)");
     });
 
     after(() => {


### PR DESCRIPTION
![mutation_assessor](https://user-images.githubusercontent.com/3604198/28693293-f05d73c8-72f1-11e7-8576-f1e6ef9af9ac.png)

# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/2805.

Changes proposed in this pull request:
- Now displaying empty string for any other value than "High", "Medium", "Low", and "Neutral"
- Slightly changed the sorting behavior to exclude empty values from sorting

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)