### PR TITLE
fix sample count in page header

### DIFF
--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -51,8 +51,8 @@ export default class QuerySummary extends React.Component<{ queryStore:QueryStor
         return <div>
             <h4><StudyLink study={this.props.store.studies.result[0]}/></h4>
             <span>
-                {(window as any).serverVars.caseSetProperties.case_set_name}
-                (<strong>{this.props.store.studies.result[0].allSampleCount}</strong> samples)
+                {(window as any).serverVars.caseSetProperties.case_set_name}&nbsp;
+                (<strong>{this.props.store.samples.result.length}</strong> samples)
                  / <strong>{this.props.store.hugoGeneSymbols.length}</strong> Genes
             </span>
         </div>


### PR DESCRIPTION
We were using sample count returned in study object.  This was not right.  Sample count should be the count of whatever us returned by samples service according to current query


# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
