### PR TITLE
Update genome nexus and use new endpoints lollipop

### DIFF
--- a/my-index.ejs
+++ b/my-index.ejs
@@ -18,7 +18,7 @@
             showOncoKB : true,
             oncoKBApiUrl : "oncokb.org/api/v1",
             showGenomeNexus : true,
-            genomeNexusApiUrl : 'genomenexus.org',
+            genomeNexusApiUrl : 'genomenexus-rc.herokuapp.com',
             skinBlurb : 'The cBioPortal for Cancer Genomics provides <b>visualization</b>, <b>analysis</b> and <b>download</b> of large-scale cancer genomics data sets.  <p>Please adhere to <u><a href="http://cancergenome.nih.gov/abouttcga/policies/publicationguidelines"> the TCGA publication guidelines</a></u> when using TCGA data in your publications.</p> <p><b>Please cite</b> <a href="http://www.ncbi.nlm.nih.gov/pubmed/23550210">Gao et al. <i>Sci. Signal.</i> 2013</a> &amp;  <a href="http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract">Cerami et al. <i>Cancer Discov.</i> 2012</a> when publishing results based on cBioPortal.</p>',
             skinExampleStudyQueries : [
                 'tcga',

--- a/src/pages/resultsView/mutation/MutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/MutationMapperStore.ts
@@ -25,8 +25,7 @@ import PdbChainDataStore from "./PdbChainDataStore";
 import {IMutationMapperConfig} from "./MutationMapper";
 import MutationDataCache from "../../../shared/cache/MutationDataCache";
 import {Gene as OncoKbGene} from "../../../shared/api/generated/OncoKbAPI";
-import {EnsemblTranscript} from "shared/api/generated/GenomeNexusAPIInternal";
-import {PfamDomain} from "shared/api/generated/GenomeNexusAPI";
+import {EnsemblTranscript, PfamDomain, PfamDomainRange} from "shared/api/generated/GenomeNexusAPI";
 
 export class MutationMapperStore {
 
@@ -149,23 +148,23 @@ export class MutationMapperStore {
         }
     }, ONCOKB_DEFAULT);
 
-    readonly pfamDomainData = remoteData<PfamDomain[] | undefined>({
-        await: ()=>[
-            this.canonicalTranscript
-        ],
+    readonly canonicalTranscript = remoteData<EnsemblTranscript | undefined>({
         invoke: async()=>{
-            if (this.canonicalTranscript.result) {
-                return fetchPfamDomainData(this.canonicalTranscript.result.transcriptId);
+            if (this.gene) {
+                return fetchCanonicalTranscript(this.gene.hugoGeneSymbol, this.isoformOverrideSource);
             } else {
                 return undefined;
             }
         }
     }, undefined);
 
-    readonly canonicalTranscript = remoteData<EnsemblTranscript | undefined>({
+    readonly pfamDomainData = remoteData<PfamDomain[] | undefined>({
+        await: ()=>[
+            this.canonicalTranscript
+        ],
         invoke: async()=>{
-            if (this.gene) {
-                return fetchCanonicalTranscript(this.gene.hugoGeneSymbol, this.isoformOverrideSource);
+            if (this.canonicalTranscript.result && this.canonicalTranscript.result.pfamDomains && this.canonicalTranscript.result.pfamDomains.length > 0) {
+                return fetchPfamDomainData(this.canonicalTranscript.result.pfamDomains.map((x: PfamDomainRange) => x.pfamDomainId));
             } else {
                 return undefined;
             }

--- a/src/shared/api/generated/CBioPortalAPI-docs.json
+++ b/src/shared/api/generated/CBioPortalAPI-docs.json
@@ -1840,6 +1840,60 @@
         }
       }
     },
+    "/sample-lists/fetch": {
+      "post": {
+        "tags": [
+          "Sample Lists"
+        ],
+        "summary": "Fetch sample lists by ID",
+        "operationId": "fetchSampleListsUsingPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "sampleListIds",
+            "description": "List of sample list IDs",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "projection",
+            "in": "query",
+            "description": "Level of detail of the response",
+            "required": false,
+            "type": "string",
+            "default": "SUMMARY",
+            "enum": [
+              "ID",
+              "SUMMARY",
+              "DETAILED",
+              "META"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SampleList"
+              }
+            }
+          }
+        }
+      }
+    },
     "/sample-lists/{sampleListId}": {
       "get": {
         "tags": [
@@ -3715,6 +3769,12 @@
         "sampleCount": {
           "type": "integer",
           "format": "int32"
+        },
+        "sampleIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "sampleListId": {
           "type": "string"

--- a/src/shared/api/generated/CBioPortalAPI.ts
+++ b/src/shared/api/generated/CBioPortalAPI.ts
@@ -186,6 +186,8 @@ export type SampleList = {
 
         'sampleCount': number
 
+        'sampleIds': Array < string >
+
         'sampleListId': string
 
         'studyId': string
@@ -2963,6 +2965,81 @@ export default class CBioPortalAPI {
                 }
 
                 request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchSampleListsUsingPOSTURL(parameters: {
+        'sampleListIds': Array < string > ,
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/sample-lists/fetch';
+
+        if (parameters['projection'] !== undefined) {
+            queryParameters['projection'] = parameters['projection'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Fetch sample lists by ID
+     * @method
+     * @name CBioPortalAPI#fetchSampleListsUsingPOST
+     * @param {} sampleListIds - List of sample list IDs
+     * @param {string} projection - Level of detail of the response
+     */
+    fetchSampleListsUsingPOST(parameters: {
+            'sampleListIds': Array < string > ,
+            'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < SampleList >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/sample-lists/fetch';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                if (parameters['sampleListIds'] !== undefined) {
+                    body = parameters['sampleListIds'];
+                }
+
+                if (parameters['sampleListIds'] === undefined) {
+                    reject(new Error('Missing required  parameter: sampleListIds'));
+                    return;
+                }
+
+                if (parameters['projection'] !== undefined) {
+                    queryParameters['projection'] = parameters['projection'];
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
 
             }).then(function(response: request.Response) {
                 return response.body;

--- a/src/shared/api/generated/GenomeNexusAPI-docs.json
+++ b/src/shared/api/generated/GenomeNexusAPI-docs.json
@@ -15,8 +15,8 @@
   "basePath": "/",
   "tags": [
     {
-      "name": "cross-reference-controller",
-      "description": "Cross Reference Controller"
+      "name": "pdb-controller",
+      "description": "PDB Controller"
     },
     {
       "name": "annotation-controller",
@@ -25,6 +25,10 @@
     {
       "name": "pfam-controller",
       "description": "PFAM Controller"
+    },
+    {
+      "name": "ensembl-controller",
+      "description": "Ensembl Controller"
     }
   ],
   "schemes": [
@@ -142,39 +146,13 @@
         }
       }
     },
-    "/pfam/domain": {
-      "get": {
-        "tags": [
-          "pfam-controller"
-        ],
-        "summary": "Retrieves all PFAM domains",
-        "operationId": "fetchAllPfamDomainsGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PfamDomain"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pfam/domain/gene": {
+    "/ensembl/canonical-transcript/hgnc": {
       "post": {
         "tags": [
-          "pfam-controller"
+          "ensembl-controller"
         ],
-        "summary": "Retrieves PFAM domains by Ensembl gene IDs",
-        "operationId": "fetchPfamDomainsByGeneIdsPOST",
+        "summary": "Retrieves Ensembl canonical transcripts by Hugo Symbols",
+        "operationId": "fetchCanonicalEnsemblTranscriptsByHugoSymbolsPOST",
         "consumes": [
           "application/json"
         ],
@@ -184,8 +162,8 @@
         "parameters": [
           {
             "in": "body",
-            "name": "geneIds",
-            "description": "List of Ensembl gene IDs. For example [\"ENSG00000136999\",\"ENSG00000272398\",\"ENSG00000198695\"]",
+            "name": "hugoSymbols",
+            "description": "List of Hugo Symbols. For example [\"TP53\",\"PIK3CA\",\"BRCA1\"]",
             "required": true,
             "schema": {
               "type": "array",
@@ -193,6 +171,14 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "isoformOverrideSource",
+            "in": "query",
+            "description": "Isoform override source. For example uniprot",
+            "required": false,
+            "type": "string",
+            "default": "uniprot"
           }
         ],
         "responses": {
@@ -201,20 +187,60 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/PfamDomain"
+                "$ref": "#/definitions/EnsemblTranscript"
               }
             }
           }
         }
       }
     },
-    "/pfam/domain/gene/{geneId}": {
+    "/ensembl/canonical-transcript/hgnc/{hugoSymbol}": {
       "get": {
         "tags": [
-          "pfam-controller"
+          "ensembl-controller"
         ],
-        "summary": "Retrieves PFAM domains by an Ensembl gene ID",
-        "operationId": "fetchPfamDomainsByGeneIdGET",
+        "summary": "Retrieves Ensembl canonical transcript by Hugo Symbol",
+        "operationId": "fetchCanonicalEnsemblTranscriptByHugoSymbolGET",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "hugoSymbol",
+            "in": "path",
+            "description": "A Hugo Symbol. For example TP53",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "isoformOverrideSource",
+            "in": "query",
+            "description": "Isoform override source. For example uniprot",
+            "required": false,
+            "type": "string",
+            "default": "uniprot"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/EnsemblTranscript"
+            }
+          }
+        }
+      }
+    },
+    "/ensembl/transcript": {
+      "get": {
+        "tags": [
+          "ensembl-controller"
+        ],
+        "summary": "Retrieves Ensembl Transcripts by protein ID, and gene ID. Retrieves all transcripts in case no query parameter provided",
+        "operationId": "fetchEnsemblTranscriptsGET",
         "consumes": [
           "application/json"
         ],
@@ -224,159 +250,16 @@
         "parameters": [
           {
             "name": "geneId",
-            "in": "path",
+            "in": "query",
             "description": "An Ensembl gene ID. For example ENSG00000136999",
-            "required": true,
+            "required": false,
             "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PfamDomain"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pfam/domain/id": {
-      "post": {
-        "tags": [
-          "pfam-controller"
-        ],
-        "summary": "Retrieves PFAM domains by PFAM domain IDs",
-        "operationId": "fetchPfamDomainsByPfamIdsPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "pfamDomainIds",
-            "description": "List of PFAM domain IDs. For example [\"PF02827\",\"PF00093\",\"PF15276\"]",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PfamDomain"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pfam/domain/id/{pfamDomainId}": {
-      "get": {
-        "tags": [
-          "pfam-controller"
-        ],
-        "summary": "Retrieves PFAM domains by a PFAM domain ID",
-        "operationId": "fetchPfamDomainsByPfamIdGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "pfamDomainId",
-            "in": "path",
-            "description": "A PFAM domain ID. For example PF02827",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PfamDomain"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pfam/domain/protein": {
-      "post": {
-        "tags": [
-          "pfam-controller"
-        ],
-        "summary": "Retrieves PFAM domains by Ensembl protein IDs",
-        "operationId": "fetchPfamDomainsByProteinIdsPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "proteinIds",
-            "description": "List of Ensembl protein IDs. For example [\"ENSP00000439985\",\"ENSP00000478460\",\"ENSP00000346196\"]",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PfamDomain"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pfam/domain/protein/{proteinId}": {
-      "get": {
-        "tags": [
-          "pfam-controller"
-        ],
-        "summary": "Retrieves PFAM domains by an Ensembl protein ID",
-        "operationId": "fetchPfamDomainsByProteinIdGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
+          },
           {
             "name": "proteinId",
-            "in": "path",
+            "in": "query",
             "description": "An Ensembl protein ID. For example ENSP00000439985",
-            "required": true,
+            "required": false,
             "type": "string"
           }
         ],
@@ -386,20 +269,18 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/PfamDomain"
+                "$ref": "#/definitions/EnsemblTranscript"
               }
             }
           }
         }
-      }
-    },
-    "/pfam/domain/transcript": {
+      },
       "post": {
         "tags": [
-          "pfam-controller"
+          "ensembl-controller"
         ],
-        "summary": "Retrieves PFAM domains by Ensembl transcript IDs",
-        "operationId": "fetchPfamDomainsByTranscriptIdsPOST",
+        "summary": "Retrieves Ensembl Transcripts by Ensembl transcript IDs, protein IDs, or gene IDs",
+        "operationId": "fetchEnsemblTranscriptsByEnsemblFilterPOST",
         "consumes": [
           "application/json"
         ],
@@ -409,14 +290,11 @@
         "parameters": [
           {
             "in": "body",
-            "name": "transcriptIds",
-            "description": "List of Ensembl transcript IDs. For example [\"ENST00000361390\",\"ENST00000361453\",\"ENST00000361624\"]",
+            "name": "ensemblFilter",
+            "description": "List of Ensembl transcript IDs. For example [\"ENST00000361390\", \"ENST00000361453\", \"ENST00000361624\"]<br>OR<br>List of Ensembl protein IDs. For example [\"ENSP00000439985\", \"ENSP00000478460\", \"ENSP00000346196\"]<br>OR<br>List of Ensembl gene IDs. For example [\"ENSG00000136999\", \"ENSG00000272398\", \"ENSG00000198695\"]",
             "required": true,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/definitions/EnsemblFilter"
             }
           }
         ],
@@ -426,20 +304,20 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/PfamDomain"
+                "$ref": "#/definitions/EnsemblTranscript"
               }
             }
           }
         }
       }
     },
-    "/pfam/domain/transcript/{transcriptId}": {
+    "/ensembl/transcript/{transcriptId}": {
       "get": {
         "tags": [
-          "pfam-controller"
+          "ensembl-controller"
         ],
-        "summary": "Retrieves PFAM domains by an Ensembl transcript ID",
-        "operationId": "fetchPfamDomainsByTranscriptIdGET",
+        "summary": "Retrieves the transcript by an Ensembl transcript ID",
+        "operationId": "fetchEnsemblTranscriptByTranscriptIdGET",
         "consumes": [
           "application/json"
         ],
@@ -459,22 +337,19 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PfamDomain"
-              }
+              "$ref": "#/definitions/EnsemblTranscript"
             }
           }
         }
       }
     },
-    "/xrefs/{accession}": {
+    "/ensembl/xrefs": {
       "get": {
         "tags": [
-          "cross-reference-controller"
+          "ensembl-controller"
         ],
-        "summary": "Perform lookups of Ensembl identifiers and retrieve their external referenes in other databases",
-        "operationId": "getGeneXrefs",
+        "summary": "Perform lookups of Ensembl identifiers and retrieve their external references in other databases",
+        "operationId": "fetchGeneXrefsGET",
         "consumes": [
           "application/json"
         ],
@@ -484,7 +359,7 @@
         "parameters": [
           {
             "name": "accession",
-            "in": "path",
+            "in": "query",
             "description": "Ensembl gene accession. For example ENSG00000169083",
             "required": true,
             "type": "string"
@@ -502,9 +377,237 @@
           }
         }
       }
+    },
+    "/pdb/header": {
+      "post": {
+        "tags": [
+          "pdb-controller"
+        ],
+        "summary": "Retrieves PDB header info by a PDB id",
+        "operationId": "fetchPdbHeaderPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "pdbIds",
+            "description": "List of pdb ids, for example [\"1a37\",\"1a4o\"]",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PdbHeader"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pdb/header/{pdbId}": {
+      "get": {
+        "tags": [
+          "pdb-controller"
+        ],
+        "summary": "Retrieves PDB header info by a PDB id",
+        "operationId": "fetchPdbHeaderGET",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pdbId",
+            "in": "path",
+            "description": "PDB id, for example 1a37",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/PdbHeader"
+            }
+          }
+        }
+      }
+    },
+    "/pfam/domain": {
+      "get": {
+        "tags": [
+          "pfam-controller"
+        ],
+        "summary": "Retrieves all PFAM domains",
+        "operationId": "fetchPfamDomainsGET",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PfamDomain"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pfam-controller"
+        ],
+        "summary": "Retrieves PFAM domains by PFAM domain accession IDs",
+        "operationId": "fetchPfamDomainsByPfamAccessionPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "pfamAccessions",
+            "description": "List of PFAM domain accession IDs. For example [\"PF02827\",\"PF00093\",\"PF15276\"]",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PfamDomain"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pfam/domain/{pfamAccession}": {
+      "get": {
+        "tags": [
+          "pfam-controller"
+        ],
+        "summary": "Retrieves a PFAM domain by a PFAM domain ID",
+        "operationId": "fetchPfamDomainsByAccessionGET",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pfamAccession",
+            "in": "path",
+            "description": "A PFAM domain accession ID. For example PF02827",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/PfamDomain"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
+    "EnsemblFilter": {
+      "type": "object",
+      "properties": {
+        "geneIds": {
+          "type": "array",
+          "description": "List of Ensembl gene IDs. For example [\"ENSG00000136999\", \"ENSG00000272398\", \"ENSG00000198695\"]",
+          "items": {
+            "type": "string"
+          }
+        },
+        "proteinIds": {
+          "type": "array",
+          "description": "List of Ensembl protein IDs. For example [\"ENSP00000439985\", \"ENSP00000478460\", \"ENSP00000346196\"]",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transcriptIds": {
+          "type": "array",
+          "description": "List of Ensembl transcript IDs. For example [\"ENST00000361390\", \"ENST00000361453\", \"ENST00000361624\"]",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "EnsemblTranscript": {
+      "type": "object",
+      "required": [
+        "geneId",
+        "proteinId",
+        "transcriptId"
+      ],
+      "properties": {
+        "transcriptId": {
+          "type": "string",
+          "description": "Ensembl transcript id"
+        },
+        "geneId": {
+          "type": "string",
+          "description": "Ensembl gene id"
+        },
+        "proteinId": {
+          "type": "string",
+          "description": "Ensembl protein id"
+        },
+        "proteinLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Length of protein"
+        },
+        "pfamDomains": {
+          "type": "array",
+          "description": "Pfam domains",
+          "items": {
+            "$ref": "#/definitions/PfamDomainRange"
+          }
+        }
+      }
+    },
     "GeneXref": {
       "type": "object",
       "required": [
@@ -557,50 +660,71 @@
         }
       }
     },
+    "PdbHeader": {
+      "type": "object",
+      "required": [
+        "pdbId",
+        "title"
+      ],
+      "properties": {
+        "compound": {
+          "type": "object"
+        },
+        "pdbId": {
+          "type": "string",
+          "description": "PDB id"
+        },
+        "source": {
+          "type": "object"
+        },
+        "title": {
+          "type": "string",
+          "description": "PDB description"
+        }
+      }
+    },
     "PfamDomain": {
       "type": "object",
       "required": [
-        "geneId",
-        "proteinId",
-        "transcriptId"
+        "name",
+        "pfamAccession"
       ],
       "properties": {
-        "geneId": {
-          "type": "string",
-          "description": "Ensembl gene id"
-        },
-        "geneSymbol": {
-          "type": "string",
-          "description": "Hugo gene symbol"
-        },
-        "pfamDomainDescription": {
+        "description": {
           "type": "string",
           "description": "PFAM domain description"
         },
-        "pfamDomainEnd": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "pfamDomainId": {
-          "type": "string",
-          "description": "PFAM domain id"
-        },
-        "pfamDomainName": {
+        "name": {
           "type": "string",
           "description": "PFAM domain name"
+        },
+        "pfamAccession": {
+          "type": "string",
+          "description": "PFAM domain accession"
+        }
+      }
+    },
+    "PfamDomainRange": {
+      "type": "object",
+      "required": [
+        "pfamDomainEnd",
+        "pfamDomainId",
+        "pfamDomainStart"
+      ],
+      "properties": {
+        "pfamDomainId": {
+          "type": "string",
+          "description": "Pfam domain id"
         },
         "pfamDomainStart": {
           "type": "integer",
           "format": "int32",
-          "description": "PFAM domain start"
+          "description": "Pfam domain start amino acid"
         },
-        "proteinId": {
-          "type": "string",
-          "description": "Ensembl translation id"
-        },
-        "transcriptId": {
-          "type": "string",
-          "description": "Ensembl transcript id"
+        "pfamDomainEnd": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Pfam domain end amino acid"
         }
       }
     },

--- a/src/shared/api/generated/GenomeNexusAPI.ts
+++ b/src/shared/api/generated/GenomeNexusAPI.ts
@@ -1,6 +1,26 @@
 import * as request from "superagent";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
+export type EnsemblFilter = {
+    'geneIds': Array < string >
+
+        'proteinIds': Array < string >
+
+        'transcriptIds': Array < string >
+
+};
+export type EnsemblTranscript = {
+    'transcriptId': string
+
+        'geneId': string
+
+        'proteinId': string
+
+        'proteinLength': number
+
+        'pfamDomains': Array < PfamDomainRange >
+
+};
 export type GeneXref = {
     'db_display_name': string
 
@@ -21,24 +41,30 @@ export type GeneXref = {
         'version': string
 
 };
+export type PdbHeader = {
+    'compound': {}
+
+    'pdbId': string
+
+        'source': {}
+
+        'title': string
+
+};
 export type PfamDomain = {
-    'geneId': string
+    'description': string
 
-        'geneSymbol': string
+        'name': string
 
-        'pfamDomainDescription': string
+        'pfamAccession': string
 
-        'pfamDomainEnd': number
-
-        'pfamDomainId': string
-
-        'pfamDomainName': string
+};
+export type PfamDomainRange = {
+    'pfamDomainId': string
 
         'pfamDomainStart': number
 
-        'proteinId': string
-
-        'transcriptId': string
+        'pfamDomainEnd': number
 
 };
 export type TranscriptConsequence = {
@@ -330,7 +356,549 @@ export default class GenomeNexusAPI {
         });
     };
 
-    fetchAllPfamDomainsGETURL(parameters: {
+    fetchCanonicalEnsemblTranscriptsByHugoSymbolsPOSTURL(parameters: {
+        'hugoSymbols': Array < string > ,
+        'isoformOverrideSource' ? : string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/ensembl/canonical-transcript/hgnc';
+
+        if (parameters['isoformOverrideSource'] !== undefined) {
+            queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves Ensembl canonical transcripts by Hugo Symbols
+     * @method
+     * @name GenomeNexusAPI#fetchCanonicalEnsemblTranscriptsByHugoSymbolsPOST
+     * @param {} hugoSymbols - List of Hugo Symbols. For example ["TP53","PIK3CA","BRCA1"]
+     * @param {string} isoformOverrideSource - Isoform override source. For example uniprot
+     */
+    fetchCanonicalEnsemblTranscriptsByHugoSymbolsPOST(parameters: {
+            'hugoSymbols': Array < string > ,
+            'isoformOverrideSource' ? : string,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < EnsemblTranscript >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/ensembl/canonical-transcript/hgnc';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                if (parameters['hugoSymbols'] !== undefined) {
+                    body = parameters['hugoSymbols'];
+                }
+
+                if (parameters['hugoSymbols'] === undefined) {
+                    reject(new Error('Missing required  parameter: hugoSymbols'));
+                    return;
+                }
+
+                if (parameters['isoformOverrideSource'] !== undefined) {
+                    queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchCanonicalEnsemblTranscriptByHugoSymbolGETURL(parameters: {
+        'hugoSymbol': string,
+        'isoformOverrideSource' ? : string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/ensembl/canonical-transcript/hgnc/{hugoSymbol}';
+
+        path = path.replace('{hugoSymbol}', parameters['hugoSymbol'] + '');
+        if (parameters['isoformOverrideSource'] !== undefined) {
+            queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves Ensembl canonical transcript by Hugo Symbol
+     * @method
+     * @name GenomeNexusAPI#fetchCanonicalEnsemblTranscriptByHugoSymbolGET
+     * @param {string} hugoSymbol - A Hugo Symbol. For example TP53
+     * @param {string} isoformOverrideSource - Isoform override source. For example uniprot
+     */
+    fetchCanonicalEnsemblTranscriptByHugoSymbolGET(parameters: {
+        'hugoSymbol': string,
+        'isoformOverrideSource' ? : string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < EnsemblTranscript > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/ensembl/canonical-transcript/hgnc/{hugoSymbol}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            path = path.replace('{hugoSymbol}', parameters['hugoSymbol'] + '');
+
+            if (parameters['hugoSymbol'] === undefined) {
+                reject(new Error('Missing required  parameter: hugoSymbol'));
+                return;
+            }
+
+            if (parameters['isoformOverrideSource'] !== undefined) {
+                queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    fetchEnsemblTranscriptsGETURL(parameters: {
+        'geneId' ? : string,
+        'proteinId' ? : string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/ensembl/transcript';
+        if (parameters['geneId'] !== undefined) {
+            queryParameters['geneId'] = parameters['geneId'];
+        }
+
+        if (parameters['proteinId'] !== undefined) {
+            queryParameters['proteinId'] = parameters['proteinId'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves Ensembl Transcripts by protein ID, and gene ID. Retrieves all transcripts in case no query parameter provided
+     * @method
+     * @name GenomeNexusAPI#fetchEnsemblTranscriptsGET
+     * @param {string} geneId - An Ensembl gene ID. For example ENSG00000136999
+     * @param {string} proteinId - An Ensembl protein ID. For example ENSP00000439985
+     */
+    fetchEnsemblTranscriptsGET(parameters: {
+            'geneId' ? : string,
+            'proteinId' ? : string,
+            $queryParameters ? : any,
+                $domain ? : string
+        }): Promise < Array < EnsemblTranscript >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/ensembl/transcript';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                if (parameters['geneId'] !== undefined) {
+                    queryParameters['geneId'] = parameters['geneId'];
+                }
+
+                if (parameters['proteinId'] !== undefined) {
+                    queryParameters['proteinId'] = parameters['proteinId'];
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchEnsemblTranscriptsByEnsemblFilterPOSTURL(parameters: {
+        'ensemblFilter': EnsemblFilter,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/ensembl/transcript';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves Ensembl Transcripts by Ensembl transcript IDs, protein IDs, or gene IDs
+     * @method
+     * @name GenomeNexusAPI#fetchEnsemblTranscriptsByEnsemblFilterPOST
+     * @param {} ensemblFilter - List of Ensembl transcript IDs. For example ["ENST00000361390", "ENST00000361453", "ENST00000361624"]<br>OR<br>List of Ensembl protein IDs. For example ["ENSP00000439985", "ENSP00000478460", "ENSP00000346196"]<br>OR<br>List of Ensembl gene IDs. For example ["ENSG00000136999", "ENSG00000272398", "ENSG00000198695"]
+     */
+    fetchEnsemblTranscriptsByEnsemblFilterPOST(parameters: {
+            'ensemblFilter': EnsemblFilter,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < EnsemblTranscript >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/ensembl/transcript';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                if (parameters['ensemblFilter'] !== undefined) {
+                    body = parameters['ensemblFilter'];
+                }
+
+                if (parameters['ensemblFilter'] === undefined) {
+                    reject(new Error('Missing required  parameter: ensemblFilter'));
+                    return;
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchEnsemblTranscriptByTranscriptIdGETURL(parameters: {
+        'transcriptId': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/ensembl/transcript/{transcriptId}';
+
+        path = path.replace('{transcriptId}', parameters['transcriptId'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves the transcript by an Ensembl transcript ID
+     * @method
+     * @name GenomeNexusAPI#fetchEnsemblTranscriptByTranscriptIdGET
+     * @param {string} transcriptId - An Ensembl transcript ID. For example ENST00000361390
+     */
+    fetchEnsemblTranscriptByTranscriptIdGET(parameters: {
+        'transcriptId': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < EnsemblTranscript > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/ensembl/transcript/{transcriptId}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            path = path.replace('{transcriptId}', parameters['transcriptId'] + '');
+
+            if (parameters['transcriptId'] === undefined) {
+                reject(new Error('Missing required  parameter: transcriptId'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    fetchGeneXrefsGETURL(parameters: {
+        'accession': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/ensembl/xrefs';
+        if (parameters['accession'] !== undefined) {
+            queryParameters['accession'] = parameters['accession'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Perform lookups of Ensembl identifiers and retrieve their external references in other databases
+     * @method
+     * @name GenomeNexusAPI#fetchGeneXrefsGET
+     * @param {string} accession - Ensembl gene accession. For example ENSG00000169083
+     */
+    fetchGeneXrefsGET(parameters: {
+            'accession': string,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < GeneXref >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/ensembl/xrefs';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                if (parameters['accession'] !== undefined) {
+                    queryParameters['accession'] = parameters['accession'];
+                }
+
+                if (parameters['accession'] === undefined) {
+                    reject(new Error('Missing required  parameter: accession'));
+                    return;
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchPdbHeaderPOSTURL(parameters: {
+        'pdbIds': Array < string > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/pdb/header';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves PDB header info by a PDB id
+     * @method
+     * @name GenomeNexusAPI#fetchPdbHeaderPOST
+     * @param {} pdbIds - List of pdb ids, for example ["1a37","1a4o"]
+     */
+    fetchPdbHeaderPOST(parameters: {
+            'pdbIds': Array < string > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < PdbHeader >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/pdb/header';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                if (parameters['pdbIds'] !== undefined) {
+                    body = parameters['pdbIds'];
+                }
+
+                if (parameters['pdbIds'] === undefined) {
+                    reject(new Error('Missing required  parameter: pdbIds'));
+                    return;
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchPdbHeaderGETURL(parameters: {
+        'pdbId': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/pdb/header/{pdbId}';
+
+        path = path.replace('{pdbId}', parameters['pdbId'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves PDB header info by a PDB id
+     * @method
+     * @name GenomeNexusAPI#fetchPdbHeaderGET
+     * @param {string} pdbId - PDB id, for example 1a37
+     */
+    fetchPdbHeaderGET(parameters: {
+        'pdbId': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < PdbHeader > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/pdb/header/{pdbId}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            path = path.replace('{pdbId}', parameters['pdbId'] + '');
+
+            if (parameters['pdbId'] === undefined) {
+                reject(new Error('Missing required  parameter: pdbId'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    fetchPfamDomainsGETURL(parameters: {
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
@@ -349,9 +917,9 @@ export default class GenomeNexusAPI {
     /**
      * Retrieves all PFAM domains
      * @method
-     * @name GenomeNexusAPI#fetchAllPfamDomainsGET
+     * @name GenomeNexusAPI#fetchPfamDomainsGET
      */
-    fetchAllPfamDomainsGET(parameters: {
+    fetchPfamDomainsGET(parameters: {
             $queryParameters ? : any,
                 $domain ? : string
         }): Promise < Array < PfamDomain >
@@ -382,12 +950,12 @@ export default class GenomeNexusAPI {
             });
         };
 
-    fetchPfamDomainsByGeneIdsPOSTURL(parameters: {
-        'geneIds': Array < string > ,
+    fetchPfamDomainsByPfamAccessionPOSTURL(parameters: {
+        'pfamAccessions': Array < string > ,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
-        let path = '/pfam/domain/gene';
+        let path = '/pfam/domain';
 
         if (parameters.$queryParameters) {
             Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
@@ -400,13 +968,13 @@ export default class GenomeNexusAPI {
     };
 
     /**
-     * Retrieves PFAM domains by Ensembl gene IDs
+     * Retrieves PFAM domains by PFAM domain accession IDs
      * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByGeneIdsPOST
-     * @param {} geneIds - List of Ensembl gene IDs. For example ["ENSG00000136999","ENSG00000272398","ENSG00000198695"]
+     * @name GenomeNexusAPI#fetchPfamDomainsByPfamAccessionPOST
+     * @param {} pfamAccessions - List of PFAM domain accession IDs. For example ["PF02827","PF00093","PF15276"]
      */
-    fetchPfamDomainsByGeneIdsPOST(parameters: {
-            'geneIds': Array < string > ,
+    fetchPfamDomainsByPfamAccessionPOST(parameters: {
+            'pfamAccessions': Array < string > ,
             $queryParameters ? : any,
             $domain ? : string
         }): Promise < Array < PfamDomain >
@@ -414,7 +982,7 @@ export default class GenomeNexusAPI {
             const domain = parameters.$domain ? parameters.$domain : this.domain;
             const errorHandlers = this.errorHandlers;
             const request = this.request;
-            let path = '/pfam/domain/gene';
+            let path = '/pfam/domain';
             let body: any;
             let queryParameters: any = {};
             let headers: any = {};
@@ -423,12 +991,12 @@ export default class GenomeNexusAPI {
                 headers['Accept'] = 'application/json';
                 headers['Content-Type'] = 'application/json';
 
-                if (parameters['geneIds'] !== undefined) {
-                    body = parameters['geneIds'];
+                if (parameters['pfamAccessions'] !== undefined) {
+                    body = parameters['pfamAccessions'];
                 }
 
-                if (parameters['geneIds'] === undefined) {
-                    reject(new Error('Missing required  parameter: geneIds'));
+                if (parameters['pfamAccessions'] === undefined) {
+                    reject(new Error('Missing required  parameter: pfamAccessions'));
                     return;
                 }
 
@@ -446,14 +1014,14 @@ export default class GenomeNexusAPI {
             });
         };
 
-    fetchPfamDomainsByGeneIdGETURL(parameters: {
-        'geneId': string,
+    fetchPfamDomainsByAccessionGETURL(parameters: {
+        'pfamAccession': string,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
-        let path = '/pfam/domain/gene/{geneId}';
+        let path = '/pfam/domain/{pfamAccession}';
 
-        path = path.replace('{geneId}', parameters['geneId'] + '');
+        path = path.replace('{pfamAccession}', parameters['pfamAccession'] + '');
 
         if (parameters.$queryParameters) {
             Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
@@ -466,496 +1034,47 @@ export default class GenomeNexusAPI {
     };
 
     /**
-     * Retrieves PFAM domains by an Ensembl gene ID
+     * Retrieves a PFAM domain by a PFAM domain ID
      * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByGeneIdGET
-     * @param {string} geneId - An Ensembl gene ID. For example ENSG00000136999
+     * @name GenomeNexusAPI#fetchPfamDomainsByAccessionGET
+     * @param {string} pfamAccession - A PFAM domain accession ID. For example PF02827
      */
-    fetchPfamDomainsByGeneIdGET(parameters: {
-            'geneId': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < PfamDomain >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/pfam/domain/gene/{geneId}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{geneId}', parameters['geneId'] + '');
-
-                if (parameters['geneId'] === undefined) {
-                    reject(new Error('Missing required  parameter: geneId'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchPfamDomainsByPfamIdsPOSTURL(parameters: {
-        'pfamDomainIds': Array < string > ,
-        $queryParameters ? : any
-    }): string {
+    fetchPfamDomainsByAccessionGET(parameters: {
+        'pfamAccession': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < PfamDomain > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/pfam/domain/{pfamAccession}';
+        let body: any;
         let queryParameters: any = {};
-        let path = '/pfam/domain/id';
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
 
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+            path = path.replace('{pfamAccession}', parameters['pfamAccession'] + '');
+
+            if (parameters['pfamAccession'] === undefined) {
+                reject(new Error('Missing required  parameter: pfamAccession'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
     };
-
-    /**
-     * Retrieves PFAM domains by PFAM domain IDs
-     * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByPfamIdsPOST
-     * @param {} pfamDomainIds - List of PFAM domain IDs. For example ["PF02827","PF00093","PF15276"]
-     */
-    fetchPfamDomainsByPfamIdsPOST(parameters: {
-            'pfamDomainIds': Array < string > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < PfamDomain >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/pfam/domain/id';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters['pfamDomainIds'] !== undefined) {
-                    body = parameters['pfamDomainIds'];
-                }
-
-                if (parameters['pfamDomainIds'] === undefined) {
-                    reject(new Error('Missing required  parameter: pfamDomainIds'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchPfamDomainsByPfamIdGETURL(parameters: {
-        'pfamDomainId': string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/pfam/domain/id/{pfamDomainId}';
-
-        path = path.replace('{pfamDomainId}', parameters['pfamDomainId'] + '');
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves PFAM domains by a PFAM domain ID
-     * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByPfamIdGET
-     * @param {string} pfamDomainId - A PFAM domain ID. For example PF02827
-     */
-    fetchPfamDomainsByPfamIdGET(parameters: {
-            'pfamDomainId': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < PfamDomain >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/pfam/domain/id/{pfamDomainId}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{pfamDomainId}', parameters['pfamDomainId'] + '');
-
-                if (parameters['pfamDomainId'] === undefined) {
-                    reject(new Error('Missing required  parameter: pfamDomainId'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchPfamDomainsByProteinIdsPOSTURL(parameters: {
-        'proteinIds': Array < string > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/pfam/domain/protein';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves PFAM domains by Ensembl protein IDs
-     * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByProteinIdsPOST
-     * @param {} proteinIds - List of Ensembl protein IDs. For example ["ENSP00000439985","ENSP00000478460","ENSP00000346196"]
-     */
-    fetchPfamDomainsByProteinIdsPOST(parameters: {
-            'proteinIds': Array < string > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < PfamDomain >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/pfam/domain/protein';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters['proteinIds'] !== undefined) {
-                    body = parameters['proteinIds'];
-                }
-
-                if (parameters['proteinIds'] === undefined) {
-                    reject(new Error('Missing required  parameter: proteinIds'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchPfamDomainsByProteinIdGETURL(parameters: {
-        'proteinId': string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/pfam/domain/protein/{proteinId}';
-
-        path = path.replace('{proteinId}', parameters['proteinId'] + '');
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves PFAM domains by an Ensembl protein ID
-     * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByProteinIdGET
-     * @param {string} proteinId - An Ensembl protein ID. For example ENSP00000439985
-     */
-    fetchPfamDomainsByProteinIdGET(parameters: {
-            'proteinId': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < PfamDomain >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/pfam/domain/protein/{proteinId}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{proteinId}', parameters['proteinId'] + '');
-
-                if (parameters['proteinId'] === undefined) {
-                    reject(new Error('Missing required  parameter: proteinId'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchPfamDomainsByTranscriptIdsPOSTURL(parameters: {
-        'transcriptIds': Array < string > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/pfam/domain/transcript';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves PFAM domains by Ensembl transcript IDs
-     * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByTranscriptIdsPOST
-     * @param {} transcriptIds - List of Ensembl transcript IDs. For example ["ENST00000361390","ENST00000361453","ENST00000361624"]
-     */
-    fetchPfamDomainsByTranscriptIdsPOST(parameters: {
-            'transcriptIds': Array < string > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < PfamDomain >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/pfam/domain/transcript';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters['transcriptIds'] !== undefined) {
-                    body = parameters['transcriptIds'];
-                }
-
-                if (parameters['transcriptIds'] === undefined) {
-                    reject(new Error('Missing required  parameter: transcriptIds'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchPfamDomainsByTranscriptIdGETURL(parameters: {
-        'transcriptId': string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/pfam/domain/transcript/{transcriptId}';
-
-        path = path.replace('{transcriptId}', parameters['transcriptId'] + '');
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves PFAM domains by an Ensembl transcript ID
-     * @method
-     * @name GenomeNexusAPI#fetchPfamDomainsByTranscriptIdGET
-     * @param {string} transcriptId - An Ensembl transcript ID. For example ENST00000361390
-     */
-    fetchPfamDomainsByTranscriptIdGET(parameters: {
-            'transcriptId': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < PfamDomain >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/pfam/domain/transcript/{transcriptId}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{transcriptId}', parameters['transcriptId'] + '');
-
-                if (parameters['transcriptId'] === undefined) {
-                    reject(new Error('Missing required  parameter: transcriptId'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    getGeneXrefsURL(parameters: {
-        'accession': string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/xrefs/{accession}';
-
-        path = path.replace('{accession}', parameters['accession'] + '');
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Perform lookups of Ensembl identifiers and retrieve their external referenes in other databases
-     * @method
-     * @name GenomeNexusAPI#getGeneXrefs
-     * @param {string} accession - Ensembl gene accession. For example ENSG00000169083
-     */
-    getGeneXrefs(parameters: {
-            'accession': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < GeneXref >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/xrefs/{accession}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{accession}', parameters['accession'] + '');
-
-                if (parameters['accession'] === undefined) {
-                    reject(new Error('Missing required  parameter: accession'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
 
 }

--- a/src/shared/api/generated/GenomeNexusAPIInternal-docs.json
+++ b/src/shared/api/generated/GenomeNexusAPIInternal-docs.json
@@ -15,6 +15,10 @@
   "basePath": "/",
   "tags": [
     {
+      "name": "cross-reference-controller",
+      "description": "Cross Reference Controller"
+    },
+    {
       "name": "cancer-hotspots-controller",
       "description": "Cancer Hotspots Controller"
     },
@@ -25,10 +29,6 @@
     {
       "name": "isoform-override-controller",
       "description": "Isoform Override Controller"
-    },
-    {
-      "name": "ensembl-controller",
-      "description": "Ensembl Controller"
     }
   ],
   "schemes": [
@@ -105,345 +105,6 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Hotspot"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript": {
-      "get": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves all Ensembl Transcripts",
-        "operationId": "fetchAllEnsemblTranscriptsGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/gene": {
-      "post": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Ensembl transcripts by Ensembl gene IDs",
-        "operationId": "fetchEnsemblTranscriptsByGeneIdsPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "geneIds",
-            "description": "List of Ensembl gene IDs. For example [\"ENSG00000136999\",\"ENSG00000272398\",\"ENSG00000198695\"]",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/gene/{geneId}": {
-      "get": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Ensembl transcripts by an Ensembl gene ID",
-        "operationId": "fetchEnsemblTranscriptsByGeneIdGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "geneId",
-            "in": "path",
-            "description": "An Ensembl gene ID. For example ENSG00000136999",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/hgnc": {
-      "post": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Ensembl transcripts by Hugo Symbols",
-        "operationId": "fetchEnsemblTranscriptsByHugoSymbolsPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "hugoSymbols",
-            "description": "List of Hugo Symbols. For example [\"TP53\",\"PIK3CA\",\"BRCA1\"]",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "isoformOverrideSource",
-            "in": "query",
-            "description": "Isoform override source. For example uniprot",
-            "required": false,
-            "type": "string",
-            "default": "uniprot"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/hgnc/{hugoSymbol}": {
-      "get": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Ensembl transcripts by an Ensembl gene ID",
-        "operationId": "fetchEnsemblTranscriptsByHugoSymbolGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "hugoSymbol",
-            "in": "path",
-            "description": "A Hugo Symbol. For example TP53",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "isoformOverrideSource",
-            "in": "query",
-            "description": "Isoform override source. For example uniprot",
-            "required": false,
-            "type": "string",
-            "default": "uniprot"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/EnsemblTranscript"
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/id": {
-      "post": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Ensembl Transcripts by Ensembl transcript IDs",
-        "operationId": "fetchEnsemblTranscriptsByTranscriptIdsPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "transcriptIds",
-            "description": "List of Ensembl transcript IDs. For example [\"ENST00000361390\",\"ENST00000361453\",\"ENST00000361624\"]",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/id/{transcriptId}": {
-      "get": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Transcripts by an Ensembl transcript ID",
-        "operationId": "fetchEnsemblTranscriptsByTranscriptIdGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "transcriptId",
-            "in": "path",
-            "description": "An Ensembl transcript ID. For example ENST00000361390",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/protein": {
-      "post": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Ensembl transcripts by Ensembl protein IDs",
-        "operationId": "fetchEnsemblTranscriptsByProteinIdsPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "proteinIds",
-            "description": "List of Ensembl protein IDs. For example [\"ENSP00000439985\",\"ENSP00000478460\",\"ENSP00000346196\"]",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ensembl/transcript/protein/{proteinId}": {
-      "get": {
-        "tags": [
-          "ensembl-controller"
-        ],
-        "summary": "Retrieves Ensembl transcripts by an Ensembl protein ID",
-        "operationId": "fetchEnsemblTranscriptsByProteinIdGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "proteinId",
-            "in": "path",
-            "description": "An Ensembl protein ID. For example ENSP00000439985",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EnsemblTranscript"
               }
             }
           }
@@ -668,33 +329,94 @@
           }
         }
       }
+    },
+    "/xrefs/{accession}": {
+      "get": {
+        "tags": [
+          "cross-reference-controller"
+        ],
+        "summary": "Perform lookups of Ensembl identifiers and retrieve their external references in other databases",
+        "operationId": "fetchGeneXrefsGET_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "accession",
+            "in": "path",
+            "description": "Ensembl gene accession. For example ENSG00000169083",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GeneXref"
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
     }
   },
   "definitions": {
-    "EnsemblTranscript": {
+    "GeneXref": {
       "type": "object",
       "required": [
-        "geneId",
-        "proteinId",
-        "transcriptId"
+        "db_display_name",
+        "dbname",
+        "description",
+        "display_id",
+        "primary_id",
+        "version"
       ],
       "properties": {
-        "geneId": {
+        "db_display_name": {
           "type": "string",
-          "description": "Ensembl gene id"
+          "description": "Database display name"
         },
-        "proteinId": {
+        "dbname": {
           "type": "string",
-          "description": "Ensembl protein id"
+          "description": "Database name"
         },
-        "proteinLength": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Length of protein"
-        },
-        "transcriptId": {
+        "description": {
           "type": "string",
-          "description": "Ensembl transcript id"
+          "description": "Description"
+        },
+        "display_id": {
+          "type": "string",
+          "description": "Display id"
+        },
+        "info_text": {
+          "type": "string",
+          "description": "Database info text"
+        },
+        "info_types": {
+          "type": "string",
+          "description": "Database info type"
+        },
+        "primary_id": {
+          "type": "string",
+          "description": "Primary id"
+        },
+        "synonyms": {
+          "type": "array",
+          "description": "Synonyms",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string",
+          "description": "Version"
         }
       }
     },

--- a/src/shared/api/generated/GenomeNexusAPIInternal.ts
+++ b/src/shared/api/generated/GenomeNexusAPIInternal.ts
@@ -1,14 +1,24 @@
 import * as request from "superagent";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
-export type EnsemblTranscript = {
-    'geneId': string
+export type GeneXref = {
+    'db_display_name': string
 
-        'proteinId': string
+        'dbname': string
 
-        'proteinLength': number
+        'description': string
 
-        'transcriptId': string
+        'display_id': string
+
+        'info_text': string
+
+        'info_types': string
+
+        'primary_id': string
+
+        'synonyms': Array < string >
+
+        'version': string
 
 };
 export type Hotspot = {
@@ -249,590 +259,6 @@ export default class GenomeNexusAPIInternal {
 
                 if (parameters['variant'] === undefined) {
                     reject(new Error('Missing required  parameter: variant'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchAllEnsemblTranscriptsGETURL(parameters: {
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves all Ensembl Transcripts
-     * @method
-     * @name GenomeNexusAPIInternal#fetchAllEnsemblTranscriptsGET
-     */
-    fetchAllEnsemblTranscriptsGET(parameters: {
-            $queryParameters ? : any,
-                $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchEnsemblTranscriptsByGeneIdsPOSTURL(parameters: {
-        'geneIds': Array < string > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/gene';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Ensembl transcripts by Ensembl gene IDs
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByGeneIdsPOST
-     * @param {} geneIds - List of Ensembl gene IDs. For example ["ENSG00000136999","ENSG00000272398","ENSG00000198695"]
-     */
-    fetchEnsemblTranscriptsByGeneIdsPOST(parameters: {
-            'geneIds': Array < string > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript/gene';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters['geneIds'] !== undefined) {
-                    body = parameters['geneIds'];
-                }
-
-                if (parameters['geneIds'] === undefined) {
-                    reject(new Error('Missing required  parameter: geneIds'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchEnsemblTranscriptsByGeneIdGETURL(parameters: {
-        'geneId': string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/gene/{geneId}';
-
-        path = path.replace('{geneId}', parameters['geneId'] + '');
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Ensembl transcripts by an Ensembl gene ID
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByGeneIdGET
-     * @param {string} geneId - An Ensembl gene ID. For example ENSG00000136999
-     */
-    fetchEnsemblTranscriptsByGeneIdGET(parameters: {
-            'geneId': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript/gene/{geneId}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{geneId}', parameters['geneId'] + '');
-
-                if (parameters['geneId'] === undefined) {
-                    reject(new Error('Missing required  parameter: geneId'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchEnsemblTranscriptsByHugoSymbolsPOSTURL(parameters: {
-        'hugoSymbols': Array < string > ,
-        'isoformOverrideSource' ? : string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/hgnc';
-
-        if (parameters['isoformOverrideSource'] !== undefined) {
-            queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
-        }
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Ensembl transcripts by Hugo Symbols
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByHugoSymbolsPOST
-     * @param {} hugoSymbols - List of Hugo Symbols. For example ["TP53","PIK3CA","BRCA1"]
-     * @param {string} isoformOverrideSource - Isoform override source. For example uniprot
-     */
-    fetchEnsemblTranscriptsByHugoSymbolsPOST(parameters: {
-            'hugoSymbols': Array < string > ,
-            'isoformOverrideSource' ? : string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript/hgnc';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters['hugoSymbols'] !== undefined) {
-                    body = parameters['hugoSymbols'];
-                }
-
-                if (parameters['hugoSymbols'] === undefined) {
-                    reject(new Error('Missing required  parameter: hugoSymbols'));
-                    return;
-                }
-
-                if (parameters['isoformOverrideSource'] !== undefined) {
-                    queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchEnsemblTranscriptsByHugoSymbolGETURL(parameters: {
-        'hugoSymbol': string,
-        'isoformOverrideSource' ? : string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/hgnc/{hugoSymbol}';
-
-        path = path.replace('{hugoSymbol}', parameters['hugoSymbol'] + '');
-        if (parameters['isoformOverrideSource'] !== undefined) {
-            queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
-        }
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Ensembl transcripts by an Ensembl gene ID
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByHugoSymbolGET
-     * @param {string} hugoSymbol - A Hugo Symbol. For example TP53
-     * @param {string} isoformOverrideSource - Isoform override source. For example uniprot
-     */
-    fetchEnsemblTranscriptsByHugoSymbolGET(parameters: {
-        'hugoSymbol': string,
-        'isoformOverrideSource' ? : string,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < EnsemblTranscript > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/ensembl/transcript/hgnc/{hugoSymbol}';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            path = path.replace('{hugoSymbol}', parameters['hugoSymbol'] + '');
-
-            if (parameters['hugoSymbol'] === undefined) {
-                reject(new Error('Missing required  parameter: hugoSymbol'));
-                return;
-            }
-
-            if (parameters['isoformOverrideSource'] !== undefined) {
-                queryParameters['isoformOverrideSource'] = parameters['isoformOverrideSource'];
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        }).then(function(response: request.Response) {
-            return response.body;
-        });
-    };
-
-    fetchEnsemblTranscriptsByTranscriptIdsPOSTURL(parameters: {
-        'transcriptIds': Array < string > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/id';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Ensembl Transcripts by Ensembl transcript IDs
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByTranscriptIdsPOST
-     * @param {} transcriptIds - List of Ensembl transcript IDs. For example ["ENST00000361390","ENST00000361453","ENST00000361624"]
-     */
-    fetchEnsemblTranscriptsByTranscriptIdsPOST(parameters: {
-            'transcriptIds': Array < string > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript/id';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters['transcriptIds'] !== undefined) {
-                    body = parameters['transcriptIds'];
-                }
-
-                if (parameters['transcriptIds'] === undefined) {
-                    reject(new Error('Missing required  parameter: transcriptIds'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchEnsemblTranscriptsByTranscriptIdGETURL(parameters: {
-        'transcriptId': string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/id/{transcriptId}';
-
-        path = path.replace('{transcriptId}', parameters['transcriptId'] + '');
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Transcripts by an Ensembl transcript ID
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByTranscriptIdGET
-     * @param {string} transcriptId - An Ensembl transcript ID. For example ENST00000361390
-     */
-    fetchEnsemblTranscriptsByTranscriptIdGET(parameters: {
-            'transcriptId': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript/id/{transcriptId}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{transcriptId}', parameters['transcriptId'] + '');
-
-                if (parameters['transcriptId'] === undefined) {
-                    reject(new Error('Missing required  parameter: transcriptId'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchEnsemblTranscriptsByProteinIdsPOSTURL(parameters: {
-        'proteinIds': Array < string > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/protein';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Ensembl transcripts by Ensembl protein IDs
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByProteinIdsPOST
-     * @param {} proteinIds - List of Ensembl protein IDs. For example ["ENSP00000439985","ENSP00000478460","ENSP00000346196"]
-     */
-    fetchEnsemblTranscriptsByProteinIdsPOST(parameters: {
-            'proteinIds': Array < string > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript/protein';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                if (parameters['proteinIds'] !== undefined) {
-                    body = parameters['proteinIds'];
-                }
-
-                if (parameters['proteinIds'] === undefined) {
-                    reject(new Error('Missing required  parameter: proteinIds'));
-                    return;
-                }
-
-                if (parameters.$queryParameters) {
-                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                        var parameter = parameters.$queryParameters[parameterName];
-                        queryParameters[parameterName] = parameter;
-                    });
-                }
-
-                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-            }).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-
-    fetchEnsemblTranscriptsByProteinIdGETURL(parameters: {
-        'proteinId': string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/ensembl/transcript/protein/{proteinId}';
-
-        path = path.replace('{proteinId}', parameters['proteinId'] + '');
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Retrieves Ensembl transcripts by an Ensembl protein ID
-     * @method
-     * @name GenomeNexusAPIInternal#fetchEnsemblTranscriptsByProteinIdGET
-     * @param {string} proteinId - An Ensembl protein ID. For example ENSP00000439985
-     */
-    fetchEnsemblTranscriptsByProteinIdGET(parameters: {
-            'proteinId': string,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < EnsemblTranscript >
-        > {
-            const domain = parameters.$domain ? parameters.$domain : this.domain;
-            const errorHandlers = this.errorHandlers;
-            const request = this.request;
-            let path = '/ensembl/transcript/protein/{proteinId}';
-            let body: any;
-            let queryParameters: any = {};
-            let headers: any = {};
-            let form: any = {};
-            return new Promise(function(resolve, reject) {
-                headers['Accept'] = 'application/json';
-                headers['Content-Type'] = 'application/json';
-
-                path = path.replace('{proteinId}', parameters['proteinId'] + '');
-
-                if (parameters['proteinId'] === undefined) {
-                    reject(new Error('Missing required  parameter: proteinId'));
                     return;
                 }
 
@@ -1246,5 +672,69 @@ export default class GenomeNexusAPIInternal {
             return response.body;
         });
     };
+
+    fetchGeneXrefsGET_1URL(parameters: {
+        'accession': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/xrefs/{accession}';
+
+        path = path.replace('{accession}', parameters['accession'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Perform lookups of Ensembl identifiers and retrieve their external references in other databases
+     * @method
+     * @name GenomeNexusAPIInternal#fetchGeneXrefsGET_1
+     * @param {string} accession - Ensembl gene accession. For example ENSG00000169083
+     */
+    fetchGeneXrefsGET_1(parameters: {
+            'accession': string,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < GeneXref >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/xrefs/{accession}';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                path = path.replace('{accession}', parameters['accession'] + '');
+
+                if (parameters['accession'] === undefined) {
+                    reject(new Error('Missing required  parameter: accession'));
+                    return;
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
 
 }

--- a/src/shared/lib/PfamUtils.spec.ts
+++ b/src/shared/lib/PfamUtils.spec.ts
@@ -1,71 +1,35 @@
 import * as _ from 'lodash';
 import { assert } from 'chai';
-import {PfamDomain} from "shared/api/generated/GenomeNexusAPI";
+import {PfamDomainRange} from "shared/api/generated/GenomeNexusAPI";
 import {generatePfamDomainColorMap} from "./PfamUtils";
 
-let domains: PfamDomain[];
+let domains: PfamDomainRange[];
 
 before(() => {
     domains = [{
-        geneId: "ENSG00000198742",
-        geneSymbol: "SMURF1",
-        pfamDomainDescription: "Domain 2",
-        pfamDomainEnd: 11,
         pfamDomainId: "PF0002",
-        pfamDomainName: "Dmn2",
         pfamDomainStart: 7,
-        proteinId: "ENSP0001",
-        transcriptId: "ENST00000361125"
+        pfamDomainEnd: 9,
     }, {
-        geneId: "ENSG00000198742",
-        geneSymbol: "SMURF1",
-        pfamDomainDescription: "Domain 2",
-        pfamDomainEnd: 29,
         pfamDomainId: "PF0002",
-        pfamDomainName: "Dmn2",
         pfamDomainStart: 23,
-        proteinId: "ENSP0001",
-        transcriptId: "ENST00000361125"
+        pfamDomainEnd: 29,
     }, {
-        geneId: "ENSG00000198742",
-        geneSymbol: "SMURF1",
-        pfamDomainDescription: "Domain 1",
-        pfamDomainEnd: 5,
         pfamDomainId: "PF0001",
-        pfamDomainName: "Dmn1",
         pfamDomainStart: 2,
-        proteinId: "ENSP0001",
-        transcriptId: "ENST00000361125"
+        pfamDomainEnd: 5,
     }, {
-        geneId: "ENSG00000198742",
-        geneSymbol: "SMURF1",
-        pfamDomainDescription: "Domain 1",
-        pfamDomainEnd: 89,
         pfamDomainId: "PF0001",
-        pfamDomainName: "Dmn1",
         pfamDomainStart: 61,
-        proteinId: "ENSP0001",
-        transcriptId: "ENST00000361125"
+        pfamDomainEnd: 89,
     }, {
-        geneId: "ENSG00000198742",
-        geneSymbol: "SMURF1",
-        pfamDomainDescription: "Domain 4",
-        pfamDomainEnd: 41,
         pfamDomainId: "PF0004",
-        pfamDomainName: "Dmn4",
         pfamDomainStart: 31,
-        proteinId: "ENSP0001",
-        transcriptId: "ENST00000361125"
+        pfamDomainEnd: 41,
     }, {
-        geneId: "ENSG00000198742",
-        geneSymbol: "SMURF1",
-        pfamDomainDescription: "Domain 3",
-        pfamDomainEnd: 17,
         pfamDomainId: "PF0003",
-        pfamDomainName: "Dmn3",
         pfamDomainStart: 13,
-        proteinId: "ENSP0003",
-        transcriptId: "ENST00000361368"
+        pfamDomainEnd: 17,
     }];
 });
 

--- a/src/shared/lib/PfamUtils.ts
+++ b/src/shared/lib/PfamUtils.ts
@@ -1,6 +1,6 @@
-import {PfamDomain} from "shared/api/generated/GenomeNexusAPI";
+import {PfamDomainRange} from "shared/api/generated/GenomeNexusAPI";
 
-export function generatePfamDomainColorMap(pfamDomains: PfamDomain[]): {[pfamAccession:string]: string}
+export function generatePfamDomainColorMap(pfamDomains: PfamDomainRange[]): {[pfamAccession:string]: string}
 {
     const colors: string[] = [
         "#2dcf00", "#ff5353", "#5b5bff", "#ebd61d", "#ba21e0",
@@ -15,9 +15,9 @@ export function generatePfamDomainColorMap(pfamDomains: PfamDomain[]): {[pfamAcc
     // sort domains by start position,
     // then assign a different color for each unique domain id.
     pfamDomains.sort(
-        (a: PfamDomain, b: PfamDomain): number =>
+        (a: PfamDomainRange, b: PfamDomainRange): number =>
             a.pfamDomainStart - b.pfamDomainStart
-    ).forEach((domain:PfamDomain) => {
+    ).forEach((domain:PfamDomainRange) => {
         if (map[domain.pfamDomainId] === undefined)
         {
             map[domain.pfamDomainId] = colors[colorIdx % colors.length];

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -100,19 +100,19 @@ export async function fetchUniprotId(swissProtAccession: string)
     return uniprotData.text.split("\n")[1];
 }
 
-export async function fetchPfamDomainData(ensemblTranscriptId: string,
+export async function fetchPfamDomainData(pfamAccessions: string[],
                                           client:GenomeNexusAPI = genomeNexusClient)
 {
-    return await client.fetchPfamDomainsByTranscriptIdGET({
-        transcriptId: ensemblTranscriptId
+    return await client.fetchPfamDomainsByPfamAccessionPOST({
+        pfamAccessions: pfamAccessions
     });
 }
 
 export async function fetchCanonicalTranscript(hugoSymbol: string,
                                                isoformOverrideSource: string,
-                                               client:GenomeNexusAPIInternal = genomeNexusInternalClient)
+                                               client:GenomeNexusAPI = genomeNexusClient)
 {
-    return await client.fetchEnsemblTranscriptsByHugoSymbolGET({
+    return await client.fetchCanonicalEnsemblTranscriptByHugoSymbolGET({
         hugoSymbol, isoformOverrideSource
     });
 }


### PR DESCRIPTION
We now return the pfam ids and ranges as part of ensembl canonical transcript
response. Update lollipop store and plot accordingly.