### PR TITLE
Don't show bar chart controls if we don't have alterations. 

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -139,6 +139,10 @@ th.reactable-header-sort-asc:after {
     line-height: 0.8px;
   }
 
+  .msk-tab {
+    margin-top:10px;
+  }
+
 }
 
 .mainTabs {

--- a/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
@@ -39,8 +39,8 @@ export default class CancerSummaryContainer extends React.Component<{ store: Res
                 return count + alterationData.alterationTotal;
             },0);
 
-            // if there are no alterations for this gene, show a grey background
-            const anchorStyle = (alterationCountAcrossCancerType === 0) ? { backgroundColor:'#ccc', color:'#999' } : {};
+            // if there are no alterations for this gene, grey out text
+            const anchorStyle = (alterationCountAcrossCancerType === 0) ? { color:'#bbb' } : {};
 
             return (
                 <MSKTab key={geneName} id={"summaryTab" + geneName} linkText={geneName} anchorStyle={anchorStyle}>

--- a/src/shared/components/cancerSummary/CancerSummaryContent.tsx
+++ b/src/shared/components/cancerSummary/CancerSummaryContent.tsx
@@ -7,6 +7,7 @@ import Slider from 'react-rangeslider';
 import Select from 'react-select';
 import {FormGroup, ControlLabel, FormControl} from 'react-bootstrap';
 import jsPDF from 'jspdf';
+import { If, Then, Else } from 'react-if';
 
 import 'react-select/dist/react-select.css';
 import 'react-rangeslider/lib/index.css';
@@ -257,6 +258,12 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
         };
     }
 
+    @computed private get hasAlterations() {
+        return _.reduce(this.props.data,(count, alterationData:ICancerTypeAlterationData)=>{
+            return count + alterationData.alterationTotal;
+        },0) > 0;
+    }
+
     private handleSelectChange (value: any) {
         const values = value.split(",");
         if (_.last(values) === "all") {
@@ -358,8 +365,11 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
             </div>
         ) : null;
         return (
-            <div>
-                <div role="group" className="btn-group">
+
+                <If condition={this.hasAlterations}>
+                    <Then>
+                    <div>
+                    <div role="group" className="btn-group">
                     <button onClick={this.toggleShowControls} className="btn btn-default btn-xs">Customize <i className="fa fa-cog" aria-hidden="true"></i></button>
                     <a className={`btn btn-default btn-xs ${this.pngAnchor ? '': ' disabled'}`}
                         href={this.pngAnchor} download="cBioPortalCancerSummary.png" style={{color: 'white'}}>
@@ -373,7 +383,14 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
                 {controls}
                 <SummaryBarGraph data={this.chartData} yAxis={this.yAxis} xAxis={this.xAxis} gene={this.props.gene} width={this.props.width}
                                  setPdfAnchor={this.setPdfAnchor} setPngAnchor={this.setPngAnchor} legend={this.showGenomicAlt}/>
-            </div>
+
+                    </div>
+                    </Then>
+                    <Else>
+                        <div className="alert alert-info">There are no alterations in this gene.</div>
+                    </Else>
+                </If>
+
         );
     }
 }

--- a/src/shared/components/cancerSummary/SummaryBarGraph.tsx
+++ b/src/shared/components/cancerSummary/SummaryBarGraph.tsx
@@ -261,9 +261,6 @@ export default class SummaryBarGraph extends React.Component<ISummaryBarGraphPro
 
     public render() {
         let errorMessage = null;
-        if (!this.hasAlterations()) {
-            errorMessage = <div className="alert alert-info">There are no alterations in this gene.</div>;
-        }
         return (
             <div style={{width:this.width}} ref={(el: HTMLDivElement) => this.chartContainer = el}
                  className="cancer-summary-chart-container">


### PR DESCRIPTION
Refactored the way we hide bar charts when there are no alterations to display.  We were not hiding the control buttons.
https://github.com/cBioPortal/cbioportal/issues/3205

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
