### PR TITLE
Add git version window.FRONTEND_{VERSION,COMMIT}

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5740,6 +5740,11 @@
         }
       }
     },
+    "git-revision-webpack-plugin": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-2.5.1.tgz",
+      "integrity": "sha1-P7Q5jzds8nZ41t6WuiZptRhkXng="
+    },
     "glob": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "fixed-data-table": "^0.6.3",
     "font-awesome": "^4.7.0",
     "font-awesome-webpack": "^0.0.4",
+    "git-revision-webpack-plugin": "^2.5.1",
     "highcharts": "^5.0.11",
     "html-webpack-plugin": "^2.26.0",
     "imports-loader": "^0.7.0",

--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -32,6 +32,10 @@ if (!window.hasOwnProperty("jQuery")) {
     window.jQuery = $;
 }
 
+// expose version on window
+window.FRONTEND_VERSION = VERSION;
+window.FRONTEND_COMMIT = COMMIT;
+
 import 'script-loader!raven-js/dist/raven.js';
 
 // explose jquery globally if it doesn't exist

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,12 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var WebpackFailPlugin = require('webpack-fail-plugin');
 var ProgressBarPlugin = require('progress-bar-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
+var GitRevisionPlugin = require('git-revision-webpack-plugin');
+
+// show full git version
+var gitRevisionPlugin = new GitRevisionPlugin({
+    versionCommand: 'describe --always --tags --dirty'
+});
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
@@ -65,6 +71,10 @@ var config = {
 
 
     plugins: [
+        new webpack.DefinePlugin({
+            'VERSION': JSON.stringify(gitRevisionPlugin.version()),
+            'COMMIT': JSON.stringify(gitRevisionPlugin.commithash()),
+        }),
         new HtmlWebpackPlugin({cache: false, template: 'my-index.ejs'}),
         new webpack.optimize.DedupePlugin(),
         WebpackFailPlugin,


### PR DESCRIPTION
Show git version on window, for debugging purposes

Tested both for development and production config. Obviously this is mostly useful for production, for development you know what commit you are on.

We should prolly also somehow pass Sentry this info instead of `appVersion` so it is more clear what version is being used.