### PR TITLE
dont include clinical track description in tooltip if same as name

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "mobx-utils": "^2.0.1",
     "mobxpromise": "^1.2.0",
     "node-sass": "^4.3.0",
-    "oncoprintjs": "^1.0.72",
+    "oncoprintjs": "^1.0.74",
     "parameter-validator": "^1.0.2",
     "pdfobject": "^2.0.201604172",
     "plotly.js": "^1.31.2",

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -448,7 +448,7 @@ function transitionClinicalTrack(
             data: nextSpec.data,
             data_id_key: "uid",
             label: nextSpec.label,
-            description: nextSpec.description,
+            description: ((nextSpec.label || "").trim() === (nextSpec.description || "").trim()) ? undefined : nextSpec.description,
             removable: true,
             removeCallback: ()=>{
                 delete getTrackSpecKeyToTrackId()[nextSpec.key];


### PR DESCRIPTION
Also update oncoprintjs version, which fixes tooltip line break issue shown in the screenshot in https://github.com/cBioPortal/cbioportal/issues/3596
  
  