### PR TITLE
Allow user input value for diagram y axis to go over the actual max

### DIFF
--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -353,17 +353,19 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
 
         this.handlers = {
             handleYAxisMaxSliderChange: action((event:any)=>{
-                let inputValue:string = (event.target as HTMLInputElement).value;
-                this._yMaxInput = _.clamp(parseInt(inputValue, 10), this.countRange[0], this.countRange[1]);
+                const inputValue:string = (event.target as HTMLInputElement).value;
+                const value = parseInt(inputValue, 10);
+                this._yMaxInput = value < this.countRange[0] ? this.countRange[0] : value;
             }),
-            handleYAxisMaxChange: action((val:string)=>{
-                this._yMaxInput = _.clamp(parseInt(val, 10), this.countRange[0], this.countRange[1]);
+            handleYAxisMaxChange: action((inputValue:string)=>{
+                const value = parseInt(inputValue, 10);
+                this._yMaxInput = value < this.countRange[0] ? this.countRange[0] : value;
             }),
             handleSVGClick:()=>{
                 fileDownload(this.toSVGDOMNode().outerHTML,`${this.hugoGeneSymbol}_lollipop.svg`);
             },
             handlePDFClick:()=>{
-                this.downloadAsPDF(`${this.hugoGeneSymbol}_lollipop.pdf`)
+                this.downloadAsPDF(`${this.hugoGeneSymbol}_lollipop.pdf`);
             },
             onYMaxInputFocused:()=>{
                 this.yMaxInputFocused = true;
@@ -380,8 +382,14 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
         };
     }
 
-    @computed get yMax() {
+    @computed get yMaxSlider() {
+        // we don't want max slider value to go over the actual max, even if the user input goes over it
         return Math.min(this.countRange[1], this._yMaxInput || this.countRange[1]);
+    }
+
+    @computed get yMaxInput() {
+        // allow the user input value to go over the actual count rage
+        return this._yMaxInput || this.countRange[1];
     }
 
     private get legend() {
@@ -457,11 +465,11 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                                         max={this.countRange[1]}
                                         step="1"
                                         onChange={this.handlers.handleYAxisMaxSliderChange}
-                                        value={this.yMax}
+                                        value={this.yMaxSlider}
                                     />
                                     <EditableSpan
                                         className={styles["ymax-number-input"]}
-                                        value={this.yMax + ""}
+                                        value={`${this.yMaxInput}`}
                                         setValue={this.handlers.handleYAxisMaxChange}
                                         numericOnly={true}
                                         onFocus={this.handlers.onYMaxInputFocused}
@@ -495,7 +503,7 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                                 this.props.store.canonicalTranscript.result.proteinLength) ||
                             (this.props.store.gene.length / 3)
                         }
-                        yMax={this.yMax}
+                        yMax={this.yMaxInput}
                         onXAxisOffset={this.props.onXAxisOffset}
                     />
                 </div>


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/3350.

![mut-dia-y-axis](https://user-images.githubusercontent.com/3604198/33461394-3ac4b1b2-d600-11e7-84a5-27ed4d44f526.png)

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)