### PR TITLE
Fix to remove hard coded URLs and add https

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -29,7 +29,7 @@ export function getStudySummaryUrl(studyId:string) {
     return cbioUrl('study', {id: studyId}, 'summary');
 }
 export function getPubMedUrl(pmid:string) {
-    return `http://www.ncbi.nlm.nih.gov/pubmed/${pmid}`;
+    return `https://www.ncbi.nlm.nih.gov/pubmed/${pmid}`;
 }
 export function getMyGeneUrl(entrezGeneId: number) {
     return `https://mygene.info/v3/gene/${entrezGeneId}?fields=uniprot`;

--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -52,7 +52,7 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                 // have to do a for loop because seamlessImmutable will make result of .map immutable,
                 // and that causes infinite loop here
                 responsePromises.push(
-                    request.get(`http://www.cbioportal.org/getMutationAligner.json?pfamAccession=${regions[i].metadata.accession}`)
+                    request.get(`getMutationAligner.json?pfamAccession=${regions[i].metadata.accession}`)
                 );
             }
             const allResponses = Promise.all(responsePromises);
@@ -292,7 +292,7 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
 
     public downloadAsPDF(filename:string) {
         const svgelement = "<?xml version='1.0'?>"+this.toSVGDOMNode().outerHTML;
-        const servletURL = "http://www.cbioportal.org/svgtopdf.do";
+        const servletURL = "svgtopdf.do";
         const filetype = "pdf_data";
         request.post(servletURL)
             .type('form')


### PR DESCRIPTION
# What? Why?
This removes hard coded references to www.cbioportal.org and adds https to the external service calls that don't go via the internal proxy (this is important for cbioportal installations hosted on a https address).

# Notify reviewers
@adamabeshouse @alisman 