### PR TITLE
Use https for genome nexus if available

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -86,10 +86,15 @@ export function getOncoKbApiUrl() {
 export function getGenomeNexusApiUrl() {
     let url = AppConfig.genomeNexusApiUrl;
     if (typeof url === 'string') {
-        // we need to support legacy configuration values
-        url = url.replace(/^http[s]?:\/\//,''); // get rid of protocol
-        url = url.replace(/\/$/,""); // get rid of trailing slashes
-        return cbioUrl(`proxy/${url}`)
+        // use url if https, otherwise use proxy
+        if (url.startsWith('https://')) {
+            return url
+        } else {
+            // we need to support legacy configuration values
+            url = url.replace(/^http[s]?:\/\//,''); // get rid of protocol
+            url = url.replace(/\/$/,""); // get rid of trailing slashes
+            return cbioUrl(`proxy/${url}`)
+        }
     } else {
         return undefined;
     }


### PR DESCRIPTION
We've been having issues using the proxy for genome nexus. This instead uses genome nexus URL directly if https is available