### PR TITLE
fixed hidden stop codon mutations on mutation lollipop diagram

### DIFF
--- a/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -158,7 +158,8 @@ export default class LollipopMutationPlot extends React.Component<ILollipopMutat
                 codon < 0 ||
                 (this.props.store.canonicalTranscript.isComplete &&
                     this.props.store.canonicalTranscript.result &&
-                    (codon > this.props.store.canonicalTranscript.result.proteinLength)))
+                    // we want to show the stop codon too (so we allow proteinLength +1 as well)
+                    (codon > this.props.store.canonicalTranscript.result.proteinLength + 1)))
             {
                 // invalid position
                 continue;

--- a/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
+++ b/src/shared/components/lollipopMutationPlot/LollipopPlotNoTooltip.tsx
@@ -483,7 +483,10 @@ export default class LollipopPlotNoTooltip extends React.Component<LollipopPlotN
                         x={this.geneX}
                         y={this.geneY}
                         height={this.geneHeight}
-                        width={this.props.vizWidth}
+                        width={
+                            // the x-axis start from 0, so the rectangle size should be (width + 1)
+                            this.props.vizWidth + 1
+                        }
                     />
                     {this.lollipops}
                     {this.domains}


### PR DESCRIPTION
![stop_codon_mutations](https://user-images.githubusercontent.com/3604198/34393251-2ef18b38-eb1f-11e7-8613-95ceeffdf4c7.png)

# What? Why?
Fixes the problem where we don't show the stop codon mutations (mutations at position `protein length + 1`).

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)