### PR TITLE
In case of multiple swiss prot ids, using the first one by default

### DIFF
--- a/src/pages/resultsView/mutation/MutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/MutationMapperStore.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import {
     Mutation, MutationFilter, Gene, ClinicalData
 } from "shared/api/generated/CBioPortalAPI";
@@ -134,7 +135,14 @@ export class MutationMapperStore {
         ],
         invoke: async() => {
             if (this.gene.result) {
-                return fetchSwissProtAccession(this.gene.result.entrezGeneId);
+                const accession:string|string[] = await fetchSwissProtAccession(this.gene.result.entrezGeneId);
+
+                if (_.isArray(accession)) {
+                    return accession[0];
+                }
+                else {
+                    return accession;
+                }
             }
             else {
                 return "";


### PR DESCRIPTION
![cdn2a_human](https://user-images.githubusercontent.com/3604198/28890677-dd1e0978-7795-11e7-829f-d34804293c50.png)

# What? Why?
Fix  https://github.com/cBioPortal/cbioportal/issues/2803.

Changes proposed in this pull request:
- Diagram is now initialized by using the first entry by default, but that's different than what we currently have on legacy portal.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)