### PR TITLE
Show more changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "license": "",
   "dependencies": {
     "3dmol": "^1.1.3",
+    "@types/chai-enzyme": "^0.6.2",
     "@types/chai": "3.5.2",
     "@types/chart.js": "^2.4.6",
     "@types/classnames": "0.0.32",
@@ -183,7 +184,6 @@
     "word-wrap": "^1.2.3"
   },
   "devDependencies": {
-    "@types/chai-enzyme": "^0.6.2",
     "argparse": "^1.0.9",
     "babel-plugin-istanbul": "^3.1.2",
     "babel-plugin-rewire": "^1.0.0",

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -59,14 +59,16 @@ function clickNextPage(table:ReactWrapper<any, any>):boolean {
     }
 }
 
-function selectItemsPerPage(table:ReactWrapper<any, any>, opt:number):boolean {
-    let selector = table.find(PaginationControls).filterWhere(x=>x.hasClass("topPagination")).find(FormControl).filterWhere(x=>x.hasClass("itemsPerPageSelector")).find('select');
+function selectItemsPerPage(table:ReactWrapper<any, any>, opt:number) {
+    /*let selector = table.find(PaginationControls).filterWhere(x=>x.hasClass("topPagination")).find(FormControl).filterWhere(x=>x.hasClass("itemsPerPageSelector")).find('select');
     if (selector.length === 0) {
         return false;
     } else {
         selector.simulate('change', {target: {value:opt+""}});
         return true;
-    }
+    }*/
+    let onChangeItemsPerPage = table.find(PaginationControls).props().onChangeItemsPerPage;
+    onChangeItemsPerPage && onChangeItemsPerPage(opt);
 }
 
 function getItemsPerPage(table:ReactWrapper<any,any>):number|undefined {

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -599,13 +599,16 @@ export default class LazyMobXTable<T> extends React.Component<LazyMobXTableProps
 			let paginationProps:IPaginationControlsProps = {
 				className:"text-center topPagination",
 				itemsPerPage:this.store.itemsPerPage,
+                totalItems:this.store.displayData.length,
 				currentPage:this.store.page,
 				onChangeItemsPerPage:this.handlers.changeItemsPerPage,
+                showItemsPerPageSelector: false,
 				onPreviousPageClick:this.handlers.decPage,
 				onNextPageClick:this.handlers.incPage,
 				previousPageDisabled:this.store.page === 0,
 				nextPageDisabled:this.store.page === this.store.maxPage,
-				textBeforeButtons:this.store.paginationStatusText
+				textBeforeButtons:this.store.paginationStatusText,
+                groupButtons: false
 			};
 			// override with given paginationProps if they exist
 			if (this.props.paginationProps) {

--- a/src/shared/components/lazyMobXTable/styles.scss
+++ b/src/shared/components/lazyMobXTable/styles.scss
@@ -10,6 +10,10 @@ th.sort-asc:after {
   .textBetweenButtons {
     opacity: 1.00 !important;
   }
+
+  display:flex;
+  align-items:center;
+  justify-content:center;
 }
 
 .tableMainToolbar {

--- a/src/shared/components/paginationControls/PaginationControls.spec.tsx
+++ b/src/shared/components/paginationControls/PaginationControls.spec.tsx
@@ -1,21 +1,104 @@
-import * as PaginationControls from './PaginationControls';
+import PaginationControls from './PaginationControls';
 import React from 'react';
-import { assert } from 'chai';
+import {default as chai, assert, expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+import chaiEnzyme from "chai-enzyme";
 import sinon from 'sinon';
+import styles from "./paginationControls.module.scss";
+
+chai.use(chaiEnzyme());
 
 describe('PaginationControls', () => {
 
-    before(()=>{
+    describe("'Show more' button", ()=>{
+        it("on click, increases the itemsPerPage until everything is shown, in proper increments, then disables", ()=>{
+            let itemsPerPage = 1;
+            let paginationControls = mount(
+                <PaginationControls
+                    showMoreButton={true}
+                    totalItems={100}
+                    itemsPerPage={itemsPerPage}
+                    itemsPerPageOptions={[1,2,3,4,40]}
+                    onChangeItemsPerPage={(x:number)=>{itemsPerPage= x;}}
+                />
+            );
+            let button = paginationControls.find("#showMoreButton");
+            expect(button).not.to.have.attr("disabled");
+            button.simulate('click');
+            assert.equal(itemsPerPage, 2);
+            paginationControls.setProps({ itemsPerPage });
+            expect(button).not.to.have.attr("disabled");
+            button.simulate('click');
+            assert.equal(itemsPerPage, 3);
+            paginationControls.setProps({ itemsPerPage });
+            expect(button).not.to.have.attr("disabled");
+            button.simulate('click');
+            assert.equal(itemsPerPage, 4);
+            paginationControls.setProps({ itemsPerPage });
+            expect(button).not.to.have.attr("disabled");
+            button.simulate('click');
+            assert.equal(itemsPerPage, 40);
+            paginationControls.setProps({ itemsPerPage });
+            expect(button).not.to.have.attr("disabled");
+            button.simulate('click');
+            assert.equal(itemsPerPage, 80);
+            paginationControls.setProps({ itemsPerPage });
+            expect(button).not.to.have.attr("disabled");
+            button.simulate('click');
+            assert.equal(itemsPerPage, 120);
+            paginationControls.setProps({ itemsPerPage });
+            expect(button).to.have.attr("disabled");
+        });
 
-    });
+        it("is disabled if everything is shown initially",()=>{
+            let paginationControls = mount(
+                <PaginationControls
+                    showMoreButton={true}
+                    totalItems={1}
+                    itemsPerPage={2}
+                    itemsPerPageOptions={[1,2,3,4]}
+                />
+            );
+            let button = paginationControls.find("#showMoreButton");
+            expect(button).to.have.attr("disabled");
+        });
 
-    after(()=>{
+        it("shows functional reset button if its showing more than minimum per page", ()=>{
+            let itemsPerPage = 1;
+            let paginationControls = mount(
+                <PaginationControls
+                    showMoreButton={true}
+                    totalItems={100}
+                    itemsPerPage={itemsPerPage}
+                    itemsPerPageOptions={[1,2,3,4,40]}
+                    onChangeItemsPerPage={(x:number)=>{itemsPerPage= x;}}
+                />
+            );
+            let showMore = paginationControls.find("#showMoreButton");
+            let reset = paginationControls.find("#resetItemsPerPageButton");
+            expect(showMore).not.to.have.attr("disabled");
+            expect(reset).to.have.className(styles["hidden-button"]);
 
-    });
 
-    it('what does it do?', ()=>{
+            showMore.simulate('click');
+            assert.equal(itemsPerPage, 2, "show more worked");
+            paginationControls.setProps({ itemsPerPage });
+            reset = paginationControls.find("#resetItemsPerPageButton");
+            assert.equal(reset.length, 1, "reset button shown now");
+            reset.simulate('click');
+            assert.equal(itemsPerPage, 1, "reset button worked");
 
+            paginationControls = mount(
+                <PaginationControls
+                    showMoreButton={true}
+                    totalItems={100}
+                    itemsPerPage={3}
+                    itemsPerPageOptions={[1,2,3,4,40]}
+                    onChangeItemsPerPage={(x:number)=>{itemsPerPage= x;}}
+                />
+            );
+            expect(reset).not.to.have.className(styles["hidden-button"]);
+        });
     });
 
 });

--- a/src/shared/components/paginationControls/paginationControls.module.scss
+++ b/src/shared/components/paginationControls/paginationControls.module.scss
@@ -19,3 +19,15 @@
 :global(.legacy) .paginationControls button i {
     line-height:1.5;
 }
+
+.margin-right-button {
+    margin-right: 15px !important;
+}
+
+.margin-left-button {
+    margin-left: 15px !important;
+}
+
+.hidden-button {
+    display: none !important;
+}


### PR DESCRIPTION
(1) Remove drop menu for page size from LazyMobXTable pagination 
(2) Show more increases until the last element in props.itemsPerPageOptions, then continues to increase in those increments 
(3) Reset button next to Show more 
(4) Spacing between pagination buttons, like in Google Scholar

![image](https://user-images.githubusercontent.com/636232/29187317-3fd91948-7ddd-11e7-9520-e07c6ebb70bb.png)

![image](https://user-images.githubusercontent.com/636232/29187321-46acf41a-7ddd-11e7-8db3-33c1320741c2.png)

