### PR TITLE
Fixes the Domain text truncation issue for lollipop diagram

### DIFF
--- a/src/shared/components/lollipopMutationPlot/Domain.tsx
+++ b/src/shared/components/lollipopMutationPlot/Domain.tsx
@@ -60,7 +60,7 @@ export default class Domain extends React.Component<DomainProps, {}> {
             return label;
         }
 
-        if (!$(label).is(":visible")) {
+        if (!$(this.textElt).is(":visible")) {
             return label;
         }
 


### PR DESCRIPTION
# What? Why?
Fixes an incorrect jQuery selector which is used to determine whether to truncate the `Domain` display text.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)