### PR TITLE
Show circles for functional impact column

### DIFF
--- a/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
+++ b/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
@@ -17,6 +17,8 @@ export function hideArrow(tooltipEl: any) {
 }
 
 export default class MutationAssessor extends React.Component<IMutationAssessorProps, {}> {
+    static MUTATION_ASSESSOR_URL:string = "http://mutationassessor.org/r3/";
+
     constructor(props: IMutationAssessorProps) {
         super(props);
 
@@ -28,17 +30,15 @@ export default class MutationAssessor extends React.Component<IMutationAssessorP
             <span className={`${annotationStyles["annotation-item-text"]}`}/>
         );
 
-        if (this.props.mutationAssessor.functionalImpact === null) {
-            //do not show any icon...
-        } else {
-			const maData = this.props.mutationAssessor;
+        if (this.props.mutationAssessor.functionalImpact !== null) {
+            const maData = this.props.mutationAssessor;
             maContent = (
-				<span className={classNames(annotationStyles["annotation-item-text"],
-								            mutationAssessorColumn[`ma-${maData.functionalImpact}`])}>
-					{maData.functionalImpact.substr(0,1).toUpperCase()}
-				</span>
+                <span className={classNames(annotationStyles["annotation-item-text"],
+                                            mutationAssessorColumn[`ma-${maData.functionalImpact}`])}>
+                    <i className='fa fa-circle' aria-hidden="true"></i>
+                </span>
             );
-			const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
+            const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
             maContent = (
                 <DefaultTooltip
                     overlay={this.tooltipContent}
@@ -50,7 +50,7 @@ export default class MutationAssessor extends React.Component<IMutationAssessorP
                 >
                     {maContent}
                 </DefaultTooltip>
-			);
+            );
         }
 
         return maContent;
@@ -62,47 +62,48 @@ export default class MutationAssessor extends React.Component<IMutationAssessorP
         const msaLink = MutationAssessor.maLink(maData.msaLink);
         const pdbLink = MutationAssessor.maLink(maData.pdbLink);
 
-		const impact = maData.functionalImpact? (
-			<div>
-				<table className={tooltipStyles['ma-tooltip-table']}>
-					<tr><td>Impact</td><td><span className={mutationAssessorColumn[`ma-${maData.functionalImpact}`]}>{maData.functionalImpact}</span></td></tr>
-					{maData.functionalImpactScore? <tr><td>Score</td><td><b>{maData.functionalImpactScore.toFixed(2)}</b></td></tr> : null}
-				</table>
-			</div>
-		) : null;
+        const impact = maData.functionalImpact? (
+            <div>
+                <table className={tooltipStyles['ma-tooltip-table']}>
+                    <tr><td>Source</td><td><a href="http://mutationassessor.org/r3">MutationAssessor</a></td></tr>
+                    <tr><td>Impact</td><td><span className={mutationAssessorColumn[`ma-${maData.functionalImpact}`]}>{maData.functionalImpact}</span></td></tr>
+                    {(maData.functionalImpactScore || maData.functionalImpactScore === 0) && (<tr><td>Score</td><td><b>{maData.functionalImpactScore.toFixed(2)}</b></td></tr>)}
+                </table>
+            </div>
+        ) : null;
 
         const xVar = xVarLink? (
-			<div className={tooltipStyles['mutation-assessor-link']}>
-				<a href={xVarLink} target='_blank'>
-					<img
-						height='15'
-						width='19'
-						src={require("./../../mutationTable/column/mutationAssessor.png")}
-						className={tooltipStyles['mutation-assessor-main-img']}
-						alt='Mutation Assessor'
-					/>
-					Go to Mutation Assessor
-				</a>
-			</div>
-		) : null;
+            <div className={tooltipStyles['mutation-assessor-link']}>
+                <a href={xVarLink} target='_blank'>
+                    <img
+                        height='15'
+                        width='19'
+                        src={require("./../../mutationTable/column/mutationAssessor.png")}
+                        className={tooltipStyles['mutation-assessor-main-img']}
+                        alt='Mutation Assessor'
+                    />
+                    Go to Mutation Assessor
+                </a>
+            </div>
+        ) : null;
 
         const msa = msaLink? (
-			<div className={tooltipStyles['mutation-assessor-link']}>
-				<a href={msaLink} target='_blank'>
-					<span className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-msa-icon']}`}>msa</span>
-					Multiple Sequence Alignment
-				</a>
-			</div>
-		) : null;
+            <div className={tooltipStyles['mutation-assessor-link']}>
+                <a href={msaLink} target='_blank'>
+                    <span className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-msa-icon']}`}>msa</span>
+                    Multiple Sequence Alignment
+                </a>
+            </div>
+        ) : null;
 
         const pdb = pdbLink? (
-			<div className={tooltipStyles['mutation-assessor-link']}>
-				<a href={pdbLink} target='_blank'>
-					<span className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-3d-icon']}`}>3D</span>
-					Mutation Assessor 3D View
-				</a>
-			</div>
-		) : null;
+            <div className={tooltipStyles['mutation-assessor-link']}>
+                <a href={pdbLink} target='_blank'>
+                    <span className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-3d-icon']}`}>3D</span>
+                    Mutation Assessor 3D View
+                </a>
+            </div>
+        ) : null;
 
         return (
             <span>

--- a/src/shared/components/annotation/genomeNexus/PolyPhen2.tsx
+++ b/src/shared/components/annotation/genomeNexus/PolyPhen2.tsx
@@ -15,6 +15,8 @@ export function hideArrow(tooltipEl: any) {
 }
 
 export default class PolyPhen2 extends React.Component<IPolyPhen2Props, {}> {
+    static POLYPHEN2_URL:string = "http://genetics.bwh.harvard.edu/pph2/";
+
     constructor(props: IPolyPhen2Props) {
         super(props);
         this.tooltipContent = this.tooltipContent.bind(this);
@@ -25,16 +27,13 @@ export default class PolyPhen2 extends React.Component<IPolyPhen2Props, {}> {
             <span className={`${annotationStyles["annotation-item-text"]}`}/>
         );
 
-        if (this.props.polyPhenPrediction === null || this.props.polyPhenPrediction === undefined || this.props.polyPhenPrediction.length === 0) {
-            //do not show any icon...
-        } else {
-            let text: string = this.props.polyPhenPrediction.split('_').length > 1? 
-                this.props.polyPhenPrediction.split('_')[1].substring(0,1).toUpperCase() : 
-                this.props.polyPhenPrediction.substring(0,1).toUpperCase();
+        if (this.props.polyPhenPrediction && this.props.polyPhenPrediction.length > 0) {
             content = (
-                <span className={classNames(annotationStyles["annotation-item-text"], tooltipStyles[`polyPhen2-${this.props.polyPhenPrediction}`])}>{text}</span>
+                <span className={classNames(annotationStyles["annotation-item-text"], tooltipStyles[`polyPhen2-${this.props.polyPhenPrediction}`])}>
+                    <i className='fa fa-circle' aria-hidden="true"></i>
+                </span>
             );
-			const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
+            const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
             content = (
                 <DefaultTooltip
                     overlay={this.tooltipContent}
@@ -46,21 +45,22 @@ export default class PolyPhen2 extends React.Component<IPolyPhen2Props, {}> {
                 >
                     {content}
                 </DefaultTooltip>
-			);
+            );
         }
 
         return content;
     }
 
     private tooltipContent() {
-		const impact = this.props.polyPhenPrediction? (
-			<div>
-				<table className={tooltipStyles['polyPhen2-tooltip-table']}>
-					<tr><td>Impact</td><td><span className={tooltipStyles[`polyPhen2-${this.props.polyPhenPrediction}`]}>{this.props.polyPhenPrediction}</span></td></tr>
-					{this.props.polyPhenScore !== undefined && this.props.polyPhenScore !== null? <tr><td>Score</td><td><b>{this.props.polyPhenScore.toFixed(2)}</b></td></tr> : null}
-				</table>
-			</div>
-		) : null;
+        const impact = this.props.polyPhenPrediction? (
+            <div>
+                <table className={tooltipStyles['polyPhen2-tooltip-table']}>
+                    <tr><td>Source</td><td><a href="http://genetics.bwh.harvard.edu/pph2/">PolyPhen-2</a></td></tr>
+                    <tr><td>Impact</td><td><span className={tooltipStyles[`polyPhen2-${this.props.polyPhenPrediction}`]}>{this.props.polyPhenPrediction}</span></td></tr>
+                    {(this.props.polyPhenScore || this.props.polyPhenScore === 0) && (<tr><td>Score</td><td><b>{this.props.polyPhenScore.toFixed(2)}</b></td></tr>)}
+                </table>
+            </div>
+        ) : null;
 
         return (
             <span>

--- a/src/shared/components/annotation/genomeNexus/Sift.tsx
+++ b/src/shared/components/annotation/genomeNexus/Sift.tsx
@@ -15,6 +15,8 @@ export function hideArrow(tooltipEl: any) {
 }
 
 export default class Sift extends React.Component<ISiftProps, {}> {
+    static SIFT_URL:string = "http://sift.bii.a-star.edu.sg/";
+
     constructor(props: ISiftProps) {
         super(props);
         this.tooltipContent = this.tooltipContent.bind(this);
@@ -25,13 +27,13 @@ export default class Sift extends React.Component<ISiftProps, {}> {
             <span className={`${annotationStyles["annotation-item-text"]}`}/>
         );
 
-        if (this.props.siftPrediction === null || this.props.siftPrediction === undefined || this.props.siftPrediction.length === 0) {
-            //do not show any icon...
-        } else {
+        if (this.props.siftPrediction && this.props.siftPrediction.length > 0) {
             siftContent = (
-                <span className={classNames(annotationStyles["annotation-item-text"], tooltipStyles[`sift-${this.props.siftPrediction}`])}>{this.props.siftPrediction.substring(0,1).toUpperCase()}</span>
+                <span className={classNames(annotationStyles["annotation-item-text"], tooltipStyles[`sift-${this.props.siftPrediction}`])}>
+                    <i className='fa fa-circle' aria-hidden="true"></i>
+                </span>
             );
-			const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
+            const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
             siftContent = (
                 <DefaultTooltip
                     overlay={this.tooltipContent}
@@ -43,21 +45,22 @@ export default class Sift extends React.Component<ISiftProps, {}> {
                 >
                     {siftContent}
                 </DefaultTooltip>
-			);
+            );
         }
 
         return siftContent;
     }
 
     private tooltipContent() {
-		const impact = this.props.siftPrediction? (
-			<div>
-				<table className={tooltipStyles['sift-tooltip-table']}>
-					<tr><td>Impact</td><td><span className={tooltipStyles[`sift-${this.props.siftPrediction}`]}>{this.props.siftPrediction}</span></td></tr>
-					{this.props.siftScore !== undefined && this.props.siftScore !== null? <tr><td>Score</td><td><b>{this.props.siftScore.toFixed(2)}</b></td></tr> : null}
-				</table>
-			</div>
-		) : null;
+        const impact = this.props.siftPrediction? (
+            <div>
+                <table className={tooltipStyles['sift-tooltip-table']}>
+                    <tr><td>Source</td><td><a href="http://sift.bii.a-star.edu.sg/">SIFT</a></td></tr>
+                    <tr><td>Impact</td><td><span className={tooltipStyles[`sift-${this.props.siftPrediction}`]}>{this.props.siftPrediction}</span></td></tr>
+                    {(this.props.siftScore || this.props.siftScore === 0) && (<tr><td>Score</td><td><b>{this.props.siftScore.toFixed(2)}</b></td></tr>)}
+                </table>
+            </div>
+        ) : null;
 
         return (
             <span>

--- a/src/shared/components/annotation/genomeNexus/styles/functionalImpact.scss
+++ b/src/shared/components/annotation/genomeNexus/styles/functionalImpact.scss
@@ -1,0 +1,4 @@
+$neutral: #c1c1c1; // gray
+$low: #ffd700; // yellow
+$medium: #ffaa22; // orange
+$high: #f00; // red

--- a/src/shared/components/annotation/genomeNexus/styles/mutationAssessorColumn.module.scss
+++ b/src/shared/components/annotation/genomeNexus/styles/mutationAssessorColumn.module.scss
@@ -1,19 +1,21 @@
+@import "functionalImpact";
+
 .ma-high {
-  color: #C83C3C;
-  font-weight:bold;
+  color: $high;
+  font-weight: bold;
 }
 
 .ma-medium {
-  color: #9F6F47;
-  font-weight:bold;
+  color: $medium;
+  font-weight: bold;
 }
 
 .ma-low {
-  color: #988A3E;
-  font-weight:bold;
+  color: $low;
+  font-weight: bold;
 }
 
 .ma-neutral {
-  color: #909090;
-  font-weight:bold;
+  color: $neutral;
+  font-weight: bold;
 }

--- a/src/shared/components/annotation/genomeNexus/styles/polyPhen2Tooltip.module.scss
+++ b/src/shared/components/annotation/genomeNexus/styles/polyPhen2Tooltip.module.scss
@@ -1,16 +1,19 @@
+@import "functionalImpact";
+
 .polyPhen2-probably_damaging {
-  color: #C83C3C;
+  color: $high;
   font-weight:bold;
 }
-
 .polyPhen2-possibly_damaging {
-  color: #988A3E;
+  color: $low;
   font-weight:bold;
 }
-
 .polyPhen2-benign {
-  color: #909090;
+  color: $neutral;
   font-weight:bold;
+}
+.polyPhen2-unknown {
+  display: none;
 }
 .polyPhen2-tooltip-table {
   td:first-child {

--- a/src/shared/components/annotation/genomeNexus/styles/siftTooltip.module.scss
+++ b/src/shared/components/annotation/genomeNexus/styles/siftTooltip.module.scss
@@ -1,16 +1,18 @@
+@import "functionalImpact";
+
 .sift-deleterious {
-  color: #C83C3C;
+  color: $high;
   font-weight:bold;
 }
 
-.sift-deleterious_low_confidence,
-.sift-tolerated_low_confidence {
-  color: #988A3E;
+.sift-deleterious_low_confidence {
+  color: $low;
   font-weight:bold;
 }
 
+.sift-tolerated_low_confidence,
 .sift-tolerated {
-  color: #909090;
+  color: $neutral;
   font-weight:bold;
 }
 

--- a/src/shared/components/annotation/styles/annotation.module.scss
+++ b/src/shared/components/annotation/styles/annotation.module.scss
@@ -10,7 +10,9 @@
 
 .annotation-item-text {
   display: inline-block;
+  font-size: 9px;
   width: 22px;
+  cursor: default;
 }
 
 .annotation-item-error {

--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import {Circle} from "better-react-spinkit";
+import classNames from 'classnames';
 import DefaultTooltip from 'shared/components/defaultTooltip/DefaultTooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import GenomeNexusCache, {GenomeNexusCacheDataType} from "shared/cache/GenomeNexusEnrichment";
@@ -7,6 +9,176 @@ import {default as TableCellStatusIndicator, TableCellStatus} from "shared/compo
 import MutationAssessor from "shared/components/annotation/genomeNexus/MutationAssessor";
 import Sift from "shared/components/annotation/genomeNexus/Sift";
 import PolyPhen2 from "shared/components/annotation/genomeNexus/PolyPhen2";
+import siftStyles from "shared/components/annotation/genomeNexus/styles/siftTooltip.module.scss";
+import polyPhen2Styles from "shared/components/annotation/genomeNexus/styles/polyPhen2Tooltip.module.scss";
+import mutationAssessorStyles from "shared/components/annotation/genomeNexus/styles/mutationAssessorColumn.module.scss";
+import annotationStyles from "shared/components/annotation/styles/annotation.module.scss";
+
+
+type FunctionalImpactColumnTooltipProps = {
+    active: 'mutationAssessor' | 'sift' | 'polyPhen2';
+}
+
+interface IFunctionalImpactColumnTooltipState {
+    active: 'mutationAssessor' | 'sift' | 'polyPhen2';
+}
+
+class FunctionalImpactColumnTooltip extends React.Component<FunctionalImpactColumnTooltipProps, IFunctionalImpactColumnTooltipState> {
+    constructor(props:FunctionalImpactColumnTooltipProps) {
+        super(props);
+        this.state = {
+            active: this.props.active
+        };
+    }
+
+    legend() {
+        return (
+            <div>
+                <table className="table table-striped table-border-top">
+                    <thead>
+                        <tr>
+                            <th>Legend</th>
+                            <th>
+                                <span
+                                    style={{display:'inline-block',width:22}}
+                                    title='Mutation Asessor'
+                                    onMouseOver={() => this.setState({active:'mutationAssessor'})}
+                                >
+                                    <img
+                                        height={14} width={14}
+                                        src={require("./mutationAssessor.png")}
+                                        alt='Mutation Assessor'
+                                    />
+                                </span>
+                            </th>
+                            <th>
+                                <span
+                                    style={{display:'inline-block',width:22}}
+                                    title='SIFT'
+                                    onMouseOver={() => this.setState({active:'sift'})}
+                                >
+                                    <img
+                                        height={14} width={14}
+                                        src={require("./siftFunnel.png")}
+                                        alt='SIFT'
+                                    />
+                                </span>
+                            </th>
+                            <th>
+                                <span
+                                    style={{display:'inline-block',width:22}}
+                                    title='PolyPhen-2'
+                                    onMouseOver={() => this.setState({active:'polyPhen2'})}
+                                >
+                                    <img
+                                        height={14} width={14}
+                                        src={require("./polyPhen-2.png")}
+                                        alt='PolyPhen-2'
+                                    />
+                                </span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <span className={classNames(annotationStyles["annotation-item-text"], mutationAssessorStyles[`ma-high`])}>
+                                    <i className='fa fa-circle' aria-hidden="true"></i>
+                                </span>
+                            </td>
+                            <td className={mutationAssessorStyles['ma-high']}>high</td>
+                            <td className={siftStyles['sift-deleterious']}>deleterious</td>
+                            <td className={polyPhen2Styles['polyPhen2-probably_damaging']}>probably_damaging</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span className={classNames(annotationStyles["annotation-item-text"], mutationAssessorStyles[`ma-medium`])}>
+                                    <i className='fa fa-circle' aria-hidden="true"></i>
+                                </span>
+                            </td>
+                            <td className={mutationAssessorStyles['ma-medium']}>medium</td>
+                            <td>-</td>
+                            <td>-</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span className={classNames(annotationStyles["annotation-item-text"], mutationAssessorStyles[`ma-low`])}>
+                                    <i className='fa fa-circle' aria-hidden="true"></i>
+                                </span>
+                            </td>
+                            <td className={mutationAssessorStyles['ma-low']}>low</td>
+                            <td className={siftStyles['sift-deleterious_low_confidence']}>deleterious_low_confidence</td>
+                            <td className={polyPhen2Styles['polyPhen2-possibly_damaging']}>possibly_damaging</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span className={classNames(annotationStyles["annotation-item-text"], mutationAssessorStyles[`ma-neutral`])}>
+                                    <i className='fa fa-circle' aria-hidden="true"></i>
+                                </span>
+                            </td>
+                            <td className={mutationAssessorStyles['ma-neutral']}>neutral</td>
+                            <td className={siftStyles['sift-tolerated_low_confidence']}>tolerated_low_confidence</td>
+                            <td className={polyPhen2Styles['polyPhen2-benign']}>benign</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>-</td>
+                            <td className={siftStyles['sift-tolerated']}>tolerated</td>
+                            <td>-</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        );
+
+    }
+
+    public static mutationAssessorText() {
+        return <div style={{width:450,height:100}}><a
+        href={MutationAssessor.MUTATION_ASSESSOR_URL} target="_blank">Mutation
+        Assessor</a> predicts the functional impact of amino-acid substitutions
+        in proteins, such as mutations discovered in cancer or missense
+        polymorphisms. The functional impact is assessed based on evolutionary
+        conservation of the affected amino acid in protein homologs. The method
+        has been validated on a large set (60k) of disease associated (OMIM)
+        and polymorphic variants.</div>;
+    }
+
+    public static siftText() {
+        return <div style={{width:450,height:100}}><a href={Sift.SIFT_URL}
+        target="_blank">SIFT</a> predicts whether an amino acid substitution
+        affects protein function based on sequence homology and the physical
+        properties of amino acids. SIFT can be applied to naturally occurring
+        nonsynonymous polymorphisms and laboratory-induced missense
+        mutations.</div>;
+    }
+
+    public static polyPhen2Text() {
+        return <div style={{width:450,height:100}}><a href={PolyPhen2.POLYPHEN2_URL}
+        target="_blank">PolyPhen-2</a> (Polymorphism Phenotyping v2) is a tool
+        which predicts possible impact of an amino acid substitution on the
+        structure and function of a human protein using straightforward
+        physical and comparative considerations.</div>;
+    }
+
+    public render() {
+
+        return (
+            <div>
+                {(this.state.active === 'mutationAssessor') && (
+                    FunctionalImpactColumnTooltip.mutationAssessorText()
+                )}
+                {(this.state.active === 'sift') && (
+                    FunctionalImpactColumnTooltip.siftText()
+                )}
+                {(this.state.active === 'polyPhen2') && (
+                    FunctionalImpactColumnTooltip.polyPhen2Text()
+                )}
+                {this.legend()}
+            </div>
+        );
+    }
+}
 
 export function placeArrow(tooltipEl: any) {
     const arrowEl = tooltipEl.querySelector('.rc-tooltip-arrow');
@@ -14,35 +186,6 @@ export function placeArrow(tooltipEl: any) {
 }
 
 export default class FunctionalImpactColumnFormatter {
-
-    public static mutationAssessorTooltip() {
-        return <div style={{maxWidth:450}}><a
-        href="http://mutationassessor.org/r3/">Mutation Assessor</a> predicts
-        the functional impact of amino-acid substitutions in proteins, such as
-        mutations discovered in cancer or missense polymorphisms. The
-        functional impact is assessed based on evolutionary conservation of the
-        affected amino acid in protein homologs. The method has been validated
-        on a large set (60k) of disease associated (OMIM) and polymorphic
-        variants.</div>;
-    }
-
-    public static siftTooltip() {
-        return <div style={{maxWidth:450}}><a
-        href="http://sift.bii.a-star.edu.sg/">SIFT</a> predicts whether an
-        amino acid substitution affects protein function based on sequence
-        homology and the physical properties of amino acids. SIFT can be
-        applied to naturally occurring nonsynonymous polymorphisms and
-        laboratory-induced missense mutations.</div>;
-    }
-
-    public static polyPhen2Tooltip() {
-        return <div style={{maxWidth:450}}><a
-        href="http://genetics.bwh.harvard.edu/pph2/">PolyPhen-2 </a>
-        (Polymorphism Phenotyping v2) is a tool which predicts possible impact
-        of an amino acid substitution on the structure and function of a human
-        protein using straightforward physical and comparative considerations.
-        </div>;
-    }
     
     public static headerRender(name: string) {
         const arrowContent = <div className="rc-tooltip-arrow-inner"  />;
@@ -51,11 +194,11 @@ export default class FunctionalImpactColumnFormatter {
                 {name}<br />
                 <div style={{height:14}}>
                     <DefaultTooltip
-                        overlay={FunctionalImpactColumnFormatter.mutationAssessorTooltip}
+                        overlay={<FunctionalImpactColumnTooltip active='mutationAssessor' />}
                         placement="topLeft"
                         trigger={['hover', 'focus']}
                         arrowContent={arrowContent}
-                        destroyTooltipOnHide={false}
+                        destroyTooltipOnHide={true}
                         onPopupAlign={placeArrow}
                     >
                         <span style={{display:'inline-block',width:22}}>
@@ -68,11 +211,11 @@ export default class FunctionalImpactColumnFormatter {
                         </span>
                     </DefaultTooltip>
                     <DefaultTooltip
-                        overlay={FunctionalImpactColumnFormatter.siftTooltip}
+                        overlay={<FunctionalImpactColumnTooltip active='sift' />}
                         placement="topLeft"
                         trigger={['hover', 'focus']}
                         arrowContent={arrowContent}
-                        destroyTooltipOnHide={false}
+                        destroyTooltipOnHide={true}
                         onPopupAlign={placeArrow}
                     >
                         <span style={{display:'inline-block',width:22}}>
@@ -85,11 +228,11 @@ export default class FunctionalImpactColumnFormatter {
                         </span>
                     </DefaultTooltip>
                     <DefaultTooltip
-                        overlay={FunctionalImpactColumnFormatter.polyPhen2Tooltip}
+                        overlay={<FunctionalImpactColumnTooltip active='polyPhen2' />}
                         placement="topLeft"
                         trigger={['hover', 'focus']}
                         arrowContent={arrowContent}
-                        destroyTooltipOnHide={false}
+                        destroyTooltipOnHide={true}
                         onPopupAlign={placeArrow}
                     >
                         <span style={{display:'inline-block',width:22}}>
@@ -141,11 +284,14 @@ export default class FunctionalImpactColumnFormatter {
             );
         }
         if (status !== null) {
-            return (
-                <TableCellStatusIndicator
+            // show loading circle
+            if (status === TableCellStatus.LOADING) {
+                return <Circle size={18} scaleEnd={0.5} scaleStart={0.2} color="#aaa" className="pull-left"/>;
+            } else {
+                return (<TableCellStatusIndicator
                     status={status}
-                />
-            );
+                />);
+            }
         }
     }
 }

--- a/src/shared/components/mutationTable/column/mutationAssessor.module.scss
+++ b/src/shared/components/mutationTable/column/mutationAssessor.module.scss
@@ -3,22 +3,22 @@
 }
 
 .oma-high {
-  color: #C83C3C;
+  color: #f00;
   font-weight:bold;
 }
 
 .oma-medium {
-  color: #9F6F47;
+  color: #ffd700;
   font-weight:bold;
 }
 
 .oma-low {
-  color: #988A3E;
+  color: #ffd700;
   font-weight:bold;
 }
 
 .oma-neutral {
-  color: #909090;
+  color: #c1c1c1;
   font-weight:bold;
 }
 


### PR DESCRIPTION
Show cirlces instead of letters.

![screen shot 2017-10-02 at 3 06 43 pm](https://user-images.githubusercontent.com/1334004/31095726-d8b533a8-a787-11e7-8124-0e5b2d54700f.png)

![functional_impact](https://user-images.githubusercontent.com/1334004/31283555-f76b8c94-aa83-11e7-9c40-41b7f4c1dbcf.gif)


Color scheme as:
https://docs.google.com/spreadsheets/d/14fdwAAXguwuD4WW7RyfgjUCn-tZYrMnolrFLY5cm8N8/edit#gid=0

How to view:
Go to
https://cbioportal-frontend-pr-652.herokuapp.com/#/patient?caseId=P04&studyId=lgg_ucsf_2014
Show `Functional Impact` column in the mutations table