### PR TITLE
Image compare fixes

### DIFF
--- a/end-to-end-tests/image-compare/upload_failed_screenshots.sh
+++ b/end-to-end-tests/image-compare/upload_failed_screenshots.sh
@@ -17,7 +17,7 @@ upload_image() {
 
 
 cd ${DIR}/../screenshots
-if [[ -d "diff/" ]]; then
+if (ls diff/*.png 2> /dev/null > /dev/null); then
     references=()
     refs_uploaded=()
     diffs_uploaded=()

--- a/end-to-end-tests/package.json
+++ b/end-to-end-tests/package.json
@@ -4,8 +4,8 @@
   "description": "Dependencies for running tests with webdriverio and browserstack",
   "main": "index.js",
   "scripts": {
-    "test-travis": "wdio wdio/travis.conf.js || bash image-compare/upload_failed_screenshots.sh",
-    "test-webdriver-manager": "wdio wdio/webdriver-manager.conf.js|| bash image-compare/upload_failed_screenshots.sh"
+    "test-travis": "rm -rf screenshots/diff/; wdio wdio/travis.conf.js || bash image-compare/upload_failed_screenshots.sh",
+    "test-webdriver-manager": "rm -rf screenshots/diff/; wdio wdio/webdriver-manager.conf.js || bash image-compare/upload_failed_screenshots.sh"
   },
   "author": "",
   "license": "",


### PR DESCRIPTION
- Remove diff screenshots before running e2e tests
- Check if any images in diff folder, instead of just checking if folder exists