### PR TITLE
Override window.frontendConfig w localStorage

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,13 @@
+// Override frontendConfig with localStorage frontendConfig if available
+let localStorageFrontendConfig:any = {};
+if (localStorage.frontendConfig) {
+    try {
+        localStorageFrontendConfig = JSON.parse(localStorage.frontendConfig);
+        console.log("Using localStorage.frontendConfig (overriding window.frontendConfig): " + localStorage.frontendConfig);
+    } catch (err) {
+        // ignore
+        console.log("Error parsing localStorage.frontendConfig")
+    }
+}
+const config:any = Object.assign((window as any).frontendConfig, localStorageFrontendConfig);
+export default config;

--- a/src/config/development.config.ts
+++ b/src/config/development.config.ts
@@ -1,4 +1,0 @@
-import {IAppConfig} from "./IAppConfig";
-
-const config:IAppConfig = (window as any).frontendConfig;
-export default config;

--- a/src/config/production.config.ts
+++ b/src/config/production.config.ts
@@ -1,4 +1,0 @@
-import {IAppConfig} from "./IAppConfig";
-
-const config:IAppConfig = (window as any).frontendConfig;
-export default config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -475,7 +475,7 @@ config.resolve.alias = {
     reducers: join(src, 'redux/modules'),
     pages: join(src, 'pages'),
     shared: join(src, 'shared'),
-    appConfig: path.join(__dirname + '/src', 'config', process.env.NODE_ENV + '.config')
+    appConfig: path.join(__dirname + '/src', 'config', ((process.env.NODE_ENV === 'test')? 'test.' : '') + 'config')
 };
 // end Roots
 


### PR DESCRIPTION
This allows trying different frontend configurations configurations without
having to redeploy the war or change the frontend config file.

Try e.g.:
```
localStorage.frontendConfig = '{"showCivic":false}'
```