### PR TITLE
Study column in mutation mapper for multiple studies

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1,6 +1,6 @@
 import {
     DiscreteCopyNumberFilter, DiscreteCopyNumberData, ClinicalData, ClinicalDataMultiStudyFilter, Sample,
-    SampleIdentifier, GeneticProfile, Mutation
+    SampleIdentifier, GeneticProfile, Mutation, CancerStudy
 } from "shared/api/generated/CBioPortalAPI";
 import client from "shared/api/cbioportalClientInstance";
 import {computed, observable, action} from "mobx";
@@ -120,6 +120,7 @@ export class ResultsViewPageStore {
                 this.samples,
                 ()=>(this.mutationDataCache),
                 this.geneticProfileIdToGeneticProfile,
+                this.studyIdToStudy,
                 this.clinicalDataForSamples,
                 this.studiesForSamplesWithoutCancerTypeClinicalData,
                 this.samplesWithoutCancerTypeClinicalData,
@@ -208,6 +209,11 @@ export class ResultsViewPageStore {
     readonly studies = remoteData({
         invoke: ()=>Promise.all(this.studyIds.map(studyId=>client.getStudyUsingGET({studyId})))
     }, []);
+
+    readonly studyIdToStudy = remoteData({
+        await: ()=>[this.studies],
+        invoke:()=>Promise.resolve(_.keyBy(this.studies.result, x=>x.studyId))
+    }, {});
 
     private getGermlineSampleListId(studyId:string):string {
         return `${studyId}_germline`;

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -182,6 +182,7 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                                     sampleIdToTumorType={this.props.store.sampleIdToTumorType}
                                     discreteCNACache={this.props.discreteCNACache}
                                     geneticProfileIdToGeneticProfile={this.props.store.geneticProfileIdToGeneticProfile.result}
+                                    studyIdToStudy={this.props.store.studyIdToStudy.result}
                                     oncoKbEvidenceCache={this.props.oncoKbEvidenceCache}
                                     pubMedCache={this.props.pubMedCache}
                                     mutationCountCache={this.props.mutationCountCache}

--- a/src/pages/resultsView/mutation/MutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/MutationMapperStore.ts
@@ -38,6 +38,7 @@ export class MutationMapperStore {
                 // and we will react when it changes to a new object.
                 private getMutationDataCache: ()=>MutationDataCache,
                 public geneticProfileIdToGeneticProfile:MobxPromise<{[geneticProfileId:string]:GeneticProfile}>,
+                public studyIdToStudy:MobxPromise<{[studyId:string]:CancerStudy}>,
                 public clinicalDataForSamples: MobxPromise<ClinicalData[]>,
                 public studiesForSamplesWithoutCancerTypeClinicalData: MobxPromise<CancerStudy[]>,
                 private samplesWithoutCancerTypeClinicalData: MobxPromise<Sample[]>,

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -21,6 +21,7 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
     {
         ...MutationTable.defaultProps,
         columns: [
+            MutationTableColumnType.STUDY,
             MutationTableColumnType.SAMPLE_ID,
             MutationTableColumnType.COPY_NUM,
             MutationTableColumnType.ANNOTATION,
@@ -47,6 +48,10 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
         ]
     };
 
+    componentWillUpdate(nextProps:IResultsViewMutationTableProps) {
+        this._columns[MutationTableColumnType.STUDY].visible = !!(nextProps.studyIdToStudy && (Object.keys(nextProps.studyIdToStudy).length > 1));
+    }
+
     protected generateColumns() {
         super.generateColumns();
 
@@ -59,6 +64,7 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
             this.props.dataStore ? this.props.dataStore.allData : this.props.data);
 
         // order columns
+        this._columns[MutationTableColumnType.STUDY].order = 0;
         this._columns[MutationTableColumnType.SAMPLE_ID].order = 10;
         this._columns[MutationTableColumnType.CANCER_TYPE].order = 15;
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].order = 20;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -3,7 +3,7 @@ import {observer} from "mobx-react";
 import {observable, computed} from "mobx";
 import * as _ from "lodash";
 import {default as LazyMobXTable, Column, SortDirection} from "shared/components/lazyMobXTable/LazyMobXTable";
-import {GeneticProfile, Mutation} from "shared/api/generated/CBioPortalAPI";
+import {CancerStudy, GeneticProfile, Mutation} from "shared/api/generated/CBioPortalAPI";
 import SampleColumnFormatter from "./column/SampleColumnFormatter";
 import TumorAlleleFreqColumnFormatter from "./column/TumorAlleleFreqColumnFormatter";
 import NormalAlleleFreqColumnFormatter from "./column/NormalAlleleFreqColumnFormatter";
@@ -38,10 +38,12 @@ import {IMobXApplicationDataStore} from "shared/lib/IMobXApplicationDataStore";
 import generalStyles from "./column/styles.module.scss";
 import classnames from 'classnames';
 import {IPaginationControlsProps} from "../paginationControls/PaginationControls";
+import StudyColumnFormatter from "./column/StudyColumnFormatter";
 
 export interface IMutationTableProps {
     sampleIdToTumorType?: {[sampleId: string]: string}
     geneticProfileIdToGeneticProfile?: {[geneticProfileId:string]:GeneticProfile};
+    studyIdToStudy?: {[studyId:string]:CancerStudy};
     discreteCNACache?:DiscreteCNACache;
     oncoKbEvidenceCache?:OncoKbEvidenceCache;
     mrnaExprRankCache?:MrnaExprRankCache;
@@ -73,6 +75,7 @@ export interface IMutationTableProps {
 }
 
 export enum MutationTableColumnType {
+    STUDY,
     SAMPLE_ID,
     TUMORS,
     GENE,
@@ -161,6 +164,17 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
 
     protected generateColumns() {
         this._columns = {};
+
+        this._columns[MutationTableColumnType.STUDY] = {
+            name: "Study",
+            render: (d:Mutation[])=> StudyColumnFormatter.renderFunction(d, this.props.geneticProfileIdToGeneticProfile, this.props.studyIdToStudy),
+            download: (d:Mutation[])=>StudyColumnFormatter.getTextValue(d, this.props.geneticProfileIdToGeneticProfile, this.props.studyIdToStudy),
+            sortBy: (d:Mutation[])=>StudyColumnFormatter.getTextValue(d, this.props.geneticProfileIdToGeneticProfile, this.props.studyIdToStudy),
+            filter: (d:Mutation[], filterString:string, filterStringUpper:string)=>{
+                return StudyColumnFormatter.filter(d, filterStringUpper, this.props.geneticProfileIdToGeneticProfile, this.props.studyIdToStudy);
+            },
+            visible: false
+        };
 
         this._columns[MutationTableColumnType.SAMPLE_ID] = {
             name: "Sample ID",

--- a/src/shared/components/mutationTable/column/StudyColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/StudyColumnFormatter.tsx
@@ -26,7 +26,9 @@ export default class StudyColumnFormatter
                 <a href={getStudySummaryUrl(study.studyId)} target="_blank">
                     <TruncatedText
                         text={study.name}
-                        tooltip={<div style={{maxWidth: 300}}>{`${study.name}: ${study.description}`}</div>}
+                        tooltip={<div style={{maxWidth: 300}} dangerouslySetInnerHTML={{
+                            __html: `${study.name}: ${study.description}`
+                        }}/>}
                         maxLength={16}
                     />
                 </a>

--- a/src/shared/components/mutationTable/column/StudyColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/StudyColumnFormatter.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
+import {CancerStudy, GeneticProfile, Mutation} from "shared/api/generated/CBioPortalAPI";
+import TruncatedText from "../../TruncatedText";
+import {getStudySummaryUrl} from "../../../api/urls";
+
+export default class StudyColumnFormatter
+{
+    private static getStudy(d:Mutation[], geneticProfileIdToGeneticProfile?:{[geneticProfileId:string]:GeneticProfile}, studyIdToStudy?:{[studyId:string]:CancerStudy}):CancerStudy|null {
+        if (!geneticProfileIdToGeneticProfile || !studyIdToStudy)
+            return null;
+
+        const geneticProfileId = d[0].geneticProfileId;
+        const geneticProfile = geneticProfileIdToGeneticProfile[geneticProfileId];
+        if (!geneticProfile)
+            return null;
+        const study = studyIdToStudy[geneticProfile.studyId];
+        return study || null;
+    }
+    public static renderFunction(d:Mutation[], geneticProfileIdToGeneticProfile?:{[geneticProfileId:string]:GeneticProfile}, studyIdToStudy?:{[studyId:string]:CancerStudy}) {
+        const study = StudyColumnFormatter.getStudy(d, geneticProfileIdToGeneticProfile, studyIdToStudy);
+        if (!study) {
+            return <span/>;
+        } else {
+            return (
+                <a href={getStudySummaryUrl(study.studyId)} target="_blank">
+                    <TruncatedText
+                        text={study.name}
+                        tooltip={<div style={{maxWidth: 300}}>{`${study.name}: ${study.description}`}</div>}
+                        maxLength={16}
+                    />
+                </a>
+            );
+        }
+    }
+
+    public static getTextValue(d:Mutation[], geneticProfileIdToGeneticProfile?:{[geneticProfileId:string]:GeneticProfile}, studyIdToStudy?:{[studyId:string]:CancerStudy}) {
+        const study = StudyColumnFormatter.getStudy(d, geneticProfileIdToGeneticProfile, studyIdToStudy);
+        if (!study) {
+            return "";
+        } else {
+            return study.name;
+        }
+    }
+
+    public static filter(d:Mutation[], filterStringUpper:string, geneticProfileIdToGeneticProfile?:{[geneticProfileId:string]:GeneticProfile}, studyIdToStudy?:{[studyId:string]:CancerStudy}) {
+        const study = StudyColumnFormatter.getStudy(d, geneticProfileIdToGeneticProfile, studyIdToStudy);
+        if (!study) {
+            return false;
+        } else {
+            return study.name.toUpperCase().indexOf(filterStringUpper) > -1;
+        }
+    }
+}


### PR DESCRIPTION
It shows the (truncated) study name, linking to that study summary, tooltip the full study name and description.

The column is always available but only visible by default if there is more than one study in the query.

![image](https://user-images.githubusercontent.com/636232/29897362-91854e7a-8dae-11e7-9b72-08cf434ea9dd.png)
