### PR TITLE
showing count header for all mutation table instances by default

### DIFF
--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -30,7 +30,6 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         ...MutationTable.defaultProps,
         initialItemsPerPage: 10,
         paginationProps:{ itemsPerPageOptions:[10,25,50,100] },
-        showCountHeader: true,
         columns: [
             MutationTableColumnType.COHORT,
             MutationTableColumnType.MRNA_EXPR,

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -145,6 +145,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
 
     public static defaultProps = {
         initialItemsPerPage: 25,
+        showCountHeader: true,
         paginationProps:{ itemsPerPageOptions:[25,50,100] },
         initialSortColumn: "Annotation",
         initialSortDirection: "desc",


### PR DESCRIPTION
# Changes proposed
Any `MutationTable` instance now shows the count & page information on top of the table by default.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)