### PR TITLE
Renamed button Submit Query to Download

### DIFF
--- a/src/shared/components/query/QueryContainer.tsx
+++ b/src/shared/components/query/QueryContainer.tsx
@@ -94,7 +94,7 @@ export default class QueryContainer extends React.Component<QueryContainerProps,
 
 				<FlexRow padded className={styles.submitRow}>
 					<button style={{paddingLeft:50, paddingRight:50, marginRight:50 }} disabled={!this.store.submitEnabled} className="btn btn-primary btn-lg" onClick={() => this.handleSubmit()} data-test='queryButton'>
-						Submit Query
+						{!this.store.forDownloadTab ? "Submit Query": "Download"}
 					</button>
 					{!!(this.store.forDownloadTab && AppConfig.genomespaceEnabled) && (
 						<button disabled={!this.store.submitEnabled} className={styles.genomeSpace} onClick={ ()=>this.store.sendToGenomeSpace() }>


### PR DESCRIPTION
# What? Why?
Front-end fix for https://github.com/cBioPortal/cbioportal/issues/2727 .

![query_download_button](https://user-images.githubusercontent.com/3604198/29094349-0768cfa0-7c5b-11e7-8a15-5091655980c1.png)

Changes proposed in this pull request:
- Renamed `Submit Query` to `Download` for the download tab of Query component

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)