### PR TITLE
Counting multiple mutations for the same patient only once

### DIFF
--- a/src/shared/lib/MutationUtils.spec.ts
+++ b/src/shared/lib/MutationUtils.spec.ts
@@ -1,5 +1,5 @@
 import {
-    somaticMutationRate, germlineMutationRate
+    somaticMutationRate, germlineMutationRate, countUniqueMutations, groupMutationsByGeneAndPatientAndProteinChange
 } from "./MutationUtils";
 import * as _ from 'lodash';
 import { assert, expect } from 'chai';
@@ -12,6 +12,7 @@ describe('MutationUtils', () => {
     let somaticMutations: Mutation[];
     let germlineMutations: Mutation[];
     let molecularProfileIdToMolecularProfile:{[molecularProfileId:string]:MolecularProfile};
+    let mutationsToCount: Mutation[];
 
     before(()=>{
         molecularProfileIdToMolecularProfile = {
@@ -68,6 +69,98 @@ describe('MutationUtils', () => {
                 molecularProfileId:"GP1"
              })
         ];
+        mutationsToCount = [
+            initMutation({ // mutation
+                sampleId: "P1_sample1",
+                patientId: "P1",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                proteinPosStart: 66,
+                proteinChange: "D66B"
+
+            }),
+            initMutation({ // mutation
+                sampleId: "P1_sample2",
+                patientId: "P1",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                proteinPosStart: 66,
+                proteinChange: "D66B"
+            }),
+            initMutation({ // mutation
+                sampleId: "P2_sample1",
+                patientId: "P2",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                proteinPosStart: 66,
+                proteinChange: "D66B"
+            }),
+            initMutation({ // mutation
+                sampleId: "P2_sample2",
+                patientId: "P2",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                proteinPosStart: 66,
+                proteinChange: "D66B"
+            }),
+            initMutation({ // mutation
+                sampleId: "P3_sample1",
+                patientId: "P3",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                proteinPosStart: 66,
+                proteinChange: "D66B"
+            }),
+            initMutation({ // mutation
+                sampleId: "P4_sample1",
+                patientId: "P4",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                proteinPosStart: 666,
+                proteinChange: "D666C"
+            }),
+            initMutation({ // mutation
+                sampleId: "P4_sample2",
+                patientId: "P4",
+                gene: {
+                    hugoGeneSymbol: "TP53",
+                },
+                proteinPosStart: 666,
+                proteinChange: "D666F"
+            }),
+        ];
+    });
+
+    describe('groupMutationsByGeneAndPatientAndProteinChange', () => {
+        it("groups mutations correctly by gene, patient, and protein change", () => {
+            const grouped = groupMutationsByGeneAndPatientAndProteinChange(mutationsToCount);
+
+            assert.equal(grouped["TP53_P1_D66B"].length, 2,
+                "There should be 2 mutations for TP53_P1_D66B");
+            assert.equal(grouped["TP53_P2_D66B"].length, 2,
+                "There should be 2 mutations for TP53_P2_D66B");
+            assert.equal(grouped["TP53_P3_D66B"].length, 1,
+                "There should be 1 mutation for TP53_P3_D66B");
+            assert.equal(grouped["TP53_P4_D666C"].length, 1,
+                "There should be 1 mutation for TP53_P4_D666C");
+            assert.equal(grouped["TP53_P4_D666F"].length, 1,
+                "There should be 1 mutation for TP53_P4_D666F");
+        });
+    });
+
+    describe('countUniqueMutations', () => {
+        it("counts unique mutations correctly", () => {
+            const count = countUniqueMutations(mutationsToCount);
+
+            assert.equal(count, 5,
+                "total number of unique mutations should be 5");
+        });
     });
 
     describe('somaticMutationRate', () => {

--- a/src/shared/lib/MutationUtils.ts
+++ b/src/shared/lib/MutationUtils.ts
@@ -100,6 +100,27 @@ export function groupMutationsByProteinStartPos(mutationData: Mutation[][]): {[p
     return map;
 }
 
+export function groupMutationsByGeneAndPatientAndProteinChange(mutations: Mutation[]): {[key: string]: Mutation[]}
+{
+    // key = <gene>_<patient>_<proteinChange>
+    const map: {[key: string]: Mutation[]} = {};
+
+    for (const mutation of mutations)
+    {
+        const key = `${mutation.gene.hugoGeneSymbol}_${mutation.patientId}_${mutation.proteinChange}`;
+        map[key] = map[key] || [];
+        map[key].push(mutation);
+    }
+
+    return map;
+}
+
+
+export function countUniqueMutations(mutations: Mutation[])
+{
+    return Object.keys(groupMutationsByGeneAndPatientAndProteinChange(mutations)).length;
+}
+
 /**
  * Protein start positions for the mutations falling between a specific start and end position range
  */


### PR DESCRIPTION
# What? Why?
Related to https://github.com/cBioPortal/cbioportal/issues/3375

![lollipop_mutation_count](https://user-images.githubusercontent.com/3604198/35947275-0bdc581c-0c35-11e8-9450-dcd3e4a0b6f0.png)

Changes proposed in this pull request:
- Counting multiple mutations for the same patient only once when generating the lollipops for the mutation diagram.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)