### PR TITLE
Add unmountOnHide mode for MSKTabs

### DIFF
--- a/src/shared/components/MSKTabs/MSKTabs.spec.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.spec.tsx
@@ -40,7 +40,7 @@ describe('MSKTabs', () => {
         assert.isTrue(tabs.find('li').at(1).hasClass('active'));
     });
 
-    it('switch tab causes mounting, switching again causes hide/show', ()=>{
+    it('if unMountOnHide = false (or not set), switch tab causes mounting, switching again causes hide/show', ()=>{
         assert.equal(tabs.find('.msk-tab').length, 1);
         tabs.setProps({ activeTabId:"two" });
         assert.equal(tabs.find('.msk-tab').length, 2);
@@ -48,6 +48,14 @@ describe('MSKTabs', () => {
         tabs.setProps({ activeTabId:"one" });
         assert.isTrue(tabs.find(MSKTab).at(1).hasClass('hiddenByPosition'));
         assert.isFalse(tabs.find(MSKTab).at(0).hasClass('hiddenByPosition'));
+    });
+
+    it('if unMountOnHide = true, switch tab causes mounting, switching again causes hide/show', ()=>{
+        tabs.setProps({ unmountOnHide:true });
+        assert.equal(tabs.find('.msk-tab').length, 1);
+        tabs.setProps({ activeTabId:"two" });
+        assert.equal(tabs.find('.msk-tab').length, 1);
+        tabs.setProps({ activeTabId:"one" });
     });
 
     it('does not display tabs that have hide={true}', ()=>{

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -54,6 +54,7 @@ interface IMSKTabsProps {
     // only used when pagination is true to style arrows
     arrowStyle?:{[k:string]:string|number|boolean};
     tabButtonStyle?:string;
+    unmountOnHide?:boolean;
 }
 
 export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
@@ -148,7 +149,7 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
                         effectiveActiveTab = this.props.activeTabId;
                         this.shownTabs.push(child.props.id);
                         memo.push(this.cloneTab(child, false, !!child.props.loading));
-                    } else if (_.includes(this.shownTabs, child.props.id) && !child.props.loading) {
+                    } else if (!this.props.unmountOnHide && _.includes(this.shownTabs, child.props.id) && !child.props.loading) {
                         memo.push(this.cloneTab(child, true, !!child.props.loading));
                     }
                 }

--- a/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/shared/components/cancerSummary/CancerSummaryContainer.tsx
@@ -124,6 +124,7 @@ export default class CancerSummaryContainer extends React.Component<{ store: Res
                 <div ref={(el: HTMLDivElement) => this.resultsViewPageContent = el}>
                     <MSKTabs onTabClick={this.handleTabClick}
                              enablePagination={true}
+                             unmountOnHide={true}
                              arrowStyle={{'line-height': .8}}
                              tabButtonStyle="pills"
                              activeTabId={this.activeTab} className="secondaryTabs">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -152,7 +152,7 @@ var config = {
 
         ],
 
-        noParse:[/3Dmol-nojquery/,/jspdf/],
+        noParse:[/3Dmol-nojquery.js/,/jspdf/],
 
         preLoaders: [
             // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.


### PR DESCRIPTION
When tabs are hidden but no unmounted, they still react to mobx events.  This is very costly.  
# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
