### PR TITLE
Switch to sorting by data in oncoprint if clinical or heatmap track...

### DIFF
--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -320,14 +320,14 @@ function transitionTracks(
     const prevHeatmapTracks = _.keyBy(prevProps.heatmapTracks || [], track=>track.key);
     for (const track of nextProps.heatmapTracks) {
         transitionHeatmapTrack(track, prevHeatmapTracks[track.key], getTrackSpecKeyToTrackId,
-                                oncoprint, trackIdForRuleSetSharing);
+                                oncoprint, nextProps, trackIdForRuleSetSharing);
         delete prevHeatmapTracks[track.key];
     }
     for (const track of (prevProps.heatmapTracks || [])) {
         if (prevHeatmapTracks.hasOwnProperty(track.key)) {
             // if its still there, then this track no longer exists
             transitionHeatmapTrack(undefined, prevHeatmapTracks[track.key], getTrackSpecKeyToTrackId,
-                                oncoprint, trackIdForRuleSetSharing);
+                                oncoprint, nextProps, trackIdForRuleSetSharing);
         }
     }
 }
@@ -459,7 +459,8 @@ function transitionClinicalTrack(
             //track_info: "\u23f3",
             sortCmpFn: getClinicalTrackSortComparator(nextSpec),
             init_sort_direction: 0 as 0,
-            target_group: 0
+            target_group: 0,
+            onSortDirectionChange: nextProps.onTrackSortDirectionChange
         };
         trackSpecKeyToTrackId[nextSpec.key] = oncoprint.addTracks([clinicalTrackParams])[0];
     } else if (nextSpec && prevSpec) {
@@ -478,6 +479,7 @@ function transitionHeatmapTrack(
     prevSpec:HeatmapTrackSpec|undefined,
     getTrackSpecKeyToTrackId:()=>{[key:string]:TrackId},
     oncoprint:OncoprintJS<any>,
+    nextProps:IOncoprintProps,
     trackIdForRuleSetSharing:{heatmap?:TrackId}
 ) {
     const trackSpecKeyToTrackId = getTrackSpecKeyToTrackId();
@@ -502,7 +504,8 @@ function transitionHeatmapTrack(
             sortCmpFn: heatmapTrackSortComparator,
             init_sort_direction: 0 as 0,
             description: `${nextSpec.label} data from ${nextSpec.molecularProfileId}`,
-            tooltipFn: makeHeatmapTrackTooltip(nextSpec.molecularAlterationType, true)
+            tooltipFn: makeHeatmapTrackTooltip(nextSpec.molecularAlterationType, true),
+            onSortDirectionChange: nextProps.onTrackSortDirectionChange
         };
         const newTrackId = oncoprint.addTracks([heatmapTrackParams])[0];
         trackSpecKeyToTrackId[nextSpec.key] = newTrackId;

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -121,6 +121,7 @@ export interface IOncoprintProps {
 
     onMinimapClose?:()=>void;
     onDeleteClinicalTrack?:(key:string)=>void;
+    onTrackSortDirectionChange?: (trackId:TrackId, dir:number)=>void;
 
     suppressRendering?:boolean;
 }

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -23,7 +23,7 @@ import _ from "lodash";
 import onMobxPromise from "shared/lib/onMobxPromise";
 import AppConfig from "appConfig";
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
-import OncoprintJS from "oncoprintjs";
+import OncoprintJS, {TrackId} from "oncoprintjs";
 import fileDownload from 'react-file-download';
 import svgToPdfDownload from "shared/lib/svgToPdfDownload";
 import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
@@ -134,6 +134,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         this.onMinimapClose = this.onMinimapClose.bind(this);
         this.oncoprintRef = this.oncoprintRef.bind(this);
         this.toggleColumnMode = this.toggleColumnMode.bind(this);
+        this.onTrackSortDirectionChange = this.onTrackSortDirectionChange.bind(this);
 
         onMobxPromise(this.props.store.heatmapMolecularProfiles, (profiles:MolecularProfile[])=>{
             // select first initially
@@ -604,6 +605,13 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         this.selectedClinicalAttributeIds.delete(this.clinicalTrackKeyToAttributeId(clinicalTrackKey));
     }
 
+    private onTrackSortDirectionChange(trackId:TrackId, dir:number) {
+        // called when a clinical or heatmap track is sorted a-Z or Z-a, selected from within oncoprintjs UI
+        if (dir === 1 || dir === -1) {
+            this.sortByData();
+        }
+    }
+
     readonly clinicalAttributes = remoteData({
         await:()=>[this.props.store.clinicalAttributes],
         invoke:()=>{
@@ -804,6 +812,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
 
                     onMinimapClose={this.onMinimapClose}
                     onDeleteClinicalTrack={this.onDeleteClinicalTrack}
+                    onTrackSortDirectionChange={this.onTrackSortDirectionChange}
                 />
             </div>
         );


### PR DESCRIPTION
...sort direction is selected

This only happens if 'Sort a->Z' or 'Sort Z->a' is selected, if 'Dont sort on this track' is selected then nothing else happens.
