### PR TITLE
restore working localdev functionality

### DIFF
--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -14,7 +14,9 @@ import * as superagent from 'superagent';
 import { getHost } from './shared/api/urls';
 import { validateParametersPatientView } from './shared/lib/validateParameters';
 
-if (localStorage.heroku && localStorage.localdev !== "true") {
+if (localStorage.localdev === 'true') {
+    __webpack_public_path__ = "//localhost:3000/"
+} else if (localStorage.heroku) {
     __webpack_public_path__ = ['//',localStorage.heroku,'.herokuapp.com','/'].join('');
 } else if (window.hasOwnProperty('frontendUrl')) {
     // use given frontendUrl as base (use when deploying frontend on external


### PR DESCRIPTION
Somehow we broken functionality of localdev===true.  This was preventing tests from working.  In case of localdev===true, we need to set webpack's base path for loading bundles
