### PR TITLE
use global store in both page specific components and local components

### DIFF
--- a/my-index.ejs
+++ b/my-index.ejs
@@ -5,7 +5,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <script>
         window.devContext = true;
-        window.defaultRoute = "/patient";
+        window.defaultRoute = "/home";
         // uncomment to enable Darwin internal MSKCC service patient view link
         // uses checkDarwinAccess.do service from cbioportal/cbioportal
         // window.enableDarwin = true;

--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -4,6 +4,7 @@ import { Provider } from 'mobx-react';
 import { hashHistory, createMemoryHistory, Router } from 'react-router';
 import { RouterStore, syncHistoryWithStore  } from 'mobx-react-router';
 import ExtendedRoutingStore from './shared/lib/ExtendedRouterStore';
+import {QueryStore} from "./shared/components/query/QueryStore";
 import {computed, extendObservable} from 'mobx';
 import makeRoutes from './routes';
 import * as _ from 'lodash';
@@ -54,12 +55,18 @@ const history = (window.historyType === 'memory') ? createMemoryHistory() : hash
 
 const syncedHistory = syncHistoryWithStore(history, routingStore);
 
+// lets make query Store since it's used in a lot of places
+const queryStore = new QueryStore(window.location.href);
+
 const stores = {
     // Key can be whatever you want
     routing: routingStore,
+    queryStore
     // ...other stores
 };
-//
+
+window.globalStores = stores;
+
 const end = superagent.Request.prototype.end;
 
 let redirecting = false;

--- a/src/globalComponents.spec.ts
+++ b/src/globalComponents.spec.ts
@@ -1,9 +1,3 @@
 import { assert } from 'chai';
 import * as React from 'react';
-import "./globalComponents";
 
-describe('globalComponents', ()=>{
-    it('should expose a function called addGenesAndSubmitQuery to the window, for use by the cbioportal main project', ()=>{
-        assert.equal(typeof (window as any).addGenesAndSubmitQuery, "function");
-    });
-});

--- a/src/globalComponents.tsx
+++ b/src/globalComponents.tsx
@@ -1,33 +1,23 @@
 import React from 'react';
 import exposeComponentRenderer from 'shared/lib/exposeComponentRenderer';
 import RightBar from "./shared/components/rightbar/RightBar";
-import {QueryStore} from "./shared/components/query/QueryStore";
-import QueryModal from "./shared/components/query/QueryModal";
 import QueryAndDownloadTabs from "./shared/components/query/QueryAndDownloadTabs";
+import {QueryStore} from "./shared/components/query/QueryStore";
 
-const queryStore = new QueryStore(window.location.href);
+class GlobalStores {
 
-(window as any).addGenesAndSubmitQuery = queryStore.addGenesAndSubmit.bind(queryStore);
+    public static get queryStore() : QueryStore {
+        return (window as any).globalStores.queryStore;
+    }
+
+}
 
 exposeComponentRenderer('renderRightBar', ()=> {
-    return <RightBar store={queryStore}/>;
+    return <RightBar store={GlobalStores.queryStore} />;
 });
-
-exposeComponentRenderer('renderQuerySelectorInModal', ()=><QueryModal store={queryStore} />);
 
 exposeComponentRenderer('renderQuerySelector', (props:{[k:string]:string|boolean|number})=> {
-    return <QueryAndDownloadTabs {...props} store={queryStore} />;
+    (window as any).addGenesAndSubmitQuery = GlobalStores.queryStore.addGenesAndSubmit.bind(GlobalStores.queryStore);
+    return <QueryAndDownloadTabs {...props} store={GlobalStores.queryStore} />;
 });
 
-// exposeComponentRenderer('renderMutationsTab', (props:{genes:string[], studyId:string, samples:string[]|string})=>{
-//     const resultsViewPageStore = new ResultsViewPageStore();
-//     resultsViewPageStore.hugoGeneSymbols = props.genes;
-//     resultsViewPageStore.studyId = props.studyId;
-//     if (typeof props.samples === "string") {
-//         resultsViewPageStore.sampleListId = props.samples;
-//     } else {
-//         resultsViewPageStore.sampleList = props.samples;
-//     }
-//
-//     return <Mutations genes={props.genes} store={resultsViewPageStore}/>
-// });

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import exposeComponentRenderer from 'shared/lib/exposeComponentRenderer';
 import {FlexCol, FlexRow} from "../../shared/components/flexbox/FlexBox";
-import {observer} from "mobx-react";
+import {observer, inject} from "mobx-react";
 import DevTools from "mobx-react-devtools";
 import {toJS, observable, action, computed, whyRun, expr} from "mobx";
 import LabeledCheckbox from "../../shared/components/labeledCheckbox/LabeledCheckbox";
@@ -37,13 +37,14 @@ function getRootElement()
 
 interface IHomePageProps
 {
+    queryStore:QueryStore
 }
 
 interface IHomePageState
 {
 }
 
-@observer
+@inject("queryStore") @observer
 export default class HomePage extends React.Component<IHomePageProps, IHomePageState>
 {
     constructor(props:IHomePageProps)
@@ -51,24 +52,9 @@ export default class HomePage extends React.Component<IHomePageProps, IHomePageS
         super(props);
     }
 
-    store = new QueryStore(window.location.href);
-
-    public componentDidMount()
-    {
-        this.exposeComponentRenderersToParentScript();
-    }
-
-    exposeComponentRenderersToParentScript()
-    {
-        exposeComponentRenderer('renderQuerySelectorInModal', this.getModalWrappedComponent.bind(this));
-
-        exposeComponentRenderer('renderQuerySelector', ()=>{ return <QueryAndDownloadTabs store={this.store} />  });
-
-	}
-
     getModalWrappedComponent(){
         return (
-            <QueryModal store={this.store} />
+            <QueryModal store={this.props.queryStore} />
         )
     }
 
@@ -79,7 +65,7 @@ export default class HomePage extends React.Component<IHomePageProps, IHomePageS
                    <div>
                        {blurb}
                    </div>
-                   <QueryAndDownloadTabs store={this.store} />
+                   <QueryAndDownloadTabs store={this.props.queryStore} />
                 </div>);
     }
 }


### PR DESCRIPTION
We were instantiating the queryStore twice, once for global components and once for page components.  This PR allows components to access global stores.  We should never use globalStores except in the globalComponents file.  Ultimately we won't need these "exposed" components anymore and stores will be passed using provider/inject, as they are now to pages.

https://github.com/cBioPortal/cbioportal/issues/2928

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
