### PR TITLE
Additional info in case there are mutations in patients with multiple samples

### DIFF
--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -118,6 +118,17 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
         }
     }
 
+    @computed get multipleMutationInfo(): string {
+        const count = this.props.store.dataStore.duplicateMutationCountInMultipleSamples;
+        const mutationsLabel = count === 1 ? "mutation" : "mutations";
+
+        return count > 0 ? `: includes ${count} duplicate ${mutationsLabel} in patients with multiple samples` : "";
+    }
+
+    @computed get itemsLabelPlural(): string {
+        return `Mutations${this.multipleMutationInfo}`;
+    }
+
     public render() {
 
         return (
@@ -216,6 +227,7 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                                     pubMedCache={this.props.pubMedCache}
                                     mutationCountCache={this.props.mutationCountCache}
                                     dataStore={this.props.store.dataStore}
+                                    itemsLabelPlural={this.itemsLabelPlural}
                                     downloadDataFetcher={this.props.store.downloadDataFetcher}
                                     myCancerGenomeData={this.props.myCancerGenomeData}
                                     hotspots={this.props.store.indexedHotspotData.result}

--- a/src/pages/resultsView/mutation/MutationMapperDataStore.ts
+++ b/src/pages/resultsView/mutation/MutationMapperDataStore.ts
@@ -5,7 +5,7 @@ import {
 import {Mutation} from "../../../shared/api/generated/CBioPortalAPI";
 import {action, computed, observable} from "mobx";
 import Immutable from "seamless-immutable";
-import {IPdbChain} from "../../../shared/model/Pdb";
+import {countDuplicateMutations, groupMutationsByGeneAndPatientAndProteinChange} from "shared/lib/MutationUtils";
 
 type PositionAttr = {[position:string]:boolean};
 type ImmutablePositionAttr = PositionAttr & Immutable.ImmutableObject<PositionAttr>;
@@ -49,6 +49,14 @@ export default class MutationMapperDataStore extends SimpleMobXApplicationDataSt
     @action public resetFilterAndSelection() {
         super.resetFilter();
         this.clearSelectedPositions();
+    }
+
+    @computed get tableDataGroupedByPatients() {
+        return groupMutationsByGeneAndPatientAndProteinChange(_.flatten(this.tableData));
+    }
+
+    @computed get duplicateMutationCountInMultipleSamples(): number {
+        return countDuplicateMutations(this.tableDataGroupedByPatients);
     }
 
     constructor(data:Mutation[][]) {

--- a/src/shared/lib/MutationUtils.spec.ts
+++ b/src/shared/lib/MutationUtils.spec.ts
@@ -1,5 +1,6 @@
 import {
-    somaticMutationRate, germlineMutationRate, countUniqueMutations, groupMutationsByGeneAndPatientAndProteinChange
+    somaticMutationRate, germlineMutationRate, countUniqueMutations, groupMutationsByGeneAndPatientAndProteinChange,
+    countDuplicateMutations
 } from "./MutationUtils";
 import * as _ from 'lodash';
 import { assert, expect } from 'chai';
@@ -160,6 +161,16 @@ describe('MutationUtils', () => {
 
             assert.equal(count, 5,
                 "total number of unique mutations should be 5");
+        });
+    });
+
+    describe('countDuplicateMutations', () => {
+        it("counts duplicates correctly for mutations grouped by patients", () => {
+            const grouped = groupMutationsByGeneAndPatientAndProteinChange(mutationsToCount);
+            const count = countDuplicateMutations(grouped);
+
+            assert.equal(count, 2,
+                "total number of duplicate mutations should be 2");
         });
     });
 

--- a/src/shared/lib/MutationUtils.ts
+++ b/src/shared/lib/MutationUtils.ts
@@ -115,8 +115,18 @@ export function groupMutationsByGeneAndPatientAndProteinChange(mutations: Mutati
     return map;
 }
 
+export function countDuplicateMutations(groupedMutations: {[key: string]: Mutation[]}): number
+{
+    // helper to count duplicate mutations
+    const countMapper = (mutations: Mutation[]) => mutations.length > 0 ? mutations.length - 1 : 0;
 
-export function countUniqueMutations(mutations: Mutation[])
+    // helper to get the total sum
+    const sumReducer = (acc: number, current: number) => acc + current;
+
+    return _.values(groupedMutations).map(countMapper).reduce(sumReducer);
+}
+
+export function countUniqueMutations(mutations: Mutation[]): number
 {
     return Object.keys(groupMutationsByGeneAndPatientAndProteinChange(mutations)).length;
 }


### PR DESCRIPTION
# What? Why?
We want to show more information in case there are mutations in patients with multiple samples.

# Changes proposed in this pull request
- Initial (unfiltered):
![unfiltered](https://user-images.githubusercontent.com/3604198/36330044-2746582a-1336-11e8-9ef8-b466a26d4ec8.png)

- Single selection:
![single_selection](https://user-images.githubusercontent.com/3604198/36330059-32bc4a52-1336-11e8-8185-d0d022e9cb9a.png)

- Multiple selection:
![multiple_selection](https://user-images.githubusercontent.com/3604198/36330081-49db620e-1336-11e8-86b3-2ed27edefd4c.png)

- Single selection (on another set):
![single_selection_02](https://user-images.githubusercontent.com/3604198/36330413-864c70e2-1337-11e8-8a1f-6cf2ef9b7c4b.png)

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)