### PR TITLE
Cancer type summary should show cancer by subtype when there's only one cancer type

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -8,9 +8,8 @@ body {
 }
 
 //get rid of blue border around active button
-button:active {
-  outline: none;
-  border: none;
+button:active, button:focus, div:focus, div:active {
+  outline: none !important;
 }
 
 /* importants are necessary for override of legacy style */

--- a/src/shared/components/cancerSummary/SummaryBarGraph.tsx
+++ b/src/shared/components/cancerSummary/SummaryBarGraph.tsx
@@ -153,11 +153,6 @@ export default class SummaryBarGraph extends React.Component<ISummaryBarGraphPro
 
         const orderedAltNames = _.values(this.props.orderedLabels);
 
-        let yAxisMax;
-        if (this.props.yAxis === 'alt-freq') {
-            yAxisMax = {max: 100};
-        }
-
         return {
             title: {
                 display: true,
@@ -207,7 +202,6 @@ export default class SummaryBarGraph extends React.Component<ISummaryBarGraphPro
                     display:true,
                     ticks: {
                         fontSize: 11,
-                        ...yAxisMax,
                         callback: (value:number) => {
                             return _.round(value, 1) + (this.props.yAxis === "abs-count" ? '': '%');
                         }

--- a/src/shared/components/cancerSummary/styles.scss
+++ b/src/shared/components/cancerSummary/styles.scss
@@ -51,7 +51,7 @@
 
   .slider-holder {
     display: flex;
-    align-items: flex-end;
+    align-items: flex-start;
     >div:first-child {
       flex: 1 1 100%;
       margin-bottom: 0px;}
@@ -75,7 +75,6 @@
     width: 20px;
     height: 20px;
     border-radius: 20px;
-    top: -4px;
     &:after {
       width: 12px;
       height: 12px;


### PR DESCRIPTION
When there is only one cancerType in a result set, we should break out cancer summary by cancer sub type,
![image](https://user-images.githubusercontent.com/186521/31636039-0441e132-b297-11e7-8255-30ccaad4d844.png)
