### PR TITLE
Switched from PFAM graphics API to genome nexus API

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -14,18 +14,19 @@ export interface IAppConfig {
     oncoKBApiUrl?: string;
     showGenomeNexus?: boolean;
     genomeNexusApiUrl?: string;
+    isoformOverrideSource?: string;
     enableDarwin?: boolean;
     appVersion?: string;
     historyType?: string;
-    skinBlurb?: string, // text on main page
-    skinDatasetHeader?: string, // header on dataset page
-    skinDatasetFooter?: string,
-    skinRightNavShowDatasets?: boolean,
-    skinRightNavShowExamples?: boolean, 
-    skinRightNavShowTestimonials?: boolean,
-    skinRightNavExamplesHTML?: string,
-    skinRightNavWhatsNewBlurb?: string,
-    querySetsOfGenes?: {"id": string, "genes":string[]}[]
+    skinBlurb?: string; // text on main page
+    skinDatasetHeader?: string; // header on dataset page
+    skinDatasetFooter?: string;
+    skinRightNavShowDatasets?: boolean;
+    skinRightNavShowExamples?: boolean;
+    skinRightNavShowTestimonials?: boolean;
+    skinRightNavExamplesHTML?: string;
+    skinRightNavWhatsNewBlurb?: string;
+    querySetsOfGenes?: {"id": string, "genes":string[]}[];
 }
 
 export type PriorityStudies = {

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -26,6 +26,7 @@ export interface IMutationMapperConfig {
     showMyCancerGenome?: boolean;
     showOncoKB?: boolean;
     showGenomeNexus?: boolean;
+    isoformOverrideSource?: string;
 }
 
 export interface IMutationMapperProps {
@@ -66,12 +67,32 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
     }
 
     @computed get geneSummary():JSX.Element {
+        const hugoGeneSymbol = this.props.store.gene.hugoGeneSymbol;
+        const uniprotId = this.props.store.uniprotId.result;
+        const transcriptId = this.props.store.canonicalTranscript.result &&
+            this.props.store.canonicalTranscript.result.transcriptId;
+
         return (
             <div style={{'paddingBottom':10}}>
-                <h4>{this.props.store.gene.hugoGeneSymbol}</h4>
-                {this.props.store.uniprotId.result && (
-                    <span>UniProt: <a href={`http://www.uniprot.org/uniprot/${this.props.store.uniprotId.result}`}>{this.props.store.uniprotId.result}</a></span>
-                )}
+                <h4>{hugoGeneSymbol}</h4>
+                <div className={this.props.store.uniprotId.result ? '' : 'invisible'}>
+                    <span>UniProt: </span>
+                    <a
+                        href={`http://www.uniprot.org/uniprot/${uniprotId}`}
+                        target="_blank"
+                    >
+                        {uniprotId}
+                    </a>
+                </div>
+                <div className={this.props.store.canonicalTranscript.result ? '' : 'invisible'}>
+                    <span>Transcript: </span>
+                    <a
+                        href={`http://grch37.ensembl.org/homo_sapiens/Transcript/Summary?t=${transcriptId}`}
+                        target="_blank"
+                    >
+                        {transcriptId}
+                    </a>
+                </div>
             </div>
         );
     }
@@ -118,8 +139,8 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                 {
                     (!this.props.store.mutationData.isPending) && (
                     <div>
-                        <LoadingIndicator isLoading={this.props.store.pfamGeneData.isPending} />
-                        { (!this.props.store.pfamGeneData.isPending) && (
+                        <LoadingIndicator isLoading={this.props.store.pfamDomainData.isPending} />
+                        { (!this.props.store.pfamDomainData.isPending) && (
                         <div style={{ display:'flex' }}>
                             <div className="borderedChart" style={{ marginRight:10 }}>
 

--- a/src/shared/api/genomeNexusInternalClientInstance.ts
+++ b/src/shared/api/genomeNexusInternalClientInstance.ts
@@ -1,0 +1,6 @@
+import {getGenomeNexusApiUrl} from "./urls";
+import GenomeNexusAPIInternal from "./generated/GenomeNexusAPIInternal";
+
+const client = new GenomeNexusAPIInternal(getGenomeNexusApiUrl());
+
+export default client;

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -38,9 +38,6 @@ export function getMyGeneUrl(entrezGeneId: number) {
 export function getUniprotIdUrl(swissProtAccession: string) {
     return cbioUrl(`proxy/uniprot.org/uniprot/?query=accession:${swissProtAccession}&format=tab&columns=entry+name`);
 }
-export function getPfamGeneDataUrl(swissProtAccession: string) {
-    return cbioUrl(`proxy/pfam.xfam.org/protein/${swissProtAccession}/graphic`);
-}
 export function getMutationAlignerUrl() {
     return cbioUrl(`getMutationAligner.json`);
 }

--- a/src/shared/components/proteinChainPanel/ProteinChainPanel.tsx
+++ b/src/shared/components/proteinChainPanel/ProteinChainPanel.tsx
@@ -183,7 +183,8 @@ export default class ProteinChainPanel extends React.Component<ProteinChainPanel
     }
 
     @computed get proteinLength() {
-        return Math.max(this.props.store.pfamGeneData.result.length, 1);
+        const proteinLength = (this.props.store.canonicalTranscript.result && this.props.store.canonicalTranscript.result.proteinLength) || 0;
+        return Math.max(proteinLength, 1);
     }
 
     @computed get tooltipVisible() {

--- a/src/shared/lib/PfamUtils.spec.ts
+++ b/src/shared/lib/PfamUtils.spec.ts
@@ -1,0 +1,84 @@
+import * as _ from 'lodash';
+import { assert } from 'chai';
+import {PfamDomain} from "shared/api/generated/GenomeNexusAPI";
+import {generatePfamDomainColorMap} from "./PfamUtils";
+
+let domains: PfamDomain[];
+
+before(() => {
+    domains = [{
+        geneId: "ENSG00000198742",
+        geneSymbol: "SMURF1",
+        pfamDomainDescription: "Domain 2",
+        pfamDomainEnd: 11,
+        pfamDomainId: "PF0002",
+        pfamDomainName: "Dmn2",
+        pfamDomainStart: 7,
+        proteinId: "ENSP0001",
+        transcriptId: "ENST00000361125"
+    }, {
+        geneId: "ENSG00000198742",
+        geneSymbol: "SMURF1",
+        pfamDomainDescription: "Domain 2",
+        pfamDomainEnd: 29,
+        pfamDomainId: "PF0002",
+        pfamDomainName: "Dmn2",
+        pfamDomainStart: 23,
+        proteinId: "ENSP0001",
+        transcriptId: "ENST00000361125"
+    }, {
+        geneId: "ENSG00000198742",
+        geneSymbol: "SMURF1",
+        pfamDomainDescription: "Domain 1",
+        pfamDomainEnd: 5,
+        pfamDomainId: "PF0001",
+        pfamDomainName: "Dmn1",
+        pfamDomainStart: 2,
+        proteinId: "ENSP0001",
+        transcriptId: "ENST00000361125"
+    }, {
+        geneId: "ENSG00000198742",
+        geneSymbol: "SMURF1",
+        pfamDomainDescription: "Domain 1",
+        pfamDomainEnd: 89,
+        pfamDomainId: "PF0001",
+        pfamDomainName: "Dmn1",
+        pfamDomainStart: 61,
+        proteinId: "ENSP0001",
+        transcriptId: "ENST00000361125"
+    }, {
+        geneId: "ENSG00000198742",
+        geneSymbol: "SMURF1",
+        pfamDomainDescription: "Domain 4",
+        pfamDomainEnd: 41,
+        pfamDomainId: "PF0004",
+        pfamDomainName: "Dmn4",
+        pfamDomainStart: 31,
+        proteinId: "ENSP0001",
+        transcriptId: "ENST00000361125"
+    }, {
+        geneId: "ENSG00000198742",
+        geneSymbol: "SMURF1",
+        pfamDomainDescription: "Domain 3",
+        pfamDomainEnd: 17,
+        pfamDomainId: "PF0003",
+        pfamDomainName: "Dmn3",
+        pfamDomainStart: 13,
+        proteinId: "ENSP0003",
+        transcriptId: "ENST00000361368"
+    }];
+});
+
+describe('PfamUtils', () => {
+    it('assigns colors for PFAM domains in the correct order', () => {
+        const colorMap = generatePfamDomainColorMap(domains);
+
+        assert.equal(_.keys(colorMap).length, 4,
+            "number of colors should be equal to the number of unique domains");
+
+        assert.equal(colorMap["PF0001"], "#2dcf00");
+        assert.equal(colorMap["PF0002"], "#ff5353");
+        assert.equal(colorMap["PF0003"], "#5b5bff");
+        assert.equal(colorMap["PF0004"], "#ebd61d");
+    });
+});

--- a/src/shared/lib/PfamUtils.ts
+++ b/src/shared/lib/PfamUtils.ts
@@ -1,0 +1,29 @@
+import {PfamDomain} from "shared/api/generated/GenomeNexusAPI";
+
+export function generatePfamDomainColorMap(pfamDomains: PfamDomain[]): {[pfamAccession:string]: string}
+{
+    const colors: string[] = [
+        "#2dcf00", "#ff5353", "#5b5bff", "#ebd61d", "#ba21e0",
+        "#ff9c42", "#ff7dff", "#b9264f", "#baba21", "#c48484",
+        "#1f88a7", "#cafeb8", "#4a9586", "#ceb86c", "#0e180f"
+    ];
+
+    const map:{[pfamAccession:string]: string} = {};
+
+    let colorIdx = 0;
+
+    // sort domains by start position,
+    // then assign a different color for each unique domain id.
+    pfamDomains.sort(
+        (a: PfamDomain, b: PfamDomain): number =>
+            a.pfamDomainStart - b.pfamDomainStart
+    ).forEach((domain:PfamDomain) => {
+        if (map[domain.pfamDomainId] === undefined)
+        {
+            map[domain.pfamDomainId] = colors[colorIdx % colors.length];
+            colorIdx++;
+        }
+    });
+
+    return map;
+}

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -6,7 +6,7 @@ import {
     DiscreteCopyNumberFilter, ClinicalData, Sample, CancerStudy, CopyNumberCountIdentifier,
     ClinicalDataSingleStudyFilter, ClinicalDataMultiStudyFilter
 } from "shared/api/generated/CBioPortalAPI";
-import {getMyGeneUrl, getPfamGeneDataUrl, getUniprotIdUrl} from "shared/api/urls";
+import {getMyGeneUrl, getUniprotIdUrl} from "shared/api/urls";
 import defaultClient from "shared/api/cbioportalClientInstance";
 import internalClient from "shared/api/cbioportalInternalClientInstance";
 import hotspot3DClient from 'shared/api/3DhotspotClientInstance';
@@ -20,6 +20,7 @@ import {
 import oncokbClient from "shared/api/oncokbClientInstance";
 import civicClient from "shared/api/civicClientInstance";
 import genomeNexusClient from "shared/api/genomeNexusClientInstance";
+import genomeNexusInternalClient from "shared/api/genomeNexusInternalClientInstance";
 import {
     generateIdToIndicatorMap, generateQueryVariant, generateEvidenceQuery
 } from "shared/lib/OncoKbUtils";
@@ -39,6 +40,8 @@ import {IHotspotData, ICancerHotspotData} from "shared/model/CancerHotspots";
 import {ICivicGeneData, ICivicVariant, ICivicGene} from "shared/model/Civic.ts";
 import CancerHotspotsAPI from "shared/api/generated/CancerHotspotsAPI";
 import {MOLECULAR_PROFILE_MUTATIONS_SUFFIX, MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "shared/constants";
+import GenomeNexusAPI from "shared/api/generated/GenomeNexusAPI";
+import GenomeNexusAPIInternal from "shared/api/generated/GenomeNexusAPIInternal";
 
 export const ONCOKB_DEFAULT: IOncoKbData = {
     sampleToTumorMap : {},
@@ -97,10 +100,21 @@ export async function fetchUniprotId(swissProtAccession: string)
     return uniprotData.text.split("\n")[1];
 }
 
-export async function fetchPfamGeneData(swissProtAccession: string)
+export async function fetchPfamDomainData(ensemblTranscriptId: string,
+                                          client:GenomeNexusAPI = genomeNexusClient)
 {
-    const pfamData:Response = await request.get(getPfamGeneDataUrl(swissProtAccession));
-    return JSON.parse(pfamData.text)[0];
+    return await client.fetchPfamDomainsByTranscriptIdGET({
+        transcriptId: ensemblTranscriptId
+    });
+}
+
+export async function fetchCanonicalTranscript(hugoSymbol: string,
+                                               isoformOverrideSource: string,
+                                               client:GenomeNexusAPIInternal = genomeNexusInternalClient)
+{
+    return await client.fetchEnsemblTranscriptsByHugoSymbolGET({
+        hugoSymbol, isoformOverrideSource
+    });
 }
 
 export async function fetchClinicalData(clinicalDataMultiStudyFilter:ClinicalDataMultiStudyFilter,


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/3083.

Current view with PFAM graphics API:
![brca1_pfam_graphics](https://user-images.githubusercontent.com/3604198/32070006-e7080172-ba58-11e7-8c55-ff825114c636.png)

Proposed view with Genome Nexus API:
![brca1_genome_nexus](https://user-images.githubusercontent.com/3604198/32069926-b6a2c3f0-ba58-11e7-859b-6f05cd12faac.png)

Changes proposed in this pull request:
- replaced PFAM graphics API calls with genome nexus API calls
- added (canonical) transcript id to the gene summary panel

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
