### PR TITLE
Fix cbioportal/cbioportal#2804

### DIFF
--- a/src/shared/components/cosmic/CosmicMutationTable.tsx
+++ b/src/shared/components/cosmic/CosmicMutationTable.tsx
@@ -78,7 +78,7 @@ export default class CosmicMutationTable extends React.Component<ICosmicTablePro
             (this.props.initialItemsPerPage || CosmicMutationTable.defaultProps.initialItemsPerPage);
 
         return (
-            <div>
+            <div className='cbioportal-frontend'>
                 <CosmicTable
                     data={data}
                     columns={columns || CosmicMutationTable.defaultProps.columns}
@@ -89,6 +89,8 @@ export default class CosmicMutationTable extends React.Component<ICosmicTablePro
                     showColumnVisibility={false}
                     showFilter={false}
                     showPagination={showPagination}
+                    showPaginationAtTop={true}
+                    paginationProps={{showMoreButton:false}}
                 />
             </div>
         );

--- a/src/shared/components/paginationControls/PaginationControls.tsx
+++ b/src/shared/components/paginationControls/PaginationControls.tsx
@@ -60,7 +60,8 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
         style:{},
         previousPageDisabled:false,
         nextPageDisabled:false,
-        pageNumberEditable: false
+        pageNumberEditable: false,
+        showMoreButton: true
     };
 
     constructor(props:IPaginationControlsProps) {
@@ -105,7 +106,12 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
         } else {
             return (<span
                         key="textBetweenButtons"
-                        className={"btn btn-default textBetweenButtons disabled" + styles["default-cursor"]}
+                        className={classNames('btn',
+                                              'btn-default',
+                                              'textBetweenButtons',
+                                              'disabled',
+                                              styles["default-cursor"])}
+                        style={{cursor:'default',color:'black'}} // HACK for parent project
                     >
                         <If condition={this.props.pageNumberEditable}>
                             <EditableSpan

--- a/src/shared/components/proteinChainPanel/PdbChainTable.tsx
+++ b/src/shared/components/proteinChainPanel/PdbChainTable.tsx
@@ -141,6 +141,7 @@ export default class PdbChainTable extends React.Component<IPdbChainTableProps, 
                 itemsLabelPlural="PDB chains"
                 paginationProps={{
                     showItemsPerPageSelector:false,
+                    showMoreButton:false
                 }}
                 initialItemsPerPage={6}
                 columns={this.columns}


### PR DESCRIPTION
Makes changes so pagination is again at the top for cosmic. This is reverting back to how it was before the `showMore` button. Also add `cbioportal-frontend` class to cosmic table. This fixes the styling issues in the parent project. 
<img width="1028" alt="screen shot 2017-08-02 at 7 50 50 pm" src="https://user-images.githubusercontent.com/1334004/28887040-f35cfe44-77bb-11e7-9b6f-696caa785175.png">

