### PR TITLE
Add right margin to right-aligned text in mutation table

### DIFF
--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
@@ -5,6 +5,7 @@ import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import {CosmicMutation} from "shared/api/generated/CBioPortalAPIInternal";
 import CosmicMutationTable from "shared/components/cosmic/CosmicMutationTable";
 import styles from "./cosmic.module.scss";
+import generalStyles from "./styles.module.scss";
 import {ICosmicData} from "shared/model/Cosmic";
 
 export function placeArrow(tooltipEl: any) {
@@ -119,7 +120,7 @@ export default class CosmicColumnFormatter
 
         // basic content is the value
         content = (
-            <span className="pull-right">
+            <span className={generalStyles["cosmic-count"]}>
                 {display}
             </span>
         );

--- a/src/shared/components/mutationTable/column/MutationCountColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutationCountColumnFormatter.tsx
@@ -3,6 +3,7 @@ import LazyLoadedTableCell from "shared/lib/LazyLoadedTableCell";
 import {Mutation, MutationCount} from "../../../api/generated/CBioPortalAPI";
 import MutationCountCache from "../../../cache/MutationCountCache";
 import MutationTable, {IMutationTableProps} from "../MutationTable";
+import styles from "./styles.module.scss";
 
 export default class MutationCountColumnFormatter {
     public static makeRenderFunction<P extends IMutationTableProps>(table:MutationTable<P>) {
@@ -18,7 +19,7 @@ export default class MutationCountColumnFormatter {
                     };
                 }
             },
-            (t:MutationCount)=>(<span className="pull-right">{t.mutationCount}</span>),
+            (t:MutationCount)=>(<span className={styles["mutation-count"]}>{t.mutationCount}</span>),
             "Mutation count not available for this sample."
         );
     }

--- a/src/shared/components/mutationTable/column/styles.module.scss
+++ b/src/shared/components/mutationTable/column/styles.module.scss
@@ -1,0 +1,9 @@
+.cosmic-count {
+  float: right;
+  margin-right: 50%;
+}
+
+.mutation-count {
+  float: right;
+  margin-right: 50%;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/636232/28989001-b40edd3a-7940-11e7-8a15-c5bf96836534.png)
