### PR TITLE
Add gene set heatmap tracks to the Oncoprint

### DIFF
--- a/OPEN-SOURCE-DOCUMENTATION
+++ b/OPEN-SOURCE-DOCUMENTATION
@@ -1,0 +1,51 @@
+Open Source bundled in this project
+
+This document contains the licenses and notices for open source software bundled in this product.
+With respect to the free/open software listed in this document, if you have any questions or
+wish to receive a copy of the source code to which you are entitled under the applicable
+free/open source license(s) (such as GNU Lesser/General Public License),
+please visit our https://github.com/cBioPortal/cbioportal-frontend or contact us at
+cbioportal@googlegroups.com.
+
+* ColorBrewer scheme: PiYG
+
+ColorBrewer scheme: PiYG
+------------------------
+Available under license:
+
+    Apache-Style Software License for ColorBrewer software and
+    ColorBrewer Color Schemes
+
+    Copyright (c) 2002 Cynthia Brewer, Mark Harrower, and The
+    Pennsylvania State University.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you
+    may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied. See the License for the specific language governing
+    permissions and limitations under the License.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions as source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. The end-user documentation included with the redistribution, if
+    any, must include the following acknowledgment:
+    "This product includes color specifications and designs developed by
+    Cynthia Brewer (http://colorbrewer.org/)."
+    Alternately, this acknowledgment may appear in the software itself,
+    if and wherever such third-party acknowledgments normally appear.
+    4. The name "ColorBrewer" must not be used to endorse or promote
+    products derived from this software without prior written
+    permission. For written permission, please contact Cynthia Brewer at
+    cbrewer@psu.edu.
+    5. Products derived from this software may not be called
+    "ColorBrewer", nor may "ColorBrewer" appear in their name, without
+    prior written permission of Cynthia Brewer.

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -48,6 +48,11 @@ function initStore(queryStore: QueryStore) {
 
     const parsedOQL = (window as any).oql_parser.parse(oqlQuery);
 
+    const genesetIds = (serverVars.genesetIds.length
+        ? serverVars.genesetIds.split(/\s+/)
+        : []
+    );
+
     const resultsViewPageStore = new ResultsViewPageStore();
 
     // following is a bunch of dirty stuff necessary to read state from jsp page
@@ -78,7 +83,8 @@ function initStore(queryStore: QueryStore) {
     }
 
     resultsViewPageStore.samplesSpecification = samplesSpecification;
-    resultsViewPageStore.hugoGeneSymbols = _.map(parsedOQL,(o:any)=>o.gene); //qSession.getQueryGenes();
+    resultsViewPageStore.hugoGeneSymbols = _.map(parsedOQL, (o: any) => o.gene); //qSession.getQueryGenes();
+    resultsViewPageStore.genesetIds = genesetIds;
     resultsViewPageStore.selectedMolecularProfileIds = serverVars.molecularProfiles; // qSession.getGeneticProfileIds();
     resultsViewPageStore.rppaScoreThreshold = serverVars.rppaScoreThreshold; // FIX!
     resultsViewPageStore.zScoreThreshold = serverVars.zScoreThreshold;

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -66,6 +66,11 @@ import {
     initializeCustomDriverAnnotationSettings, computeGenePanelInformation
 } from "./ResultsViewPageStoreUtils";
 
+type Optional<T> = (
+    {isApplicable: true, value: T}
+    | {isApplicable: false, value?: undefined}
+);
+
 export type SamplesSpecificationElement = {studyId: string, sampleId: string, sampleListId: undefined} |
     {studyId: string, sampleId: undefined, sampleListId: string};
 
@@ -1290,7 +1295,7 @@ export class ResultsViewPageStore {
         }
     });
 
-    readonly genesetMolecularProfile = remoteData<MolecularProfile | undefined>({
+    readonly genesetMolecularProfile = remoteData<Optional<MolecularProfile>>({
         await: () => [
             this.selectedMolecularProfiles
         ],
@@ -1303,9 +1308,15 @@ export class ResultsViewPageStore {
                 )
             );
             if (applicableProfiles.length > 1) {
-                return Promise.reject("Queried more than one gene set score profile");
+                return Promise.reject(new Error("Queried more than one gene set score profile"));
             }
-            return Promise.resolve(applicableProfiles.pop());
+            const genesetProfile = applicableProfiles.pop();
+            const value: Optional<MolecularProfile> = (
+                genesetProfile
+                ? {isApplicable: true, value: genesetProfile}
+                : {isApplicable: false}
+            );
+            return Promise.resolve(value);
         }
     });
 

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -74,8 +74,9 @@ export const AlterationTypeConstants = {
     COPY_NUMBER_ALTERATION: 'COPY_NUMBER_ALTERATION',
     MRNA_EXPRESSION: 'MRNA_EXPRESSION',
     PROTEIN_LEVEL: 'PROTEIN_LEVEL',
-    FUSION: 'FUSION'
-}
+    FUSION: 'FUSION',
+    GENESET_SCORE: 'GENESET_SCORE'
+};
 
 export interface ExtendedAlteration extends Mutation, GeneMolecularData {
     molecularProfileAlterationType: MolecularProfile["molecularAlterationType"];
@@ -1294,11 +1295,10 @@ export class ResultsViewPageStore {
             this.molecularProfilesInStudies
         ],
         invoke: () => {
-            const GENESET_SCORE = "GENESET_SCORE";
             const applicableProfiles = _.filter(
                 this.molecularProfilesInStudies.result!,
                 profile => (
-                    profile.molecularAlterationType === GENESET_SCORE
+                    profile.molecularAlterationType === AlterationTypeConstants.GENESET_SCORE
                     && profile.showProfileInAnalysisTab
                 )
             );

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1292,11 +1292,11 @@ export class ResultsViewPageStore {
 
     readonly genesetMolecularProfile = remoteData<MolecularProfile | undefined>({
         await: () => [
-            this.molecularProfilesInStudies
+            this.selectedMolecularProfiles
         ],
         invoke: () => {
             const applicableProfiles = _.filter(
-                this.molecularProfilesInStudies.result!,
+                this.selectedMolecularProfiles.result!,
                 profile => (
                     profile.molecularAlterationType === AlterationTypeConstants.GENESET_SCORE
                     && profile.showProfileInAnalysisTab

--- a/src/shared/cache/GenesetMolecularDataCache.ts
+++ b/src/shared/cache/GenesetMolecularDataCache.ts
@@ -1,0 +1,78 @@
+import LazyMobXCache, {AugmentedData} from "../lib/LazyMobXCache";
+import {GenesetMolecularData, GenesetDataFilterCriteria} from "../api/generated/CBioPortalAPIInternal";
+import client from "shared/api/cbioportalInternalClientInstance";
+import _ from "lodash";
+import {IDataQueryFilter} from "../lib/StoreUtils";
+
+interface IQuery {
+    genesetId: string;
+    molecularProfileId: string;
+}
+
+type SampleFilterByProfile = {
+    [molecularProfileId: string]: IDataQueryFilter
+};
+
+function queryToKey(q: IQuery) {
+    return `${q.molecularProfileId}~${q.genesetId}`;
+}
+
+function dataToKey(d:GenesetMolecularData[], q:IQuery) {
+    return `${q.molecularProfileId}~${q.genesetId}`;
+}
+
+/**
+/* Pairs each IQuery with an (array-wrapped) array of any matching data.
+*/
+function augmentQueryResults(queries: IQuery[], results: GenesetMolecularData[][]) {
+    const keyedAugments: {[key: string]: AugmentedData<GenesetMolecularData[], IQuery>} = {};
+    for (const query of queries) {
+        keyedAugments[queryToKey(query)] = {
+            data: [[]],
+            meta: query
+        };
+    }
+    for (const queryResult of results) {
+        for (const datum of queryResult) {
+            keyedAugments[
+                queryToKey({
+                    molecularProfileId: datum.geneticProfileId,
+                    genesetId: datum.genesetId
+                })
+            ].data[0].push(datum);
+        }
+    }
+    return _.values(keyedAugments);
+}
+
+async function fetch(
+    queries:IQuery[],
+    sampleFilterByProfile: SampleFilterByProfile
+): Promise<AugmentedData<GenesetMolecularData[], IQuery>[]> {
+    const genesetIdsByProfile = _.mapValues(
+        _.groupBy(queries, q => q.molecularProfileId),
+        profileQueries => profileQueries.map(q => q.genesetId)
+    );
+    const params = Object.keys(genesetIdsByProfile)
+        .map(profileId => ({
+            geneticProfileId: profileId,
+            // the Swagger-generated type expected by the client method below
+            // incorrectly requires both samples and a sample list;
+            // use 'as' to tell TypeScript that this object really does fit.
+            // tslint:disable-next-line: no-object-literal-type-assertion
+            genesetDataFilterCriteria: {
+                genesetIds: genesetIdsByProfile[profileId],
+                ...sampleFilterByProfile[profileId]
+            } as GenesetDataFilterCriteria
+        })
+    );
+    const dataPromises = params.map(param => client.fetchGeneticDataItemsUsingPOST(param));
+    const results: GenesetMolecularData[][] = await Promise.all(dataPromises);
+    return augmentQueryResults(queries, results);
+}
+
+export default class GenesetMolecularDataCache extends LazyMobXCache<GenesetMolecularData[], IQuery, IQuery>{
+    constructor(molecularProfileIdToSampleFilter: SampleFilterByProfile) {
+        super(queryToKey, dataToKey, fetch, molecularProfileIdToSampleFilter);
+    }
+}

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -1,11 +1,15 @@
 import { assert } from 'chai';
 import {fillClinicalTrackDatum, fillGeneticTrackDatum, fillHeatmapTrackDatum, selectDisplayValue} from "./DataUtils";
-import {GeneticTrackDatum} from "shared/components/oncoprint/Oncoprint";
+import {GeneticTrackDatum, IGeneHeatmapTrackDatum} from "shared/components/oncoprint/Oncoprint";
 import {AlterationTypeConstants, AnnotatedExtendedAlteration} from "../../../pages/resultsView/ResultsViewPageStore";
 import {ClinicalAttribute, GeneMolecularData, Sample} from "../../api/generated/CBioPortalAPI";
 import {SpecialAttribute} from "../../cache/ClinicalDataCache";
 import {OncoprintClinicalAttribute} from "./ResultsViewOncoprint";
 import {MutationSpectrum} from "../../api/generated/CBioPortalAPIInternal";
+
+/* Type assertions are used throughout this file to force functions to accept
+/* mocked parameters known to be sufficient. */
+/* tslint:disable no-object-literal-type-assertion */
 
 describe("DataUtils", ()=>{
    describe("selectDisplayValue", ()=>{
@@ -528,24 +532,43 @@ describe("DataUtils", ()=>{
 
    describe("fillHeatmapTrackDatum", ()=>{
        it("sets na true if no data", ()=>{
-           assert.isTrue(fillHeatmapTrackDatum({}, "", {} as Sample).na);
+           assert.isTrue(
+               fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                   {}, "hugo_gene_symbol", "", {} as Sample
+               ).na
+           );
        });
        it("sets data for sample", ()=>{
-           let data:any[] = [
+           const data:any[] = [
                {value:3}
            ];
-           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {sampleId:"sample", studyId:"study"} as Sample, data),
-               {hugo_gene_symbol:"gene", study:"study", profile_data:3});
+           assert.deepEqual(
+               fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                   {},
+                   "hugo_gene_symbol",
+                   "gene",
+                   {sampleId:"sample", studyId:"study"} as Sample,
+                   data
+               ),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:3}
+           );
        });
        it("throws exception if more than one data given for sample",()=>{
-           let data:any[] = [
+           const data:any[] = [
                {value:3},
                {value:2}
            ];
            try {
-               fillHeatmapTrackDatum({}, "gene", {sampleId:"sample", studyId:"study"} as Sample, data);
+               fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                   {},
+                   "hugo_gene_symbol",
+                   "gene",
+                   {sampleId:"sample", studyId:"study"} as Sample,
+                   data
+               );
                assert(false);
            } catch(e) {
+               // Succeed if an exception occurred before asserting false
            }
        });
        it("sets data for patient, if multiple then maximum in abs value", ()=>{
@@ -553,30 +576,62 @@ describe("DataUtils", ()=>{
                {value:3},
                {value:2}
            ];
-           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
-               {hugo_gene_symbol:"gene", study:"study", profile_data:3});
+           assert.deepEqual(
+               fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                   {},
+                   "hugo_gene_symbol",
+                   "gene",
+                   {patientId:"patient", studyId:"study"} as Sample,
+                   data
+               ),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:3}
+           );
 
            data = [
                {value:2}
            ];
-           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
-               {hugo_gene_symbol:"gene", study:"study", profile_data:2});
+           assert.deepEqual(
+               fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                   {},
+                   "hugo_gene_symbol",
+                   "gene",
+                   {patientId:"patient", studyId:"study"} as Sample,
+                   data
+               ),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:2}
+           );
 
            data = [
                {value:2},
                {value:3},
                {value:4}
            ];
-           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
-               {hugo_gene_symbol:"gene", study:"study", profile_data:4});
+           assert.deepEqual(
+               fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                   {},
+                   "hugo_gene_symbol",
+                   "gene",
+                   {patientId:"patient", studyId:"study"} as Sample,
+                   data
+               ),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:4}
+           );
 
            data = [
                {value:-10},
                {value:3},
                {value:4}
            ];
-           assert.deepEqual(fillHeatmapTrackDatum({}, "gene", {patientId:"patient", studyId:"study"} as Sample, data),
-               {hugo_gene_symbol:"gene", study:"study", profile_data:-10});
+           assert.deepEqual(
+               fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                   {},
+                   "hugo_gene_symbol",
+                   "gene",
+                   {patientId:"patient", studyId:"study"} as Sample,
+                   data
+               ),
+               {hugo_gene_symbol:"gene", study:"study", profile_data:-10}
+           );
        });
    });
 

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -1,6 +1,10 @@
 import { assert } from 'chai';
 import {fillClinicalTrackDatum, fillGeneticTrackDatum, fillHeatmapTrackDatum, selectDisplayValue} from "./DataUtils";
-import {GeneticTrackDatum, IGeneHeatmapTrackDatum} from "shared/components/oncoprint/Oncoprint";
+import {
+    GeneticTrackDatum,
+    IGeneHeatmapTrackDatum,
+    IGenesetHeatmapTrackDatum
+} from "shared/components/oncoprint/Oncoprint";
 import {AlterationTypeConstants, AnnotatedExtendedAlteration} from "../../../pages/resultsView/ResultsViewPageStore";
 import {ClinicalAttribute, GeneMolecularData, Sample} from "../../api/generated/CBioPortalAPI";
 import {SpecialAttribute} from "../../cache/ClinicalDataCache";
@@ -631,6 +635,20 @@ describe("DataUtils", ()=>{
                    data
                ),
                {hugo_gene_symbol:"gene", study:"study", profile_data:-10}
+           );
+       });
+       it("fills data for a gene set if that's requested", ()=>{
+           const partialTrackDatum = {};
+           fillHeatmapTrackDatum<IGenesetHeatmapTrackDatum, "geneset_id">(
+               partialTrackDatum,
+               "geneset_id",
+               "MY_FAVORITE_GENE_SET-3",
+               {sampleId:"sample", studyId:"study"} as Sample,
+               [{value: "7"}]
+           );
+           assert.deepEqual(
+               partialTrackDatum,
+               {geneset_id:"MY_FAVORITE_GENE_SET-3", study:"study", profile_data:7}
            );
        });
    });

--- a/src/shared/components/oncoprint/DeltaUtils.spec.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "./DeltaUtils";
 import {spy} from "sinon";
 import OncoprintJS from "oncoprintjs";
-import {CLINICAL_TRACK_GROUP_INDEX, GENETIC_TRACK_GROUP_INDEX, HeatmapTrackSpec} from "./Oncoprint";
+import {CLINICAL_TRACK_GROUP_INDEX, GENETIC_TRACK_GROUP_INDEX, IGeneHeatmapTrackSpec} from "./Oncoprint";
 
 describe("Oncoprint DeltaUtils", ()=>{
     describe("numTracksWhoseDataChanged", ()=>{
@@ -43,24 +43,24 @@ describe("Oncoprint DeltaUtils", ()=>{
         });
         it("should not do anything if the heatmap tracks are the same", ()=>{
             transitionTrackGroupSortPriority(
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}] as HeatmapTrackSpec[]},
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}] as HeatmapTrackSpec[]},
+                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
+                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
                 oncoprint
             );
             assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 0);
         });
         it("should not do anything if the heatmap tracks are different but same groups", ()=>{
             transitionTrackGroupSortPriority(
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}] as HeatmapTrackSpec[]},
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 2}, { trackGroupIndex: 2}, {trackGroupIndex: 3}] as HeatmapTrackSpec[]},
+                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
+                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 2}, { trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
                 oncoprint
             );
             assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 0);
         });
         it("should set the track group sort priority if the heatmap track groups have changed", ()=>{
             transitionTrackGroupSortPriority(
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 4}, { trackGroupIndex: 2}, {trackGroupIndex: 3}] as HeatmapTrackSpec[]},
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}] as HeatmapTrackSpec[]},
+                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 4}, { trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
+                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
                 oncoprint
             );
             assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 1, "called once");

--- a/src/shared/components/oncoprint/DeltaUtils.spec.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.spec.ts
@@ -35,38 +35,90 @@ describe("Oncoprint DeltaUtils", ()=>{
     describe("transitionTrackGroupSortPriority", ()=>{
         let oncoprint:any;
         beforeEach(()=>{
-            oncoprint = { setTrackGroupSortPriority:spy(()=>{}) };
+            oncoprint = {setTrackGroupSortPriority: spy()};
         });
         it("should not do anything if the heatmap tracks are both empty", ()=>{
-           transitionTrackGroupSortPriority({heatmapTracks:[]}, {heatmapTracks:[]}, oncoprint);
+           transitionTrackGroupSortPriority(
+               {heatmapTracks:[], genesetHeatmapTracks:[]},
+               {heatmapTracks:[], genesetHeatmapTracks:[]},
+               oncoprint
+           );
+           assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 0);
+        });
+        it("should not do anything on initialisation if no heatmap tracks are added", ()=>{
+           transitionTrackGroupSortPriority(
+               {heatmapTracks:[], genesetHeatmapTracks:[]},
+               {},
+               oncoprint
+           );
            assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 0);
         });
         it("should not do anything if the heatmap tracks are the same", ()=>{
             transitionTrackGroupSortPriority(
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
+                {heatmapTracks:[{trackGroupIndex: 2}, {trackGroupIndex: 3}], genesetHeatmapTracks: []},
+                {heatmapTracks:[{trackGroupIndex: 2}, {trackGroupIndex: 3}], genesetHeatmapTracks: []},
+                oncoprint
+            );
+            assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 0);
+        });
+        it("should not do anything if the gene set heatmap tracks are the same", ()=>{
+            transitionTrackGroupSortPriority(
+                {heatmapTracks:[], genesetHeatmapTracks: [{trackGroupIndex: 2}]},
+                {heatmapTracks:[], genesetHeatmapTracks: [{trackGroupIndex: 2}]},
                 oncoprint
             );
             assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 0);
         });
         it("should not do anything if the heatmap tracks are different but same groups", ()=>{
             transitionTrackGroupSortPriority(
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 2}, { trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
+                {heatmapTracks:[{trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}], genesetHeatmapTracks: []},
+                {heatmapTracks:[{trackGroupIndex: 2}, {trackGroupIndex: 2}, {trackGroupIndex: 2}, {trackGroupIndex: 3}], genesetHeatmapTracks: []},
                 oncoprint
             );
             assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 0);
         });
-        it("should set the track group sort priority if the heatmap track groups have changed", ()=>{
+        it("should set the track group sort priority if the heatmap track groups have changed and no gene set heatmap is present", ()=>{
             transitionTrackGroupSortPriority(
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 4}, { trackGroupIndex: 2}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
-                {heatmapTracks:[{ trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}] as IGeneHeatmapTrackSpec[]},
+                {heatmapTracks:[{trackGroupIndex: 2}, {trackGroupIndex: 4}, {trackGroupIndex: 2}, {trackGroupIndex: 3}], genesetHeatmapTracks: []},
+                {heatmapTracks:[{trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}], genesetHeatmapTracks: []},
                 oncoprint
             );
             assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 1, "called once");
             assert.deepEqual(
                 oncoprint.setTrackGroupSortPriority.args[0][0],
                 [CLINICAL_TRACK_GROUP_INDEX, 2, 3, 4, GENETIC_TRACK_GROUP_INDEX],
+                "right priority order"
+            );
+        });
+        it("should set the track group sort priority including gene set heatmaps if heatmap track groups have changed", ()=>{
+            transitionTrackGroupSortPriority(
+                {
+                    heatmapTracks: [{trackGroupIndex: 2}, {trackGroupIndex: 4}, {trackGroupIndex: 2}, {trackGroupIndex: 3}],
+                    genesetHeatmapTracks: [{trackGroupIndex: 5}]
+                },
+                {
+                    heatmapTracks:[{trackGroupIndex: 2}, {trackGroupIndex: 3}, {trackGroupIndex: 3}, {trackGroupIndex: 3}],
+                    genesetHeatmapTracks: [{trackGroupIndex: 4}]
+                },
+                oncoprint
+            );
+            assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 1, "called once");
+            assert.deepEqual(
+                oncoprint.setTrackGroupSortPriority.args[0][0],
+                [CLINICAL_TRACK_GROUP_INDEX, 2, 3, 4, 5, GENETIC_TRACK_GROUP_INDEX],
+                "right priority order"
+            );
+        });
+        it("should set the track group sort priority on initialisation if only a gene set heatmap is present", ()=>{
+            transitionTrackGroupSortPriority(
+                {heatmapTracks:[], genesetHeatmapTracks: [{trackGroupIndex: 2}, {trackGroupIndex: 2}]},
+                {},
+                oncoprint
+            );
+            assert.equal(oncoprint.setTrackGroupSortPriority.callCount, 1, "called once");
+            assert.deepEqual(
+                oncoprint.setTrackGroupSortPriority.args[0][0],
+                [CLINICAL_TRACK_GROUP_INDEX, 2, GENETIC_TRACK_GROUP_INDEX],
                 "right priority order"
             );
         });

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -47,13 +47,25 @@ export function transition(
     }
 }
 
+type TrackSpecsWithDynamicGroups = {
+    heatmapTracks: {trackGroupIndex: number}[],
+    genesetHeatmapTracks: {trackGroupIndex: number}[]
+};
 export function transitionTrackGroupSortPriority(
-    nextProps:{ heatmapTracks:IOncoprintProps["heatmapTracks"]},
-    prevProps:{ heatmapTracks?:IOncoprintProps["heatmapTracks"]},
-    oncoprint:OncoprintJS<any>
+    nextProps: TrackSpecsWithDynamicGroups,
+    prevProps: Partial<TrackSpecsWithDynamicGroups>,
+    oncoprint: OncoprintJS<any>
 ) {
-    const prevHeatmapTrackGroups = _.sortBy(_.uniq((prevProps.heatmapTracks || []).map(x=>x.trackGroupIndex)));
-    const nextHeatmapTrackGroups = _.sortBy(_.uniq(nextProps.heatmapTracks.map(x=>x.trackGroupIndex)));
+    const prevHeatmapTrackGroups = _.sortBy(_.uniq(
+        (prevProps.heatmapTracks || [])
+        .concat(prevProps.genesetHeatmapTracks || [])
+        .map(x => x.trackGroupIndex)
+    ));
+    const nextHeatmapTrackGroups = _.sortBy(_.uniq(
+        nextProps.heatmapTracks
+        .concat(nextProps.genesetHeatmapTracks)
+        .map(x=>x.trackGroupIndex)
+    ));
     if (_.xor(nextHeatmapTrackGroups, prevHeatmapTrackGroups).length) {
         // if track groups have changed
         oncoprint.setTrackGroupSortPriority([CLINICAL_TRACK_GROUP_INDEX].concat(nextHeatmapTrackGroups).concat(GENETIC_TRACK_GROUP_INDEX));

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -549,7 +549,7 @@ function transitionGenesetHeatmapTrack(
             has_column_spacing: false,
             track_padding: 0,
             label: nextSpec.label,
-            target_group: 30,
+            target_group: nextSpec.trackGroupIndex,
             sort_direction_changeable: true,
             sortCmpFn: heatmapTrackSortComparator,
             init_sort_direction: 0 as 0,

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -42,15 +42,20 @@ export type ClinicalTrackSpec = {
     datatype: "string";
 });
 
-export type HeatmapTrackDatum = {
-    hugo_gene_symbol: string;
+export interface IBaseHeatmapTrackDatum {
     profile_data: number|null;
     sample?: string;
     patient?: string;
     study: string;
     uid: string;
     na?:boolean;
-};
+}
+export interface IGeneHeatmapTrackDatum extends IBaseHeatmapTrackDatum {
+    hugo_gene_symbol: string;
+}
+export interface IGenesetHeatmapTrackDatum extends IBaseHeatmapTrackDatum {
+    geneset_id: string;
+}
 
 export type GeneticTrackDatum = {
     gene: string;
@@ -77,16 +82,22 @@ export type GeneticTrackSpec = {
     data: GeneticTrackDatum[];
 };
 
-export type HeatmapTrackSpec = {
+interface IBaseHeatmapTrackSpec {
     key: string; // for efficient diffing, just like in React. must be unique
     label: string;
     molecularProfileId: string; // source
     molecularAlterationType: MolecularProfile["molecularAlterationType"];
     datatype: MolecularProfile["datatype"];
-    data: HeatmapTrackDatum[];
+    data: IBaseHeatmapTrackDatum[];
     trackGroupIndex: number;
-    onRemove:()=>void;
-};
+}
+export interface IGeneHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
+    data: IGeneHeatmapTrackDatum[];
+    onRemove: () => void;
+}
+export interface IGenesetHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
+    data: IGenesetHeatmapTrackDatum[];
+}
 
 export const GENETIC_TRACK_GROUP_INDEX = 1;
 export const CLINICAL_TRACK_GROUP_INDEX = 0;
@@ -96,7 +107,8 @@ export interface IOncoprintProps {
 
     clinicalTracks: ClinicalTrackSpec[];
     geneticTracks: GeneticTrackSpec[];
-    heatmapTracks: HeatmapTrackSpec[];
+    genesetHeatmapTracks: IGenesetHeatmapTrackSpec[];
+    heatmapTracks: IGeneHeatmapTrackSpec[];
     divId:string;
     width:number;
 

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -251,8 +251,11 @@ export function makeGenesetHeatmapTracksMobxPromise(
             const molecularProfile = oncoprint.props.store.genesetMolecularProfile.result!;
             const dataCache = oncoprint.props.store.genesetMolecularDataCache.result!;
 
+            if (!molecularProfile.isApplicable) {
+                return [];
+            }
+            const molecularProfileId = molecularProfile.value.molecularProfileId;
             const genesetIds = oncoprint.props.store.genesetIds;
-            const molecularProfileId = molecularProfile.molecularProfileId;
 
             const cacheQueries = genesetIds.map((genesetId) => ({molecularProfileId, genesetId}));
             await dataCache.getPromise(cacheQueries, true);
@@ -261,8 +264,8 @@ export function makeGenesetHeatmapTracksMobxPromise(
                 key: `GENESETHEATMAPTRACK_${molecularProfileId},${genesetId}`,
                 label: genesetId,
                 molecularProfileId,
-                molecularAlterationType: molecularProfile.molecularAlterationType,
-                datatype: molecularProfile.datatype,
+                molecularAlterationType: molecularProfile.value.molecularAlterationType,
+                datatype: molecularProfile.value.datatype,
                 data: makeHeatmapTrackData<IGenesetHeatmapTrackDatum, 'geneset_id'>(
                     'geneset_id',
                     genesetId,

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -7,7 +7,7 @@ import {
     reaction
 } from "mobx";
 import {remoteData} from "../../api/remoteData";
-import Oncoprint from "./Oncoprint";
+import {default as Oncoprint, GENETIC_TRACK_GROUP_INDEX} from "./Oncoprint";
 import OncoprintControls, {
     IOncoprintControlsHandlers,
     IOncoprintControlsState
@@ -729,17 +729,26 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         return (this.columnMode === "sample" ? this.sampleClinicalTracks : this.patientClinicalTracks);
     }
 
+    readonly sampleHeatmapTracks = makeHeatmapTracksMobxPromise(this, true);
+    readonly patientHeatmapTracks = makeHeatmapTracksMobxPromise(this, false);
+    @computed get heatmapTracks() {
+        return (this.columnMode === "sample" ? this.sampleHeatmapTracks : this.patientHeatmapTracks);
+    }
+
+    readonly genesetHeatmapTrackGroup = remoteData<number>({
+        await: () => [this.heatmapTracks],
+        invoke: () => Promise.resolve(1 + Math.max(
+            GENETIC_TRACK_GROUP_INDEX,
+            ...(this.heatmapTracks.result!.map(hmTrack => hmTrack.trackGroupIndex))
+        ))
+    });
+
     readonly sampleGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, true);
     readonly patientGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, false);
     @computed get genesetHeatmapTracks() {
         return (this.columnMode === "sample" ? this.sampleGenesetHeatmapTracks : this.patientGenesetHeatmapTracks);
     }
 
-    readonly sampleHeatmapTracks = makeHeatmapTracksMobxPromise(this, true);
-    readonly patientHeatmapTracks = makeHeatmapTracksMobxPromise(this, false);
-    @computed get heatmapTracks() {
-        return (this.columnMode === "sample" ? this.sampleHeatmapTracks : this.patientHeatmapTracks);
-    }
 
     @computed get clusterHeatmapTrackGroupIndex() {
         if (this.sortMode.type === "heatmap") {

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -1,10 +1,10 @@
-import Oncoprint, {ClinicalTrackSpec, GeneticTrackSpec, HeatmapTrackSpec} from "./Oncoprint";
+import Oncoprint, {ClinicalTrackSpec, GeneticTrackSpec, IGeneHeatmapTrackSpec} from "./Oncoprint";
 import fileDownload from "react-file-download";
 
 export default function tabularDownload(
     geneticTracks:GeneticTrackSpec[],
     clinicalTracks:ClinicalTrackSpec[],
-    heatmapTracks:HeatmapTrackSpec[],
+    heatmapTracks:IGeneHeatmapTrackSpec[],
     uidOrder:string[],
     getCaseId:(uid:string)=>string,
     columnMode:"sample"|"patient",

--- a/src/shared/lib/QuerySession.ts
+++ b/src/shared/lib/QuerySession.ts
@@ -1,4 +1,4 @@
-import {GeneticTrackDatum, HeatmapTrackDatum} from "../components/oncoprint/Oncoprint";
+import {GeneticTrackDatum, IGeneHeatmapTrackDatum} from "../components/oncoprint/Oncoprint";
 import {SingleGeneQuery} from "./oql/oql-parser";
 export type OncoprintSampleGeneticTrackData = {
     altered_sample_uids: string[];
@@ -44,7 +44,7 @@ export type OncoprintHeatmapTrackData = {
     gene: string;
     genetic_alteration_type: string;
     genetic_profile_id: string;
-    oncoprint_data: HeatmapTrackDatum[];
+    oncoprint_data: IGeneHeatmapTrackDatum[];
 };
 
 export type KnownMutationSettings = {


### PR DESCRIPTION
If the user queries gene sets and a gene set profile in addition to
genes, add the corresponding tracks to the bottom of the Oncoprint with
an appropriate rule set.

## Screenshot ##
![Screenshot of an Oncoprint showing some genetic tracks, some expression heatmap tracks, and below that, two gene set tracks in a green-to-dark-pink scale](https://user-images.githubusercontent.com/4929431/35055646-efb79df8-fbaf-11e7-9fdf-21151e61a7b9.png)
