### PR TITLE
Fix cbioportal/cbioportal#2882 timeline axis

### DIFF
--- a/src/pages/patientView/timeline/legacy.js
+++ b/src/pages/patientView/timeline/legacy.js
@@ -53,6 +53,9 @@ function plotCaseLabelsInTimeline(caseIds, clinicalDataMap, caseMetaData) {
             window.pvTimeline.addDataPointTooltip(g);
         }
     }
+
+    // hack to keep axis visible (somehow visibility is set to hidden)
+    $("#timeline .axis").css({"visibility":"visible"});
 }
 
 export function buildTimeline(params, caseIds, patientInfo, clinicalDataMap, caseMetaData, data, width) {


### PR DESCRIPTION
The axis for some reason has visibility set to hidden which cause the axis to
disappear when zooming in/out on chrome. This is a simple hack for legacy code.

Fix cbioportal/cbioportal#2882

Test by zooming in and out at: http://www.cbioportal.org/case.do#/patient?caseId=P04&studyId=lgg_ucsf_2014