### PR TITLE
Ignore two common Sentry errors

### DIFF
--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -50,7 +50,8 @@ if (/cbioportal\.mskcc\.org|www.cbioportal\.org/.test(window.location.hostname) 
         tags:{
           fullUrl:window.location.href
         },
-        release:window.appVersion || '',
+        release:window.FRONTEND_COMMIT || '',
+        ignoreErrors: ['_germline', 'symlink_by_patient'],
         serverName: window.location.hostname
     }).install();
 }


### PR DESCRIPTION
- datahub checking for pathology slides (symlink_by_patient is in
the URL)
- ignore checking _germline case lists

Tested it locally using localStorage trick:
```
localStorage.sentry = true
```