### PR TITLE
Restore percentage sign after zoom text area in oncoprint controls. dd back absolute count of altered samples in sample summmary/header. Reduce rounding to one digit in percentage

### DIFF
--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -55,7 +55,7 @@ export default class QuerySummary extends React.Component<{ queryStore:QueryStor
     private get multipleStudyUI() {
         return <div>
             <span>
-                This combined study contains samples from {this.props.store.studies.result.length} studies
+                Querying {this.props.store.samples.result.length} samples in {this.props.store.studies.result.length} studies
                  &nbsp;
                  <DefaultTooltip
                      placement='bottom'
@@ -111,7 +111,7 @@ export default class QuerySummary extends React.Component<{ queryStore:QueryStor
                         {
                             (loadingComplete) && (<div className="query-summary__alterationData">
                                 <h4>Gene Set / Pathway is altered
-                                in {_.round(alterationPercentage, 2)}% of queried samples</h4>
+                                in {this.props.store.totalAlterationStats.result!.alteredSampleCount} ({_.round(alterationPercentage, 1)}%) of queried samples</h4>
                             </div>)
                         }
                     </div>

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -814,9 +814,11 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
                         border:'none',
                         padding:0,
                         marginTop:0,
-                        marginBottom:0
+                        marginBottom:0,
+                        marginRight:2
                     }}
                 />
+                <div>%</div>
 
                 <DefaultTooltip
                     overlay={<span>Zoom in to oncoprint.</span>}


### PR DESCRIPTION
Restore percentage sign after zoom text area in oncoprint controls. dd back absolute count of altered samples in sample summmary/header. Reduce rounding to one digit in percentage
![image](https://user-images.githubusercontent.com/186521/34956731-625a6b92-f9f8-11e7-8bd4-41a941d70dc5.png)
