### PR TITLE
Keep lock file in sync on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,10 @@ jobs:
 
       - run: npm install
 
+      - run:
+          name: "Make sure lock file is still the same"
+          command: "git diff --quiet package-lock.json"
+
       - save_cache:
           paths:
             - node_modules


### PR DESCRIPTION
Make sure the packe-lock.json file is unchanged after running npm install. This
is to keep builds consistent on linux.