### PR TITLE
Add strong typings to collections based on alteration subtypes.  Fix bar chart perf issue.

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -32,6 +32,11 @@ import {filterCBioPortalWebServiceData} from "../../shared/lib/oql/oqlfilter.js"
 import {keepAlive} from "mobx-utils";
 import MutationMapper from "./mutation/MutationMapper";
 import {CacheData} from "../../shared/lib/LazyMobXCache";
+import {Dictionary} from "lodash";
+import {
+    ICancerTypeAlterationData,
+    ICancerTypeAlterationPlotData
+} from "../../shared/components/cancerSummary/CancerSummaryContent";
 
 export type SamplesSpecificationElement = {studyId: string, sampleId: string, sampleListId: undefined} |
     {studyId: string, sampleId: undefined, sampleListId: string};
@@ -82,10 +87,12 @@ export function countAlterationOccurences(samplesByCancerType: {[cancerType: str
 
     return _.mapValues(samplesByCancerType, (samples: Sample[], cancerType: string) => {
 
-        const counts = {
+        const counts: ICancerTypeAlterationData = {
             mutated: 0,
-            amplified: 0,
-            deleted: 0,
+            amp: 0, // 2
+            homdel: 0, // -2
+            hetloss: 0, // -1
+            gain:0, // 1
             fusion: 0,
             mrnaExpressionUp: 0,
             mrnaExpressionDown: 0,
@@ -114,8 +121,8 @@ export function countAlterationOccurences(samplesByCancerType: {[cancerType: str
                     _.forEach(uniqueAlterations, (alteration: ExtendedAlteration) => {
                         switch (alteration.alterationType) {
                             case AlterationTypeConstants.COPY_NUMBER_ALTERATION:
-                                if (alteration.alterationSubType === 'amp') counts.amplified++;
-                                if (alteration.alterationSubType === 'homdel') counts.deleted++;
+                                // to do: type oqlfilter so that we can be sure alterationSubType is truly key of interface
+                                counts[(alteration.alterationSubType as keyof ICancerTypeAlterationPlotData)]++;
                                 break;
                             case AlterationTypeConstants.MRNA_EXPRESSION:
                                 if (alteration.alterationSubType === 'up') counts.mrnaExpressionUp++;

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -8,6 +8,7 @@ import {ThreeBounce} from 'better-react-spinkit';
 import ReactResizeDetector from 'react-resize-detector';
 import onNextRenderFrame from "shared/lib/onNextRenderFrame";
 import './styles.scss';
+import {ReactElement} from "react";
 
 interface IMSKTabProps {
     inactive?:boolean;
@@ -135,31 +136,6 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
 
             let children = (this.props.children as React.ReactElement<IMSKTabProps>[]);
 
-            // let hasActive: boolean = false;
-            // let effectiveActiveTab: string = "";
-            //
-            // const arr = _.reduce(React.Children.toArray(children), (memo: React.ReactElement<IMSKTabProps>[], child:React.ReactElement<IMSKTabProps>) => {
-            //     if (!child.props.hide) {
-            //         if (child.props.id === this.props.activeTabId) {
-            //             hasActive = true;
-            //             effectiveActiveTab = this.props.activeTabId;
-            //             this.shownTabs.push(child.props.id);
-            //             memo.push(this.cloneTab(child, false, !!child.props.loading));
-            //         } else if (_.includes(this.shownTabs, child.props.id) && !child.props.loading) {
-            //             memo.push(this.cloneTab(child, true, !!child.props.loading));
-            //         }
-            //     }
-            //     return memo;
-            // }, []);
-            //
-            // // if we don't have an active child, then default to first
-            // if (hasActive === false) {
-            //     this.shownTabs.push(children[0].props.id);
-            //     arr[0] = this.cloneTab(children[0], false, !!children[0].props.loading);
-            //     effectiveActiveTab = children[0].props.id;
-            // }
-
-
             let hasActive: boolean = false;
             let effectiveActiveTab: string = "";
 
@@ -181,9 +157,10 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
 
             // if we don't have an active child, then default to first
             if (hasActive === false) {
-                this.shownTabs.push(toArrayedChildren[0].props.id);
-                arr[0] = this.cloneTab(toArrayedChildren[0], false, !!toArrayedChildren[0].props.loading);
-                effectiveActiveTab = toArrayedChildren[0].props.id;
+                const tabElement = toArrayedChildren[0] as React.ReactElement<IMSKTabProps>
+                this.shownTabs.push(tabElement.props.id);
+                arr[0] = this.cloneTab(tabElement, false, !!tabElement.props.loading);
+                effectiveActiveTab = tabElement.props.id;
             }
 
 

--- a/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
@@ -24,7 +24,7 @@ const anchorStyle = {
 export default class CancerSummaryContainer extends React.Component<{store: ResultsViewPageStore},{}> {
 
     @observable private activeTab: string = "all";
-    @observable private resultsViewPageWidth:number;
+    @observable private resultsViewPageWidth:number = 1150;
     private resultsViewPageContent:HTMLElement;
 
     constructor() {
@@ -40,19 +40,12 @@ export default class CancerSummaryContainer extends React.Component<{store: Resu
         return 'all';
     }
 
-    componentDidUpdate(){
-        if (this.props.store.alterationCountsForCancerTypesForAllGenes.isComplete &&
-            this.props.store.alterationCountsForCancerTypesByGene.isComplete) {
-                this.resultsViewPageWidth = this.resultsViewPageContent.offsetWidth;
-        }
-    }
-
     @computed
     private get tabs() {
 
         const geneTabs = _.map(this.props.store.alterationCountsForCancerTypesByGene.result, (geneData, geneName) => (
             <MSKTab key={geneName} id={"summaryTab" + geneName} linkText={geneName} anchorStyle={anchorStyle}>
-                <CancerSummaryContent data={geneData} gene={this.activeTab} width={this.resultsViewPageWidth}/>
+                <CancerSummaryContent data={geneData} gene={geneName} width={this.resultsViewPageWidth}/>
             </MSKTab>
         ));
 

--- a/src/shared/components/cancerSummary/CancerSummaryContent.tsx
+++ b/src/shared/components/cancerSummary/CancerSummaryContent.tsx
@@ -13,12 +13,20 @@ import 'react-rangeslider/lib/index.css';
 
 import SummaryBarGraph from './SummaryBarGraph';
 
+
 export interface ICancerTypeAlterationPlotData {
-    mutated:number;
-    amplified:number;
-    deleted:number;
+    mutated: number;
+    amp:number;
+    homdel:number;
+    hetloss:number;
+    gain:number;
+    fusion:number;
+    mrnaExpressionUp:number;
+    mrnaExpressionDown:number;
+    protExpressionUp:number;
+    protExpressionDown:number;
     multiple:number;
-}
+};
 
 export interface IBarGraphDataset {
     label: string;
@@ -174,20 +182,21 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
     }
 
     private getColors(color:string) {
-        const colors:{[id:string]:string} = {
+        const alterationToColor: Record<keyof ICancerTypeAlterationPlotData, string> = {
             mutated:"#008000",
-            amplified:"#ff0000",
-            deleted:"#0000ff",
-            multiple:"#383838",
-            fusion:"#8B00C9",
-            gain:"rgb(255,182,193)",
+            amp:"#ff0000",
             homdel:"rgb(0,0,255)",
+            hetloss:"#000",
+            gain:"rgb(255,182,193)",
+            fusion:"#8B00C9",
             mrnaExpressionUp:"#FF989A",
             mrnaExpressionDown:"#529AC8",
             protExpressionUp:"#FF989A",
             protExpressionDown:"#E0FFFF",
+            multiple:"#666"
         };
-        return this.showGenomicAlt ? (colors[color] || "#000000") : '#aaaaaa';
+        // TODO: fix ts index signature issue so we don't have to cast alterationToColor as any
+        return this.showGenomicAlt ? ((alterationToColor as any)[color] || "#000000") : '#aaaaaa';
     }
 
     @computed private get cancerTypes() {

--- a/src/shared/components/cancerSummary/SummaryBarGraph.tsx
+++ b/src/shared/components/cancerSummary/SummaryBarGraph.tsx
@@ -3,7 +3,10 @@ import * as _ from 'lodash';
 import {computed, observable} from "mobx";
 import { ChartTooltipItem } from 'chart.js';
 import Chart, {ChartLegendItem} from 'chart.js';
-import {IBarGraphConfigOptions, IBarGraphDataset} from './CancerSummaryContent';
+import {
+    IBarGraphConfigOptions, IBarGraphDataset,
+    ICancerTypeAlterationPlotData
+} from './CancerSummaryContent';
 import {observer} from "mobx-react";
 import classnames from 'classnames';
 import './styles.scss';
@@ -133,21 +136,21 @@ export default class SummaryBarGraph extends React.Component<ISummaryBarGraphPro
     }
 
     private getLegendNames(id:string) {
-        const names: {[alterationName:string]:string} = {
+        const names: Record<keyof ICancerTypeAlterationPlotData, string> = {
             mutated: "Mutation",
-            amplified: "Amplification",
-            // deleted: "Deletion",
-            fusion: "Fusion",
+            amp: "Amplification",
+            homdel: "Deep Deletion",
+            hetloss: "Shallow Deletion",
             gain: "Gain",
+            fusion: "Fusion",
             mrnaExpressionUp: "mRNA Upregulation",
             mrnaExpressionDown: "mRNA Downregulation",
             protExpressionUp: "Protein Upregulation",
             protExpressionDown: "Protein Downregulation",
-            multiple: "Multiple Alterations",
-            homdel: "Deep Deletion",
-            hetloss: "Shallow Deletion"
+            multiple: "Multiple Alterations"
         };
-        return names[id] || id;
+        //TODO: figure out ts issue with index signature.
+        return (names as any)[id] || id;
     }
 
     private get chartOptions() {
@@ -177,6 +180,7 @@ export default class SummaryBarGraph extends React.Component<ISummaryBarGraphPro
                 xAxes: [{
                     gridLines: {display: false},
                     stacked: true,
+                    maxBarThickness:30,
                     ticks: {
                         maxRotation: 90,
                         autoSkip: false
@@ -251,7 +255,7 @@ export default class SummaryBarGraph extends React.Component<ISummaryBarGraphPro
     }
 
     private get width() {
-        const maxWidth = 220 + this.props.data.labels.length * 57;
+        const maxWidth = 220 + this.props.data.labels.length * 45;
         const conWidth = (this.props.width || 1159);
         return maxWidth > conWidth ? conWidth : maxWidth;
     }


### PR DESCRIPTION
Gene tags in cacner type summury were re-rendering unecessarily because of error in assignment of gene attribute.
Also, the alteration subtypes weren't lining up properly with color and label text collections.  Application of stronger types prevents this.