### PR TITLE
Update timeline version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2146,9 +2146,9 @@
       "dev": true
     },
     "clinical-timeline": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/clinical-timeline/-/clinical-timeline-0.0.15.tgz",
-      "integrity": "sha1-v4s4KW0aLn0PwNjaua9orITJaXw=",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/clinical-timeline/-/clinical-timeline-0.0.16.tgz",
+      "integrity": "sha1-sXjRsnK2OvBNHY+SDCK5FDXErnw=",
       "requires": {
         "d3": "3.5.17"
       },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "bundle-loader": "^0.5.4",
     "chart.js": "^2.6.0",
     "classnames": "^2.2.5",
-    "clinical-timeline": "0.0.15",
+    "clinical-timeline": "0.0.16",
     "convert-css-color-name-to-hex": "^0.1.1",
     "copy-webpack-plugin": "^4.0.1",
     "cross-env": "^3.1.4",


### PR DESCRIPTION
- Fix for Imaging track showing long rectangles instead of squares when
  timeline is trimmed
From long rectangles:
![screen shot 2017-11-13 at 2 33 20 pm](https://user-images.githubusercontent.com/1334004/32745086-a70cba88-c87f-11e7-8e8d-8a71c6b83840.png)
To squares:
![screen shot 2017-11-13 at 2 33 06 pm](https://user-images.githubusercontent.com/1334004/32745096-ac2d1e2c-c87f-11e7-8ebf-5ad7acce6796.png)
