### PR TITLE
Showing message when unrecognized string is interpreted as mutation code

### DIFF
--- a/src/shared/components/query/QueryContainer.tsx
+++ b/src/shared/components/query/QueryContainer.tsx
@@ -19,6 +19,7 @@ const styles = styles_any as {
 	QueryContainer: string,
 	queryContainerContent: string,
 	errorMessage: string,
+	oqlMessage: string,
 	downloadSubmitExplanation: string,
 	transposeDataMatrix: string,
 	submitRow: string,
@@ -101,12 +102,22 @@ export default class QueryContainer extends React.Component<QueryContainerProps,
 							Send to GenomeSpace
 						</button>
 					)}
+					<FlexCol>
+						{!!(this.store.submitError) && (
+							<span className={styles.errorMessage}>
+							{this.store.submitError}
+						</span>
+						)}
 
-					{!!(this.store.submitError) && (
-						<span className={styles.errorMessage}>
-						{this.store.submitError}
-					</span>
-					)}
+						{this.store.oqlMessages.map(msg=>{
+							return (
+								<span className={styles.oqlMessage}>
+									<i className='fa fa-info-circle' style={{marginRight: 5}}/>
+									{msg}
+								</span>
+							);
+						})}
+					</FlexCol>
 
 				</FlexRow>
 			</FlexCol>

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -9,7 +9,7 @@ import CancerStudyTreeData from "./CancerStudyTreeData";
 import {remoteData} from "../../api/remoteData";
 import {labelMobxPromises, cached, debounceAsync} from "mobxpromise";
 import internalClient from "../../api/cbioportalInternalClientInstance";
-import oql_parser from "../../lib/oql/oql-parser";
+import oql_parser, {MUTCommand} from "../../lib/oql/oql-parser";
 import memoize from "memoize-weak-decorator";
 import AppConfig from 'appConfig';
 import {gsUploadByGet} from "../../api/gsuploadwindow";
@@ -693,6 +693,15 @@ export class QueryStore
 			this.genes.isComplete &&
 			this.asyncUrlParams.isComplete
 		) || !!this.oql.error; // to make "Please click 'Submit' to see location of error." possible
+	}
+
+	@computed get oqlMessages():string[] {
+		let unrecognizedMutations = _.flatten(this.oql.query.map(result => {
+			return (result.alterations || []).filter(alt => (alt.alteration_type === 'mut' && (alt.info as any).unrecognized)) as MUTCommand<any>[];
+		}));
+		return unrecognizedMutations.map(mutCommand=>{
+			return `Unrecognized input "${(mutCommand as any).constr_val}" is interpreted as a mutation code.`;
+		});
 	}
 
 	@computed get submitError()

--- a/src/shared/components/query/styles.module.scss
+++ b/src/shared/components/query/styles.module.scss
@@ -73,6 +73,11 @@
     color: $redError;
     font-weight: bold;
   }
+
+  .oqlMessage {
+    color: $brand-info;
+    font-weight: bold;
+  }
 }
 
 .CancerStudySelector,
@@ -404,6 +409,7 @@ div.SelectedStudiesWindow {
     line-height: 17px;
   }
   span.pendingMessage,
+  span.oqlNotice,
   span.errorMessage {
     font-size: small;
   }

--- a/src/shared/lib/oql/generateParser.py
+++ b/src/shared/lib/oql/generateParser.py
@@ -7,11 +7,16 @@ os.system("pegjs "+sys.argv[1]+" oql-parser-tmp.js")
 f = open("oql-parser-tmp.js","r")
 nf = open("oql-parser.js","w")
 
-if not (len(sys.argv) >= 3 and sys.argv[2].startswith("-t")):
+test = len(sys.argv) >= 3 and sys.argv[2].startswith("-t")
+
+if not test:
 	f.readline()
-	nf.write("oql_parser = (function() {\n")
+	nf.write("const oql_parser = (function() {\n")
 
 for line in f:
 	nf.write(line)
+
+if not test:
+	nf.write("export default oql_parser;\n");
 
 os.system("rm oql-parser-tmp.js")

--- a/src/shared/lib/oql/oql-parser.d.ts
+++ b/src/shared/lib/oql/oql-parser.d.ts
@@ -93,7 +93,7 @@ export declare type CNACommand = {alteration_type:'cna', constr_rel:ComparisonOp
 // 	/ "MUT" { return {"alteration_type":"mut"}; }
 // 	/ mutation:Mutation { return {"alteration_type":"mut", "constr_rel": "=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info}; }
 export declare type MUTCommand<M extends Mutation> = (
-	{alteration_type:'mut'} |
+	{alteration_type:'mut', info:{}} |
 	{alteration_type:'mut', constr_rel:'='|'!=', constr_type:M['type'], constr_val:M['value'], info:M['info']}
 );
 //
@@ -130,8 +130,9 @@ export declare type ComparisonOp = '>=' | '<=' | '>' | '<';
 //         / letter:AminoAcid position:NaturalNumber { return {"type":"position", "value":parseInt(position), "info":{"amino_acid":letter.toUpperCase()}}; }
 // 	/ mutation_name:String { return {"type":"name", "value":mutation_name, "info":{}}; }
 export declare type MutationType = 'MISSENSE'|'NONSENSE'|'NONSTART'|'NONSTOP'|'FRAMESHIFT'|'INFRAME'|'SPLICE'|'TRUNC'|'PROMOTER';
+
 export declare type Mutation = (
-	{type:'class', value:MutationType, info:object} |
-	{type:'name', value:string, info:object} |
+	{type:'class', value:MutationType, info:{}} |
+	{type:'name', value:string, info:{unrecognized?:boolean}} |
 	{type:'position', value:number, info:{amino_acid:AminoAcid}}
 );

--- a/src/shared/lib/oql/oql-parser.js
+++ b/src/shared/lib/oql/oql-parser.js
@@ -100,7 +100,7 @@ const oql_parser = (function() {
         peg$c65 = "!=",
         peg$c66 = { type: "literal", value: "!=", description: "\"!=\"" },
         peg$c67 = function(mutation) { return {"alteration_type":"mut", "constr_rel": "!=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info}; },
-        peg$c68 = function() { return {"alteration_type":"mut"}; },
+        peg$c68 = function() { return {"alteration_type":"mut", "info":{}}; },
         peg$c69 = "EXP",
         peg$c70 = function(op, constrval) { return {"alteration_type":"exp", "constr_rel":op, "constr_val":parseFloat(constrval)}; },
         peg$c71 = "FUSION",
@@ -149,7 +149,7 @@ const oql_parser = (function() {
         peg$c114 = function() { return {"type":"class", "value":"PROMOTER", "info":{}}; },
         peg$c115 = function(letter, position, string) { return {"type":"name" , "value":(letter+position+string), "info":{}};},
         peg$c116 = function(letter, position) { return {"type":"position", "value":parseInt(position), "info":{"amino_acid":letter.toUpperCase()}}; },
-        peg$c117 = function(mutation_name) { return {"type":"name", "value":mutation_name, "info":{}}; },
+        peg$c117 = function(mutation_name) { return {"type":"name", "value":mutation_name, "info":{"unrecognized":true}}; },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -1753,5 +1753,4 @@ const oql_parser = (function() {
     parse:       parse
   };
 })();
-
 export default oql_parser;

--- a/src/shared/lib/oql/oql_basic.pegjs
+++ b/src/shared/lib/oql/oql_basic.pegjs
@@ -69,7 +69,7 @@ CNACommand
 MUTCommand
 	= "MUT" msp "=" msp mutation:Mutation { return {"alteration_type":"mut", "constr_rel": "=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info}; }
 	/ "MUT" msp "!=" msp mutation:Mutation { return {"alteration_type":"mut", "constr_rel": "!=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info}; }
-	/ "MUT" { return {"alteration_type":"mut"}; }
+	/ "MUT" { return {"alteration_type":"mut", "info":{}}; }
 	/ mutation:Mutation { return {"alteration_type":"mut", "constr_rel": "=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info}; }
 
 EXPCommand
@@ -96,7 +96,7 @@ Mutation
 	/ "INFRAME"i { return {"type":"class", "value":"INFRAME", "info":{}}; }
 	/ "SPLICE"i { return {"type":"class", "value":"SPLICE", "info":{}}; }
 	/ "TRUNC"i { return {"type":"class", "value":"TRUNC", "info":{}}; }
-        / "PROMOTER"i { return {"type":"class", "value":"PROMOTER", "info":{}}; }
-        / letter:AminoAcid position:NaturalNumber string:String { return {"type":"name" , "value":(letter+position+string), "info":{}};}
-        / letter:AminoAcid position:NaturalNumber { return {"type":"position", "value":parseInt(position), "info":{"amino_acid":letter.toUpperCase()}}; }
-	/ mutation_name:String { return {"type":"name", "value":mutation_name, "info":{}}; }
+    / "PROMOTER"i { return {"type":"class", "value":"PROMOTER", "info":{}}; }
+    / letter:AminoAcid position:NaturalNumber string:String { return {"type":"name" , "value":(letter+position+string), "info":{}};}
+    / letter:AminoAcid position:NaturalNumber { return {"type":"position", "value":parseInt(position), "info":{"amino_acid":letter.toUpperCase()}}; }
+	/ mutation_name:String { return {"type":"name", "value":mutation_name, "info":{"unrecognized":true}}; }

--- a/src/shared/lib/oql/test-oql-parser.js
+++ b/src/shared/lib/oql/test-oql-parser.js
@@ -67,26 +67,26 @@ doTest("TP53", [{gene:"TP53", alterations:false}]);
 doTest("TP53;", [{gene:"TP53", alterations:false}]);
 doTest("TP53\n", [{gene:"TP53", alterations:false}]);
 doTest("TP53 BRCA1 KRAS NRAS", [{gene:"TP53", alterations:false}, {gene:"BRCA1", alterations:false}, {gene:"KRAS", alterations:false}, {gene:"NRAS", alterations:false}]);
-doTest("TP53:MUT", [{gene:"TP53", alterations:[{alteration_type: "mut"}]}])
+doTest("TP53:MUT", [{gene:"TP53", alterations:[{alteration_type: "mut", info:{}}]}])
 doTest("TP53:MISSENSE PROMOTER", [{gene:"TP53", alterations:[{alteration_type: "mut", constr_rel: "=", constr_type: "class", constr_val: "MISSENSE", info: {}},{alteration_type: "mut", constr_rel: "=", constr_type: "class", constr_val: "PROMOTER", info: {}}]}])
-doTest("TP53:MUT;", [{gene:"TP53", alterations:[{alteration_type: "mut"}]}])
-doTest("TP53:MUT\n", [{gene:"TP53", alterations:[{alteration_type: "mut"}]}])
-doTest("TP53:MUT; BRCA1: gAiN hetloss EXP>=3 PROT<1", [{gene:"TP53", alterations:[{alteration_type: "mut"}]},
+doTest("TP53:MUT;", [{gene:"TP53", alterations:[{alteration_type: "mut", info:{}}]}])
+doTest("TP53:MUT\n", [{gene:"TP53", alterations:[{alteration_type: "mut", info:{}}]}])
+doTest("TP53:MUT; BRCA1: gAiN hetloss EXP>=3 PROT<1", [{gene:"TP53", alterations:[{alteration_type: "mut", info:{}}]},
 							{gene:"BRCA1", alterations:[{alteration_type: "cna", constr_rel: "=", constr_val: "GAIN"}, 
 										    {alteration_type: "cna", constr_rel: "=", constr_val: "HETLOSS"},
 										    {alteration_type: "exp", constr_rel: ">=", constr_val: 3},
 										    {alteration_type: "prot", constr_rel: "<", constr_val: 1}]}])
-doTest("TP53:MUT;;;\n BRCA1: AMP HOMDEL EXP>=3 PROT<1", [{gene:"TP53", alterations:[{alteration_type: "mut"}]},
+doTest("TP53:MUT;;;\n BRCA1: AMP HOMDEL EXP>=3 PROT<1", [{gene:"TP53", alterations:[{alteration_type: "mut", info:{}}]},
 							{gene:"BRCA1", alterations:[{alteration_type: "cna", constr_rel: "=", constr_val: "AMP"}, 
 										    {alteration_type: "cna", constr_rel: "=", constr_val: "HOMDEL"},
 										    {alteration_type: "exp", constr_rel: ">=", constr_val: 3},
 										    {alteration_type: "prot", constr_rel: "<", constr_val: 1}]}])
-doTest("TP53:MUT;\n BRCA1: amp GAIN EXP>=3 PROT<1", [{gene:"TP53", alterations:[{alteration_type: "mut"}]},
+doTest("TP53:MUT;\n BRCA1: amp GAIN EXP>=3 PROT<1", [{gene:"TP53", alterations:[{alteration_type: "mut", info:{}}]},
 							{gene:"BRCA1", alterations:[{alteration_type: "cna", constr_rel: "=", constr_val: "AMP"}, 
 										    {alteration_type: "cna", constr_rel: "=", constr_val: "GAIN"},
 										    {alteration_type: "exp", constr_rel: ">=", constr_val: 3},
 										    {alteration_type: "prot", constr_rel: "<", constr_val: 1}]}])
-doTest("TP53:MUT\n BRCA1: AMP HOMDEL EXP>=3 PROT<1;", [{gene:"TP53", alterations:[{alteration_type: "mut"}]},
+doTest("TP53:MUT\n BRCA1: AMP HOMDEL EXP>=3 PROT<1;", [{gene:"TP53", alterations:[{alteration_type: "mut", info:{}}]},
 							{gene:"BRCA1", alterations:[{alteration_type: "cna", constr_rel: "=", constr_val: "AMP"}, 
 										    {alteration_type: "cna", constr_rel: "=", constr_val: "HOMDEL"},
 										    {alteration_type: "exp", constr_rel: ">=", constr_val: 3},


### PR DESCRIPTION
Addresses https://github.com/cBioPortal/cbioportal/issues/3031

![image](https://user-images.githubusercontent.com/636232/30296212-5b9205d0-9711-11e7-8b21-4a5891eb433d.png)

In this example, it does not have any notes, because it recognizes the form AMINO_ACID_CODE + NUMBER + STRING, but we can easily change it to have a note in this case as well
![image](https://user-images.githubusercontent.com/636232/30296222-69be253a-9711-11e7-9d0d-596e9abc94cb.png)

In this example, it recognizes the form AMINO_ACID_CODE + NUMBER, and will be submitting V600 as a position filter. But with just the number, it does not recognize that form, which is something to consider.
![image](https://user-images.githubusercontent.com/636232/30296237-79e03660-9711-11e7-87f3-ed83bf9b4804.png)
