### PR TITLE
Bar chart no longer attempts to display when maxTreeDepth is set to 0.

### DIFF
--- a/src/shared/components/barGraph/BarGraph.tsx
+++ b/src/shared/components/barGraph/BarGraph.tsx
@@ -78,6 +78,8 @@ export default class BarGraph extends React.Component<IBarGraphProps, {}> {
     componentDidMount() {
 
         const cancerStudies = this.byPrimarySiteStudies;
+
+        if (!cancerStudies.length) return;
         cancerStudies.forEach(study => {study.caseCount = study.studies.reduce((sum:number, cStudy) => sum + cStudy.allSampleCount, 0)});
 
         const cancerTypeStudiesArray = cancerStudies.sort((a, b) => b.caseCount! - a.caseCount!).slice(0, 20).map(study => this.getShortName(study));


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/3011.