### PR TITLE
remove nbsp chars which get corrupted by production build

### DIFF
--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -133,7 +133,7 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                                     />
                                 </div>
 
-                                <div>
+                                <div className="mutationMapperMetaColumn">
                                     {this.geneSummary}
 
                                     {this.mutationRateSummary}

--- a/src/pages/resultsView/mutation/MutationRateSummary.tsx
+++ b/src/pages/resultsView/mutation/MutationRateSummary.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {observer} from "mobx-react";
 import { Mutation } from "shared/api/generated/CBioPortalAPI";
 import {germlineMutationRate, somaticMutationRate} from "shared/lib/MutationUtils";
-import classnames from 'classnames';
 
 export interface IMutationRateSummaryProps {
     patientIds: string[];
@@ -28,7 +27,7 @@ export default class MutationRateSummary extends React.Component<IMutationRateSu
         return (
             <div>
                 <div data-test="somaticMutationRate">
-                <label>Somatic Mutation Frequency:</label>&nbsp;
+                <label>Somatic Mutation Frequency:</label>
                 {somaticMutationRate(this.props.hugoGeneSymbol,
                               this.props.mutations,
                               this.props.patientIds).toFixed(1)}%
@@ -36,7 +35,7 @@ export default class MutationRateSummary extends React.Component<IMutationRateSu
 
 
                 <div data-test='germlineMutationRate' className={(gmr > 0) ? '' : 'invisible' }>
-                    <label>Germline Mutation Frequency:</label>&nbsp;
+                    <label>Germline Mutation Frequency:</label>
                     {(gmr > 0) ? `${gmr.toFixed(1)}%` : '--'}
                 </div>
 

--- a/src/pages/resultsView/mutation/mutations.scss
+++ b/src/pages/resultsView/mutation/mutations.scss
@@ -2,5 +2,11 @@
   padding-top: 5px !important;
   border-top:none !important;
   border-bottom:none !important;
+
+  .mutationMapperMetaColumn label {
+    margin-right:5px;
+  }
 }
+
+
 


### PR DESCRIPTION
&nbsp entites get garbled by production build.  this is annoying issue that can only be worked around for now until we fix build env

https://github.com/cBioPortal/cbioportal/issues/2911

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
