### PR TITLE
3D viewer panel updates

### DIFF
--- a/src/shared/components/structureViewer/StructureViewer.tsx
+++ b/src/shared/components/structureViewer/StructureViewer.tsx
@@ -11,6 +11,7 @@ export interface IStructureViewerProps extends IStructureVisualizerProps {
     chainId: string;
     bounds: {width: number|string, height: number|string};
     residues?: IResidueSpec[];
+    containerRef?: (div: HTMLDivElement) => void;
 }
 
 @observer
@@ -18,7 +19,6 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
 {
     private _3dMolDiv: HTMLDivElement|undefined;
     private _pdbId: string;
-    private _bounds: {width: number|string, height: number|string};
     private wrapper: StructureVisualizer3D;
 
     public constructor() {
@@ -47,11 +47,10 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
             this.wrapper = new StructureVisualizer3D(this._3dMolDiv, this.props);
             this.wrapper.init(this.props.pdbId, this.props.chainId, this.props.residues);
             this._pdbId = this.props.pdbId;
-            this._bounds = this.props.bounds;
         }
     }
 
-    public componentDidUpdate() {
+    public componentDidUpdate(prevProps: IStructureViewerProps) {
         if (this.wrapper) {
             // if pdbId is updated we need to reload the structure
             if (this.props.pdbId !== this._pdbId) {
@@ -63,7 +62,7 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
                 this.wrapper.updateViewer(this.props.chainId, this.props.residues, this.props);
             }
 
-            if (!_.isEqual(this.props.bounds, this._bounds)) {
+            if (!_.isEqual(this.props.bounds, prevProps.bounds)) {
                 this.wrapper.resize();
             }
         }
@@ -71,5 +70,9 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
 
     private divHandler(div:HTMLDivElement) {
          this._3dMolDiv = div;
+
+         if (this.props.containerRef) {
+             this.props.containerRef(div);
+         }
     }
 }

--- a/src/shared/components/structureViewer/StructureViewer.tsx
+++ b/src/shared/components/structureViewer/StructureViewer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import {observer} from "mobx-react";
 import {
     IStructureVisualizerProps, IResidueSpec
@@ -8,6 +9,7 @@ import StructureVisualizer3D from "./StructureVisualizer3D";
 export interface IStructureViewerProps extends IStructureVisualizerProps {
     pdbId: string;
     chainId: string;
+    bounds: {width: number|string, height: number|string};
     residues?: IResidueSpec[];
 }
 
@@ -16,6 +18,7 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
 {
     private _3dMolDiv: HTMLDivElement|undefined;
     private _pdbId: string;
+    private _bounds: {width: number|string, height: number|string};
     private wrapper: StructureVisualizer3D;
 
     public constructor() {
@@ -29,7 +32,12 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
         return (
             <div
                 ref={this.divHandler}
-                style={{height: 300}}
+                style={{
+                    height: this.props.bounds.height,
+                    width: this.props.bounds.width,
+                    padding: 0
+                }}
+                className="borderedChart"
             />
         );
     }
@@ -39,6 +47,7 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
             this.wrapper = new StructureVisualizer3D(this._3dMolDiv, this.props);
             this.wrapper.init(this.props.pdbId, this.props.chainId, this.props.residues);
             this._pdbId = this.props.pdbId;
+            this._bounds = this.props.bounds;
         }
     }
 
@@ -52,6 +61,10 @@ export default class StructureViewer extends React.Component<IStructureViewerPro
             // other updates just require selection/style updates without reloading the structure
             else {
                 this.wrapper.updateViewer(this.props.chainId, this.props.residues, this.props);
+            }
+
+            if (!_.isEqual(this.props.bounds, this._bounds)) {
+                this.wrapper.resize();
             }
         }
     }

--- a/src/shared/components/structureViewer/StructureViewerPanel.tsx
+++ b/src/shared/components/structureViewer/StructureViewerPanel.tsx
@@ -22,11 +22,11 @@ import {
     getProteinStartPositionsByRange
 } from "shared/lib/MutationUtils";
 import StructureViewer from "./StructureViewer";
+import PdbChainInfo from "../PdbChainInfo";
 import {ProteinScheme, ProteinColor, SideChain, MutationColor, IResidueSpec} from "./StructureVisualizer";
 import PyMolScriptGenerator from "./PyMolScriptGenerator";
 
 import styles from "./structureViewer.module.scss";
-import PdbChainInfo from "../PdbChainInfo";
 
 export interface IStructureViewerPanelProps extends IProteinImpactTypeColors
 {
@@ -47,6 +47,11 @@ export default class StructureViewerPanel extends React.Component<IStructureView
     @observable protected sideChain:SideChain = SideChain.SELECTED;
     @observable protected mutationColor:MutationColor = MutationColor.MUTATION_TYPE;
     @observable protected displayBoundMolecules:boolean = true;
+
+    @observable protected structureViewerBounds: {width: number|string, height: number|string} = {
+        width: "auto",
+        height: 350
+    };
 
     constructor() {
         super();
@@ -403,8 +408,7 @@ export default class StructureViewerPanel extends React.Component<IStructureView
                             </div>
                         </div>
                     </If>
-                    <div className={`${styles["vis-container"]} row`}>
-                        <hr />
+                    <div className="row" style={{paddingTop: 5, paddingBottom: 5}}>
                         <StructureViewer
                             displayBoundMolecules={this.displayBoundMolecules}
                             proteinScheme={this.proteinScheme}
@@ -414,8 +418,8 @@ export default class StructureViewerPanel extends React.Component<IStructureView
                             pdbId={this.pdbId}
                             chainId={this.chainId}
                             residues={this.residues}
+                            bounds={this.structureViewerBounds}
                         />
-                        <hr />
                     </div>
                 </span>
             );

--- a/src/shared/components/structureViewer/StructureViewerPanel.tsx
+++ b/src/shared/components/structureViewer/StructureViewerPanel.tsx
@@ -42,21 +42,21 @@ export interface IStructureViewerPanelProps extends IProteinImpactTypeColors
 export default class StructureViewerPanel extends React.Component<IStructureViewerPanelProps, {}> {
 
     @observable protected isCollapsed:boolean = false;
+    @observable protected isIncreasedSize:boolean = false;
     @observable protected proteinScheme:ProteinScheme = ProteinScheme.CARTOON;
     @observable protected proteinColor:ProteinColor = ProteinColor.UNIFORM;
     @observable protected sideChain:SideChain = SideChain.SELECTED;
     @observable protected mutationColor:MutationColor = MutationColor.MUTATION_TYPE;
     @observable protected displayBoundMolecules:boolean = true;
 
-    @observable protected structureViewerBounds: {width: number|string, height: number|string} = {
-        width: "auto",
-        height: 350
-    };
+    protected _3dMolDiv: HTMLDivElement|undefined;
 
     constructor() {
         super();
 
+        this.containerRefHandler = this.containerRefHandler.bind(this);
         this.toggleCollapse = this.toggleCollapse.bind(this);
+        this.toggleDoubleSize = this.toggleDoubleSize.bind(this);
         this.handleProteinSchemeChange = this.handleProteinSchemeChange.bind(this);
         this.handleProteinColorChange = this.handleProteinColorChange.bind(this);
         this.handleSideChainChange = this.handleSideChainChange.bind(this);
@@ -362,12 +362,17 @@ export default class StructureViewerPanel extends React.Component<IStructureView
     public header()
     {
         return (
-            <div className='row'>
+            <div className={classnames('row', styles["header"])}>
                 <div className='col col-sm-10'>
                     <span>3D Structure</span>
                 </div>
                 <div className="col col-sm-2">
                     <span className="pull-right">
+                        <i
+                            className={classnames("fa", {"fa-compress": this.isIncreasedSize, "fa-expand": !this.isIncreasedSize})}
+                            onClick={this.toggleDoubleSize}
+                            style={{marginRight: 5, cursor: "pointer"}}
+                        />
                         <i
                             className="fa fa-minus-circle"
                             onClick={this.toggleCollapse}
@@ -419,6 +424,7 @@ export default class StructureViewerPanel extends React.Component<IStructureView
                             chainId={this.chainId}
                             residues={this.residues}
                             bounds={this.structureViewerBounds}
+                            containerRef={this.containerRefHandler}
                         />
                     </div>
                 </span>
@@ -445,22 +451,36 @@ export default class StructureViewerPanel extends React.Component<IStructureView
             <Draggable
                 handle=".structure-viewer-header"
             >
-                <div className={classnames(styles["main-3d-panel"], {[styles["collapsed-panel"]]: this.isCollapsed})}>
+                <div
+                    className={
+                        classnames(styles["main-3d-panel"], {
+                            [styles["increased-size-panel"]]: this.isIncreasedSize
+                        })
+                    }
+                >
                     <div className="structure-viewer-header row">
                         {this.header()}
                         <hr style={{borderTopColor: "#BBBBBB"}} />
                     </div>
-                    {this.mainContent()}
-                    <div className='row'>
-                        {this.topToolbar()}
-                        <hr />
-                    </div>
-                    <div className="row">
-                        <div className='col col-sm-6'>
-                            {this.proteinStyleMenu()}
+                    <div
+                        className={
+                            classnames(styles["body"], {
+                                [styles["collapsed-panel"]]: this.isCollapsed
+                            })
+                        }
+                    >
+                        {this.mainContent()}
+                        <div className='row'>
+                            {this.topToolbar()}
+                            <hr />
                         </div>
-                        <div className='col col-sm-6'>
-                            {this.mutationStyleMenu()}
+                        <div className="row">
+                            <div className='col col-sm-6'>
+                                {this.proteinStyleMenu()}
+                            </div>
+                            <div className='col col-sm-6'>
+                                {this.mutationStyleMenu()}
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -468,8 +488,16 @@ export default class StructureViewerPanel extends React.Component<IStructureView
         );
     }
 
+    private containerRefHandler(div: HTMLDivElement) {
+        this._3dMolDiv = div;
+    }
+
     private toggleCollapse() {
         this.isCollapsed = !this.isCollapsed;
+    }
+
+    private toggleDoubleSize() {
+        this.isIncreasedSize = !this.isIncreasedSize;
     }
 
     private handleProteinSchemeChange(evt:React.FormEvent<HTMLSelectElement>) {
@@ -511,6 +539,24 @@ export default class StructureViewerPanel extends React.Component<IStructureView
             fileDownload(this.pyMolScript, filename);
         }
     }
+
+    @computed get structureViewerBounds(): {width: number|string, height: number|string} {
+        let width: number|string;
+        let height: number|string;
+
+        // if 3Dmol container div is not initialized yet, just set to a default value: width=auto; height=350
+        // otherwise toggle the size
+        if (this.isIncreasedSize) {
+            width = this._3dMolDiv ? Math.floor(this._3dMolDiv.offsetWidth * (5/3)) : "auto";
+            height = this._3dMolDiv ? this._3dMolDiv.offsetHeight * 2 : 350;
+        }
+        else {
+            width = this._3dMolDiv ? Math.floor(this._3dMolDiv.offsetWidth / (5/3)) : "auto";
+            height = this._3dMolDiv ? this._3dMolDiv.offsetHeight / 2 : 350;
+        }
+
+        return {width, height};
+    };
 
     @computed get pdbId()
     {

--- a/src/shared/components/structureViewer/StructureVisualizer3D.ts
+++ b/src/shared/components/structureViewer/StructureVisualizer3D.ts
@@ -216,6 +216,13 @@ export default class StructureVisualizer3D extends StructureVisualizer
         } as IStructureVisualizerState);
     }
 
+    public resize()
+    {
+        if (this._3dMolViewer) {
+            this._3dMolViewer.resize();
+        }
+    }
+
     protected selectAll()
     {
         return {};

--- a/src/shared/components/structureViewer/structureViewer.module.scss
+++ b/src/shared/components/structureViewer/structureViewer.module.scss
@@ -9,13 +9,26 @@
   border:1px solid $borderColor;
   border-radius: $cornerBorderRadius;
   background-color: #FFFFFF;
-  padding: 5px 30px 15px;
   /* fix for bootstrap 3 */
   box-sizing: content-box;
 }
 
+.header {
+  padding: 5px 30px 0;
+}
+
+.body {
+  padding: 5px 30px 15px;
+}
+
 .collapsed-panel {
-  height: 8px;
+  height: 0;
+  padding: 0 30px;
+  overflow: hidden;
+}
+
+.increased-size-panel {
+  width: auto;
 }
 
 .main-3d-panel canvas {

--- a/src/shared/components/structureViewer/structureViewer.module.scss
+++ b/src/shared/components/structureViewer/structureViewer.module.scss
@@ -1,10 +1,10 @@
 .main-3d-panel {
-  width: 420px;
+  width: 480px;
   position: absolute;
   float: right;
   overflow: hidden;
   right: 0;
-  //top: 0;
+  top: 0;
   z-index: 100;
   border:1px solid $borderColor;
   border-radius: $cornerBorderRadius;


### PR DESCRIPTION
Changes proposed in this pull request:
- Added a border around 3Dmol viewer
- Minor style improvements
- Added a button to toggle the panel size

![3d_panel_default](https://user-images.githubusercontent.com/3604198/29143929-f63b6ed4-7d24-11e7-829c-c4582a74f204.png)

![3d_panel_large](https://user-images.githubusercontent.com/3604198/29143931-f873370e-7d24-11e7-88bf-cd49060a632c.png)

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)