### PR TITLE
Query Page: configurable list of sets of genes

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -23,7 +23,8 @@ export interface IAppConfig {
     skinRightNavShowExamples?: boolean, 
     skinRightNavShowTestimonials?: boolean,
     skinRightNavExamplesHTML?: string,
-    skinRightNavWhatsNewBlurb?: string 
+    skinRightNavWhatsNewBlurb?: string,
+    querySetsOfGenes?: {"id": string, "genes":string[]}[]
 }
 
 export type PriorityStudies = {

--- a/src/config/development.config.ts
+++ b/src/config/development.config.ts
@@ -22,7 +22,8 @@ const config:IAppConfig = {
     skinRightNavShowExamples: (window as any).skinRightNavShowExamples, 
     skinRightNavShowTestimonials: (window as any).skinRightNavShowTestimonials,
     skinRightNavExamplesHTML: (window as any).skinRightNavExamplesHTML,
-    skinRightNavWhatsNewBlurb: (window as any).skinRightNavWhatsNewBlurb
+    skinRightNavWhatsNewBlurb: (window as any).skinRightNavWhatsNewBlurb,
+    querySetsOfGenes: (window as any).querySetsOfGenes
 };
 
 export default config;

--- a/src/config/production.config.ts
+++ b/src/config/production.config.ts
@@ -22,7 +22,8 @@ const config:IAppConfig = {
     skinRightNavShowExamples: (window as any).skinRightNavShowExamples, 
     skinRightNavShowTestimonials: (window as any).skinRightNavShowTestimonials,
     skinRightNavExamplesHTML: (window as any).skinRightNavExamplesHTML,
-    skinRightNavWhatsNewBlurb: (window as any).skinRightNavWhatsNewBlurb
+    skinRightNavWhatsNewBlurb: (window as any).skinRightNavWhatsNewBlurb,
+    querySetsOfGenes: (window as any).querySetsOfGenes
 };
 
 export default config;

--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -13,6 +13,7 @@ import {QueryStoreComponent} from "./QueryStore";
 import MutSigGeneSelector from "./MutSigGeneSelector";
 import GisticGeneSelector from "./GisticGeneSelector";
 import SectionHeader from "../sectionHeader/SectionHeader";
+import AppConfig from "appConfig";
 
 const styles = styles_any as {
 	GeneSetSelector: string,
@@ -40,16 +41,21 @@ export default class GeneSetSelector extends QueryStoreComponent<GeneSetSelector
 
 	@computed get geneListOptions()
 	{
-		return [
-			{
-				label: 'User-defined List',
-				value: ''
-			},
-			...gene_lists.map(item => ({
-				label: `${item.id} (${item.genes.length} genes)`,
-				value: item.genes.join(' ')
-			}))
-		];
+	    let geneList: {"id": string, "genes": string[]}[] = gene_lists;
+	    if (AppConfig.querySetsOfGenes) {
+	        geneList = AppConfig.querySetsOfGenes;
+	    }
+
+	    return [
+	        {
+	            label: 'User-defined List',
+	            value: ''
+	        },
+	        ...geneList.map(item => ({
+	            label: `${item.id} (${item.genes.length} genes)`,
+	            value: item.genes.join(' ')
+	        }))
+	    ];
 	}
 
 	@computed get textAreaRef()


### PR DESCRIPTION
# What? Why?
We have created a property in portal.properties (`querypage.setsofgenes.location`) where the user can specify a different file that describes the list of sets of genes displayed in the query page. This file must be a JSON string.

This PR goes together with the PR cbioportal/cbioportal#3249.