### PR TITLE
Improve detection of overlap detection based on patterns in studyId

### DIFF
--- a/src/shared/lib/getOverlappingStudies.spec.ts
+++ b/src/shared/lib/getOverlappingStudies.spec.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import getOverlappingStudies from "./getOverlappingStudies";
 import {CancerStudy} from "../api/generated/CBioPortalAPI";
 
-describe('getOverlappingStudies',()=>{
+describe.only('getOverlappingStudies',()=>{
 
     it('finds overlapping studies based on pub/nonpub signature in studyId', ()=>{
 
@@ -13,7 +13,7 @@ describe('getOverlappingStudies',()=>{
 
         let ret = getOverlappingStudies(studies as CancerStudy[]);
 
-        assert.equal(ret.length, 0);
+        assert.equal(ret.length, 0, 'shouldn\'t find anything');
 
         // now adjust
         studies = [
@@ -25,6 +25,49 @@ describe('getOverlappingStudies',()=>{
 
         assert.equal(ret[0][0].studyId,'moo_tcga');
         assert.equal(ret[0][1].studyId,'moo_tcga_pub');
+
+    });
+
+    it('finds overlapping studies based on year suffix', ()=>{
+
+        let studies = [
+            { studyId:'moo_tcga_2016'},
+            { studyId: 'moo_tcga_2015'},
+            { studyId: 'doo_tcga_2011'},
+            { studyId: 'doo_tcga_2012'},
+            { studyId: 'scoo_tcga_2011'},
+            { studyId: 'floo_tcga_2012'}
+        ];
+
+        let ret = getOverlappingStudies(studies as CancerStudy[]);
+
+        assert.equal(ret.length, 2);
+
+    });
+
+    it('doesn\'nt detect non TCGA stuides', ()=>{
+
+        let studies = [
+            { studyId: 'blca_mskcc_solit_2014'},
+            { studyId: 'blca_mskcc_solit_2012'}
+        ];
+
+        let ret = getOverlappingStudies(studies as CancerStudy[]);
+
+        assert.equal(ret.length, 0);
+
+    });
+
+    it('finds them when year and pub are suffixes', ()=>{
+
+        let studies = [
+            { studyId: 'brca_tcga_pub2015' },
+            { studyId: 'brca_tcga_pub'}
+        ];
+
+        let ret = getOverlappingStudies(studies as CancerStudy[]);
+
+        assert.equal(ret.length, 1);
 
     });
 

--- a/src/shared/lib/getOverlappingStudies.ts
+++ b/src/shared/lib/getOverlappingStudies.ts
@@ -1,19 +1,19 @@
 import {CancerStudy} from "../api/generated/CBioPortalAPI";
 import * as _ from 'lodash';
 
-//testIt
 export default function getOverlappingStudies(studies: CancerStudy[]):CancerStudy[][] {
     const groupedTCGAStudies = _.reduce(studies,(memo, study:CancerStudy)=>{
         if (/_tcga/.test(study.studyId)) {
-            const initial = study.studyId.match(/^[^_]*_[^_]*/);
+            const initial = study.studyId.replace(/(_\d\d\d\d|_pub|(_pub\d\d\d\d))$/,'');
             if (initial) {
-                if (initial[0] in memo) {
-                    memo[initial[0]].push(study);
+                if (initial in memo) {
+                    memo[initial].push(study);
                 } else {
-                    memo[initial[0]] = [study];
+                    memo[initial] = [study];
                 }
             }
         }
+
         return memo;
     }, {} as { [studyId:string]:CancerStudy[] });
     return _.filter(groupedTCGAStudies, (grouping)=>grouping.length > 1);


### PR DESCRIPTION
The following patters are considered overlapping (same samples may be included):
###_tcga_pub
###_tcga_pub2016
###_tcta_####_###
###_tcg

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
