### PR TITLE
Fix input:range style in lollipop for IE

### DIFF
--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -426,10 +426,10 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                             </button>
                         </div>
 
-                        <div className="small" style={{float:'right',display:'flex'}}>
+                        <div className="small" style={{float:'right',display:'flex', alignItems:'center'}}>
                                 <span>Y-Axis Max:</span>
                                     <input
-                                        style={{display:"inline-block", width:200, marginLeft:10, marginRight:10}}
+                                        style={{display:"inline-block", padding:0, width:200, marginLeft:10, marginRight:10}}
                                         type="range"
                                         min={this.countRange[0]}
                                         max={this.countRange[1]}


### PR DESCRIPTION
https://github.com/cBioPortal/cbioportal/issues/2826

In lollipol diagrame the input:range style doesn't look right.

Remove default padding.  Add vertical alignment center. 
Before:
![image](https://user-images.githubusercontent.com/186521/29076263-06e7ab38-7c23-11e7-8295-6aa6519a1a85.png)
After:
![image](https://user-images.githubusercontent.com/186521/29076506-bfdb15a8-7c23-11e7-92f7-360061b6313e.png)

