### PR TITLE
Fix #3138 Move uniprot link to right

### DIFF
--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -67,8 +67,11 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
 
     @computed get geneSummary():JSX.Element {
         return (
-            <div>
+            <div style={{'paddingBottom':10}}>
                 <h4>{this.props.store.gene.hugoGeneSymbol}</h4>
+                {this.props.store.uniprotId.result && (
+                    <span>UniProt: <a href={`http://www.uniprot.org/uniprot/${this.props.store.uniprotId.result}`}>{this.props.store.uniprotId.result}</a></span>
+                )}
             </div>
         );
     }

--- a/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
@@ -471,7 +471,18 @@ export default class LollipopPlotNoTooltip extends React.Component<LollipopPlotN
                         onClick={this.handlers.onBackgroundClick}
                         onMouseMove={this.handlers.onBackgroundMouseMove}
                     />
-                    {this.sequenceSegments}
+                    // Originally this had tooltips by having separate segments
+                    // with hit zones. We disabled those separate segments with
+                    // tooltips (this.sequenceSegments) and instead just draw
+                    // one rectangle
+                    // {this.sequenceSegments}
+                    <rect
+                        fill="#BABDB6"
+                        x={this.geneX}
+                        y={this.geneY}
+                        height={this.geneHeight}
+                        width={this.props.vizWidth}
+                    />
                     {this.lollipops}
                     {this.domains}
                     <SVGAxis


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/3138

Disable tooltips on gray segments. Move uniprot link to the right

![screen shot 2017-10-02 at 6 55 54 pm](https://user-images.githubusercontent.com/1334004/31103228-d79a3a7e-a7a3-11e7-8e83-1ab493e973c6.png)

Another idea would be to move uniprot link in a `?` so these details only show up for those who are interested about the details
