### PR TITLE
Disable rerendering of mutations tabs

### DIFF
--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -45,6 +45,7 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
                         enablePagination={true}
                         arrowStyle={{'line-height':.8}}
                         tabButtonStyle="pills"
+                        unmountOnHide={true}
                     >
                         {this.generateTabs(this.props.genes)}
                     </MSKTabs>


### PR DESCRIPTION
This stops double calling the genome nexus endpoint when clicking on a tab. But there is still an issue that when switching back to the previous tab the data is not stored.