### PR TITLE
Refactored Download Tab

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -436,4 +436,7 @@ th.reactable-header-sort-asc:after {
   border:1px dashed $borderColor;
 }
 
-
+h3.hr {
+  margin:0 30px;
+  border:1px dashed $borderColor !important;
+}

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -14,6 +14,7 @@ import Mutations from "./mutation/Mutations";
 import {stringListToSet} from "../../shared/lib/StringUtils";
 import MutualExclusivityTab from "./mutualExclusivity/MutualExclusivityTab";
 import SurvivalTab from "./survival/SurvivalTab";
+import DownloadTab from "./download/DownloadTab";
 import Chart from 'chart.js';
 import {CancerStudy, Sample} from "../../shared/api/generated/CBioPortalAPI";
 import AppConfig from 'appConfig';
@@ -286,6 +287,14 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
             return (<div className="cbioportal-frontend">
                 <SurvivalTab store={this.resultsViewPageStore}/>
             </div>)
+        });
+
+        exposeComponentRenderer('renderDownloadTab', () => {
+            return (
+                <div>
+                    <DownloadTab store={this.resultsViewPageStore} />
+                </div>
+            );
         });
     }
 

--- a/src/pages/resultsView/download/CaseAlterationTable.tsx
+++ b/src/pages/resultsView/download/CaseAlterationTable.tsx
@@ -1,0 +1,162 @@
+import {observer} from "mobx-react";
+import * as React from 'react';
+import LazyMobXTable from "shared/components/lazyMobXTable/LazyMobXTable";
+import {OQLLineFilterOutput} from "shared/lib/oql/oqlfilter";
+import {AnnotatedExtendedAlteration} from "../ResultsViewPageStore";
+
+export interface ISubAlteration {
+    type: string;
+    value: string;
+}
+
+export interface IOqlData {
+    geneSymbol: string;
+    mutation: string[];
+    fusion: string[];
+    cna: ISubAlteration[];
+    mrnaExp: ISubAlteration[];
+    proteinLevel: ISubAlteration[];
+}
+
+export interface ICaseAlteration {
+    studyId: string;
+    sampleId: string;
+    patientId: string;
+    altered: boolean;
+    oqlData: {[oqlLine: string]: IOqlData};
+}
+
+export interface ICaseAlterationTableProps {
+    caseAlterationData: ICaseAlteration[];
+    oqls: OQLLineFilterOutput<AnnotatedExtendedAlteration>[];
+}
+
+export function generateOqlValue(data: IOqlData): string
+{
+    const oqlValue: string[] = [];
+
+    // helper functions to map the display value for different alteration types
+    const stringMapper = (alterationData: (string|ISubAlteration)[]) => alterationData;
+    const subAlterationMapper = (alterationData: (string|ISubAlteration)[]) =>
+        alterationData.map((alteration: ISubAlteration) => alteration.type);
+
+    // generator labels and data extraction functions for different alteration types
+    const generators = [
+        {
+            label: "MUT",
+            getAlterationData: (oqlData: IOqlData) => oqlData.mutation,
+            getValues: stringMapper
+        },
+        {
+            label: "FUSION",
+            getAlterationData: (oqlData: IOqlData) => oqlData.fusion,
+            getValues: stringMapper
+        },
+        {
+            label: "CNA",
+            getAlterationData: (oqlData: IOqlData) => oqlData.cna,
+            getValues: subAlterationMapper
+        },
+        {
+            label: "EXP",
+            getAlterationData: (oqlData: IOqlData) => oqlData.mrnaExp,
+            getValues: subAlterationMapper
+        },
+        {
+            label: "PROT",
+            getAlterationData: (oqlData: IOqlData) => oqlData.proteinLevel,
+            getValues: subAlterationMapper
+        }
+    ];
+
+    // for each alteration type, transform alteration data into a comma separated string
+    generators.forEach((generator) => {
+        const alterationData = generator.getAlterationData(data);
+
+        if (alterationData.length > 0) {
+            oqlValue.push(`${generator.label}: ${generator.getValues(alterationData).join(",")};`);
+        }
+    });
+
+    // finally, generate a single line summary with all alteration data combined.
+    return oqlValue.join(" ");
+}
+
+class CaseAlterationTableComponent extends LazyMobXTable<ICaseAlteration> {}
+
+@observer
+export default class CaseAlterationTable extends React.Component<ICaseAlterationTableProps, {}> {
+    public render()
+    {
+        const columns = [
+            {
+                name: 'Study ID',
+                render: (data: ICaseAlteration) => <span style={{whiteSpace: "nowrap"}}>{data.studyId}</span>,
+                download: (data: ICaseAlteration) => data.studyId,
+                sortBy: (data: ICaseAlteration) => data.studyId,
+                filter: (data: ICaseAlteration, filterString: string, filterStringUpper: string) => {
+                    return data.studyId.toUpperCase().includes(filterStringUpper);
+                }
+            },
+            {
+                name: 'Sample ID',
+                render: (data: ICaseAlteration) => <span style={{whiteSpace: "nowrap"}}>{data.sampleId}</span>,
+                download: (data: ICaseAlteration) => `${data.sampleId}`,
+                sortBy: (data: ICaseAlteration) => data.sampleId,
+                filter: (data: ICaseAlteration, filterString: string, filterStringUpper: string) => {
+                    return data.sampleId.toUpperCase().includes(filterStringUpper);
+                }
+            },
+            {
+                name: 'Patient ID',
+                render: (data: ICaseAlteration) => <span style={{whiteSpace: "nowrap"}}>{data.patientId}</span>,
+                download: (data: ICaseAlteration) => `${data.patientId}`,
+                sortBy: (data: ICaseAlteration) => data.patientId,
+                filter: (data: ICaseAlteration, filterString: string, filterStringUpper: string) => {
+                    return data.patientId.toUpperCase().includes(filterStringUpper);
+                }
+            },
+            {
+                name: 'Altered',
+                tooltip: <span>1 = Case harbors alteration in one of the input genes</span>,
+                render: (data: ICaseAlteration) => <span>{data.altered ? "1" : "0"}</span>,
+                download: (data: ICaseAlteration) => data.altered ? "1" : "0",
+                sortBy: (data: ICaseAlteration) => data.altered ? 1 : 0
+            }
+        ];
+
+        this.props.oqls.forEach(oql => {
+            columns.push({
+                name: oql.gene,
+                tooltip: <span>{oql.oql_line}</span>,
+                render: (data: ICaseAlteration) =>
+                    <span style={{whiteSpace: "nowrap"}}>{data.oqlData ? generateOqlValue(data.oqlData[oql.oql_line]) : ""}</span>,
+                download: (data: ICaseAlteration) =>
+                    data.oqlData ? generateOqlValue(data.oqlData[oql.oql_line]) : "",
+                sortBy: (data: ICaseAlteration) =>
+                    data.oqlData ? generateOqlValue(data.oqlData[oql.oql_line]) : "",
+                filter: (data: ICaseAlteration, filterString: string, filterStringUpper: string) => {
+                    return data.oqlData &&
+                        generateOqlValue(data.oqlData[oql.oql_line]).toUpperCase().includes(filterStringUpper);
+                }
+            });
+        });
+
+
+        return (
+            <CaseAlterationTableComponent
+                data={this.props.caseAlterationData}
+                columns={columns}
+                initialSortColumn="Altered"
+                initialSortDirection={'desc'}
+                initialItemsPerPage={20}
+                showPagination={true}
+                showColumnVisibility={true}
+                showFilter={true}
+                showCopyDownload={true}
+                enableHorizontalScroll={true}
+                copyDownloadProps={{downloadFilename: "alterations_across_samples.tsv"}}
+            />
+        );
+    }
+}

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -1,0 +1,380 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {computed} from "mobx";
+import {observer} from 'mobx-react';
+import fileDownload from 'react-file-download';
+import {AnnotatedExtendedAlteration, ExtendedAlteration, ResultsViewPageStore} from "../ResultsViewPageStore";
+import {OQLLineFilterOutput} from "shared/lib/oql/oqlfilter";
+import FeatureTitle from "shared/components/featureTitle/FeatureTitle";
+import {SimpleCopyDownloadControls} from "shared/components/copyDownloadControls/SimpleCopyDownloadControls";
+import {default as GeneAlterationTable, IGeneAlteration} from "./GeneAlterationTable";
+import {default as CaseAlterationTable, ICaseAlteration} from "./CaseAlterationTable";
+import {
+    generateCaseAlterationData, generateCnaData, generateDownloadData, generateGeneAlterationData, generateMrnaData,
+    generateMutationData, generateMutationDownloadData,
+    generateProteinData, hasValidData, hasValidMutationData, stringify2DArray
+} from "./DownloadUtils";
+
+import styles from "./styles.module.scss";
+import classNames from 'classnames';
+
+export interface IDownloadTabProps {
+    store: ResultsViewPageStore;
+}
+
+@observer
+export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
+{
+    constructor(props: IDownloadTabProps)
+    {
+        super(props);
+
+        this.handleMutationDownload = this.handleMutationDownload.bind(this);
+        this.handleTransposedMutationDownload = this.handleTransposedMutationDownload.bind(this);
+        this.handleCnaDownload = this.handleCnaDownload.bind(this);
+        this.handleTransposedCnaDownload = this.handleTransposedCnaDownload.bind(this);
+        this.handleMrnaDownload = this.handleMrnaDownload.bind(this);
+        this.handleTransposedMrnaDownload = this.handleTransposedMrnaDownload.bind(this);
+        this.handleProteinDownload = this.handleProteinDownload.bind(this);
+        this.handleTransposedProteinDownload = this.handleTransposedProteinDownload.bind(this);
+    }
+
+    @computed get caseAggregatedDataByOQLLine() {
+        return this.props.store.putativeDriverFilteredCaseAggregatedDataByOQLLine.result;
+    }
+
+    @computed get unfilteredCaseAggregatedData() {
+        return this.props.store.unfilteredCaseAggregatedData.result;
+    }
+
+    @computed get sequencedSampleKeysByGene() {
+        return this.props.store.sequencedSampleKeysByGene.result;
+    }
+
+    @computed get samples() {
+        return this.props.store.samples.result;
+    }
+
+    @computed get genes() {
+        return this.props.store.genes.result;
+    }
+
+    @computed get genePanelInformation() {
+        return this.props.store.genePanelInformation.result;
+    }
+
+    @computed get geneAlterationData(): IGeneAlteration[] {
+        return generateGeneAlterationData(this.caseAggregatedDataByOQLLine, this.sequencedSampleKeysByGene);
+    }
+
+    @computed get caseAlterationData(): ICaseAlteration[] {
+        return generateCaseAlterationData(
+            this.caseAggregatedDataByOQLLine, this.genePanelInformation, this.samples);
+    }
+
+    @computed get mutationData(): {[key: string]: ExtendedAlteration[]} {
+        return generateMutationData(this.unfilteredCaseAggregatedData);
+    }
+
+    @computed get mutationDownloadData(): string[][] {
+        return generateMutationDownloadData(this.mutationData, this.samples, this.genes);
+    }
+
+    @computed get transposedMutationDownloadData(): string[][] {
+        return _.unzip(this.mutationDownloadData);
+    }
+
+    @computed get mutationDataText(): string {
+        return stringify2DArray(this.mutationDownloadData);
+    }
+
+    @computed get transposedMutationDataText(): string {
+        return stringify2DArray(this.transposedMutationDownloadData);
+    }
+
+    @computed get mrnaData(): {[key: string]: ExtendedAlteration[]} {
+        return generateMrnaData(this.unfilteredCaseAggregatedData);
+    }
+
+    @computed get mrnaDownloadData(): string[][] {
+        return generateDownloadData(this.mrnaData, this.samples, this.genes);
+    }
+
+    @computed get transposedMrnaDownloadData(): string[][] {
+        return _.unzip(this.mrnaDownloadData);
+    }
+
+    @computed get mrnaDataText(): string {
+        return stringify2DArray(this.mrnaDownloadData);
+    }
+
+    @computed get transposedMrnaDataText(): string {
+        return stringify2DArray(this.transposedMrnaDownloadData);
+    }
+
+    @computed get proteinData(): {[key: string]: ExtendedAlteration[]} {
+        return generateProteinData(this.unfilteredCaseAggregatedData);
+    }
+
+    @computed get proteinDownloadData(): string[][] {
+        return generateDownloadData(this.proteinData, this.samples, this.genes);
+    }
+
+    @computed get transposedProteinDownloadData(): string[][] {
+        return _.unzip(this.proteinDownloadData);
+    }
+
+    @computed get proteinDataText(): string {
+        return stringify2DArray(this.proteinDownloadData);
+    }
+
+    @computed get transposedProteinDataText(): string {
+        return stringify2DArray(this.transposedProteinDownloadData);
+    }
+
+    @computed get cnaData(): {[key: string]: ExtendedAlteration[]} {
+        return generateCnaData(this.unfilteredCaseAggregatedData);
+    }
+
+    @computed get cnaDownloadData(): string[][] {
+        return generateDownloadData(this.cnaData, this.samples, this.genes);
+    }
+
+    @computed get transposedCnaDownloadData(): string[][] {
+        return _.unzip(this.cnaDownloadData);
+    }
+
+    @computed get cnaDataText(): string {
+        return stringify2DArray(this.cnaDownloadData);
+    }
+
+    @computed get transposedCnaDataText(): string {
+        return stringify2DArray(this.transposedCnaDownloadData);
+    }
+
+    @computed get alteredSamples(): string[] {
+        return this.caseAlterationData
+            .filter(caseAlteration => caseAlteration.altered)
+            .map(caseAlteration => `${caseAlteration.studyId}:${caseAlteration.sampleId}`);
+    }
+
+    @computed get alteredSamplesText(): string {
+        return this.alteredSamples.join("\n");
+    }
+
+    @computed get sampleMatrix(): string[][] {
+        return this.caseAlterationData
+            .map(caseAlteration =>
+                [`${caseAlteration.studyId}:${caseAlteration.sampleId}`, caseAlteration.altered ? "1" : "0"]);
+    }
+
+    @computed get sampleMatrixText(): string {
+        return stringify2DArray(this.sampleMatrix);
+    }
+
+    @computed get oqls(): OQLLineFilterOutput<AnnotatedExtendedAlteration>[] {
+        return this.caseAggregatedDataByOQLLine ?
+            this.caseAggregatedDataByOQLLine.map(data => data.oql) : [];
+    }
+
+    public render() {
+        const loadingGeneAlterationData =
+            this.props.store.putativeDriverFilteredCaseAggregatedDataByOQLLine.status === "pending" ||
+            this.props.store.sequencedSampleKeysByGene.status === "pending";
+
+        const errorGeneAlterationData =
+            this.props.store.putativeDriverFilteredCaseAggregatedDataByOQLLine.status === "error" ||
+            this.props.store.sequencedSampleKeysByGene.status === "error";
+
+        const loadingCaseAlterationData =
+            this.props.store.putativeDriverFilteredCaseAggregatedDataByOQLLine.status === "pending" ||
+            this.props.store.samples.status === "pending" ||
+            this.props.store.genePanelInformation.status === "pending";
+
+        const errorCaseAlterationData =
+            this.props.store.putativeDriverFilteredCaseAggregatedDataByOQLLine.status === "error" ||
+            this.props.store.samples.status === "error" ||
+            this.props.store.genePanelInformation.status === "error";
+
+        const loadingDownloadData = loadingGeneAlterationData ||
+            this.props.store.unfilteredCaseAggregatedData.status === "pending";
+
+        const errorDownloadData = errorCaseAlterationData ||
+            this.props.store.unfilteredCaseAggregatedData.status === "error";
+
+        return (
+            <div className="cbioportal-frontend">
+                <div>
+                    <FeatureTitle
+                        title="Downloadable Data Files"
+                        className="forceHeaderStyle h4"
+                        isLoading={loadingDownloadData}
+                        style={{marginBottom:15}}
+                    />
+                    {!loadingDownloadData && !errorDownloadData && this.downloadableFilesTable()}
+                </div>
+                <hr/>
+                <div className={styles["tables-container"]}>
+                    <FeatureTitle
+                        title="Gene Alteration Frequency"
+                        isLoading={loadingGeneAlterationData}
+                        className="pull-left forceHeaderStyle h4"
+                    />
+                    <GeneAlterationTable geneAlterationData={this.geneAlterationData} />
+                </div>
+                <hr/>
+                <div className={styles["tables-container"]}>
+                    <FeatureTitle
+                        title="Type of Genetic alterations across all samples"
+                        isLoading={loadingCaseAlterationData}
+                        className="pull-left forceHeaderStyle h4"
+                    />
+                    <CaseAlterationTable
+                        caseAlterationData={this.caseAlterationData}
+                        oqls={this.oqls}
+                    />
+                </div>
+            </div>
+        );
+    }
+
+    private downloadableFilesTable(): JSX.Element
+    {
+        return (
+            <table className={ classNames("table", "table-striped", styles.downloadCopyTable) }>
+                <tbody>
+                    {hasValidData(this.cnaData) && this.cnaDownloadControls()}
+                    {hasValidMutationData(this.mutationData) && this.mutationDownloadControls()}
+                    {hasValidData(this.mrnaData) && this.mrnaExprDownloadControls()}
+                    {hasValidData(this.proteinData) && this.proteinExprDownloadControls()}
+                    {this.alteredSamplesDownloadControls()}
+                    {this.sampleMatrixDownloadControls()}
+                </tbody>
+            </table>
+        );
+    }
+
+    private cnaDownloadControls(): JSX.Element
+    {
+        return this.downloadControlsRow("Copy-number Alterations",
+                                        this.handleCnaDownload,
+                                        this.handleTransposedCnaDownload);
+    }
+
+    private mutationDownloadControls(): JSX.Element
+    {
+        return this.downloadControlsRow("Mutations",
+                                        this.handleMutationDownload,
+                                        this.handleTransposedMutationDownload);
+    }
+
+    private mrnaExprDownloadControls(): JSX.Element
+    {
+        return this.downloadControlsRow("mRNA Expression",
+                                        this.handleMrnaDownload,
+                                        this.handleTransposedMrnaDownload);
+    }
+
+    private proteinExprDownloadControls(): JSX.Element
+    {
+        return this.downloadControlsRow("Protein Expression",
+                                        this.handleProteinDownload,
+                                        this.handleTransposedProteinDownload);
+    }
+
+    private downloadControlsRow(title:string,
+                                handleTabDelimitedDownload: () => void,
+                                handleTransposedMatrixDownload: () => void)
+    {
+        return (
+            <tr>
+                <td style={{width: 500}}>{title}</td>
+                <td>
+                    <a onClick={handleTabDelimitedDownload}>
+                        <i className='fa fa-cloud-download' style={{marginRight: 5}}/>Tab Delimited Format
+                    </a>
+                    <span style={{margin:'0px 10px'}}>|</span>
+                    <a onClick={handleTransposedMatrixDownload}>
+                        <i className='fa fa-cloud-download' style={{marginRight: 5}}/>Transposed Matrix
+                    </a>
+                </td>
+            </tr>
+        );
+    }
+
+    private copyDownloadControlsRow(title:string,
+                                    handleDownload: () => string,
+                                    filename: string)
+    {
+        return (
+            <tr>
+                <td>{title}</td>
+                <td>
+                    <SimpleCopyDownloadControls
+                        controlsStyle='LINK'
+                        downloadData={handleDownload}
+                        downloadFilename={filename}
+                    />
+                </td>
+            </tr>
+        );
+    }
+
+    private alteredSamplesDownloadControls(): JSX.Element
+    {
+        const handleDownload = () => this.alteredSamplesText;
+
+        return this.copyDownloadControlsRow("Samples affected: Only samples with an alteration are included",
+                                            handleDownload,
+                                            "affected_samples.txt");
+    }
+
+    private sampleMatrixDownloadControls(): JSX.Element
+    {
+        const handleDownload = () => this.sampleMatrixText;
+
+        return this.copyDownloadControlsRow("Sample matrix: 1 = Sample harbors alteration in one of the input genes",
+                                            handleDownload,
+                                            "sample_matrix.txt");
+    }
+
+    private handleMutationDownload()
+    {
+        fileDownload(this.mutationDataText, "mutations.txt");
+    }
+
+    private handleTransposedMutationDownload()
+    {
+        fileDownload(this.transposedMutationDataText, "mutations_transposed.txt");
+    }
+
+    private handleMrnaDownload()
+    {
+        fileDownload(this.mrnaDataText, "mRNA_exp.txt");
+    }
+
+    private handleTransposedMrnaDownload()
+    {
+        fileDownload(this.transposedMrnaDataText, "mRNA_exp_transposed.txt");
+    }
+
+    private handleProteinDownload()
+    {
+        fileDownload(this.proteinDataText, "protein_exp.txt");
+    }
+
+    private handleTransposedProteinDownload()
+    {
+        fileDownload(this.transposedProteinDataText, "protein_exp_transposed.txt");
+    }
+
+    private handleCnaDownload()
+    {
+        fileDownload(this.cnaDataText, "cna.txt");
+    }
+
+    private handleTransposedCnaDownload()
+    {
+        fileDownload(this.transposedCnaDataText, "cna_transposed.txt");
+    }
+}

--- a/src/pages/resultsView/download/DownloadUtils.spec.ts
+++ b/src/pages/resultsView/download/DownloadUtils.spec.ts
@@ -1,0 +1,613 @@
+import {assert} from 'chai';
+
+import {GeneticTrackDatum} from "shared/components/oncoprint/Oncoprint";
+import {Sample} from "shared/api/generated/CBioPortalAPI";
+import {
+    generateCaseAlterationData, generateDownloadData, generateGeneAlterationData, generateMutationDownloadData, generateOqlData
+} from "./DownloadUtils";
+import {
+    AnnotatedMutation, ExtendedAlteration
+} from "../ResultsViewPageStore";
+
+describe('DownloadUtils', () => {
+
+    const genes = [
+        {
+            "entrezGeneId": 5728,
+            "hugoGeneSymbol": "PTEN",
+            "type": "protein-coding",
+            "cytoband": "10q23.31",
+            "length": 87892669,
+            "chromosome": "10"
+        },
+        {
+            "entrezGeneId": 7157,
+            "hugoGeneSymbol": "TP53",
+            "type": "protein-coding",
+            "cytoband": "17p13.1",
+            "length": 19149,
+            "chromosome": "17"
+        },
+        {
+            "entrezGeneId": 1956,
+            "hugoGeneSymbol": "EGFR",
+            "type": "protein-coding",
+            "cytoband": "7p11.2",
+            "length": 188307,
+            "chromosome": "7"
+        }
+    ];
+
+    const samples = [{
+        uniqueSampleKey: "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+        uniquePatientKey: "UC0wMDAwMzc4Om1za19pbXBhY3RfMjAxNw",
+        sampleType: "Primary Solid Tumor",
+        sampleId: "P-0000378-T01-IM3",
+        patientId: "P-0000378",
+        cancerTypeId: "mixed",
+        studyId: "msk_impact_2017",
+    }, {
+        uniqueSampleKey: "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ",
+        uniquePatientKey: "VENHQS1FRS1BMjBDOnNrY21fdGNnYQ",
+        sampleType: "Metastatic",
+        sampleId: "TCGA-EE-A20C-06",
+        patientId: "TCGA-EE-A20C",
+        cancerTypeId: "skcm",
+        studyId: "skcm_tcga",
+    }] as Sample[];
+
+    const sampleDataWithNoAlteration: (ExtendedAlteration&AnnotatedMutation)[] = [];
+
+    const mrnaDataForTCGAEEA20C = {
+        oncoKbOncogenic: "",
+        uniqueSampleKey: "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ",
+        uniquePatientKey: "VENHQS1FRS1BMjBDOnNrY21fdGNnYQ",
+        molecularProfileId: "skcm_tcga_rna_seq_v2_mrna_median_Zscores",
+        sampleId: "TCGA-EE-A20C-06",
+        patientId: "TCGA-EE-A20C",
+        studyId: "skcm_tcga",
+        value: "2.4745",
+        entrezGeneId: 5728,
+        gene: {
+            entrezGeneId: 5728,
+            hugoGeneSymbol: "PTEN",
+            type: "protein-coding",
+            cytoband: "10q23.31",
+            length: 87892669
+        },
+        molecularProfileAlterationType: "MRNA_EXPRESSION",
+        alterationType: "MRNA_EXPRESSION",
+        alterationSubType: "up"
+    };
+
+    const proteinDataForTCGAEEA20C = {
+        oncoKbOncogenic: "",
+        uniqueSampleKey: "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ",
+        uniquePatientKey: "VENHQS1FRS1BMjBDOnNrY21fdGNnYQ",
+        molecularProfileId: "skcm_tcga_rppa_Zscores",
+        sampleId: "TCGA-EE-A20C-06",
+        patientId: "TCGA-EE-A20C",
+        studyId: "skcm_tcga",
+        value: "2.5406",
+        entrezGeneId: 5728,
+        gene: {
+            entrezGeneId: 5728,
+            hugoGeneSymbol: "PTEN",
+            type: "protein-coding",
+            cytoband: "10q23.31",
+            length: 87892669
+        },
+        molecularProfileAlterationType: "PROTEIN_LEVEL",
+        alterationType: "PROTEIN_LEVEL",
+        alterationSubType: "up"
+    };
+
+    const cnaDataForTCGAEEA20C = {
+        molecularProfileAlterationType: "COPY_NUMBER_ALTERATION",
+        uniqueSampleKey: "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ",
+        uniquePatientKey: "VENHQS1FRS1BMjBDOnNrY21fdGNnYQ",
+        molecularProfileId: "skcm_tcga_gistic",
+        sampleId: "TCGA-EE-A20C-06",
+        patientId: "TCGA-EE-A20C",
+        studyId: "skcm_tcga",
+        value: "-1",
+        entrezGeneId: 7157,
+        gene: {
+            entrezGeneId: 7157,
+            hugoGeneSymbol: "TP53",
+            type: "protein-coding",
+            cytoband: "17p13.1",
+            length: 19149
+        }
+    };
+
+    const sampleDataWithBothMutationAndFusion = [
+        {
+            "putativeDriver": true,
+            "isHotspot": true,
+            "oncoKbOncogenic": "likely oncogenic",
+            "simplifiedMutationType": "missense",
+            "uniqueSampleKey": "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+            "uniquePatientKey": "UC0wMDAwMzc4Om1za19pbXBhY3RfMjAxNw",
+            "molecularProfileId": "msk_impact_2017_mutations",
+            "sampleId": "P-0000378-T01-IM3",
+            "patientId": "P-0000378",
+            "entrezGeneId": 1956,
+            "gene": {
+                "entrezGeneId": 1956,
+                "hugoGeneSymbol": "EGFR",
+                "type": "protein-coding",
+                "cytoband": "7p11.2",
+                "length": 188307,
+                "chromosome": "7"
+            },
+            "studyId": "msk_impact_2017",
+            "center": "NA",
+            "mutationStatus": "NA",
+            "validationStatus": "NA",
+            "tumorAltCount": 425,
+            "tumorRefCount": 7757,
+            "normalAltCount": -1,
+            "normalRefCount": -1,
+            "startPosition": 55233043,
+            "endPosition": 55233043,
+            "referenceAllele": "G",
+            "proteinChange": "G598A",
+            "mutationType": "Missense_Mutation",
+            "functionalImpactScore": "M",
+            "fisValue": 2.855,
+            "linkXvar": "getma.org/?cm=var&var=hg19,7,55233043,G,C&fts=all",
+            "linkPdb": "getma.org/pdb.php?prot=EGFR_HUMAN&from=482&to=681&var=G598A",
+            "linkMsa": "getma.org/?cm=msa&ty=f&p=EGFR_HUMAN&rb=482&re=681&var=G598A",
+            "ncbiBuild": "GRCh37",
+            "variantType": "SNP",
+            "keyword": "EGFR G598 missense",
+            "driverFilter": "",
+            "driverFilterAnnotation": "",
+            "driverTiersFilter": "",
+            "driverTiersFilterAnnotation": "",
+            "variantAllele": "C",
+            "refseqMrnaId": "NM_005228.3",
+            "proteinPosStart": 598,
+            "proteinPosEnd": 598,
+            "molecularProfileAlterationType": "MUTATION_EXTENDED",
+            "alterationType": "MUTATION_EXTENDED",
+            "alterationSubType": "missense"
+        },
+        {
+            "putativeDriver": true,
+            "isHotspot": false,
+            "oncoKbOncogenic": "likely oncogenic",
+            "simplifiedMutationType": "fusion",
+            "uniqueSampleKey": "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+            "uniquePatientKey": "UC0wMDAwMzc4Om1za19pbXBhY3RfMjAxNw",
+            "molecularProfileId": "msk_impact_2017_mutations",
+            "sampleId": "P-0000378-T01-IM3",
+            "patientId": "P-0000378",
+            "entrezGeneId": 1956,
+            "gene": {
+                "entrezGeneId": 1956,
+                "hugoGeneSymbol": "EGFR",
+                "type": "protein-coding",
+                "cytoband": "7p11.2",
+                "length": 188307,
+                "chromosome": "7"
+            },
+            "studyId": "msk_impact_2017",
+            "center": "MSKCC-DMP",
+            "mutationStatus": "NA",
+            "validationStatus": "NA",
+            "tumorAltCount": -1,
+            "tumorRefCount": -1,
+            "normalAltCount": -1,
+            "normalRefCount": -1,
+            "startPosition": -1,
+            "endPosition": -1,
+            "referenceAllele": "NA",
+            "proteinChange": "EGFR-intragenic",
+            "mutationType": "Fusion",
+            "functionalImpactScore": "NA",
+            "fisValue": -1,
+            "linkXvar": "NA",
+            "linkPdb": "NA",
+            "linkMsa": "NA",
+            "ncbiBuild": "NA",
+            "variantType": "NA",
+            "keyword": "EGFR EGFR-intragenic",
+            "variantAllele": "NA",
+            "refseqMrnaId": "NA",
+            "proteinPosStart": -1,
+            "proteinPosEnd": -1,
+            "molecularProfileAlterationType": "MUTATION_EXTENDED",
+            "alterationType": "FUSION",
+            "alterationSubType": "fusion"
+        },
+        {
+            "putativeDriver": false,
+            "isHotspot": false,
+            "oncoKbOncogenic": "",
+            "simplifiedMutationType": "missense",
+            "uniqueSampleKey": "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+            "uniquePatientKey": "UC0wMDAwMzc4Om1za19pbXBhY3RfMjAxNw",
+            "molecularProfileId": "msk_impact_2017_mutations",
+            "sampleId": "P-0000378-T01-IM3",
+            "patientId": "P-0000378",
+            "entrezGeneId": 1956,
+            "gene": {
+                "entrezGeneId": 1956,
+                "hugoGeneSymbol": "EGFR",
+                "type": "protein-coding",
+                "cytoband": "7p11.2",
+                "length": 188307,
+                "chromosome": "7"
+            },
+            "studyId": "msk_impact_2017",
+            "center": "NA",
+            "mutationStatus": "NA",
+            "validationStatus": "NA",
+            "tumorAltCount": 1694,
+            "tumorRefCount": 3870,
+            "normalAltCount": -1,
+            "normalRefCount": -1,
+            "startPosition": 55220325,
+            "endPosition": 55220325,
+            "referenceAllele": "G",
+            "proteinChange": "G239C",
+            "mutationType": "Missense_Mutation",
+            "functionalImpactScore": "",
+            "fisValue": 1.4013e-45,
+            "linkXvar": "",
+            "linkPdb": "",
+            "linkMsa": "",
+            "ncbiBuild": "GRCh37",
+            "variantType": "SNP",
+            "keyword": "EGFR G239 missense",
+            "driverFilter": "",
+            "driverFilterAnnotation": "",
+            "driverTiersFilter": "",
+            "driverTiersFilterAnnotation": "",
+            "variantAllele": "T",
+            "refseqMrnaId": "NM_005228.3",
+            "proteinPosStart": 239,
+            "proteinPosEnd": 239,
+            "molecularProfileAlterationType": "MUTATION_EXTENDED",
+            "alterationType": "MUTATION_EXTENDED",
+            "alterationSubType": "missense"
+        }
+    ] as (ExtendedAlteration&AnnotatedMutation)[];
+
+    const caseAggregatedDataByOQLLine = [{
+        cases: {
+            samples: {
+                "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": sampleDataWithBothMutationAndFusion,
+                "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": []
+            }
+        },
+        oql: {
+            gene: "EGFR",
+            oql_line: "EGFR: AMP HOMDEL MUT FUSION;",
+            data: sampleDataWithBothMutationAndFusion
+        }
+    }, {
+        cases: {
+            samples: {
+                "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [mrnaDataForTCGAEEA20C, proteinDataForTCGAEEA20C]
+            }
+        },
+        oql: {
+            gene: "PTEN",
+            oql_line: "PTEN: AMP HOMDEL MUT FUSION;",
+            data: [mrnaDataForTCGAEEA20C, proteinDataForTCGAEEA20C]
+        }
+    }, {
+        cases: {
+            samples: {
+                "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": []
+            }
+        },
+        oql: {
+            gene: "TP53",
+            oql_line: "TP53: AMP HOMDEL MUT FUSION;",
+            data: []
+        }
+    }] as any;
+
+    describe('generateOqlData', () => {
+
+        it('generates empty oql data for a sample with no alteration data', () => {
+
+            const geneticTrackDatum = {
+                sample: "TCGA-BF-A1PV-01",
+                study_id: "skcm_tcga",
+                uid: "VENHQS1CRi1BMVBWLTAxOnNrY21fdGNnYQ",
+                wholeExomeSequenced: true,
+                gene: "PTEN",
+                data: sampleDataWithNoAlteration
+            };
+
+            const oqlData = generateOqlData(geneticTrackDatum);
+
+            assert.equal(oqlData.geneSymbol, "PTEN",
+                "gene symbol is correct for the sample with no alteration");
+            assert.equal(oqlData.cna.length, 0,
+                "cna data is empty for the sample with no alteration");
+            assert.equal(oqlData.mutation.length, 0,
+                "mutation data is empty for the sample with no alteration");
+            assert.equal(oqlData.fusion.length, 0,
+                "fusion data is empty for the sample with no alteration");
+            assert.equal(oqlData.mrnaExp.length, 0,
+                "mRNA expression data is empty for the sample with no alteration");
+            assert.equal(oqlData.proteinLevel.length, 0,
+                "protein level data is empty for the sample with no alteration");
+        });
+
+
+        it('generates oql data properly for samples with multiple alteration types', () => {
+
+            const geneticTrackDatum = {
+                sample: "TCGA-EE-A20C-06",
+                study_id: "skcm_tcga",
+                uid: "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ",
+                wholeExomeSequenced: true,
+                gene: "PTEN",
+                data: [mrnaDataForTCGAEEA20C, proteinDataForTCGAEEA20C],
+                disp_mrna: "up",
+                disp_prot: "up"
+            } as GeneticTrackDatum;
+
+            const oqlData = generateOqlData(geneticTrackDatum);
+
+            assert.equal(oqlData.geneSymbol, "PTEN",
+                "gene symbol is correct for the sample with mrna and protein data only");
+            assert.equal(oqlData.cna.length, 0,
+                "cna data is empty for the sample with mrna and protein data only");
+            assert.equal(oqlData.mutation.length, 0,
+                "mutation data is empty for the sample with mrna and protein data only");
+            assert.equal(oqlData.fusion.length, 0,
+                "fusion data is empty for the sample with mrna and protein data only");
+
+            assert.equal(oqlData.mrnaExp.length, 1,
+                "mRNA expression data exists for the sample with mrna and protein data only");
+            assert.equal(oqlData.proteinLevel.length, 1,
+                "protein level data exists for the sample with mrna and protein data only");
+
+            assert.deepEqual(oqlData.mrnaExp, [{type: "UP", value: "2.4745"}],
+                "mRNA expression data is correct for the sample with mrna and protein data only");
+            assert.deepEqual(oqlData.proteinLevel, [{type: "UP", value: "2.5406"}],
+                "protein level data is correct for the sample with mrna and protein data only");
+        });
+
+        it('generates oql data properly for samples with multiple mutations/fusions', () => {
+
+            const geneticTrackDatum = {
+                sample: "P-0000378-T01-IM3",
+                study_id: "msk_impact_2017",
+                uid: "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+                gene: "EGFR",
+                data: sampleDataWithBothMutationAndFusion,
+                disp_fusion: true,
+                disp_cna: "amp",
+                disp_mut: "missense_rec"
+            } as GeneticTrackDatum;
+
+            const oqlData = generateOqlData(geneticTrackDatum);
+
+            assert.equal(oqlData.geneSymbol, "EGFR",
+                "gene symbol is correct for the sample with both mutation and fusion data");
+            assert.deepEqual(oqlData.mrnaExp, [],
+                "mRNA expression data is empty for the sample with mutation and fusion data");
+            assert.deepEqual(oqlData.proteinLevel, [],
+                "protein level data is empty for the sample with mutation and fusion data");
+            assert.deepEqual(oqlData.cna, [],
+                "CNA data is empty for the sample with mutation and fusion data");
+            assert.deepEqual(oqlData.fusion, ["EGFR-intragenic"],
+                "fusion data is correct for the sample with mutation and fusion data");
+            assert.deepEqual(oqlData.mutation, ["G598A", "G239C"],
+                "mutation data is correct for the sample with mutation and fusion data");
+        });
+    });
+
+    describe('generateGeneAlterationData', () => {
+        it('generates gene alteration data for multiple samples', () => {
+
+            const sampleKeys = {
+                PTEN: [
+                    "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+                    "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ"
+                ],
+                TP53: [
+                    "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+                    "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ"
+                ],
+                EGFR: [
+                    "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
+                    "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ"
+                ]
+            };
+
+            const caseAlterationData = generateGeneAlterationData(caseAggregatedDataByOQLLine, sampleKeys);
+
+            assert.equal(caseAlterationData[0].oqlLine, "EGFR: AMP HOMDEL MUT FUSION;",
+                "OQL line is correct for the gene EGFR");
+            assert.equal(caseAlterationData[0].altered, 1,
+                "number of altered samples is correct for the gene EGFR");
+            assert.equal(caseAlterationData[0].percentAltered, "50%",
+                "alteration percent is correct for the gene EGFR");
+
+            assert.equal(caseAlterationData[1].oqlLine, "PTEN: AMP HOMDEL MUT FUSION;",
+                "OQL line is correct for the gene PTEN");
+            assert.equal(caseAlterationData[1].altered, 1,
+                "number of altered samples is correct for the gene PTEN");
+            assert.equal(caseAlterationData[1].percentAltered, "50%",
+                "alteration percent is correct for the gene PTEN");
+
+            assert.equal(caseAlterationData[2].oqlLine, "TP53: AMP HOMDEL MUT FUSION;",
+                "OQL line is correct for the gene TP53");
+            assert.equal(caseAlterationData[2].altered, 0,
+                "number of altered samples is correct for the gene TP53");
+            assert.equal(caseAlterationData[2].percentAltered, "0%",
+                "alteration percent is correct for the gene TP53");
+        });
+    });
+
+    describe('generateMutationDownloadData', () => {
+
+        it('generates download data for mutated samples',() => {
+
+            const sampleAlterationDataByGene = {
+                "EGFR_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [
+                    ...sampleDataWithBothMutationAndFusion
+                ],
+                "PTEN_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "TP53_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "EGFR_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [],
+                "PTEN_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [],
+                "TP53_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": []
+            };
+
+            const downloadData = generateMutationDownloadData(sampleAlterationDataByGene, samples, genes);
+
+            const expectedResult = [
+                ["STUDY_ID", "SAMPLE_ID", "PTEN", "TP53", "EGFR"],
+                ["msk_impact_2017", "P-0000378-T01-IM3", "NA", "NA", "G598A EGFR-intragenic G239C"],
+                ["skcm_tcga", "TCGA-EE-A20C-06", "NA", "NA", "NA"]
+            ];
+
+            assert.deepEqual(downloadData, expectedResult,
+                "mutation download data is correctly generated");
+        });
+
+    });
+
+    describe('generateDownloadData', () => {
+
+        it('generates download data for mRNA expression alterations',() => {
+
+            const sampleAlterationDataByGene = {
+                "EGFR_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "PTEN_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "TP53_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "EGFR_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [],
+                "PTEN_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [
+                    mrnaDataForTCGAEEA20C as ExtendedAlteration&AnnotatedMutation
+                ],
+                "TP53_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": []
+            };
+
+            const downloadData = generateDownloadData(sampleAlterationDataByGene, samples, genes);
+
+            const expectedResult = [
+                ["STUDY_ID", "SAMPLE_ID", "PTEN", "TP53", "EGFR"],
+                ["msk_impact_2017", "P-0000378-T01-IM3", "NA", "NA", "NA"],
+                ["skcm_tcga", "TCGA-EE-A20C-06", "2.4745", "NA", "NA"]
+            ];
+
+            assert.deepEqual(downloadData, expectedResult,
+                "mRNA download data is correctly generated");
+        });
+
+        it('generates download data for protein expression alterations',() => {
+
+            const sampleAlterationDataByGene = {
+                "EGFR_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "PTEN_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "TP53_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "EGFR_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [],
+                "PTEN_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [
+                    proteinDataForTCGAEEA20C as ExtendedAlteration&AnnotatedMutation
+                ],
+                "TP53_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": []
+            };
+
+            const downloadData = generateDownloadData(sampleAlterationDataByGene, samples, genes);
+
+            const expectedResult = [
+                ["STUDY_ID", "SAMPLE_ID", "PTEN", "TP53", "EGFR"],
+                ["msk_impact_2017", "P-0000378-T01-IM3", "NA", "NA", "NA"],
+                ["skcm_tcga", "TCGA-EE-A20C-06", "2.5406", "NA", "NA"]
+            ];
+
+            assert.deepEqual(downloadData, expectedResult,
+                "protein download data is correctly generated");
+        });
+
+        it('generates download data for copy number altered samples',() => {
+
+            const sampleAlterationDataByGene = {
+                "EGFR_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "PTEN_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "TP53_UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": [],
+                "EGFR_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [],
+                "PTEN_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [],
+                "TP53_VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": [
+                    cnaDataForTCGAEEA20C as ExtendedAlteration&AnnotatedMutation
+                ]
+            };
+
+            const downloadData = generateDownloadData(sampleAlterationDataByGene, samples, genes);
+
+            const expectedResult = [
+                ["STUDY_ID", "SAMPLE_ID", "PTEN", "TP53", "EGFR"],
+                ["msk_impact_2017", "P-0000378-T01-IM3", "NA", "NA", "NA"],
+                ["skcm_tcga", "TCGA-EE-A20C-06", "NA", "-1", "NA"]
+            ];
+
+            assert.deepEqual(downloadData, expectedResult,
+                "CNA download data is correctly generated");
+        });
+    });
+
+    describe('generateCaseAlterationData', () => {
+
+        it('generates case alteration data for multiple samples',() => {
+
+            const genePanelInformation = {
+                samples: {
+                    "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3": {
+                        "sequencedGenes": {},
+                        "wholeExomeSequenced": true
+                    },
+                    "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ": {
+                        "sequencedGenes": {},
+                        "wholeExomeSequenced": true
+                    }
+                },
+                patients: {}
+            };
+
+
+            const caseAlterationData = generateCaseAlterationData(caseAggregatedDataByOQLLine, genePanelInformation, samples);
+
+            assert.equal(caseAlterationData.length, 2,
+                "case alteration data has correct size");
+
+            assert.equal(caseAlterationData[0].sampleId, "P-0000378-T01-IM3",
+                "sample id is correct for the sample key UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3");
+            assert.equal(caseAlterationData[0].studyId, "msk_impact_2017",
+                "study id is correct for the sample key UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3");
+            assert.isTrue(caseAlterationData[0].altered,
+                "sample UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3 is altered");
+            assert.deepEqual(caseAlterationData[0].oqlData["EGFR: AMP HOMDEL MUT FUSION;"].mutation,
+                ["G598A", "G239C"],
+                "mutation data is correct for the sample key UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3");
+            assert.deepEqual(caseAlterationData[0].oqlData["EGFR: AMP HOMDEL MUT FUSION;"].fusion,
+                ["EGFR-intragenic"],
+                "fusion data is correct for the sample key UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3");
+
+            assert.equal(caseAlterationData[1].sampleId, "TCGA-EE-A20C-06",
+                "sample id is correct for the sample key VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ");
+            assert.equal(caseAlterationData[1].studyId, "skcm_tcga",
+                "study id is correct for the sample key VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ");
+            assert.isTrue(caseAlterationData[1].altered,
+                "sample VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ is altered");
+            assert.deepEqual(caseAlterationData[1].oqlData["PTEN: AMP HOMDEL MUT FUSION;"].mrnaExp,
+                [{type: 'UP', value: '2.4745'}],
+                "mRNA data is correct for the sample key VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ");
+            assert.deepEqual(caseAlterationData[1].oqlData["PTEN: AMP HOMDEL MUT FUSION;"].proteinLevel,
+                [{type: 'UP', value: '2.5406'}],
+                "protein data is correct for the sample key VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ");
+        });
+    });
+});

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -1,0 +1,345 @@
+import * as _ from 'lodash';
+import {
+    AlterationTypeConstants, AnnotatedExtendedAlteration, CaseAggregatedData, ExtendedAlteration, GenePanelInformation
+} from "../ResultsViewPageStore";
+import {
+    alterationInfoForCaseAggregatedDataByOQLLine
+} from "shared/components/oncoprint/OncoprintUtils";
+import {makeGeneticTrackData} from "shared/components/oncoprint/DataUtils";
+import {OQLLineFilterOutput} from "shared/lib/oql/oqlfilter";
+import {GeneticTrackDatum} from "shared/components/oncoprint/Oncoprint";
+import {Sample, Gene} from "shared/api/generated/CBioPortalAPI";
+import {ICaseAlteration, IOqlData, ISubAlteration} from "./CaseAlterationTable";
+import {IGeneAlteration} from "./GeneAlterationTable";
+
+
+export interface IDownloadFileRow {
+    studyId: string;
+    patientId: string;
+    sampleId: string;
+    alterationData: {[gene: string]: string[]};
+}
+
+export function generateOqlData(datum: GeneticTrackDatum): IOqlData
+{
+    const proteinChanges: string[] = [];
+    const fusions: string[] = [];
+    const cnaAlterations: ISubAlteration[] = [];
+    const proteinLevels: ISubAlteration[] = [];
+    const mrnaExpressions: ISubAlteration[] = [];
+
+    // there might be multiple alterations for a single sample
+    for (const alteration of datum.data)
+    {
+        const molecularAlterationType = alteration.molecularProfileAlterationType;
+        const alterationSubType = alteration.alterationSubType.toUpperCase();
+
+        switch (molecularAlterationType)
+        {
+            case AlterationTypeConstants.COPY_NUMBER_ALTERATION:
+                if (alterationSubType.length > 0) {
+                    cnaAlterations.push({
+                        type: alterationSubType,
+                        value: alteration.value
+                    });
+                }
+                break;
+            case AlterationTypeConstants.MRNA_EXPRESSION:
+                if (alterationSubType.length > 0) {
+                    mrnaExpressions.push({
+                        type: alterationSubType,
+                        value: alteration.value
+                    });
+                }
+                break;
+            case AlterationTypeConstants.PROTEIN_LEVEL:
+                if (alterationSubType.length > 0) {
+                    proteinLevels.push({
+                        type: alterationSubType,
+                        value: alteration.value
+                    });
+                }
+                break;
+            case AlterationTypeConstants.MUTATION_EXTENDED:
+                if (alteration.mutationType.toLowerCase().includes("fusion")) {
+                    fusions.push(alteration.proteinChange);
+                }
+                else {
+                    proteinChanges.push(alteration.proteinChange);
+                }
+                break;
+        }
+    }
+
+    return ({
+        geneSymbol: datum.gene,
+        mutation: proteinChanges,
+        fusion: fusions,
+        cna: cnaAlterations,
+        mrnaExp: mrnaExpressions,
+        proteinLevel: proteinLevels
+    });
+}
+
+export function generateGeneAlterationData(
+    caseAggregatedDataByOQLLine?: {
+        cases:CaseAggregatedData<AnnotatedExtendedAlteration>,
+        oql:OQLLineFilterOutput<AnnotatedExtendedAlteration>
+    }[],
+    sequencedSampleKeysByGene: {[hugoGeneSymbol:string]:string[]} = {}): IGeneAlteration[]
+{
+    return (caseAggregatedDataByOQLLine) ?
+        caseAggregatedDataByOQLLine.map(data => {
+            const info = alterationInfoForCaseAggregatedDataByOQLLine(
+                true, data, sequencedSampleKeysByGene, {});
+
+            return {
+                gene: data.oql.gene,
+                oqlLine: data.oql.oql_line,
+                altered: info.altered,
+                sequenced: info.sequenced,
+                percentAltered: info.percent
+            };
+        }) :
+        [];
+}
+
+export function stringify2DArray(data: string[][], colDelimiter: string = "\t", rowDelimiter: string = "\n")
+{
+    return data.map(mutation => mutation.join(colDelimiter)).join(rowDelimiter);
+}
+
+export function generateMutationData(unfilteredCaseAggregatedData?: CaseAggregatedData<ExtendedAlteration>):
+    {[key: string]: ExtendedAlteration[]}
+{
+    const sampleFilter = (alteration: ExtendedAlteration) => {
+        return (
+            alteration.molecularProfileAlterationType === AlterationTypeConstants.MUTATION_EXTENDED ||
+            alteration.molecularProfileAlterationType === AlterationTypeConstants.FUSION
+        );
+    };
+
+    return unfilteredCaseAggregatedData ?
+        generateSampleAlterationDataByGene(unfilteredCaseAggregatedData, sampleFilter) : {};
+}
+
+export function generateMutationDownloadData(sampleAlterationDataByGene: {[key: string]: ExtendedAlteration[]},
+                                             samples: Sample[] = [],
+                                             genes: Gene[] = []): string[][]
+{
+    return sampleAlterationDataByGene ?
+        generateDownloadData(sampleAlterationDataByGene, samples, genes, extractMutationValue) : [];
+}
+
+export function generateMrnaData(unfilteredCaseAggregatedData?: CaseAggregatedData<ExtendedAlteration>):
+    {[key: string]: ExtendedAlteration[]}
+{
+    const sampleFilter = (alteration: ExtendedAlteration) => {
+        return alteration.molecularProfileAlterationType === AlterationTypeConstants.MRNA_EXPRESSION;
+    };
+
+    return unfilteredCaseAggregatedData ?
+        generateSampleAlterationDataByGene(unfilteredCaseAggregatedData, sampleFilter) : {};
+}
+
+
+export function generateProteinData(unfilteredCaseAggregatedData?: CaseAggregatedData<ExtendedAlteration>):
+    {[key: string]: ExtendedAlteration[]}
+{
+    const sampleFilter = (alteration: ExtendedAlteration) => {
+        return alteration.molecularProfileAlterationType === AlterationTypeConstants.PROTEIN_LEVEL;
+    };
+
+    return unfilteredCaseAggregatedData ?
+        generateSampleAlterationDataByGene(unfilteredCaseAggregatedData, sampleFilter) : {};
+}
+
+export function generateCnaData(unfilteredCaseAggregatedData?: CaseAggregatedData<ExtendedAlteration>):
+    {[key: string]: ExtendedAlteration[]}
+{
+    const sampleFilter = (alteration: ExtendedAlteration) => {
+        return alteration.molecularProfileAlterationType === AlterationTypeConstants.COPY_NUMBER_ALTERATION;
+    };
+
+    return unfilteredCaseAggregatedData ?
+        generateSampleAlterationDataByGene(unfilteredCaseAggregatedData, sampleFilter) : {};
+}
+
+export function generateSampleAlterationDataByGene(unfilteredCaseAggregatedData: CaseAggregatedData<ExtendedAlteration>,
+                                                   sampleFilter?: (alteration: ExtendedAlteration) => boolean): {[key: string]: ExtendedAlteration[]}
+{
+    // key => gene + uniqueSampleKey
+    const sampleDataByGene: {[key: string]: ExtendedAlteration[]} = {};
+
+    _.values(unfilteredCaseAggregatedData.samples).forEach(alterations => {
+        alterations.forEach(alteration => {
+            const key = `${alteration.gene.hugoGeneSymbol}_${alteration.uniqueSampleKey}`;
+            sampleDataByGene[key] = sampleDataByGene[key] || [];
+
+            // if no filter function provided nothing is filtered out,
+            // otherwise alteration is filtered out if filter function returns false
+            if (!sampleFilter || sampleFilter(alteration)) {
+                sampleDataByGene[key].push(alteration);
+            }
+        });
+    });
+
+    return sampleDataByGene;
+}
+
+export function generateDownloadFileRows(sampleAlterationDataByGene: {[key: string]: ExtendedAlteration[]},
+                                         geneSymbols: string[],
+                                         sampleIndex: {[sampleKey: string]: Sample},
+                                         sampleKeys: string[],
+                                         extractValue?: (alteration: ExtendedAlteration) => string): {[sampleKey: string]: IDownloadFileRow}
+{
+    const rows: {[sampleKey: string]: IDownloadFileRow} = {};
+
+    sampleKeys.forEach(sampleKey => {
+        const sample = sampleIndex[sampleKey];
+
+        const row: IDownloadFileRow = rows[sampleKey] || {
+            studyId: sample.studyId,
+            sampleId: sample.sampleId,
+            patientId: sample.patientId,
+            alterationData: {}
+        };
+
+        rows[sampleKey] = row;
+
+        geneSymbols.forEach(gene => {
+            row.alterationData[gene] = row.alterationData[gene] || [];
+
+            const key = `${gene}_${sampleKey}`;
+
+            if (sampleAlterationDataByGene[key]) {
+                sampleAlterationDataByGene[key].forEach(alteration => {
+                    const value = extractValue ? extractValue(alteration) : alteration.value;
+                    row.alterationData[gene].push(value);
+                });
+            }
+        });
+    });
+
+    return rows;
+}
+
+export function generateDownloadData(sampleAlterationDataByGene: {[key: string]: ExtendedAlteration[]},
+                                     samples: Sample[] = [],
+                                     genes: Gene[] = [],
+                                     extractValue?: (alteration:ExtendedAlteration) => string,
+                                     formatData?: (data: string[]) => string)
+{
+    const geneSymbols = genes.map(gene => gene.hugoGeneSymbol);
+
+    // we need the sample index for better performance
+    const sampleIndex = _.keyBy(samples, 'uniqueSampleKey');
+    const sampleKeys = samples.map(sample => sample.uniqueSampleKey);
+
+    // generate row data (keyed by uniqueSampleKey)
+    const rows = generateDownloadFileRows(sampleAlterationDataByGene, geneSymbols, sampleIndex, sampleKeys, extractValue);
+
+    const downloadData: string[][] = [];
+
+    // add headers
+    downloadData.push(["STUDY_ID", "SAMPLE_ID"].concat(geneSymbols));
+
+    // convert row data into a 2D array of strings
+    sampleKeys.forEach(sampleKey => {
+        const rowData = rows[sampleKey];
+        const row: string[] = [];
+
+        row.push(rowData.studyId);
+        row.push(rowData.sampleId);
+
+        geneSymbols.forEach(gene => {
+            const formattedValue = formatData ?
+                formatData(rowData.alterationData[gene]) : // if provided format with the custom data formatter
+                rowData.alterationData[gene].join(" ") || "NA"; // else, default format: space delimited join
+
+            row.push(formattedValue);
+        });
+
+        downloadData.push(row);
+    });
+
+    return downloadData;
+}
+
+export function generateCaseAlterationData(
+    caseAggregatedDataByOQLLine?: {
+        cases:CaseAggregatedData<AnnotatedExtendedAlteration>,
+        oql:OQLLineFilterOutput<AnnotatedExtendedAlteration>
+    }[],
+    genePanelInformation?: GenePanelInformation,
+    samples: Sample[] = []): ICaseAlteration[]
+{
+    const caseAlterationData: {[studyCaseId: string] : ICaseAlteration} = {};
+
+    if (caseAggregatedDataByOQLLine &&
+        genePanelInformation)
+    {
+        // we need the sample index for better performance
+        const sampleIndex = _.keyBy(samples, 'uniqueSampleKey');
+
+        caseAggregatedDataByOQLLine.forEach(data => {
+            const geneticTrackData = makeGeneticTrackData(
+                data.cases.samples, data.oql.gene, samples, genePanelInformation);
+
+            geneticTrackData.forEach(datum => {
+                const studyId = datum.study_id;
+                const sampleId = datum.sample || (sampleIndex[datum.uid] ? sampleIndex[datum.uid].sampleId : "");
+                const key = studyId + ":" + datum.uid;
+
+                // initialize the row data
+                caseAlterationData[key] = caseAlterationData[key] || {
+                    studyId,
+                    sampleId,
+                    patientId: sampleIndex[datum.uid] ? sampleIndex[datum.uid].patientId : "",
+                    altered: false,
+                    oqlData: {}
+                };
+
+                // update altered: a single alteration in any track means altered
+                caseAlterationData[key].altered = caseAlterationData[key].altered || datum.data.length > 0;
+
+                // for each track (for each oql line/gene) the oql data is different
+                // that's why we need a map here
+                caseAlterationData[key].oqlData[data.oql.oql_line] = generateOqlData(datum);
+            });
+        });
+    }
+
+    return _.values(caseAlterationData);
+}
+
+export function hasValidData(sampleAlterationDataByGene: {[key: string]: ExtendedAlteration[]},
+                             extractValue?: (alteration: ExtendedAlteration) => string): boolean
+{
+    for (const alterations of _.values(sampleAlterationDataByGene))
+    {
+        for (const alteration of alterations)
+        {
+            const value = extractValue ? extractValue(alteration) : alteration.value;
+
+            // at least one valid value means, there is valid data
+            // TODO also filter out values like "NA", "N/A", etc. ?
+            if (value && value.length > 0) {
+                return true;
+            }
+        }
+    }
+
+    // if no valid value is found, then there is no valid data
+    return false;
+}
+
+export function hasValidMutationData(sampleAlterationDataByGene: {[key: string]: ExtendedAlteration[]}): boolean
+{
+    return hasValidData(sampleAlterationDataByGene, extractMutationValue);
+}
+
+function extractMutationValue(alteration: ExtendedAlteration)
+{
+    return alteration.proteinChange;
+}

--- a/src/pages/resultsView/download/GeneAlterationTable.tsx
+++ b/src/pages/resultsView/download/GeneAlterationTable.tsx
@@ -1,0 +1,79 @@
+import {observer} from "mobx-react";
+import * as React from 'react';
+import LazyMobXTable from "shared/components/lazyMobXTable/LazyMobXTable";
+import FrequencyBar from "shared/components/cohort/FrequencyBar";
+
+export interface IGeneAlteration {
+    gene: string;
+    oqlLine: string;
+    sequenced: number;
+    altered: number;
+    percentAltered: string;
+}
+
+export interface IGeneAlterationTableProps {
+    geneAlterationData: IGeneAlteration[];
+}
+
+class GeneAlterationTableComponent extends LazyMobXTable<IGeneAlteration> {}
+
+@observer
+export default class GeneAlterationTable extends React.Component<IGeneAlterationTableProps, {}> {
+    public render()
+    {
+        return (
+            <GeneAlterationTableComponent
+                data={this.props.geneAlterationData}
+                columns={
+                    [
+                        {
+                            name: 'Gene Symbol',
+                            render: (data: IGeneAlteration) => <span>{data.gene}</span>,
+                            download: (data: IGeneAlteration) => data.gene,
+                            sortBy: (data: IGeneAlteration) => data.gene,
+                            filter: (data: IGeneAlteration, filterString: string, filterStringUpper: string) => {
+                                return data.gene.toUpperCase().indexOf(filterStringUpper) > -1;
+                            }
+                        },
+                        {
+                            name: 'OQL Line',
+                            visible: false,
+                            render: (data: IGeneAlteration) => <span>{data.oqlLine}</span>,
+                            download: (data: IGeneAlteration) => data.oqlLine,
+                            sortBy: (data: IGeneAlteration) => data.oqlLine,
+                            filter: (data: IGeneAlteration, filterString: string, filterStringUpper: string) => {
+                                return data.oqlLine.toUpperCase().indexOf(filterStringUpper) > -1;
+                            }
+                        },
+                        {
+                            name: 'Num Samples Altered',
+                            render: (data: IGeneAlteration) => <span>{data.altered}</span>,
+                            download: (data: IGeneAlteration) => `${data.altered}`,
+                            sortBy: (data: IGeneAlteration) => data.altered
+                        },
+                        {
+                            name: 'Percent Samples Altered',
+                            render: (data: IGeneAlteration) => (
+                                <FrequencyBar
+                                    barWidth={200}
+                                    counts={[data.altered]}
+                                    totalCount={data.sequenced}
+                                />
+                            ),
+                            download: (data: IGeneAlteration) => data.percentAltered,
+                            sortBy: (data: IGeneAlteration) => data.altered / data.sequenced,
+                        }
+                    ]
+                }
+                initialSortColumn="Percent Samples Altered"
+                initialSortDirection={'desc'}
+                showPagination={true}
+                initialItemsPerPage={10}
+                showColumnVisibility={true}
+                showFilter={true}
+                showCopyDownload={true}
+                copyDownloadProps={{downloadFilename: "gene_alteration_frequency.tsv"}}
+            />
+        );
+    }
+}

--- a/src/pages/resultsView/download/styles.module.scss
+++ b/src/pages/resultsView/download/styles.module.scss
@@ -1,0 +1,9 @@
+.tables-container {
+  margin-top: 30px;
+}
+
+.downloadCopyTable {
+  td {
+    vertical-align:middle !important;
+  }
+}

--- a/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import {If} from 'react-if';
+import {Button, ButtonGroup} from 'react-bootstrap';
+import DefaultTooltip from 'shared/components/defaultTooltip/DefaultTooltip';
+import {ICopyDownloadInputsProps} from "./ICopyDownloadControls";
+
+export interface ICopyDownloadButtonsProps extends ICopyDownloadInputsProps {
+    copyButtonRef?: (el: HTMLButtonElement|null) => void;
+}
+
+export class CopyDownloadButtons extends React.Component<ICopyDownloadButtonsProps, {}>
+{
+    public static defaultProps = {
+        className: "",
+        copyLabel: "",
+        downloadLabel: "",
+        showCopy: true,
+        showDownload: true,
+        showCopyMessage: false
+    };
+
+    public render() {
+        return (
+            <span className={this.props.className}>
+                <If condition={this.props.showCopyMessage}>
+                    <span style={{marginLeft: 10}} className="alert-success">Copied!</span>
+                </If>
+                <ButtonGroup style={{ marginLeft:10 }} className={this.props.className}>
+                    <If condition={this.props.showCopy}>
+                        <DefaultTooltip
+                            overlay={<span>Copy</span>}
+                            placement="top"
+                            mouseLeaveDelay={0}
+                            mouseEnterDelay={0.5}
+                        >
+                            <button
+                                ref={this.props.copyButtonRef}
+                                className="btn btn-sm btn-default"
+                                data-clipboard-text="NA"
+                                id="copyButton"
+                                onClick={this.props.handleCopy}
+                            >
+                                {this.props.copyLabel} <i className='fa fa-clipboard'/>
+                            </button>
+                        </DefaultTooltip>
+                    </If>
+                    <If condition={this.props.showDownload}>
+                        <DefaultTooltip
+                            overlay={<span>Download TSV</span>}
+                            mouseLeaveDelay={0}
+                            mouseEnterDelay={0.5}
+                            placement="top"
+                        >
+                            <Button className="btn-sm" onClick={this.props.handleDownload}>
+                                {this.props.downloadLabel} <i className='fa fa-cloud-download'/>
+                            </Button>
+                        </DefaultTooltip>
+                    </If>
+                </ButtonGroup>
+            </span>
+        );
+    }
+}

--- a/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import {Modal, Button, ButtonGroup} from 'react-bootstrap';
+import {Modal, Button} from 'react-bootstrap';
 import {ThreeBounce} from 'better-react-spinkit';
-import DefaultTooltip from 'shared/components/defaultTooltip/DefaultTooltip';
 import {If} from 'react-if';
 import fileDownload from 'react-file-download';
 import {action, observable} from "mobx";
@@ -9,13 +8,11 @@ import {observer} from "mobx-react";
 const Clipboard = require('clipboard');
 
 import copyDownloadStyles from "./copyDownloadControls.module.scss";
+import {CopyDownloadButtons} from "./CopyDownloadButtons";
+import {ICopyDownloadControlsProps} from "./ICopyDownloadControls";
 
-export interface ICopyDownloadControlsProps {
-    className?: string;
-    showCopy?: boolean;
-    showDownload?: boolean;
+export interface IAsyncCopyDownloadControlsProps extends ICopyDownloadControlsProps {
     downloadData?: () => Promise<ICopyDownloadData>;
-    downloadFilename?: string;
 }
 
 export interface ICopyDownloadData {
@@ -28,7 +25,7 @@ export interface ICopyDownloadData {
  * @author Aaron Lisman
  */
 @observer
-export class CopyDownloadControls extends React.Component<ICopyDownloadControlsProps, {}>
+export class CopyDownloadControls extends React.Component<IAsyncCopyDownloadControlsProps, {}>
 {
     @observable downloadingData = false;
     @observable copyingData = false;
@@ -40,7 +37,7 @@ export class CopyDownloadControls extends React.Component<ICopyDownloadControlsP
 
     private _copyText: string|null = null;
 
-    public static defaultProps:ICopyDownloadControlsProps = {
+    public static defaultProps:IAsyncCopyDownloadControlsProps = {
         className: "",
         showCopy: true,
         showDownload: true,
@@ -81,41 +78,16 @@ export class CopyDownloadControls extends React.Component<ICopyDownloadControlsP
 
         return (
             <span>
-                <ButtonGroup className={this.props.className} style={{ marginLeft:10 }}>
-                    <If condition={this.props.showCopy}>
-                        <DefaultTooltip
-                            overlay={<span>Copy</span>}
-                            placement="top"
-                            mouseLeaveDelay={0}
-                            mouseEnterDelay={0.5}
-                            arrowContent={arrowContent}
-                        >
-                            <button
-                                ref={(el:HTMLButtonElement) => {this._copyButton = el;}}
-                                className="btn btn-sm btn-default"
-                                data-clipboard-text="NA"
-                                id="copyButton"
-                                onClick={this.handleCopy}
-                            >
-                                <i className='fa fa-clipboard'/>
-                            </button>
-                        </DefaultTooltip>
-                    </If>
-
-                    <If condition={this.props.showDownload}>
-                        <DefaultTooltip
-                            overlay={<span>Download TSV</span>}
-                            mouseLeaveDelay={0}
-                            mouseEnterDelay={0.5}
-                            placement="top"
-                            arrowContent={arrowContent}
-                        >
-                            <Button className="btn-sm" onClick={this.handleDownload}>
-                                <i className='fa fa-cloud-download'/>
-                            </Button>
-                        </DefaultTooltip>
-                    </If>
-                </ButtonGroup>
+                <CopyDownloadButtons
+                    className={this.props.className}
+                    showCopy={this.props.showCopy}
+                    showDownload={this.props.showDownload}
+                    copyLabel={this.props.copyLabel}
+                    downloadLabel={this.props.downloadLabel}
+                    handleDownload={this.handleDownload}
+                    handleCopy={this.handleCopy}
+                    copyButtonRef={(el:HTMLButtonElement) => {this._copyButton = el;}}
+                />
                 {this.downloadIndicatorModal()}
                 {this.copyIndicatorModal()}
                 {this.downloadErrorModal()}

--- a/src/shared/components/copyDownloadControls/CopyDownloadLinks.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadLinks.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {If} from 'react-if';
+import {ICopyDownloadInputsProps} from "./ICopyDownloadControls";
+
+export interface ICopyDownloadLinksProps extends ICopyDownloadInputsProps {
+    copyLinkRef?: (el: HTMLAnchorElement|null) => void;
+}
+
+export class CopyDownloadLinks extends React.Component<ICopyDownloadLinksProps, {}>
+{
+    public static defaultProps = {
+        className: "",
+        copyButtonLabel: "Copy",
+        downloadButtonLabel: "Download",
+        showCopy: true,
+        showDownload: true,
+    };
+
+    public render() {
+        return (
+            <span className={this.props.className}>
+                {
+                    this.props.showCopy &&
+                    <a onClick={this.props.handleCopy} ref={this.props.copyLinkRef}>
+                        <i className='fa fa-clipboard' style={{marginRight: 5}}/>{this.props.copyLabel}
+                    </a>
+                }
+                {
+                    this.props.showCopy && this.props.showDownload &&
+                    <span style={{margin: '0px 10px'}}>|</span>
+                }
+                {
+                    this.props.showDownload &&
+                    <a onClick={this.props.handleDownload} style={{marginRight: 10}}>
+                        <i className='fa fa-cloud-download' style={{marginRight: 5}}/>{this.props.downloadLabel}
+                    </a>
+                }
+                {
+                    this.props.showCopyMessage &&
+                    <span className="alert-success">Copied!</span>
+                }
+            </span>
+        );
+    }
+}

--- a/src/shared/components/copyDownloadControls/ICopyDownloadControls.ts
+++ b/src/shared/components/copyDownloadControls/ICopyDownloadControls.ts
@@ -1,0 +1,26 @@
+export type CopyDownloadControlsStyle = 'BUTTON' | 'LINK';
+
+export interface ICopyDownloadControlsProps
+{
+    className?: string;
+    downloadFilename?: string;
+    showCopy?: boolean;
+    copyLabel?: string;
+    downloadLabel?: string;
+    copyMessageDuration?: number;
+    showDownload?: boolean;
+    controlsStyle?: CopyDownloadControlsStyle;
+}
+
+export interface ICopyDownloadInputsProps
+{
+    className?: string;
+    showCopy?: boolean;
+    showCopyMessage?: boolean;
+    showDownload?: boolean;
+    copyLabel?: string;
+    downloadLabel?: string;
+    handleDownload?: () => void;
+    handleCopy?: () => void;
+}
+

--- a/src/shared/components/copyDownloadControls/SimpleCopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/SimpleCopyDownloadControls.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import fileDownload from 'react-file-download';
+import {observer} from "mobx-react";
+import {observable} from "mobx";
+import {CopyDownloadLinks} from "./CopyDownloadLinks";
+import {CopyDownloadButtons} from "./CopyDownloadButtons";
+import {ICopyDownloadControlsProps} from "./ICopyDownloadControls";
+const Clipboard = require('clipboard');
+
+export interface ISimpleCopyDownloadControlsProps extends ICopyDownloadControlsProps {
+    downloadData?: () => string;
+}
+
+@observer
+export class SimpleCopyDownloadControls extends React.Component<ISimpleCopyDownloadControlsProps, {}>
+{
+    public static defaultProps: ISimpleCopyDownloadControlsProps = {
+        className: "",
+        showCopy: true,
+        copyMessageDuration: 3000,
+        showDownload: true,
+        copyLabel: "Copy",
+        downloadLabel: "Download",
+        downloadFilename: "data.tsv",
+        controlsStyle: 'LINK'
+    };
+
+    @observable
+    private showCopyMessage = false;
+
+    constructor(props: ISimpleCopyDownloadControlsProps)
+    {
+        super(props);
+
+        this.handleDownload = this.handleDownload.bind(this);
+        this.copyLinkRef = this.copyLinkRef.bind(this);
+        this.copyButtonRef = this.copyButtonRef.bind(this);
+        this.handleAfterCopy = this.handleAfterCopy.bind(this);
+    }
+
+    public render()
+    {
+        if (this.props.controlsStyle === 'LINK') {
+            return (
+                <CopyDownloadLinks
+                    className={this.props.className}
+                    handleDownload={this.handleDownload}
+                    copyLinkRef={this.copyLinkRef}
+                    handleCopy={this.handleAfterCopy}
+                    copyLabel={this.props.copyLabel}
+                    downloadLabel={this.props.downloadLabel}
+                    showCopyMessage={this.showCopyMessage}
+                />
+            );
+        }
+        else {
+            return (
+                <CopyDownloadButtons
+                    className={this.props.className}
+                    handleDownload={this.handleDownload}
+                    copyButtonRef={this.copyButtonRef}
+                    handleCopy={this.handleAfterCopy}
+                    showCopyMessage={this.showCopyMessage}
+                />
+            );
+        }
+    }
+
+    private handleDownload()
+    {
+        if (this.props.downloadData) {
+            fileDownload(this.props.downloadData(), this.props.downloadFilename);
+        }
+    }
+
+    private copyLinkRef(el: HTMLAnchorElement|null)
+    {
+        this.handleCopyRef(el);
+    }
+
+    private copyButtonRef(el: HTMLButtonElement|null)
+    {
+        this.handleCopyRef(el);
+    }
+
+    private handleCopyRef(el: HTMLElement|null)
+    {
+        if (el) {
+            new Clipboard(el, {
+                text: this.props.downloadData
+            });
+        }
+    }
+
+    private handleAfterCopy()
+    {
+        this.showCopyMessage = true;
+
+        setTimeout(() => {
+            this.showCopyMessage = false;
+        }, this.props.copyMessageDuration);
+    }
+}

--- a/src/shared/components/featureTitle/FeatureTitle.tsx
+++ b/src/shared/components/featureTitle/FeatureTitle.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import {ThreeBounce} from 'better-react-spinkit';
 import { If, Else } from 'react-if';
+import {CSSProperties, DetailedHTMLProps} from "react";
 
 export interface IFeatureTitleProps {
     isLoading:Boolean;
     title:string;
     className?:string;
+    style?:CSSProperties;
     isHidden?:Boolean;
 }
 
@@ -15,7 +17,7 @@ export default class FeatureTitle extends React.Component<IFeatureTitleProps, {}
        return (
             <If condition={this.props.isHidden}>
 
-                <Else><h4 className={this.props.className || ''}>{this.props.title}
+                <Else><h4 style={this.props.style || {}} className={this.props.className || ''}>{this.props.title}
                     <If condition={this.props.isLoading}>
                         <ThreeBounce style={{ display:'inline-block', marginLeft:10 }} />
                     </If>

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -1063,18 +1063,18 @@ describe('LazyMobXTable', ()=>{
     describe('downloading data', ()=>{
         it("gives just the column names when theres no data in the table", async ()=>{
             let table = mount(<Table columns={columns} data={[]}/>);
-            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadDataPromise()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n");
         });
         it("gives one row of data when theres one row. data given for every column, including hidden, and without download def'n. if no data, gives empty string for that cell.", async ()=>{
             let table = mount(<Table columns={columns} data={[data[0]]}/>);
-            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadDataPromise()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n");
         });
         it("gives data for all rows. data given for every column, including hidden, and without download def'n. if no data, gives empty string for that cell", async ()=>{
             let table = mount(<Table columns={columns} data={data}/>)
-            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadDataPromise()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n"+
                 "1\t6\tkdfjpo\t\t1HELLO123456\t\t\r\n"+
@@ -1085,7 +1085,7 @@ describe('LazyMobXTable', ()=>{
         it("gives data back in sorted order according to initially selected sort column and direction", async ()=>{
             let table = mount(<Table columns={columns} data={data} initialSortColumn="Number" initialSortDirection="asc"/>);
 
-            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadDataPromise()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "3\t-1\tzijxcpo\t\t3HELLO123456\t\t\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n"+
@@ -1096,7 +1096,7 @@ describe('LazyMobXTable', ()=>{
         
         it("gives data for data with multiple elements", async ()=>{
             let table = mount(<Table columns={columns} data={multiData}/>)
-            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadData()).text,
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadDataPromise()).text,
                 "Name\tNumber\tString\tNumber List\tInitially invisible column\tInitially invisible column with no download\tString without filter function\r\n"+
                 "0\t0\tasdfj\t\t0HELLO123456\t\t\r\n"+
                 "1\t6\tkdfjpo\t\t1HELLO123456\t\t\r\n"+


### PR DESCRIPTION
# Changes proposed in this pull request
- Adds a new download tab component that uses  the `ResultsViewPageStore` data to generate download files/tables.

![download_tab](https://user-images.githubusercontent.com/3604198/35533883-d7f3cb18-050c-11e8-965b-0899c7a6750b.png)

# Still missing... 
- [x] expose the component in the main project (https://github.com/cBioPortal/cbioportal/pull/3814)
- [x] improve overall tab style

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)