### PR TITLE
Add mutation rate summary to mutation mapper

### DIFF
--- a/end-to-end-tests/specs/home.spec.js
+++ b/end-to-end-tests/specs/home.spec.js
@@ -101,8 +101,8 @@ describe('cross cancer query', function() {
         var checkBoxes = $$('[data-test="StudySelect"]');
         
         checkBoxes.forEach(function (checkBox, i) {
-            // select a tenth of existing studies
-            if (i % 10 === 0) {
+            // select a proportion of existing studies
+            if (i % 20 === 0) {
                 checkBox.click();
             }
         });
@@ -118,5 +118,49 @@ describe('cross cancer query', function() {
         // check if TP53 is in the title of the bar chart
         var text = browser.getText('.cctitle')
         assert(text.search('TP53') > -1);
+    });
+});
+
+describe('single study query', function() {
+    describe('mutation mapper ', function() {
+        it('should show somatic and germline mutation rate', function() {
+            browser.url(`${CBIOPORTAL_URL}`);
+
+            var input = $(".autosuggest input[type=text]");
+
+            input.waitForExist(10000); 
+
+            input.setValue('ovarian nature 2011');
+            
+            browser.pause(500);
+
+            // should only be one element
+            assert.equal(browser.elements('[data-test="cancerTypeListContainer"] > ul > ul').value.length, 1);
+
+            var checkBox = $('[data-test="StudySelect"]');
+
+            checkBox.waitForExist(10000);
+            
+            browser.click('[data-test="StudySelect"]');
+
+            // query BRCA1 and BRCA2
+            $('[data-test="geneSet"]').setValue('BRCA1 BRCA2');
+
+            browser.waitForEnabled('[data-test="queryButton"]', 30000);
+            browser.click('[data-test="queryButton"]');
+
+            // click mutations tab
+            $('#mutation-result-tab').waitForExist(30000);
+            $('#mutation-result-tab').click();
+
+            $('[data-test="germlineMutationRate"]').waitForExist(60000);
+            var text = browser.getText('[data-test="germlineMutationRate"]')
+            // check germline mutation rate
+            assert(text.search('8.2%' > -1));
+            // check somatic mutation 
+            var text = browser.getText('[data-test="somaticMutationRate"]')
+            assert(text.search('3.5%' > -1));
+
+        });
     });
 });

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -17,6 +17,7 @@ import LollipopMutationPlot from "../../../shared/components/lollipopMutationPlo
 import ProteinImpactTypePanel from "../../../shared/components/mutationTypePanel/ProteinImpactTypePanel";
 import ProteinChainPanel from "../../../shared/components/proteinChainPanel/ProteinChainPanel";
 import {computed, action, observable} from "mobx";
+import MutationRateSummary from "pages/resultsView/mutation/MutationRateSummary";
 
 export interface IMutationMapperConfig {
     showCivic?: boolean;
@@ -61,6 +62,26 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
         };
     }
 
+    @computed get mutationRateSummary():JSX.Element|null {
+        if (this.props.store.gene.result &&
+            this.props.store.gene.result.length > 0 &&
+            this.props.store.patientIds.result &&
+            this.props.store.patientIds.result.length > 0 &&
+            this.props.store.mutationData.isComplete &&
+            this.props.store.mutationData.result.length > 0 &&
+            this.props.store.mskImpactGermlineConsentedPatientIds.result &&
+            this.props.store.mskImpactGermlineConsentedPatientIds.isComplete) {
+            return <MutationRateSummary
+                        hugoGeneSymbol={this.props.store.gene.result.hugoGeneSymbol}
+                        mutations={this.props.store.mutationData.result}
+                        patientIds={this.props.store.patientIds.result}
+                        mskImpactGermlineConsentedPatientIds={this.props.store.mskImpactGermlineConsentedPatientIds.result}
+                    />
+        } else {
+            return null;
+        }
+    }
+
     public render() {
         return (
             <div>
@@ -82,6 +103,7 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                 {
                     (this.props.store.mutationData.isComplete && this.props.store.gene.result) && (
                         <div>
+                            {this.mutationRateSummary}
                             <LollipopMutationPlot
                                 store={this.props.store}
                                 onXAxisOffset={this.handlers.onXAxisOffset}

--- a/src/pages/resultsView/mutation/MutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/MutationMapperStore.ts
@@ -29,7 +29,9 @@ export class MutationMapperStore {
                 mutationGeneticProfileId: MobxPromise<string>,
                 sampleIds: MobxPromise<string[]>,
                 clinicalDataForSamples: MobxPromise<ClinicalData[]>,
-                sampleListId: string|null)
+                sampleListId: string|null,
+                patientIds: MobxPromise<string[]>,
+                mskImpactGermlineConsentedPatientIds: MobxPromise<string[]>)
     {
         this.config = config;
         this.hugoGeneSymbol = hugoGeneSymbol;
@@ -37,6 +39,8 @@ export class MutationMapperStore {
         this.sampleIds = sampleIds;
         this.clinicalDataForSamples = clinicalDataForSamples;
         this.sampleListId = sampleListId;
+        this.patientIds = patientIds;
+        this.mskImpactGermlineConsentedPatientIds = mskImpactGermlineConsentedPatientIds;
 
         labelMobxPromises(this);
     }
@@ -49,6 +53,8 @@ export class MutationMapperStore {
     mutationGeneticProfileId: MobxPromise<string>;
     clinicalDataForSamples: MobxPromise<ClinicalData[]>;
     sampleIds: MobxPromise<string[]>;
+    patientIds: MobxPromise<string[]>;
+    mskImpactGermlineConsentedPatientIds: MobxPromise<string[]>;
 
     readonly cosmicData = remoteData({
         await: () => [

--- a/src/pages/resultsView/mutation/MutationRateSummary.tsx
+++ b/src/pages/resultsView/mutation/MutationRateSummary.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import {observer} from "mobx-react";
+import { Mutation } from "shared/api/generated/CBioPortalAPI";
+import {germlineMutationRate, somaticMutationRate} from "shared/lib/MutationUtils";
+
+export interface IMutationRateSummaryProps {
+    patientIds: string[];
+    mutations: Mutation[];
+    hugoGeneSymbol: string;
+    mskImpactGermlineConsentedPatientIds: string[];
+}
+
+export default class MutationRateSummary extends React.Component<IMutationRateSummaryProps, {}>
+{
+    render() {
+        // for germline mutation rate
+        // - only use germline constented patients for impact study
+        // - in all other cases assume that every patient had germline testing
+        //   if > 0 germline mutations are found
+        const patientIds = (this.props.mskImpactGermlineConsentedPatientIds.length > 0)?
+                                this.props.mskImpactGermlineConsentedPatientIds :
+                                this.props.patientIds;
+        const gmr = germlineMutationRate(this.props.hugoGeneSymbol,
+                                         this.props.mutations,
+                                         patientIds)
+        const germlineMutationRateElement:JSX.Element|null =
+            (gmr > 0)?
+            (
+                <span style={{paddingRight: 5}}>
+                 Germline Mutation Rate:
+                     <span style={{paddingLeft:2}} data-test='germlineMutationRate'>
+                        {gmr.toFixed(1)}%,
+                     </span>
+                </span>
+            )
+            : null;
+
+        return (
+            <h4 style={{paddingBottom:8,paddingTop:8}}>
+                {this.props.hugoGeneSymbol}:
+                     [{germlineMutationRateElement}
+                  Somatic Mutation Rate:
+                     <span style={{paddingLeft:2}} data-test='somaticMutationRate'>
+                     {somaticMutationRate(this.props.hugoGeneSymbol,
+                                          this.props.mutations,
+                                          this.props.patientIds).toFixed(1)}%]
+                     </span>
+            </h4>
+        );
+    }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,2 +1,8 @@
 export const GENETIC_PROFILE_MUTATIONS_SUFFIX = '_mutations';
 export const GENETIC_PROFILE_UNCALLED_MUTATIONS_SUFFIX = `${GENETIC_PROFILE_MUTATIONS_SUFFIX}_uncalled`;
+export const MUTATION_STATUS_GERMLINE = 'Germline';
+// Clinical patient attribute for private impact study that indicates whether
+// or not the patient consented to germline testing (allows differentiating
+// between patients that have no germline mutations and those that weren't
+// screened)
+export const IMPACT_GERMLINE_TESTING_CONSENT = '12_245_PARTC_CONSENTED';

--- a/src/shared/lib/MutationUtils.spec.ts
+++ b/src/shared/lib/MutationUtils.spec.ts
@@ -1,0 +1,150 @@
+import {
+    somaticMutationRate, germlineMutationRate
+} from "./MutationUtils";
+import * as _ from 'lodash';
+import { assert, expect } from 'chai';
+import sinon from 'sinon';
+import {Mutation} from "../api/generated/CBioPortalAPI";
+import {initMutation} from "test/MutationMockUtils";
+import { MUTATION_STATUS_GERMLINE } from "shared/constants";
+
+describe('MutationUtils', () => {
+    let somaticMutations: Mutation[];
+    let germlineMutations: Mutation[];
+
+    before(()=>{
+        somaticMutations = [
+            initMutation({ // mutation
+                patientId: "PATIENT1",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+             }),
+            initMutation({ // mutation in same gene, same patient
+                patientId: "PATIENT1",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+             }),
+            initMutation({ // mutation in same patient different gene
+                patientId: "PATIENT2",
+                gene: {
+                    hugoGeneSymbol: "PIK3CA",
+                },
+             })
+        ];
+        germlineMutations = [
+            initMutation({ // mutation
+                patientId: "PATIENT1",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                mutationStatus: MUTATION_STATUS_GERMLINE
+             }),
+            initMutation({ // mutation in same gene, same patient
+                patientId: "PATIENT1",
+                gene: {
+                    hugoGeneSymbol: "BRCA1",
+                },
+                mutationStatus: MUTATION_STATUS_GERMLINE
+             }),
+            initMutation({ // mutation in same patient different gene
+                patientId: "PATIENT2",
+                gene: {
+                    hugoGeneSymbol: "BRCA2",
+                },
+                mutationStatus: MUTATION_STATUS_GERMLINE
+             })
+        ];
+    });
+
+    describe('somaticMutationRate', () => {
+        it("calculates rate correctly", () => {
+            // only one of the patients has a TP53 mutation
+            let result:number = 
+                somaticMutationRate(
+                    "TP53",
+                    somaticMutations,
+                    ['PATIENT1', 'PATIENT2']
+                );
+            assert.equal(result, 50)
+
+            // No non-existing gene mutations
+            result = 
+                somaticMutationRate(
+                    "NASDASFASG",
+                    somaticMutations,
+                    ['PATIENT1', 'PATIENT2']
+                );
+            assert.equal(result, 0)
+
+            // when nr of given patientIds is 1 it should give 100% (not sure if
+            // this should be an error instead)
+            result = 
+                somaticMutationRate(
+                    "PIK3CA",
+                    somaticMutations,
+                    ['PATIENT2']
+                );
+            assert.equal(result, 100)
+
+            // germline mutations should be ignored
+            result = 
+                somaticMutationRate(
+                    "BRCA1",
+                    somaticMutations.concat(germlineMutations),
+                    ['PATIENT2']
+                );
+            assert.equal(result, 0)
+
+            // ignore all mutations for non existent patient id
+            result = 
+                somaticMutationRate(
+                    "PIK3CA",
+                    somaticMutations,
+                    ['XXXX']
+                );
+            assert.equal(result, 0)
+        });
+    });
+
+    describe('germlineMutationRate', () => {
+        it("calculates rate correctly", () => {
+            // only half of patients have BRCA1 mutation
+            let result:number =
+                germlineMutationRate(
+                    "BRCA1",
+                    germlineMutations,
+                    ['PATIENT1', 'PATIENT2'],
+                );
+            assert.equal(result, 50)
+
+            // somatic mutations should be ignored
+            result = 
+                germlineMutationRate(
+                    "PIK3CA",
+                    germlineMutations.concat(somaticMutations),
+                    ['PATIENT1', 'PATIENT2'],
+                );
+            assert.equal(result, 0)
+
+            // ignore all mutations for non existent patient id
+            result = 
+                germlineMutationRate(
+                    "BRCA2",
+                    germlineMutations,
+                    ['XXXX']
+                );
+            assert.equal(result, 0)
+
+            // No non-existing gene mutations
+            result = 
+                germlineMutationRate(
+                    "NASDASFASG",
+                    germlineMutations,
+                    ['PATIENT1', 'PATIENT2']
+                );
+            assert.equal(result, 0)
+        });
+    });
+});

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -119,12 +119,13 @@ export async function fetchClinicalData(clinicalDataMultiStudyFilter:ClinicalDat
 
 export async function fetchClinicalDataInStudy(studyId:string,
                                                clinicalDataSingleStudyFilter:ClinicalDataSingleStudyFilter,
+                                               clinicalDataType: 'SAMPLE' | 'PATIENT',
                                                client:CBioPortalAPI = defaultClient)
 {
     if (clinicalDataSingleStudyFilter) {
         return await client.fetchAllClinicalDataInStudyUsingPOST({
             studyId: studyId,
-            clinicalDataType: 'SAMPLE',
+            clinicalDataType: clinicalDataType,
             clinicalDataSingleStudyFilter: clinicalDataSingleStudyFilter,
             projection: 'SUMMARY',
         });


### PR DESCRIPTION
Determine somatic mutation rate. That is divide number of cases with a somatic
mutation by total number of cases (patients) queried. Calculate germline mutation rate if
there are germline mutations. For the private impact study there is a specific clinical
attribute that indicates whether the patient was screened for germline
mutations `12_245_PARTC_CONSENTED`. Use number of cases that consented as
denominator if that is available (subset of total).