### PR TITLE
Grey gene button

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -130,8 +130,15 @@ th.reactable-header-sort-asc:after {
         }
       }
     }
-
   }
+
+  li a {
+    font-size: 12px;
+    padding: 10px 6px !important;
+    cursor: pointer;
+    line-height: 0.8px;
+  }
+
 }
 
 .mainTabs {

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -56,15 +56,6 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
     protected generateTabs(genes: string[])
     {
         const tabs: JSX.Element[] = [];
-        const anchorStyle = {
-            'font-size': '12px',
-            'padding-left': '6px',
-            'padding-right': '6px',
-            'padding-top': '10px',
-            'padding-bottom': '10px',
-            'cursor': 'pointer',
-            'line-height': .8
-        }
 
         genes.forEach((gene: string) => {
             const mutationMapperStore = this.props.store.getMutationMapperStore(gene);
@@ -72,7 +63,7 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
             if (mutationMapperStore)
             {
                 tabs.push(
-                    <MSKTab key={gene} id={gene} linkText={gene} anchorStyle={anchorStyle}>
+                    <MSKTab key={gene} id={gene} linkText={gene}>
                         <MutationMapper
                             store={mutationMapperStore}
                             discreteCNACache={this.props.store.discreteCNACache}

--- a/src/shared/components/MSKTabs/styles.scss
+++ b/src/shared/components/MSKTabs/styles.scss
@@ -1,5 +1,0 @@
-.msk-tabs {
-  .msk-tab {
-    margin-top:10px;
-  }
-}

--- a/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
@@ -9,17 +9,6 @@ import {CancerSummaryContent} from './CancerSummaryContent';
 import {ResultsViewPageStore} from "../../../pages/resultsView/ResultsViewPageStore";
 import Loader from "../loadingIndicator/LoadingIndicator";
 
-const anchorStyle = {
-    'font-size': '12px',
-    'padding-left': '6px',
-    'padding-right': '6px',
-    'padding-top': '10px',
-    'padding-bottom': '10px',
-    'cursor': 'pointer',
-    'line-height': .8
-}
-
-
 @observer
 export default class CancerSummaryContainer extends React.Component<{store: ResultsViewPageStore},{}> {
 
@@ -44,14 +33,14 @@ export default class CancerSummaryContainer extends React.Component<{store: Resu
     private get tabs() {
 
         const geneTabs = _.map(this.props.store.alterationCountsForCancerTypesByGene.result, (geneData, geneName) => (
-            <MSKTab key={geneName} id={"summaryTab" + geneName} linkText={geneName} anchorStyle={anchorStyle}>
+            <MSKTab key={geneName} id={"summaryTab" + geneName} linkText={geneName}>
                 <CancerSummaryContent data={geneData} gene={geneName} width={this.resultsViewPageWidth}/>
             </MSKTab>
         ));
 
         // only add combined gene tab if there's more than one gene
         if (geneTabs.length > 1) {
-            geneTabs.unshift(<MSKTab key="all" id="allGenes" linkText="All Queried Genes" anchorStyle={anchorStyle}>
+            geneTabs.unshift(<MSKTab key="all" id="allGenes" linkText="All Queried Genes">
                 <CancerSummaryContent gene={'all'} width={this.resultsViewPageWidth}
                                       data={this.props.store.alterationCountsForCancerTypesForAllGenes.result!}/>
             </MSKTab>)

--- a/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
@@ -5,16 +5,16 @@ import {observer} from "mobx-react";
 import {MSKTabs, MSKTab} from "shared/components/MSKTabs/MSKTabs";
 import {If, Then, Else} from 'react-if';
 import {ThreeBounce} from 'better-react-spinkit';
-import {CancerSummaryContent} from './CancerSummaryContent';
+import {CancerSummaryContent, ICancerTypeAlterationData} from './CancerSummaryContent';
 import {ResultsViewPageStore} from "../../../pages/resultsView/ResultsViewPageStore";
 import Loader from "../loadingIndicator/LoadingIndicator";
 
 @observer
-export default class CancerSummaryContainer extends React.Component<{store: ResultsViewPageStore},{}> {
+export default class CancerSummaryContainer extends React.Component<{ store: ResultsViewPageStore }, {}> {
 
     @observable private activeTab: string = "all";
-    @observable private resultsViewPageWidth:number = 1150;
-    private resultsViewPageContent:HTMLElement;
+    @observable private resultsViewPageWidth: number = 1150;
+    private resultsViewPageContent: HTMLElement;
 
     constructor() {
         super();
@@ -32,11 +32,22 @@ export default class CancerSummaryContainer extends React.Component<{store: Resu
     @computed
     private get tabs() {
 
-        const geneTabs = _.map(this.props.store.alterationCountsForCancerTypesByGene.result, (geneData, geneName) => (
-            <MSKTab key={geneName} id={"summaryTab" + geneName} linkText={geneName}>
-                <CancerSummaryContent data={geneData} gene={geneName} width={this.resultsViewPageWidth}/>
-            </MSKTab>
-        ));
+        const geneTabs = _.map(this.props.store.alterationCountsForCancerTypesByGene.result, (geneData, geneName: string) => {
+
+            // count how many alterations there are across all cancer types for this gene
+            const alterationCountAcrossCancerType = _.reduce(geneData,(count, alterationData:ICancerTypeAlterationData)=>{
+                return count + alterationData.alterationTotal;
+            },0);
+
+            // if there are no alterations for this gene, show a grey background
+            const anchorStyle = (alterationCountAcrossCancerType === 0) ? { backgroundColor:'#ccc', color:'#999' } : {};
+
+            return (
+                <MSKTab key={geneName} id={"summaryTab" + geneName} linkText={geneName} anchorStyle={anchorStyle}>
+                    <CancerSummaryContent data={geneData} gene={geneName} width={this.resultsViewPageWidth}/>
+                </MSKTab>
+            )
+        });
 
         // only add combined gene tab if there's more than one gene
         if (geneTabs.length > 1) {
@@ -57,7 +68,7 @@ export default class CancerSummaryContainer extends React.Component<{store: Resu
                 <div ref={(el: HTMLDivElement) => this.resultsViewPageContent = el}>
                     <MSKTabs onTabClick={this.handleTabClick}
                              enablePagination={true}
-                             arrowStyle={{'line-height':.8}}
+                             arrowStyle={{'line-height': .8}}
                              tabButtonStyle="pills"
                              activeTabId={this.activeTab} className="secondaryTabs">
                         {this.tabs}

--- a/src/shared/components/cancerSummary/SummaryBarGraph.tsx
+++ b/src/shared/components/cancerSummary/SummaryBarGraph.tsx
@@ -4,8 +4,7 @@ import {computed, observable} from "mobx";
 import { ChartTooltipItem } from 'chart.js';
 import Chart, {ChartLegendItem} from 'chart.js';
 import {
-    IBarGraphConfigOptions, IBarGraphDataset,
-    ICancerTypeAlterationPlotData
+    IBarGraphConfigOptions, IBarGraphDataset, ICancerTypeAlterationCounts, ICancerTypeAlterationData
 } from './CancerSummaryContent';
 import {observer} from "mobx-react";
 import classnames from 'classnames';
@@ -136,7 +135,7 @@ export default class SummaryBarGraph extends React.Component<ISummaryBarGraphPro
     }
 
     private getLegendNames(id:string) {
-        const names: Record<keyof ICancerTypeAlterationPlotData, string> = {
+        const names: Record<keyof ICancerTypeAlterationCounts, string> = {
             mutated: "Mutation",
             amp: "Amplification",
             homdel: "Deep Deletion",


### PR DESCRIPTION
When a gene has no alterations (for any cancer type) we should show it's button as greyed out.  but it should still be clickeable.  also cleaned up the interface for alteration counts

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
