### PR TITLE
Show Twitter Embed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3971,6 +3971,11 @@
         "original": "1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -10973,6 +10978,17 @@
         "warning": "3.0.0"
       }
     },
+    "react-twitter-widgets": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/react-twitter-widgets/-/react-twitter-widgets-1.7.1.tgz",
+      "integrity": "sha512-bAcR/NKqRbVRJav981bHrm2+xka7NA2nQJB6Urtj9BARqP7aeGHPC0CrrC7wdYIaluOqiF8MiTtURqIJjFs2ZA==",
+      "requires": {
+        "exenv": "1.2.2",
+        "lodash": "4.17.4",
+        "prop-types": "15.5.10",
+        "scriptjs": "2.5.8"
+      }
+    },
     "react-zeroclipboard": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-zeroclipboard/-/react-zeroclipboard-3.3.0.tgz",
@@ -11856,6 +11872,11 @@
       "requires": {
         "raw-loader": "0.5.1"
       }
+    },
+    "scriptjs": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.8.tgz",
+      "integrity": "sha1-0MQ5VcLmutM7bk7fe1O4llqnyl8="
     },
     "scss-tokenizer": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "react-text-truncate": "^0.9.0",
     "react-tooltip": "^3.2.2",
     "react-transition-group": "^1.1.3",
+    "react-twitter-widgets": "^1.7.1",
     "react-zeroclipboard": "^3.2.2",
     "reactable": "^0.14.1",
     "recharts": "^0.20.5",

--- a/src/shared/components/rightbar/RightBar.tsx
+++ b/src/shared/components/rightbar/RightBar.tsx
@@ -6,15 +6,27 @@ import Testimonials from "../testimonials/Testimonials";
 import {ThreeBounce} from 'better-react-spinkit';
 import AppConfig from "appConfig";
 import {QueryStore} from "shared/components/query/QueryStore";
+import { Timeline } from 'react-twitter-widgets';
 
 
 interface IRightBarProps
 {
     store:QueryStore;
 }
+interface IRightBarState
+{
+    twitterLoading: boolean;
+}
 
 @observer
-export default class RightBar extends React.Component<IRightBarProps, {}> {
+export default class RightBar extends React.Component<IRightBarProps, IRightBarState> {
+    constructor(props:IRightBarProps) {
+        super(props);
+        this.state = {
+            twitterLoading: true // only used for default what's new
+        };
+    }
+
 
     get studyStore() {
       return this.props.store;
@@ -41,17 +53,50 @@ export default class RightBar extends React.Component<IRightBarProps, {}> {
         ));
     }
 
-    static getWhatsNewBlurb() {
-        const defaultWhatsNewBlurb:JSX.Element = (
-            <div>
-                <p>Sign up for low-volume email news alerts:</p>
-                <a target="_blank" className="btn btn-default btn-sm" href="http://groups.google.com/group/cbioportal-news/boxsubscribe" style={{width: "100%"}}>Subscribe</a>
-            </div>
-        );
+    private getWhatsNew() {
         if (AppConfig.skinRightNavWhatsNewBlurb) {
-            return <div dangerouslySetInnerHTML={{__html:AppConfig.skinRightNavWhatsNewBlurb}}></div>;
+            return (
+                <div className="rightBarSection">
+                    <h3>What's New</h3>
+                    <div dangerouslySetInnerHTML={{__html:AppConfig.skinRightNavWhatsNewBlurb}}></div>;
+                </div>
+            );
         } else {
-            return defaultWhatsNewBlurb;
+            return (
+                <div className="rightBarSection" style={{paddingBottom:20}}>
+                    <h3 style={{borderBottom:0}}>
+                        What's New
+                        <a href="http://www.twitter.com/cbioportal" className="pull-right">
+                            @cbioportal <i className="fa fa-twitter" aria-hidden="true"></i>
+                        </a>
+                    </h3>
+                    <div style={{marginTop:3}}>
+                        <Timeline
+                            dataSource={{
+                                sourceType: 'profile',
+                                screenName: 'cbioportal'
+                            }}
+                            options={{
+                                username: 'cbioportal',
+                                height: '200',
+                                chrome: 'noheader%20nofooter',
+                            }}
+                            onLoad={() => this.setState({twitterLoading:false})}
+                        />
+                    </div>
+                    <div>
+                        {this.state.twitterLoading &&
+                             (<ThreeBounce className="center-block text-center" />) ||
+                             (
+                                <div style={{paddingTop:5}}>
+                                    <p style={{textAlign:'center'}}>Sign up for low-volume email news alerts</p>
+                                    <a target="_blank" className="btn btn-default btn-sm" href="http://groups.google.com/group/cbioportal-news/boxsubscribe" style={{width: "100%"}}>Subscribe</a>
+                                 </div>
+                             )
+                        }
+                    </div>
+                </div>
+            );
         }
     }
 
@@ -136,15 +181,7 @@ export default class RightBar extends React.Component<IRightBarProps, {}> {
 
         return (
             <div>
-                <div className="rightBarSection">
-                    <h3>
-                        What's New
-                        <a href="http://www.twitter.com/cbioportal" className="pull-right">
-                            @cbioportal <i className="fa fa-twitter" aria-hidden="true"></i>
-                        </a>
-                    </h3>
-                    {RightBar.getWhatsNewBlurb()}
-                </div>
+                {this.getWhatsNew()}
                 {datasets}
                 {examples}
                 {testimonials}


### PR DESCRIPTION
Fix https://github.com/cbioportal/cbioportal/issues/3115

Do we like something like this?

![screen shot 2017-10-16 at 1 45 22 pm](https://user-images.githubusercontent.com/1334004/31626754-ec64782c-b278-11e7-8889-68bcf78a41fe.png)

We can add a prop to change the twitter handle if we want. This is just overriding default.

In the spec we mentioned 3 tweets, but yeah with a scrollbar it might be ok to do more as I've done in this example. How many tweets are visible depends on the size of the tweets themselves.