### PR TITLE
add default to protein impact type so that 'other' category is correc…

### DIFF
--- a/src/shared/lib/getCanonicalMutationType.spec.ts
+++ b/src/shared/lib/getCanonicalMutationType.spec.ts
@@ -1,0 +1,19 @@
+import { getProteinImpactType } from './getCanonicalMutationType';
+import { assert } from 'chai';
+
+describe('getProteinImpactType', ()=>{
+
+    it('maps mutation types to appropriate buckets',()=>{
+
+        assert.equal(getProteinImpactType('5\'Flank'),'other');
+        assert.equal(getProteinImpactType('Missense_Mutation'),'missense');
+        assert.equal(getProteinImpactType('Nonsense_Mutation'),'truncating');
+        assert.equal(getProteinImpactType('Frame_Shift_Del'),'truncating');
+        assert.equal(getProteinImpactType('In_Frame_Deletion'),'inframe');
+
+
+
+    })
+
+
+});

--- a/src/shared/lib/getCanonicalMutationType.ts
+++ b/src/shared/lib/getCanonicalMutationType.ts
@@ -98,6 +98,7 @@ export function getProteinImpactTypeFromCanonical(mutationType:CanonicalMutation
         case "fusion":
         case "silent":
         case "other":
+        default:
             return "other";
     }
 }


### PR DESCRIPTION
Add default to protein impact type so that 'other' category is correctly populated

https://github.com/cBioPortal/cbioportal/issues/3023

![image](https://user-images.githubusercontent.com/186521/29530741-43f2ca44-8673-11e7-9e4e-cf1695a7e27b.png)

correct:

![image](https://user-images.githubusercontent.com/186521/29530757-538cd4e0-8673-11e7-9c0d-e4f303b343b7.png)


