### PR TITLE
Fix LazyMobXTable maxPage calculation

### DIFF
--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -10,11 +10,12 @@ import expect from 'expect';
 import expectJSX from 'expect-jsx';
 import lolex from "lolex";
 import {Clock} from "lolex";
-import {PaginationControls} from "../paginationControls/PaginationControls";
+import {PaginationControls, SHOW_ALL_PAGE_SIZE} from "../paginationControls/PaginationControls";
 import {Button, FormControl, Checkbox} from 'react-bootstrap';
 import {ColumnVisibilityControls} from "../columnVisibilityControls/ColumnVisibilityControls";
 import {SimpleMobXApplicationDataStore} from "../../lib/IMobXApplicationDataStore";
 import cloneJSXWithoutKeyAndRef from "shared/lib/cloneJSXWithoutKeyAndRef";
+import {maxPage} from "./utils";
 
 expect.extend(expectJSX);
 chai.use(chaiEnzyme());
@@ -214,6 +215,35 @@ describe('LazyMobXTable', ()=>{
 
     after(()=>{
         clock.uninstall();
+    });
+
+    describe('utils', ()=>{
+        describe('maxPage', ()=>{
+            it("gives the correct outputs in various cases", ()=>{
+                assert.equal(maxPage(0, SHOW_ALL_PAGE_SIZE), 0 , "maxPage is 0 when showing all");
+                assert.equal(maxPage(100, SHOW_ALL_PAGE_SIZE), 0 , "maxPage is 0 when showing all");
+                assert.equal(maxPage(1000, SHOW_ALL_PAGE_SIZE), 0 , "maxPage is 0 when showing all");
+
+                assert.equal(maxPage(0, 50), 0, "maxPage is 0 when no data");
+                assert.equal(maxPage(0, 25), 0, "maxPage is 0 when no data");
+                assert.equal(maxPage(0, 100), 0, "maxPage is 0 when no data");
+
+                assert.equal(maxPage(1, 50), 0, "maxPage is 0 when less than page size");
+                assert.equal(maxPage(5, 50), 0, "maxPage is 0 when less than page size");
+                assert.equal(maxPage(10, 50), 0, "maxPage is 0 when less than page size");
+                assert.equal(maxPage(3, 10), 0, "maxPage is 0 when less than page size");
+                assert.equal(maxPage(7, 10), 0, "maxPage is 0 when less than page size");
+                assert.equal(maxPage(9, 10), 0, "maxPage is 0 when less than page size");
+
+                assert.equal(maxPage(50, 50), 0, "maxPage is 0 when equal to page size");
+                assert.equal(maxPage(24, 24), 0, "maxPage is 0 when equal to page size");
+                assert.equal(maxPage(1, 1), 0, "maxPage is 0 when equal to page size");
+
+                assert.equal(maxPage(25,10), 2, "maxPage calculated correctly");
+                assert.equal(maxPage(50,10), 4, "maxPage calculated correctly");
+                assert.equal(maxPage(11,2), 5, "maxPage calculated correctly");
+            });
+        });
     });
 
     describe('lazyMobXTableSort', ()=>{

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -1,6 +1,6 @@
 import SimpleTable from "../simpleTable/SimpleTable";
 import * as React from 'react';
-import {observable, computed, action, reaction, IReactionDisposer} from "mobx";
+import {observable, computed, action, reaction, IReactionDisposer, autorun} from "mobx";
 import {observer, Observer} from "mobx-react";
 import './styles.scss';
 import {
@@ -16,6 +16,7 @@ import {ButtonToolbar} from "react-bootstrap";
 import { If } from 'react-if';
 import {SortMetric} from "../../lib/ISortMetric";
 import {IMobXApplicationDataStore, SimpleMobXApplicationDataStore} from "../../lib/IMobXApplicationDataStore";
+import {maxPage} from "./utils";
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -190,11 +191,7 @@ class LazyMobXTableStore<T> {
     }
 
     @computed get maxPage() {
-        if (this.itemsPerPage === PAGINATION_SHOW_ALL) {
-            return 0;
-        } else {
-            return Math.floor(this.displayData.length / this.itemsPerPage);
-        }
+        return maxPage(this.displayData.length, this.itemsPerPage);
     }
 
     @computed get filterStringUpper() {
@@ -501,6 +498,8 @@ class LazyMobXTableStore<T> {
 
         this._page = 0;
         this.itemsPerPage = lazyMobXTableProps.initialItemsPerPage || 50;
+
+        reaction(()=>this.displayData.length, ()=>{ this.page = this.clampPage(this.page); /* update for possibly reduced maxPage */});
     }
 }
 

--- a/src/shared/components/lazyMobXTable/utils.ts
+++ b/src/shared/components/lazyMobXTable/utils.ts
@@ -1,0 +1,8 @@
+import {SHOW_ALL_PAGE_SIZE} from "../paginationControls/PaginationControls";
+export function maxPage(displayDataLength:number, itemsPerPage:number) {
+    if (itemsPerPage === SHOW_ALL_PAGE_SIZE) {
+        return 0;
+    } else {
+        return Math.floor(Math.max(displayDataLength-1,0) / itemsPerPage);
+    }
+}


### PR DESCRIPTION
and reclamp page when data length changes (eg filter added)