### PR TITLE
Properly handling empty mutation set when counting duplicate mutations

### DIFF
--- a/src/shared/lib/MutationUtils.spec.ts
+++ b/src/shared/lib/MutationUtils.spec.ts
@@ -156,6 +156,11 @@ describe('MutationUtils', () => {
     });
 
     describe('countUniqueMutations', () => {
+        it("counts unique mutations as zero when there are no mutations", () => {
+            assert.equal(countUniqueMutations([]), 0,
+                "total number of unique mutations should be 0");
+        });
+
         it("counts unique mutations correctly", () => {
             const count = countUniqueMutations(mutationsToCount);
 
@@ -165,6 +170,11 @@ describe('MutationUtils', () => {
     });
 
     describe('countDuplicateMutations', () => {
+        it("counts duplicate mutations as zero when there are no mutations", () => {
+            assert.equal(countDuplicateMutations({}), 0,
+                "total number of duplicate mutations should be 0");
+        });
+
         it("counts duplicates correctly for mutations grouped by patients", () => {
             const grouped = groupMutationsByGeneAndPatientAndProteinChange(mutationsToCount);
             const count = countDuplicateMutations(grouped);

--- a/src/shared/lib/MutationUtils.ts
+++ b/src/shared/lib/MutationUtils.ts
@@ -123,7 +123,7 @@ export function countDuplicateMutations(groupedMutations: {[key: string]: Mutati
     // helper to get the total sum
     const sumReducer = (acc: number, current: number) => acc + current;
 
-    return _.values(groupedMutations).map(countMapper).reduce(sumReducer);
+    return _.values(groupedMutations).map(countMapper).reduce(sumReducer, 0);
 }
 
 export function countUniqueMutations(mutations: Mutation[]): number


### PR DESCRIPTION
# What? Why?
Fixed a bug in the `countDuplicateMutations` function.

# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)