### PR TITLE
Temporary patch to use gene length when no PFAM domain information available

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -686,7 +686,7 @@ export class ResultsViewPageStore {
             return _.sortBy(await client.fetchGenesUsingPOST({
                 geneIdType: "HUGO_GENE_SYMBOL",
                 geneIds: this.hugoGeneSymbols.slice(),
-                projection: "ID"
+                projection: "SUMMARY"
             }), (gene: Gene) => order[gene.hugoGeneSymbol]);
         } else {
             return [];

--- a/src/pages/resultsView/mutation/MutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/MutationMapperStore.ts
@@ -94,6 +94,12 @@ export class MutationMapperStore {
 
     readonly swissProtId = remoteData({
         invoke: async() => {
+            // do not try fetching swissprot data for invalid entrez gene ids,
+            // just return the default value
+            if (this.gene.entrezGeneId < 1) {
+                return "";
+            }
+
             const accession:string|string[] = await fetchSwissProtAccession(this.gene.entrezGeneId);
 
             if (_.isArray(accession)) {

--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -211,7 +211,7 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
     }
 
     @computed private get domains():DomainSpec[] {
-        if (!this.props.store.pfamGeneData.isComplete) {
+        if (!this.props.store.pfamGeneData.isComplete || !this.props.store.pfamGeneData.result.regions) {
             return [];
         } else {
             return this.props.store.pfamGeneData.result.regions.map((region:any)=>{
@@ -468,7 +468,7 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                         dataStore={this.props.store.dataStore}
                         vizWidth={this.props.geneWidth}
                         vizHeight={130}
-                        xMax={this.props.store.pfamGeneData.result.length}
+                        xMax={this.props.store.pfamGeneData.result.length || (this.props.store.gene.length / 3)}
                         yMax={this.yMax}
                         onXAxisOffset={this.props.onXAxisOffset}
                     />


### PR DESCRIPTION
# What? Why?
- Partial fix for https://github.com/cBioPortal/cbioportal/issues/3218.

![unknown_entrez_gene](https://user-images.githubusercontent.com/3604198/31522492-fca6d84c-af7b-11e7-940a-a8c7492dd9f6.png)

Changes proposed in this pull request:
- In case of an error with the PFAM graphics API, using the `gene length / 3` approach to determine the protein length. This prevents infinite spinning of the lollipop diagram loader

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
