### PR TITLE
Add tests of oncoprint data creation

### DIFF
--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -1,0 +1,785 @@
+import { assert } from 'chai';
+import {fillClinicalTrackDatum, fillGeneticTrackDatum, fillHeatmapTrackDatum, selectDisplayValue} from "./DataUtils";
+import {GeneticTrackDatum} from "shared/components/oncoprint/Oncoprint";
+import {AlterationTypeConstants, AnnotatedExtendedAlteration} from "../../../pages/resultsView/ResultsViewPageStore";
+import {ClinicalAttribute, GeneMolecularData, Sample} from "../../api/generated/CBioPortalAPI";
+import {SpecialAttribute} from "../../cache/ClinicalDataCache";
+import {OncoprintClinicalAttribute} from "./ResultsViewOncoprint";
+import {MutationSpectrum} from "../../api/generated/CBioPortalAPIInternal";
+
+describe("DataUtils", ()=>{
+   describe("selectDisplayValue", ()=>{
+       it("returns undefined if no values", ()=>{
+           assert.equal(selectDisplayValue({}, {}), undefined);
+       });
+       it("returns the lone value if one value", ()=>{
+           assert.equal(selectDisplayValue({"a":0}, {"a":0}), "a");
+       });
+       it("returns the lowest priority value if two values", ()=>{
+           assert.equal(selectDisplayValue({"a":0, "b":0}, {"a":0, "b":1}), "a");
+           assert.equal(selectDisplayValue({"a":0, "b":0}, {"a":1, "b":0}), "b");
+       });
+       it("returns the lowest priority value if several values", ()=>{
+           assert.equal(selectDisplayValue({"a":0, "b":0, "c":5}, {"a":0, "b":1, "c":2}), "a");
+           assert.equal(selectDisplayValue({"a":20, "b":0, "c":10}, {"a":2, "b":1, "c":0}), "c");
+       });
+       it("returns the lowest priority, highest count value if two values w same priority", ()=>{
+           assert.equal(selectDisplayValue({"a":1, "b":0}, {"a":0, "b":0}), "a");
+           assert.equal(selectDisplayValue({"a":0, "b":1}, {"a":0, "b":0}), "b");
+       });
+       it("returns the lowest priority, highest count value if several values w same priority", ()=>{
+           assert.equal(selectDisplayValue({"a":1, "b":0, "c":5}, {"a":0, "b":0, "c":2}), "a");
+           assert.equal(selectDisplayValue({"a":20, "b":0, "c":10}, {"a":0, "b":1, "c":0}), "a");
+       });
+   });
+
+   describe("fillGeneticTrackDatum", ()=>{
+       it("fills a datum w no data correctly", ()=>{
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", []),
+               {
+                   gene:"gene",
+                   data: [],
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any);
+       });
+       it("fills a datum w one mutation data correctly", ()=>{
+           let data = [{
+               mutationType: "missense",
+               putativeDriver: true,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: "missense_rec"
+               } as any, "test1");
+
+           data = [{
+               mutationType: "in_frame_del",
+               putativeDriver: false,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: "inframe"
+               } as any, "test2");
+
+           data = [{
+               mutationType: "truncating",
+               putativeDriver: false,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: "trunc"
+               } as any, "test3");
+
+           data = [{
+               mutationType: "fusion",
+               putativeDriver: false,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined,
+                   disp_fusion: true
+               } as any, "test4");
+       });
+       it("fills a datum w one cna data correctly", ()=>{
+           let data = [{
+               value: "2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "amp",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test1");
+
+           data = [{
+               value: "1",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "gain",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test2");
+
+           data = [{
+               value: "-1",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "hetloss",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test3");
+
+           data = [{
+               value: "-2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "homdel",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test4");
+
+           data = [{
+               value: "0",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test5");
+       });
+       it("fills a datum w one mrna data correctly", ()=>{
+           let data = [{
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: "up",
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test1");
+
+           data = [{
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: "down",
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test2");
+       });
+       it("fills a datum w one protein data correctly", ()=>{
+           let data = [{
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: "up",
+                   disp_mut: undefined
+               } as any, "test1");
+
+           data = [{
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: "down",
+                   disp_mut: undefined
+               } as any, "test2");
+       });
+       it("fills a datum w two mutation data w correct priority", ()=>{
+           let data = [{
+               mutationType: "missense",
+               putativeDriver: true,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration,{
+               mutationType: "truncating",
+               putativeDriver: true,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: "trunc_rec"
+               } as any, "test1");
+
+           data = [{
+               mutationType: "missense",
+               putativeDriver: true,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration,{
+               mutationType: "truncating",
+               putativeDriver: false,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: "missense_rec"
+               } as any, "test2");
+
+           data = [{
+               mutationType: "missense",
+               putativeDriver: false,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration,{
+               mutationType: "truncating",
+               putativeDriver: false,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: "trunc"
+               } as any, "test3");
+       });
+       it("fills a datum w multiple cna data w correct priority", ()=>{
+           let data = [{
+               value: "2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration,{
+               value: "1",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "amp",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test1");
+
+           data = [{
+               value: "-2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration,{
+               value: "0",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "homdel",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test2");
+
+           data = [{
+               value: "-2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration,{
+               value: "-2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration, {
+               value: "2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "homdel",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test3");
+
+           data = [{
+               value: "-2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration,{
+               value: "2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration, {
+               value: "2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "amp",
+                   disp_mrna: undefined,
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test4");
+       });
+       it("fills a datum w multiple mrna data w correct priority", ()=>{
+           let data = [{
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: "down",
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test1");
+
+           data = [{
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: "up",
+                   disp_prot: undefined,
+                   disp_mut: undefined
+               } as any, "test2");
+       });
+       it("fills a datum w multiple protein data w correct priority", ()=>{
+           let data = [{
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: "down",
+                   disp_mut: undefined
+               } as any, "test1");
+
+           data = [{
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: undefined,
+                   disp_mrna: undefined,
+                   disp_prot: "up",
+                   disp_mut: undefined
+               } as any, "test2");
+       });
+       it("fills a datum w several data of different types correctly", ()=>{
+           let data = [{
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"up",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration, {
+               alterationSubType:"down",
+               molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
+           } as AnnotatedExtendedAlteration, {
+               value: "-2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration,{
+               value: "-2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration, {
+               value: "2",
+               molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
+           } as AnnotatedExtendedAlteration,{
+               mutationType: "missense",
+               putativeDriver: true,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration,{
+               mutationType: "truncating",
+               putativeDriver: true,
+               molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
+           } as AnnotatedExtendedAlteration];
+           assert.deepEqual(
+               fillGeneticTrackDatum({}, "gene", data),
+               {
+                   gene:"gene",
+                   data: data,
+                   disp_cna: "homdel",
+                   disp_mrna: "up",
+                   disp_prot: "down",
+                   disp_mut: "trunc_rec"
+               } as any, "test1");
+       });
+   });
+
+   describe("fillHeatmapTrackDatum", ()=>{
+       it("sets na true if no data", ()=>{
+           assert.isTrue(fillHeatmapTrackDatum({}, "", {} as Sample).na);
+       });
+       it("sets data for sample", ()=>{
+           let data:any[] = [
+               {value:3}
+           ];
+           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {sampleId:"sample", studyId:"study"} as Sample, data),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:3});
+       });
+       it("throws exception if more than one data given for sample",()=>{
+           let data:any[] = [
+               {value:3},
+               {value:2}
+           ];
+           try {
+               fillHeatmapTrackDatum({}, "gene", {sampleId:"sample", studyId:"study"} as Sample, data);
+               assert(false);
+           } catch(e) {
+           }
+       });
+       it("sets data for patient, if multiple then maximum in abs value", ()=>{
+           let data:any[] = [
+               {value:3},
+               {value:2}
+           ];
+           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:3});
+
+           data = [
+               {value:2}
+           ];
+           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:2});
+
+           data = [
+               {value:2},
+               {value:3},
+               {value:4}
+           ];
+           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:4});
+
+           data = [
+               {value:-10},
+               {value:3},
+               {value:4}
+           ];
+           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:-10});
+       });
+   });
+
+   describe("fillClinicalTrackDatum", ()=>{
+        it("creates datum correctly when no data given", ()=>{
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute"} as ClinicalAttribute,
+                    {sampleId:"sample", studyId:"study"} as Sample
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id:"study",
+                    attr_val_counts: {},
+                    na: true
+                }, "test1"
+            );
+
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:SpecialAttribute.MutationCount} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample
+                ),
+                {
+                    attr_id: SpecialAttribute.MutationCount,
+                    study_id:"study",
+                    attr_val_counts: {},
+                    attr_val: 0
+                }, "test2"
+            );
+        });
+        it("creates data correctly for number data",()=>{
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"number"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{value:3}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{3:1},
+                    attr_val: 3
+                }
+            );
+
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"number"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{value:"abc"}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{},
+                    na: true
+                }
+            );
+
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"number"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{value:3}, {value:2}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{2.5:1},
+                    attr_val: 2.5
+                }
+            );
+
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"number"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{mutationCount:3}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{3:1},
+                    attr_val: 3
+                }
+            );
+
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"number"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{mutationCount:3}, {mutationCount:2}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{2.5:1},
+                    attr_val: 2.5
+                }
+            );
+        });
+        it("creates data correctly for string data",()=>{
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"string"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{value:"a"}, {value:"a"}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{"a":2},
+                    attr_val: "a"
+                }
+            );
+
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"string"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{value:"a"}, {value:"b"}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{"a":1, "b":1},
+                    attr_val: "Mixed"
+                }
+            );
+
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:"clinicalAttribute", datatype:"string"} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{value:"a"}, {value:"b"}, {value:"b"}] as any[]
+                ),
+                {
+                    attr_id: "clinicalAttribute",
+                    study_id: "study",
+                    attr_val_counts:{"a":1, "b":2},
+                    attr_val: "Mixed"
+                }
+            );
+        });
+        it("creates data correctly for mutation spectrum data",()=>{
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:SpecialAttribute.MutationSpectrum} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [] as MutationSpectrum[]
+                ),
+                {
+                    attr_id: SpecialAttribute.MutationSpectrum,
+                    study_id: "study",
+                    attr_val_counts:{},
+                    na:true
+                },
+                "NA if no data given"
+            );
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:SpecialAttribute.MutationSpectrum, datatype:""} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{CtoA:0, CtoG:0, CtoT:0, TtoA:0, TtoC:0, TtoG:0}] as MutationSpectrum[]
+                ),
+                {
+                    attr_id: SpecialAttribute.MutationSpectrum,
+                    study_id: "study",
+                    attr_val_counts:{"C>A":0, "C>G":0, "C>T":0, "T>A":0, "T>C":0,"T>G":0},
+                    attr_val: {"C>A":0, "C>G":0, "C>T":0, "T>A":0, "T>C":0,"T>G":0},
+                    na:true
+                }, "NA if no mutations"
+            );
+            assert.deepEqual(
+                fillClinicalTrackDatum(
+                    {},
+                    {clinicalAttributeId:SpecialAttribute.MutationSpectrum, datatype:""} as any,
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    [{CtoA:1, CtoG:0, CtoT:0, TtoA:0, TtoC:0, TtoG:0},
+                        {CtoA:0, CtoG:2, CtoT:0, TtoA:0, TtoC:0, TtoG:0},
+                        {CtoA:0, CtoG:0, CtoT:3, TtoA:0, TtoC:0, TtoG:0},
+                        {CtoA:0, CtoG:0, CtoT:0, TtoA:0, TtoC:6, TtoG:4}] as MutationSpectrum[]
+                ),
+                {
+                    attr_id: SpecialAttribute.MutationSpectrum,
+                    study_id: "study",
+                    attr_val_counts:{"C>A":1,"C>G":2,"C>T":3,"T>A":0,"T>C":6,"T>G":4},
+                    attr_val: {"C>A":1,"C>G":2,"C>T":3,"T>A":0,"T>C":6,"T>G":4}
+                }, "sum"
+            );
+        });
+   });
+});

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -16,6 +16,7 @@ import {getSimplifiedMutationType, SimplifiedMutationType} from "../../lib/oql/a
 import _ from "lodash";
 import {FractionGenomeAltered, MutationSpectrum} from "../../api/generated/CBioPortalAPIInternal";
 import {SpecialAttribute} from "../../cache/ClinicalDataCache";
+import {OncoprintClinicalAttribute} from "./ResultsViewOncoprint";
 
 const cnaDataToString:{[integerCNA:string]:string|undefined} = {
     "-2": "homdel",
@@ -57,7 +58,7 @@ export function getOncoprintMutationType(type:SimplifiedMutationType):OncoprintM
     }
 }
 
-function selectDisplayValue(counts:{[value:string]:number}, priority:{[value:string]:number}) {
+export function selectDisplayValue(counts:{[value:string]:number}, priority:{[value:string]:number}) {
     const options = Object.keys(counts).map(k=>({key:k, value:counts[k]}));
     if (options.length > 0) {
         options.sort(function (kv1, kv2) {
@@ -82,11 +83,11 @@ function selectDisplayValue(counts:{[value:string]:number}, priority:{[value:str
     }
 };
 
-function fillGeneticTrackDatum(
+export function fillGeneticTrackDatum(
     newDatum:Partial<GeneticTrackDatum>,
     hugoGeneSymbol:string,
     data:AnnotatedExtendedAlteration[]
-):void {
+):GeneticTrackDatum {
     newDatum.gene = hugoGeneSymbol;
     newDatum.data = data;
 
@@ -142,6 +143,8 @@ function fillGeneticTrackDatum(
     newDatum.disp_mrna = selectDisplayValue(dispMrnaCounts, mrnaRenderPriority);
     newDatum.disp_prot = selectDisplayValue(dispProtCounts, protRenderPriority);
     newDatum.disp_mut = selectDisplayValue(dispMutCounts, mutRenderPriority);
+
+    return newDatum as GeneticTrackDatum; // return for convenience, even though changes made in place
 }
 
 export function makeGeneticTrackData(
@@ -223,7 +226,7 @@ export function makeGeneticTrackData(
 }
 
 
-function fillHeatmapTrackDatum(
+export function fillHeatmapTrackDatum(
     trackDatum: Partial<HeatmapTrackDatum>,
     hugoGeneSymbol: string,
     case_:Sample|Patient,
@@ -291,7 +294,7 @@ export function makeHeatmapTrackData(
 
 function fillNoDataValue(
     trackDatum:Partial<ClinicalTrackDatum>,
-    attribute:ClinicalAttribute,
+    attribute:OncoprintClinicalAttribute,
 ) {
     if (attribute.clinicalAttributeId === SpecialAttribute.MutationCount) {
         trackDatum.attr_val = 0;
@@ -299,9 +302,9 @@ function fillNoDataValue(
         trackDatum.na = true;
     }
 }
-function fillClinicalTrackDatum(
+export function fillClinicalTrackDatum(
     trackDatum:Partial<ClinicalTrackDatum>,
-    attribute:ClinicalAttribute,
+    attribute:OncoprintClinicalAttribute,
     case_:Sample|Patient,
     data?:(ClinicalData|MutationCount|FractionGenomeAltered|MutationSpectrum)[],
 ) {

--- a/src/shared/components/oncoprint/OncoprintUtils.spec.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.spec.ts
@@ -1,0 +1,19 @@
+import {assert} from 'chai';
+import {percentAltered} from "./OncoprintUtils";
+
+describe('OncoprintUtils', ()=>{
+    describe('percentAltered',()=>{
+        it("returns the percentage with no decimal digits, for percentages >= 3", ()=>{
+            assert.equal(percentAltered(3,100), "3%");
+            assert.equal(percentAltered(20,100), "20%");
+            assert.equal(percentAltered(3,3), "100%");
+            assert.equal(percentAltered(50,99), "51%");
+        })
+        it("returns the percentage with one decimal digit, for percentages < 3, unless its exact", ()=>{
+            assert.equal(percentAltered(22,1000), "2.2%");
+            assert.equal(percentAltered(156,10000), "1.6%");
+            assert.equal(percentAltered(0,3), "0%");
+            assert.equal(percentAltered(2,100), "2%");
+        })
+    });
+});

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -92,16 +92,6 @@ export function percentAltered(altered:number, sequenced:number) {
     return fixed+"%";
 }
 
-export function getPercentAltered(oncoprintTrackData:OncoprintSampleGeneticTrackData|OncoprintPatientGeneticTrackData):string {
-    if (oncoprintTrackData.hasOwnProperty("altered_samples")) {
-        return percentAltered((oncoprintTrackData as OncoprintSampleGeneticTrackData).altered_sample_uids.length,
-                            (oncoprintTrackData as OncoprintSampleGeneticTrackData).sequenced_samples.length);
-    } else {
-        return percentAltered((oncoprintTrackData as OncoprintPatientGeneticTrackData).altered_patient_uids.length,
-            (oncoprintTrackData as OncoprintPatientGeneticTrackData).sequenced_patients.length);
-    }
-}
-
 export function makeGeneticTracksMobxPromise(oncoprint:ResultsViewOncoprint, sampleMode:boolean) {
     return remoteData<GeneticTrackSpec[]>({
         await:()=>[

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -16,7 +16,7 @@ import OncoprintControls, {
 import {ResultsViewPageStore} from "../../../pages/resultsView/ResultsViewPageStore";
 import {ClinicalAttribute, Gene, MolecularProfile, Mutation, Sample} from "../../api/generated/CBioPortalAPI";
 import {
-    percentAltered, getPercentAltered, makeGeneticTracksMobxPromise,
+    percentAltered, makeGeneticTracksMobxPromise,
     makeHeatmapTracksMobxPromise, makeClinicalTracksMobxPromise
 } from "./OncoprintUtils";
 import _ from "lodash";


### PR DESCRIPTION
These are tests of the functionality that turns web API data into oncoprint data, as well as some code reorganization to facilitate testing.

Besides this, I think the rest of oncoprint-related code should be tested via e2e