### PR TITLE
Pass frontend config through window.frontendConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ npm run start
 In another terminal run the e2e tests
 ```bash
 # get CBIOPORTAL backend url from my-index.ejs
-export CBIOPORTAL_URL=http://$(grep '__API_ROOT__' my-index.ejs | cut -d= -f2 | tr -d "'" | tr -d [:space:] | tr -d ';')
+eval "$(./scripts/env_vars.sh)"
 cd end-to-end-tests
 npm install
 npm run test-webdriver-manager

--- a/my-index.ejs
+++ b/my-index.ejs
@@ -6,35 +6,37 @@
     <script>
         window.devContext = true;
         window.defaultRoute = "/home";
-        // uncomment to enable Darwin internal MSKCC service patient view link
-        // uses checkDarwinAccess.do service from cbioportal/cbioportal
-        // window.enableDarwin = true;
         // Set default API in case none is specified in .env
-        __API_ROOT__ = 'www.cbioportal.org/beta';
-        window.showCivic = true;
-        window.showHotspot = true;
-        window.showMyCancerGenome = true;
-        window.showOncoKB = true;
-        window.oncoKBApiUrl = "oncokb.org/api/v1";
-        window.showGenomeNexus = true;
-        window.genomeNexusApiUrl = 'genomenexus.herokuapp.com';
-        window.skinBlurb = 'The cBioPortal for Cancer Genomics provides <b>visualization</b>, <b>analysis</b> and <b>download</b> of large-scale cancer genomics data sets.  <p>Please adhere to <u><a href="http://cancergenome.nih.gov/abouttcga/policies/publicationguidelines"> the TCGA publication guidelines</a></u> when using TCGA data in your publications.</p> <p><b>Please cite</b> <a href="http://www.ncbi.nlm.nih.gov/pubmed/23550210">Gao et al. <i>Sci. Signal.</i> 2013</a> &amp;  <a href="http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract">Cerami et al. <i>Cancer Discov.</i> 2012</a> when publishing results based on cBioPortal.</p>';
-        window.skinExampleStudyQueries = [
-            'tcga',
-            'tcga -provisional',
-            'tcga -moratorium',
-            'tcga OR icgc',
-            '-"cell line"',
-            'prostate mskcc',
-            'esophageal OR stomach',
-            'serous',
-            'breast',
-        ];
-        window.skinDatasetHeader = 'The portal currently contains data from the following cancer genomics studies.  The table below lists the number of available samples per data type and tumor.'
-        window.skinDatasetFooter = 'Data sets of TCGA studies were downloaded from Broad Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the TCGA working groups directly.';
-        window.skinRightNavShowDatasets = true;
-        window.skinRightNavShowExamples = true;
-        window.skinRightNavShowTestimonials = true;
+        window.frontendConfig = {
+            // uncomment to enable Darwin internal MSKCC service patient view link
+            // uses checkDarwinAccess.do service from cbioportal/cbioportal
+            // enableDarwin : true,
+            apiRoot: 'www.cbioportal.org/beta',
+            showCivic : true,
+            showHotspot : true,
+            showMyCancerGenome : true,
+            showOncoKB : true,
+            oncoKBApiUrl : "oncokb.org/api/v1",
+            showGenomeNexus : true,
+            genomeNexusApiUrl : 'genomenexus.org',
+            skinBlurb : 'The cBioPortal for Cancer Genomics provides <b>visualization</b>, <b>analysis</b> and <b>download</b> of large-scale cancer genomics data sets.  <p>Please adhere to <u><a href="http://cancergenome.nih.gov/abouttcga/policies/publicationguidelines"> the TCGA publication guidelines</a></u> when using TCGA data in your publications.</p> <p><b>Please cite</b> <a href="http://www.ncbi.nlm.nih.gov/pubmed/23550210">Gao et al. <i>Sci. Signal.</i> 2013</a> &amp;  <a href="http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract">Cerami et al. <i>Cancer Discov.</i> 2012</a> when publishing results based on cBioPortal.</p>',
+            skinExampleStudyQueries : [
+                'tcga',
+                'tcga -provisional',
+                'tcga -moratorium',
+                'tcga OR icgc',
+                '-"cell line"',
+                'prostate mskcc',
+                'esophageal OR stomach',
+                'serous',
+                'breast',
+            ],
+            skinDatasetHeader : 'The portal currently contains data from the following cancer genomics studies.  The table below lists the number of available samples per data type and tumor.',
+            skinDatasetFooter : 'Data sets of TCGA studies were downloaded from Broad Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the TCGA working groups directly.',
+            skinRightNavShowDatasets : true,
+            skinRightNavShowExamples : true,
+            skinRightNavShowTestimonials : true,
+        }
     </script>
     <script src="reactapp/common.bundle.js"></script>
     <link href="reactapp/prefixed-bootstrap.min.css" rel="stylesheet"></link>

--- a/scripts/env_vars.sh
+++ b/scripts/env_vars.sh
@@ -2,5 +2,5 @@
 # eval output of this file to get appropriate env variables e.g. eval "$(./env_vars.sh)"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-echo "export CBIOPORTAL_URL=http://$(grep '__API_ROOT__' ${SCRIPT_DIR}/../my-index.ejs | cut -d= -f2 | tr -d "'" | tr -d [:space:] | tr -d ';')"
-echo "export GENOME_NEXUS_URL=http://$(grep 'window.genomeNexusApiUrl' ${SCRIPT_DIR}/../my-index.ejs | cut -d= -f2 | tr -d "'" | tr -d [:space:] | tr -d ';')"
+echo "export CBIOPORTAL_URL=http://$(grep 'apiRoot' ${SCRIPT_DIR}/../my-index.ejs | cut -d: -f2 | cut -d, -f1 | tr -d "'" | tr -d [:space:] | tr -d ';')"
+echo "export GENOME_NEXUS_URL=http://$(grep 'genomeNexusApiUrl' ${SCRIPT_DIR}/../my-index.ejs | cut -d: -f2 | cut -d, -f1 | tr -d "'" | tr -d [:space:] | tr -d ';')"

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -1,4 +1,5 @@
 export interface IAppConfig {
+    apiRoot?: string;
     genomespaceEnabled: boolean;
     cancerStudySearchPresets: string[]; // in query the example searches
     priorityStudies: PriorityStudies;

--- a/src/config/development.config.ts
+++ b/src/config/development.config.ts
@@ -1,29 +1,4 @@
 import {IAppConfig} from "./IAppConfig";
 
-const config:IAppConfig = {
-    //host: 'cbioportal-rc.herokuapp.com',
-    genomespaceEnabled: false,
-    cancerStudySearchPresets: (window as any).skinExampleStudyQueries,
-    priorityStudies: (window as any).priorityStudies,
-    showCivic: (window as any).showCivic,
-    showHotspot: (window as any).showHotspot,
-    showMyCancerGenome: (window as any).showMyCancerGenome,
-    showOncoKB: (window as any).showOncoKB,
-    oncoKBApiUrl: (window as any).oncoKBApiUrl,
-    showGenomeNexus: (window as any).showGenomeNexus,
-    genomeNexusApiUrl: (window as any).genomeNexusApiUrl,
-    enableDarwin: (window as any).enableDarwin,
-    appVersion: (window as any).appVersion,
-    historyType: (window as any).historyType,
-    skinBlurb: (window as any).skinBlurb,
-    skinDatasetHeader: (window as any).skinDatasetHeader,
-    skinDatasetFooter: (window as any).skinDatasetFooter,
-    skinRightNavShowDatasets: (window as any).skinRightNavShowDatasets,
-    skinRightNavShowExamples: (window as any).skinRightNavShowExamples, 
-    skinRightNavShowTestimonials: (window as any).skinRightNavShowTestimonials,
-    skinRightNavExamplesHTML: (window as any).skinRightNavExamplesHTML,
-    skinRightNavWhatsNewBlurb: (window as any).skinRightNavWhatsNewBlurb,
-    querySetsOfGenes: (window as any).querySetsOfGenes
-};
-
+const config:IAppConfig = (window as any).frontendConfig;
 export default config;

--- a/src/config/production.config.ts
+++ b/src/config/production.config.ts
@@ -1,29 +1,4 @@
 import {IAppConfig} from "./IAppConfig";
 
-const config:IAppConfig = {
-    //host: 'cbioportal-rc.herokuapp.com',
-    genomespaceEnabled: false,
-    cancerStudySearchPresets: (window as any).skinExampleStudyQueries,
-    priorityStudies: (window as any).priorityStudies,
-    showCivic: (window as any).showCivic,
-    showHotspot: (window as any).showHotspot,
-    showMyCancerGenome: (window as any).showMyCancerGenome,
-    showOncoKB: (window as any).showOncoKB,
-    oncoKBApiUrl: (window as any).oncoKBApiUrl,
-    showGenomeNexus: (window as any).showGenomeNexus,
-    genomeNexusApiUrl: (window as any).genomeNexusApiUrl,
-    enableDarwin: (window as any).enableDarwin,
-    appVersion: (window as any).appVersion,
-    historyType: (window as any).historyType,
-    skinBlurb: (window as any).skinBlurb,
-    skinDatasetHeader: (window as any).skinDatasetHeader,
-    skinDatasetFooter: (window as any).skinDatasetFooter,
-    skinRightNavShowDatasets: (window as any).skinRightNavShowDatasets,
-    skinRightNavShowExamples: (window as any).skinRightNavShowExamples, 
-    skinRightNavShowTestimonials: (window as any).skinRightNavShowTestimonials,
-    skinRightNavExamplesHTML: (window as any).skinRightNavExamplesHTML,
-    skinRightNavWhatsNewBlurb: (window as any).skinRightNavWhatsNewBlurb,
-    querySetsOfGenes: (window as any).querySetsOfGenes
-};
-
+const config:IAppConfig = (window as any).frontendConfig;
 export default config;

--- a/src/config/test.config.ts
+++ b/src/config/test.config.ts
@@ -17,7 +17,7 @@ const config:IAppConfig = {
     priorityStudies: {
         'Shared institutional Data Sets': ['mskimpact', 'cellline_mskcc'],
         'Priority Studies': ['blca_tcga_pub', 'coadread_tcga_pub', 'brca_tcga_pub2015'], // for demo
-    },
+    }
 };
 
 export default config;

--- a/src/shared/api/index.jsx
+++ b/src/shared/api/index.jsx
@@ -1,7 +1,8 @@
 import Swagger from 'swagger-client';
+import AppConfig from "appConfig";
 
 const clientPromise = new Swagger({
-    url: `http://${__API_ROOT__}/v2/api-docs`,
+    url: `http://${AppConfig.apiRoot}/v2/api-docs`,
     usePromise: true
 });
 export default clientPromise;

--- a/src/shared/api/urls.spec.ts
+++ b/src/shared/api/urls.spec.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
+import AppConfig from 'appConfig';
 
 describe('url library', () => {
 
@@ -11,11 +12,11 @@ describe('url library', () => {
     });
 
     after(()=>{
-        delete (global as any).window.oncoKBApiUrl;
+        delete AppConfig.oncoKBApiUrl;
     });
 
     it('transforms oncokb url configuration url to proxied url: removes protocol and trailing slash', ()=>{
-        (global as any).window.oncoKBApiUrl = 'http://www.test.com/hello/';
+        AppConfig.oncoKBApiUrl = 'http://www.test.com/hello/';
         // note that this is WRONG (http: should be followed by double shlash)
         // but this is due to testing env and url builder library
         // this works correctly in browser env
@@ -23,7 +24,8 @@ describe('url library', () => {
     });
 
     it('transforms oncokb url configuration url to proxied url: removes protocol and trailing slash', ()=>{
-        (global as any).window.oncoKBApiUrl = null;
+        AppConfig.oncoKBApiUrl = undefined;
+        // note that this is WRONG (http: should be followed by double shlash)
         // note that this is WRONG (http: should be followed by double shlash)
         // but this is due to testing env and url builder library
         // this works correctly in browser env

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -1,7 +1,8 @@
 import {default as URL, QueryParams} from "url";
+import AppConfig from "appConfig";
 
 export function getHost(){
-    return (window as any).__API_ROOT__;
+    return AppConfig.apiRoot;
 }
 
 export type BuildUrlParams = {pathname:string, query?:QueryParams, hash?:string};
@@ -53,7 +54,7 @@ export function getHotspots3DApiUrl() {
     return cbioUrl('proxy/3dhotspots.org/3d');
 }
 export function getOncoKbApiUrl() {
-    let url = (window as any).oncoKBApiUrl;
+    let url = AppConfig.oncoKBApiUrl;
 
     if (typeof url === 'string') {
         // we need to support legacy configuration values
@@ -66,7 +67,7 @@ export function getOncoKbApiUrl() {
 
 }
 export function getGenomeNexusApiUrl() {
-    let url = (window as any).genomeNexusApiUrl;
+    let url = AppConfig.genomeNexusApiUrl;
     if (typeof url === 'string') {
         // we need to support legacy configuration values
         url = url.replace(/^http[s]?:\/\//,''); // get rid of protocol


### PR DESCRIPTION
Having one object allows us to no longer have to add frontend configuration
props in the backend.