### PR TITLE
Genome Nexus Cache and mutation table download improvements

### DIFF
--- a/src/shared/cache/GenomeNexusEnrichment.ts
+++ b/src/shared/cache/GenomeNexusEnrichment.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import genomeNexusClient from "shared/api/genomeNexusClientInstance";
 import {generateGenomeNexusQuery} from "shared/lib/GenomeNexusUtils";
 import {VariantAnnotation} from "shared/api/generated/GenomeNexusAPI";
@@ -20,9 +21,10 @@ export function fetch(queries: Mutation[]):Promise<VariantAnnotationEnriched[]> 
     if (queries.length > 0) {
         return genomeNexusClient.fetchVariantAnnotationPOST(
             {
-                variants: queries.map((m) => generateGenomeNexusQuery(m)),
-                // TODO: update genome nexus API to return all fields by
-                // default
+                variants: _.uniq(queries.map(
+                    mutation => generateGenomeNexusQuery(mutation)).filter(
+                        query => query.length > 0)),
+                // TODO: update genome nexus API to return all fields by default
                 fields: ['hotspots', 'mutation_assessor']
             }
         ) as Promise<VariantAnnotationEnriched[]>; 

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -1063,18 +1063,18 @@ describe('LazyMobXTable', ()=>{
     describe('downloading data', ()=>{
         it("gives just the column names when theres no data in the table", async ()=>{
             let table = mount(<Table columns={columns} data={[]}/>);
-            assert.deepEqual(await (table.instance() as LazyMobXTable<any>).getDownloadData(),
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n");
         });
         it("gives one row of data when theres one row. data given for every column, including hidden, and without download def'n. if no data, gives empty string for that cell.", async ()=>{
             let table = mount(<Table columns={columns} data={[data[0]]}/>);
-            assert.deepEqual(await (table.instance() as LazyMobXTable<any>).getDownloadData(),
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n");
         });
         it("gives data for all rows. data given for every column, including hidden, and without download def'n. if no data, gives empty string for that cell", async ()=>{
             let table = mount(<Table columns={columns} data={data}/>)
-            assert.deepEqual(await (table.instance() as LazyMobXTable<any>).getDownloadData(),
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n"+
                 "1\t6\tkdfjpo\t\t1HELLO123456\t\t\r\n"+
@@ -1085,7 +1085,7 @@ describe('LazyMobXTable', ()=>{
         it("gives data back in sorted order according to initially selected sort column and direction", async ()=>{
             let table = mount(<Table columns={columns} data={data} initialSortColumn="Number" initialSortDirection="asc"/>);
 
-            assert.deepEqual(await (table.instance() as LazyMobXTable<any>).getDownloadData(),
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "3\t-1\tzijxcpo\t\t3HELLO123456\t\t\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n"+
@@ -1096,7 +1096,7 @@ describe('LazyMobXTable', ()=>{
         
         it("gives data for data with multiple elements", async ()=>{
             let table = mount(<Table columns={columns} data={multiData}/>)
-            assert.deepEqual(await (table.instance() as LazyMobXTable<any>).getDownloadData(),
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n"+
                 "1\t6\tkdfjpo\t\t1HELLO123456\t\t\r\n"+


### PR DESCRIPTION
# What? Why?
- Improved genome nexus cache (Fix https://github.com/cBioPortal/cbioportal/issues/3540)
- Allowing partial table data download in case of a fetch error

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)