### PR TITLE
Fix sample labels disappearing on timeline

### DIFF
--- a/src/pages/patientView/timeline/legacy.js
+++ b/src/pages/patientView/timeline/legacy.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import * as _ from 'lodash';
+import * as d3 from 'd3';
 
 import clinicalTimelineExports from './timeline-lib';
 


### PR DESCRIPTION
Add d3 as dependency to legacy timeline code. It was throwing an
undefined error after upgrading to webpack 4 in
https://github.com/cBioPortal/cbioportal-frontend/commit/b5621cf8a4dff08d3d9aef1f3aa558857fdb294b.
Surprising that this code worked originally, since it requires d3.