### PR TITLE
some UI changes to make obvious there are more pages of data in tables

### DIFF
--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -166,6 +166,7 @@ export default class CopyNumberTableWrapper extends React.Component<ICopyNumberT
                         initialItemsPerPage={10}
                         itemsLabel="Copy Number Alteration"
                         itemsLabelPlural="Copy Number Alterations"
+                        showCountHeader={true}
                     />
                 )
             }

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -30,6 +30,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         ...MutationTable.defaultProps,
         initialItemsPerPage: 10,
         paginationProps:{ itemsPerPageOptions:[10,25,50,100] },
+        showCountHeader: true,
         columns: [
             MutationTableColumnType.COHORT,
             MutationTableColumnType.MRNA_EXPR,

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -55,6 +55,7 @@ type LazyMobXTableProps<T> = {
     columnVisibilityProps?:IColumnVisibilityControlsProps;
     highlightColor?:"yellow"|"bluegray";
     pageToHighlight?:boolean;
+    showCountHeader?:boolean;
 };
 
 function compareValues<U extends number|string>(a:U|null, b:U|null, asc:boolean):number {
@@ -393,7 +394,6 @@ class LazyMobXTableStore<T> {
     {
         let firstVisibleItemDisp;
         let lastVisibleItemDisp;
-        let itemsLabel:string = "";
 
         if (this.rows.length === 0) {
             firstVisibleItemDisp = 0;
@@ -410,21 +410,14 @@ class LazyMobXTableStore<T> {
             );
         }
 
-        if (this._itemsLabel) {
-            // use itemsLabel for plural in case no itemsLabelPlural provided
-            if (!this._itemsLabelPlural || this.displayData.length === 1) {
-                itemsLabel = this._itemsLabel;
-            }
-            else {
-                itemsLabel = this._itemsLabelPlural;
-            }
-
+        let itemsLabel:string = this.itemsLabel;
+        if (itemsLabel.length) {
             // we need to prepend the space here instead of within the actual return value
             // to avoid unnecessary white-space at the end of the string
             itemsLabel = ` ${itemsLabel}`;
         }
 
-        return `${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${this.displayData.length}${itemsLabel}`;
+        return `Showing ${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${this.displayData.length}${itemsLabel}`;
     }
 
     @computed get tds():JSX.Element[][] {
@@ -480,6 +473,20 @@ class LazyMobXTableStore<T> {
             }
             return match;
         });
+    }
+
+    @computed get itemsLabel() {
+        if (this._itemsLabel) {
+            // use itemsLabel for plural in case no itemsLabelPlural provided
+            if (!this._itemsLabelPlural || this.displayData.length === 1) {
+                return this._itemsLabel;
+            }
+            else {
+                return this._itemsLabelPlural;
+            }
+        } else {
+            return "";
+        }
     }
 
     @action setProps(props:LazyMobXTableProps<T>) {
@@ -567,7 +574,8 @@ export default class LazyMobXTable<T> extends React.Component<LazyMobXTableProps
         showPagination: true,
         showColumnVisibility: true,
         highlightColor: "yellow",
-		showPaginationAtTop: false
+		showPaginationAtTop: false,
+        showCountHeader: false
     };
 
     public getDownloadData(): string
@@ -657,7 +665,8 @@ export default class LazyMobXTable<T> extends React.Component<LazyMobXTableProps
 				previousPageDisabled:this.store.page === 0,
 				nextPageDisabled:this.store.page === this.store.maxPage,
 				textBeforeButtons:this.store.paginationStatusText,
-                groupButtons: false
+                groupButtons: false,
+                bsStyle:"primary"
 			};
 			// override with given paginationProps if they exist
 			if (this.props.paginationProps) {
@@ -678,8 +687,17 @@ export default class LazyMobXTable<T> extends React.Component<LazyMobXTableProps
         // }
     }
 
-    private getTopToolbar() {
+    private get countHeader() {
         return (
+            <span style={{float:"left", color:"black", fontSize: "16px", fontWeight: "bold"}}>
+                {this.store.displayData.length} {this.store.itemsLabel} (page {this.store.page + 1} of {this.store.maxPage + 1})
+            </span>
+        );
+    }
+
+    private getTopToolbar() {
+        return (<div>
+            { this.props.showCountHeader && this.countHeader }
             <ButtonToolbar style={{marginLeft:0}} className="tableMainToolbar">
                 { this.props.showFilter ? (
                     <div className={`pull-right form-group has-feedback input-group-sm tableFilter`} style={{ display:'inline-block', marginLeft: 5}}>
@@ -707,6 +725,7 @@ export default class LazyMobXTable<T> extends React.Component<LazyMobXTableProps
                     </Observer>
                 ) : null}
             </ButtonToolbar>
+            </div>
         );
     }
 

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -72,7 +72,8 @@ export interface IMutationTableProps {
     itemsLabelPlural?:string;
     initialSortColumn?:string;
     initialSortDirection?:SortDirection,
-    paginationProps?:IPaginationControlsProps
+    paginationProps?:IPaginationControlsProps,
+    showCountHeader?:boolean
 }
 
 export enum MutationTableColumnType {
@@ -496,6 +497,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
                 itemsLabel={this.props.itemsLabel}
                 itemsLabelPlural={this.props.itemsLabelPlural}
                 paginationProps={this.props.paginationProps}
+                showCountHeader={this.props.showCountHeader}
             />
         );
     }

--- a/src/shared/components/paginationControls/PaginationControls.tsx
+++ b/src/shared/components/paginationControls/PaginationControls.tsx
@@ -42,6 +42,7 @@ export interface IPaginationControlsProps {
     pageNumberEditable?:boolean;
     groupButtons?:boolean;
     hidePaginationIfOnePage?:boolean;
+    bsStyle?:"default"|"primary"|"success"|"info"|"warning";
 }
 
 @observer
@@ -66,7 +67,8 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
         pageNumberEditable: false,
         showMoreButton: true,
         groupButtons: true,
-        hidePaginationIfOnePage:true
+        hidePaginationIfOnePage:true,
+        bsStyle: "default"
     };
 
     constructor(props:IPaginationControlsProps) {
@@ -119,6 +121,7 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
                             disabled={!this.props.itemsPerPageOptions || !this.props.itemsPerPage || !this.props.totalItems || (this.props.itemsPerPage >= this.props.totalItems)}
                             onClick={this.handleShowMore}
                             style={{width:200}}
+                            bsStyle={this.props.bsStyle}
                     >
                         Show more
                     </Button>
@@ -169,6 +172,7 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
                         disabled={!!this.props.firstPageDisabled}
                         onClick={this.props.onFirstPageClick}
                         className={classNames(this.props.groupButtons ? undefined : styles['margin-right-button'])}
+                        bsStyle={this.props.bsStyle}
                 >
                     {this.props.firstButtonContent}
                 </Button>
@@ -178,6 +182,7 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
                 bsSize="sm"
                 disabled={!!this.props.previousPageDisabled}
                 onClick={this.props.onPreviousPageClick}
+                bsStyle={this.props.bsStyle}
             >
                 {this.props.previousButtonContent}
             </Button>,
@@ -186,7 +191,9 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
                     key="nextPageBtn"
                     bsSize="sm"
                     disabled={!!this.props.nextPageDisabled}
-                    onClick={this.props.onNextPageClick}>
+                    onClick={this.props.onNextPageClick}
+                    bsStyle={this.props.bsStyle}
+            >
                 {this.props.nextButtonContent}
             </Button>,
             <If condition={!!this.props.showLastPage}>
@@ -195,6 +202,7 @@ export class PaginationControls extends React.Component<IPaginationControlsProps
                         disabled={!!this.props.lastPageDisabled}
                         onClick={this.props.onLastPageClick}
                         className={classNames(this.props.groupButtons ? undefined : styles['margin-left-button'])}
+                        bsStyle={this.props.bsStyle}
                 >
                     {this.props.lastButtonContent}
                 </Button>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/636232/31408686-60a48958-add7-11e7-8a4c-3d10b952ac28.png)

We've decided to deal with table resizing by optimizing oncoKB calls and delaying table rendering until we have it loaded. For now, until we can optimize oncoKB, we'll just make these simple UI changes (blue button, descriptive header)