### PR TITLE
Removed AppConfig dependency from MutationTable instances

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -359,7 +359,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         civicGenes={patientViewPageStore.civicGenes}
                                         civicVariants={patientViewPageStore.civicVariants}
                                         enableOncoKb={AppConfig.showOncoKB}
-                                        enableGenomeNexus={AppConfig.showGenomeNexus}
+                                        enableFunctionalImpact={AppConfig.showGenomeNexus}
                                         enableHotspot={AppConfig.showHotspot}
                                         enableMyCancerGenome={AppConfig.showMyCancerGenome}
                                         enableCivic={AppConfig.showCivic}

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -11,7 +11,6 @@ import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
 import {isUncalled} from "shared/lib/MutationUtils";
 import TumorAlleleFreqColumnFormatter from "shared/components/mutationTable/column/TumorAlleleFreqColumnFormatter";
-import AppConfig from 'appConfig';
 
 export interface IPatientViewMutationTableProps extends IMutationTableProps {
     sampleManager:SampleManager | null;
@@ -50,13 +49,11 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             MutationTableColumnType.CHROMOSOME,
             MutationTableColumnType.PROTEIN_CHANGE,
             MutationTableColumnType.MUTATION_TYPE,
-        ].concat(
-            AppConfig.showGenomeNexus? [MutationTableColumnType.FUNCTIONAL_IMPACT] : []
-        ).concat([
+            MutationTableColumnType.FUNCTIONAL_IMPACT,
             MutationTableColumnType.COSMIC,
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
             MutationTableColumnType.TUMORS
-        ])
+        ]
     };
 
     protected getSamples():string[] {
@@ -116,9 +113,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         this._columns[MutationTableColumnType.GENE].order = 20;
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].order = 30;
         this._columns[MutationTableColumnType.ANNOTATION].order = 35;
-        if (AppConfig.showGenomeNexus) {
-            this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 36;
-        }
+        this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;
         this._columns[MutationTableColumnType.CHROMOSOME].order = 40;
         this._columns[MutationTableColumnType.START_POS].order = 50;
         this._columns[MutationTableColumnType.END_POS].order = 60;

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -199,7 +199,7 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                                 civicGenes={this.props.store.civicGenes}
                                 civicVariants={this.props.store.civicVariants}
                                 enableOncoKb={this.props.config.showOncoKB}
-                                enableGenomeNexus={this.props.config.showGenomeNexus}
+                                enableFunctionalImpact={this.props.config.showGenomeNexus}
                                 enableHotspot={this.props.config.showHotspot}
                                 enableMyCancerGenome={this.props.config.showMyCancerGenome}
                                 enableCivic={this.props.config.showCivic}

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -5,7 +5,6 @@ import {
 } from "shared/components/mutationTable/MutationTable";
 import CancerTypeColumnFormatter from "shared/components/mutationTable/column/CancerTypeColumnFormatter";
 import TumorAlleleFreqColumnFormatter from "shared/components/mutationTable/column/TumorAlleleFreqColumnFormatter";
-import AppConfig from 'appConfig';
 
 export interface IResultsViewMutationTableProps extends IMutationTableProps {
     // add results view specific props here if needed
@@ -25,9 +24,7 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
             MutationTableColumnType.SAMPLE_ID,
             MutationTableColumnType.COPY_NUM,
             MutationTableColumnType.ANNOTATION,
-        ].concat(
-            AppConfig.showGenomeNexus? [MutationTableColumnType.FUNCTIONAL_IMPACT] : []
-        ).concat([
+            MutationTableColumnType.FUNCTIONAL_IMPACT,
             MutationTableColumnType.REF_READS_N,
             MutationTableColumnType.VAR_READS_N,
             MutationTableColumnType.REF_READS,
@@ -47,7 +44,7 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
             MutationTableColumnType.NORMAL_ALLELE_FREQ,
             MutationTableColumnType.CANCER_TYPE,
             MutationTableColumnType.NUM_MUTATIONS
-        ])
+        ]
     };
 
     protected generateColumns() {
@@ -65,9 +62,7 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
         this._columns[MutationTableColumnType.CANCER_TYPE].order = 15;
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].order = 20;
         this._columns[MutationTableColumnType.ANNOTATION].order = 30;
-        if (AppConfig.showGenomeNexus) {
-            this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 35;
-        }
+        this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;
         this._columns[MutationTableColumnType.MUTATION_TYPE].order = 40;
         this._columns[MutationTableColumnType.COPY_NUM].order = 50;
         this._columns[MutationTableColumnType.COSMIC].order = 60;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -41,21 +41,21 @@ import classnames from 'classnames';
 import {IPaginationControlsProps} from "../paginationControls/PaginationControls";
 
 export interface IMutationTableProps {
-    sampleIdToTumorType?: {[sampleId: string]: string}
+    sampleIdToTumorType?: {[sampleId: string]: string};
     molecularProfileIdToMolecularProfile?: {[molecularProfileId:string]:MolecularProfile};
     discreteCNACache?:DiscreteCNACache;
     oncoKbEvidenceCache?:OncoKbEvidenceCache;
     genomeNexusEnrichmentCache?:GenomeNexusEnrichmentCache;
     mrnaExprRankCache?:MrnaExprRankCache;
     variantCountCache?:VariantCountCache;
-    pubMedCache?:PubMedCache
+    pubMedCache?:PubMedCache;
     mutationCountCache?:MutationCountCache;
     mutSigData?:IMutSigData;
     enableOncoKb?: boolean;
     enableMyCancerGenome?: boolean;
     enableHotspot?: boolean;
     enableCivic?: boolean;
-    enableGenomeNexus?: boolean;
+    enableFunctionalImpact?: boolean;
     myCancerGenomeData?: IMyCancerGenomeData;
     hotspots?: IHotspotData;
     cosmicData?:ICosmicData;
@@ -72,9 +72,9 @@ export interface IMutationTableProps {
     itemsLabel?:string;
     itemsLabelPlural?:string;
     initialSortColumn?:string;
-    initialSortDirection?:SortDirection,
-    paginationProps?:IPaginationControlsProps,
-    showCountHeader?:boolean
+    initialSortDirection?:SortDirection;
+    paginationProps?:IPaginationControlsProps;
+    showCountHeader?:boolean;
 }
 
 export enum MutationTableColumnType {
@@ -393,16 +393,15 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
                 MutationTypeColumnFormatter.getDisplayValue(d).toUpperCase().indexOf(filterStringUpper) > -1
         };
 
-        if (this.props.enableGenomeNexus) {
-            this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT] = {
-                name:"Functional Impact",
-                render:(d:Mutation[])=>(this.props.genomeNexusEnrichmentCache
-                    ? FunctionalImpactColumnFormatter.renderFunction(d, this.props.genomeNexusEnrichmentCache as GenomeNexusEnrichmentCache)
-                    : (<span></span>)),
-                headerRender: FunctionalImpactColumnFormatter.headerRender,
-                visible: false,
-            };
-        }
+        this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT] = {
+            name:"Functional Impact",
+            render:(d:Mutation[])=>(this.props.genomeNexusEnrichmentCache
+                ? FunctionalImpactColumnFormatter.renderFunction(d, this.props.genomeNexusEnrichmentCache as GenomeNexusEnrichmentCache)
+                : (<span></span>)),
+            headerRender: FunctionalImpactColumnFormatter.headerRender,
+            visible: false,
+            shouldExclude: () => !this.props.enableFunctionalImpact
+        };
 
         this._columns[MutationTableColumnType.COSMIC] = {
             name: "COSMIC",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Removed `AppConfig` dependency from `MutationTable` instances
- Simplified `Functional Impact` column initialization

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)