### PR TITLE
Removed duplicate PDF download logic from LollipopMutationPlot

### DIFF
--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -11,12 +11,12 @@ import Response = request.Response;
 import {observer, Observer} from "mobx-react";
 import {computed, observable, action} from "mobx";
 import _ from "lodash";
+import svgToPdfDownload from "shared/lib/svgToPdfDownload";
 import {longestCommonStartingSubstring} from "shared/lib/StringUtils";
 import {getColorForProteinImpactType, IProteinImpactTypeColors} from "shared/lib/MutationUtils";
 import {generatePfamDomainColorMap} from "shared/lib/PfamUtils";
 import {getMutationAlignerUrl} from "shared/api/urls";
 import ReactDOM from "react-dom";
-import {Form, Button, FormGroup, InputGroup} from "react-bootstrap";
 import fileDownload from "react-file-download";
 import styles from "./lollipopMutationPlot.module.scss";
 import Collapse from "react-collapse";
@@ -304,31 +304,6 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
         // Add label to top
     }
 
-    private base64ToArrayBuffer(base64:string) {
-        var binaryString = window.atob(base64);
-        var binaryLen = binaryString.length;
-        var bytes = new Uint8Array(binaryLen);
-        for (var i = 0; i < binaryLen; i++) {
-            var ascii = binaryString.charCodeAt(i);
-            bytes[i] = ascii;
-        }
-        return bytes;
-    }
-
-    public downloadAsPDF(filename:string) {
-        const svgelement = "<?xml version='1.0'?>"+this.toSVGDOMNode().outerHTML;
-        const servletURL = "svgtopdf.do";
-        const filetype = "pdf_data";
-        request.post(servletURL)
-            .type('form')
-            .send({ filetype, svgelement})
-            .end((err, res)=>{
-                if (!err && res.ok) {
-                    fileDownload(this.base64ToArrayBuffer(res.text), filename);
-                }
-            });
-    }
-
     @computed get hugoGeneSymbol() {
         return this.props.store.gene.hugoGeneSymbol;
     }
@@ -365,10 +340,10 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                 this._yMaxInput = value < this.countRange[0] ? this.countRange[0] : value;
             }),
             handleSVGClick:()=>{
-                fileDownload(this.toSVGDOMNode().outerHTML,`${this.hugoGeneSymbol}_lollipop.svg`);
+                fileDownload((new XMLSerializer()).serializeToString(this.toSVGDOMNode()), `${this.hugoGeneSymbol}_lollipop.svg`);
             },
             handlePDFClick:()=>{
-                this.downloadAsPDF(`${this.hugoGeneSymbol}_lollipop.pdf`);
+                svgToPdfDownload(`${this.hugoGeneSymbol}_lollipop.pdf`, this.toSVGDOMNode());
             },
             onYMaxInputFocused:()=>{
                 this.yMaxInputFocused = true;

--- a/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
@@ -471,11 +471,13 @@ export default class LollipopPlotNoTooltip extends React.Component<LollipopPlotN
                         onClick={this.handlers.onBackgroundClick}
                         onMouseMove={this.handlers.onBackgroundMouseMove}
                     />
-                    // Originally this had tooltips by having separate segments
-                    // with hit zones. We disabled those separate segments with
-                    // tooltips (this.sequenceSegments) and instead just draw
-                    // one rectangle
-                    // {this.sequenceSegments}
+                    {
+                        // Originally this had tooltips by having separate segments
+                        // with hit zones. We disabled those separate segments with
+                        // tooltips (this.sequenceSegments) and instead just draw
+                        // one rectangle
+                        // this.sequenceSegments
+                    }
                     <rect
                         fill="#BABDB6"
                         x={this.geneX}


### PR DESCRIPTION
# What? Why?
- Removed PDF download function, using the function implemented in `svgToPdfDownload` instead.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)