### PR TITLE
Fix lollipop plot

### DIFF
--- a/src/shared/components/SVGAxis.tsx
+++ b/src/shared/components/SVGAxis.tsx
@@ -39,7 +39,7 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                             textAnchor="end"
                             style={{
                                 fontSize:"10px",
-                                fontFamily:"sans-serif"
+                                fontFamily:"arial"
                             }}
                             dx={-1*labelPadding}
                             dy="0.4em"
@@ -55,7 +55,7 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                             textAnchor="middle"
                             style={{
                                 fontSize:"10px",
-                                fontFamily:"sans-serif"
+                                fontFamily:"arial"
                             }}
                             x={x2}
                             y={y2}
@@ -100,7 +100,7 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                 <text
                     textAnchor="middle"
                     style={{
-                        fontFamily: "sans-serif",
+                        fontFamily: "arial",
                         fontSize: "12px",
                         fontWeight: "normal"
                     }}

--- a/src/shared/components/lollipopMutationPlot/Domain.tsx
+++ b/src/shared/components/lollipopMutationPlot/Domain.tsx
@@ -88,7 +88,7 @@ export default class Domain extends React.Component<DomainProps, {}> {
             fill:(this.props.labelColor || "#FFFFFF"),
             style:{
                 fontSize: "12px",
-                fontFamily: "sans-serif",
+                fontFamily: "arial",
             }
         };
         const text = (reference ? (this.props.label || "") : this.displayText);

--- a/src/shared/components/lollipopMutationPlot/Lollipop.tsx
+++ b/src/shared/components/lollipopMutationPlot/Lollipop.tsx
@@ -50,7 +50,7 @@ export default class Lollipop extends React.Component<LollipopProps, {}> {
                     fill="#2E3436"
                     style={{
                         fontSize: "10px",
-                        fontFamily: "sans-serif",
+                        fontFamily: "arial",
                     }}
                     textAnchor="middle"
                     x={this.props.x}

--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -366,7 +366,7 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
     private get legend() {
         return (
             <div style={{maxWidth: 700, marginTop: 5}}>
-                <span style={{color: "#2153AA", fontWeight:"bold", fontSize:"14px", fontFamily:"verdana, arial, sans-serif"}}>
+                <span style={{color: "#2153AA", fontWeight:"bold", fontSize:"14px", fontFamily:"verdana, arial"}}>
                     Color Codes
                 </span>
                 <p>
@@ -379,24 +379,24 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                     Mutation types and corresponding color codes are as follows:
                     <ul>
                         <li>
-                            <span style={{color:this.props.missenseColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial, sans-serif"}}>
+                            <span style={{color:this.props.missenseColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial"}}>
                                 Missense Mutations
                             </span>
                         </li>
                         <li>
-                            <span style={{color:this.props.truncatingColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial, sans-serif"}}>
+                            <span style={{color:this.props.truncatingColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial"}}>
                                 Truncating Mutations
                             </span>
                             : Nonsense, Nonstop, Frameshift deletion, Frameshift insertion, Splice site
                         </li>
                         <li>
-                            <span style={{color:this.props.inframeColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial, sans-serif"}}>
+                            <span style={{color:this.props.inframeColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial"}}>
                                 Inframe Mutations
                             </span>
                             : Inframe deletion, Inframe insertion
                         </li>
                         <li>
-                            <span style={{color:this.props.otherColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial, sans-serif"}}>
+                            <span style={{color:this.props.otherColor, fontWeight: "bold", fontSize: "14px", fontFamily:"verdana, arial"}}>
                                 Other Mutations
                             </span>
                             : All other types of mutations
@@ -449,9 +449,6 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                         </div>
                         {'  '}
                 </span>
-                <Collapse isOpened={this.legendShown}>
-                    {this.legend}
-                </Collapse>
             </div>
         );
     }
@@ -461,6 +458,9 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
             return (
                 <div style={{display: "inline-block"}} onMouseEnter={this.handlers.onMouseEnterPlot} onMouseLeave={this.handlers.onMouseLeavePlot}>
                     {this.controls}
+                    <Collapse isOpened={this.legendShown}>
+                        {this.legend}
+                    </Collapse>
                     <LollipopPlot
                         ref={this.handlers.ref}
                         sequence={this.sequence}


### PR DESCRIPTION
(1) Change all fonts from sans-serif to Arial to fix opening downloaded SVG in Adobe Illustrator
(2) Make legend separate from controls, so it does not fade out on mouse out.

Signed-off-by: Abeshouse, Adam A./Sloan Kettering Institute <abeshoua@mskcc.org>

To test, go to cbioportal.org, open the javascript console and type 
```localStorage.heroku = 'cbioportal-frontend-pr-667';```