### PR TITLE
Fixed lollipop diagram axis label overlap

### DIFF
--- a/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
@@ -219,12 +219,15 @@ export default class LollipopPlotNoTooltip extends React.Component<LollipopPlotN
     }
 
     private calculateTicks(tickInterval:number, rangeSize:number, labelEvenTicks:boolean) {
-        const ret = [];
+        const ret: {position: number, label: string|undefined}[] = [];
         let nextTick = tickInterval;
         while (nextTick < rangeSize) {
-            let label = undefined;
+            let label: string|undefined = undefined;
+
+            // add label only for the even ticks
+            // but do not add label if it is too close to the end value
             if (labelEvenTicks
-                && (rangeSize - nextTick > tickInterval / 3)
+                && (rangeSize - nextTick > (2*tickInterval) / 3)
                 && (nextTick % (2*tickInterval) === 0)) {
                 label = nextTick + "";
             }


### PR DESCRIPTION
![lollipop_x_axis](https://user-images.githubusercontent.com/3604198/28853981-312830e6-7702-11e7-86dd-f73e8f15c28d.png)

# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/2886.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
