### PR TITLE
Use symbolic links for getting pathology reports

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -224,14 +224,23 @@ export class PatientViewPageStore {
 
     readonly pathologyReport = remoteData({
         await: () => [this.derivedPatientId],
-        invoke: async() => {
+        invoke: () => {
+            const pathLinkUrl = "https://raw.githubusercontent.com/inodb/datahub/a0d36d77b242e32cda3175127de73805b028f595/tcga/pathology_reports/symlink_by_patient";
+            const rawPdfUrl = "https://github.com/cBioPortal/datahub/raw/master/tcga/pathology_reports";
+            const reports: PathologyReportPDF[] = [];
 
-            let resp: any = await request.get(`https://api.github.com/search/code?q=${this.patientId}+extension:pdf+in:path+repo:cBioPortal/datahub`);
-
-            const parsedResp: any = JSON.parse(resp.text);
-
-            return handlePathologyReportCheckResponse(this.patientId, parsedResp);
-
+            // keep checking if patient has more reports recursively
+            function getPathologyReport(patientId:string, i:number):any {
+                return request.get(`${pathLinkUrl}/${patientId}.${i}`).then(function(resp){
+                        // add report
+                        let pdfName: string = resp.text.split('/')[1];
+                        reports.push({name: `${pdfName}`, url: `${rawPdfUrl}/${pdfName}`});
+                        // check if patient has more reports
+                        return getPathologyReport(patientId, i+1);
+                    }, () => reports);
+            }
+            
+           return getPathologyReport(this.patientId, 0);
         },
         onError: (err: Error) => {
             // fail silently

--- a/src/pages/patientView/pathologyReport/PathologyReport.tsx
+++ b/src/pages/patientView/pathologyReport/PathologyReport.tsx
@@ -3,6 +3,7 @@ import {PathologyReportPDF} from "../clinicalInformation/PatientViewPageStore";
 import { If, Then, Else } from 'react-if';
 import * as _ from 'lodash';
 import IFrameLoader from "../../../shared/components/iframeLoader/IFrameLoader";
+import {observer} from "mobx-react";
 
 export type IPathologyReportProps = {
 
@@ -12,6 +13,7 @@ export type IPathologyReportProps = {
 }
 
 
+@observer
 export default class PathologyReport extends React.Component<IPathologyReportProps,{ pdfUrl:string; }> {
 
     pdfSelectList:any;
@@ -21,15 +23,15 @@ export default class PathologyReport extends React.Component<IPathologyReportPro
 
         super();
 
-        this.state = { pdfUrl: this.buildPDFUrl(props.pdfs[0].name) }
+        this.state = { pdfUrl: this.buildPDFUrl(props.pdfs[0].url) }
 
         this.handleSelection = this.handleSelection.bind(this);
 
     }
 
-    buildPDFUrl(name: string):string {
+    buildPDFUrl(url: string):string {
 
-        return `https://drive.google.com/viewerng/viewer?url=https://github.com/cBioPortal/datahub/raw/master/tcga/pathology_reports/${name}?pid=explorer&efh=false&a=v&chrome=false&embedded=true`;
+        return `https://drive.google.com/viewerng/viewer?url=${url}?pid=explorer&efh=false&a=v&chrome=false&embedded=true`;
 
     }
 
@@ -47,7 +49,7 @@ export default class PathologyReport extends React.Component<IPathologyReportPro
 
             <If condition={this.props.pdfs.length > 1}>
                 <select ref={(el)=>this.pdfSelectList = el} style={{ marginBottom:15 }} onChange={ this.handleSelection }>{  _.map(this.props.pdfs, (pdf: PathologyReportPDF)=>
-                    <option value={pdf.name}>{pdf.name}</option>)    }
+                    <option value={pdf.url}>{pdf.name}</option>)    }
                 </select>
             </If>
 


### PR DESCRIPTION
Fix cbioportal/cbioportal#3367

Instead of using the Github search API, which is rate limited, directly access
the symbolic links of type PATIENT_ID.number (patients can have multiple
reports). The symbolic links contain the name of the actual PDF file, which can
then be used to display the report.

3 reports:
http://www.cbioportal.org/case.do#/patient?caseId=TCGA-TQ-A7RK&navCaseIds=TCGA-TQ-A7RK&studyId=lgg_tcga&tab=pathologyReportTab

1 report:
http://www.cbioportal.org/case.do#/patient?caseId=TCGA-BK-A0CC&studyId=ucec_tcga_pub&tab=pathologyReportTab

no report:
http://www.cbioportal.org/case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04