### PR TITLE
Expand correlated genes from gene set heatmaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12028,9 +12028,9 @@
       }
     },
     "oncoprintjs": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.0.83.tgz",
-      "integrity": "sha1-/g5MW9XMH2DTg9hNFhs+rI/tY6s=",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.0.84.tgz",
+      "integrity": "sha1-0A48+YvAogyltCl8xVbRgPWfgp8=",
       "requires": {
         "express": "4.15.4",
         "gl-matrix": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "mobx-utils": "^2.0.1",
     "mobxpromise": "^1.2.0",
     "node-sass": "^4.3.0",
-    "oncoprintjs": "^1.0.83",
+    "oncoprintjs": "^1.0.84",
     "parameter-validator": "^1.0.2",
     "pdfobject": "^2.0.201604172",
     "plotly.js": "^1.31.2",

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -46,6 +46,7 @@ import {PatientSurvival} from "../../shared/model/PatientSurvival";
 import {filterCBioPortalWebServiceDataByOQLLine, OQLLineFilterOutput} from "../../shared/lib/oql/oqlfilter";
 import GeneMolecularDataCache from "../../shared/cache/GeneMolecularDataCache";
 import GenesetMolecularDataCache from "../../shared/cache/GenesetMolecularDataCache";
+import GenesetCorrelatedGeneCache from "../../shared/cache/GenesetCorrelatedGeneCache";
 import GeneCache from "../../shared/cache/GeneCache";
 import ClinicalDataCache from "../../shared/cache/ClinicalDataCache";
 import {IHotspotIndex} from "../../shared/model/CancerHotspots";
@@ -1690,6 +1691,17 @@ export class ResultsViewPageStore {
         ],
         invoke: () => Promise.resolve(
             new GenesetMolecularDataCache(
+                this.molecularProfileIdToDataQueryFilter.result!
+            )
+        )
+    });
+
+    readonly genesetCorrelatedGeneCache = remoteData({
+        await:() => [
+            this.molecularProfileIdToDataQueryFilter
+        ],
+        invoke: () => Promise.resolve(
+            new GenesetCorrelatedGeneCache(
                 this.molecularProfileIdToDataQueryFilter.result!
             )
         )

--- a/src/shared/cache/GenesetCorrelatedGeneCache.spec.ts
+++ b/src/shared/cache/GenesetCorrelatedGeneCache.spec.ts
@@ -1,0 +1,223 @@
+import GenesetCorrelatedGeneCache from './GenesetCorrelatedGeneCache';
+import client from 'shared/api/cbioportalInternalClientInstance';
+import * as _ from 'lodash';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+describe('GenesetCorrelatedGeneCache', () => {
+    beforeEach(() => {
+        sinon.stub(client, 'fetchCorrelatedGenesUsingPOST');
+    });
+    afterEach(() => {
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub).restore();
+    });
+
+    it('provides as many genes as requested if more available', () => {
+        // given an API client with 4 available genes and a cache with a started iteration
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub)
+            .returns(Promise.resolve([
+                {"entrezGeneId": 0, "hugoGeneSymbol": "string0", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 1, "hugoGeneSymbol": "string1", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 2, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 3, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"}
+            ]));
+        const cache = new GenesetCorrelatedGeneCache(
+            {profile1: {sampleIds: ['sample1', 'sample2']}}
+        );
+        cache.initIteration(
+            'track1_expansions',
+            {genesetId: 'geneset1', molecularProfileId: 'profile1'}
+        );
+        // when next is called to request 2 genes in the iteration
+        const geneListPromise = cache.next('track1_expansions', 2);
+        // then it should resolve with 2 genes
+        return geneListPromise.then((genes) => {
+            assert.lengthOf(genes, 2);
+        });
+    });
+
+    it('provides as many genes as available if more requested', () => {
+        // given an API client with 4 available genes and a cache with a started iteration
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub)
+            .returns(Promise.resolve([
+                {"entrezGeneId": 0, "hugoGeneSymbol": "string0", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 1, "hugoGeneSymbol": "string1", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 2, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 3, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"}
+            ]));
+        const cache = new GenesetCorrelatedGeneCache(
+            {profile1: {sampleIds: ['sample1', 'sample2']}}
+        );
+        cache.initIteration(
+            'track1_expansions',
+            {genesetId: 'geneset1', molecularProfileId: 'profile1'}
+        );
+        // when next is called to request 5 genes in the iteration
+        const geneListPromise = cache.next('track1_expansions', 5);
+        // then it should resolve with 4 genes
+        return geneListPromise.then((genes) => {
+            assert.lengthOf(genes, 4);
+        });
+    });
+
+    it('provides an empty array if nothing available', () => {
+        // given an API client with 0 available genes and a cache with a started iteration
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub)
+            .returns(Promise.resolve([]));
+        const cache = new GenesetCorrelatedGeneCache(
+            {profile1: {sampleIds: ['sample1', 'sample2']}}
+        );
+        cache.initIteration(
+            'track1_expansions',
+            {genesetId: 'geneset1', molecularProfileId: 'profile1'}
+        );
+        // when next is called to request 4 genes in the iteration
+        const geneListPromise = cache.next('track1_expansions', 4);
+        // then it should resolve with two genes
+        return geneListPromise.then((genes) => {
+            assert.instanceOf(genes, Array);
+            assert.lengthOf(genes, 0);
+        });
+    });
+
+    it('provides the next n genes if called a second time', () => {
+        // given an API client with 4 available genes and a cache with a started
+        // iteration
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub)
+            .returns(Promise.resolve([
+                {"entrezGeneId": 0, "hugoGeneSymbol": "string0", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 1, "hugoGeneSymbol": "string1", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 2, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 3, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"}
+            ]));
+        const cache = new GenesetCorrelatedGeneCache(
+            {profile1: {sampleIds: ['sample1', 'sample2']}}
+        );
+        cache.initIteration(
+            'track1_expansions',
+            {genesetId: 'geneset1', molecularProfileId: 'profile1'}
+        );
+        // when next is called to request 2 genes in the iteration twice
+        const geneListPromise1 = cache.next('track1_expansions', 2);
+        const geneListPromise2 = cache.next('track1_expansions', 2);
+        // then the two promises should resolve with arrays starting at gene 0
+        // and 2 respectively
+        return Promise.all([
+            geneListPromise1.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 0);
+            }),
+            geneListPromise2.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 2);
+            })
+        ]);
+    });
+
+    it('provides the first n genes again after reset is called', () => {
+        // given an API client with 4 available genes and a cache with a started
+        // iteration
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub)
+            .returns(Promise.resolve([
+                {"entrezGeneId": 0, "hugoGeneSymbol": "string0", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 1, "hugoGeneSymbol": "string1", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 2, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 3, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"}
+            ]));
+        const cache = new GenesetCorrelatedGeneCache(
+            {profile1: {sampleIds: ['sample1', 'sample2']}}
+        );
+        cache.initIteration(
+            'track1_expansions',
+            {genesetId: 'geneset1', molecularProfileId: 'profile1'}
+        );
+        // when next is called to request 2 genes in the iteration twice with a
+        // call to reset for the iteration in between
+        const geneListPromise1 = cache.next('track1_expansions', 2);
+        cache.reset('track1_expansions');
+        const geneListPromise2 = cache.next('track1_expansions', 2);
+        // then the both promises should resolve with arrays starting at gene 0
+        return Promise.all([
+            geneListPromise1.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 0);
+            }),
+            geneListPromise2.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 0);
+            })
+        ]);
+    });
+
+    it('leaves pre-existing iterations untouched when requesting', () => {
+        // given an API client with 4 available genes and a cache with 2 started
+        // iterations
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub)
+            .returns(Promise.resolve([
+                {"entrezGeneId": 0, "hugoGeneSymbol": "string0", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 1, "hugoGeneSymbol": "string1", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 2, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 3, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"}
+            ]));
+        const cache = new GenesetCorrelatedGeneCache(
+            {profile1: {sampleIds: ['sample1', 'sample2']}}
+        );
+        cache.initIteration(
+            'track1_expansions',
+            {genesetId: 'geneset1', molecularProfileId: 'profile1'}
+        );
+        cache.initIteration(
+            'track2_expansions',
+            {genesetId: 'geneset2', molecularProfileId: 'profile1'}
+        );
+        // when next is called to request 2 genes in the first iteration twice with a
+        // call for the second iteration in between
+        const geneListPromise1 = cache.next('track1_expansions', 2);
+        cache.next('track2_expansions', 2);
+        const geneListPromise2 = cache.next('track1_expansions', 2);
+        // then the promises for the first iteration should resolve with arrays
+        // starting at gene 0 and 2 respectively
+        return Promise.all([
+            geneListPromise1.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 0);
+            }),
+            geneListPromise2.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 2);
+            })
+        ]);
+    });
+
+    it('leaves pre-existing iterations untouched when resetting', () => {
+        // given an API client with 4 available genes and a cache with 2 started
+        // iterations
+        (client.fetchCorrelatedGenesUsingPOST as sinon.SinonStub)
+            .returns(Promise.resolve([
+                {"entrezGeneId": 0, "hugoGeneSymbol": "string0", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 1, "hugoGeneSymbol": "string1", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 2, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"},
+                {"entrezGeneId": 3, "hugoGeneSymbol": "string2", "correlationValue": 0, "expressionGeneticProfileId": "string", "zScoreGeneticProfileId": "string"}
+            ]));
+        const cache = new GenesetCorrelatedGeneCache(
+            {profile1: {sampleIds: ['sample1', 'sample2']}}
+        );
+        cache.initIteration(
+            'track1_expansions',
+            {genesetId: 'geneset1', molecularProfileId: 'profile1'}
+        );
+        cache.initIteration(
+            'track2_expansions',
+            {genesetId: 'geneset2', molecularProfileId: 'profile1'}
+        );
+        // when next is called to request 2 genes in the first iteration twice with a
+        // call to reset for the second iteration in between
+        const geneListPromise1 = cache.next('track1_expansions', 2);
+        cache.reset('track2_expansions');
+        const geneListPromise2 = cache.next('track1_expansions', 2);
+        // then the promises for the first iteration should resolve with arrays
+        // starting at gene 0 and 2 respectively
+        return Promise.all([
+            geneListPromise1.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 0);
+            }),
+            geneListPromise2.then((genes) => {
+                assert.equal(genes[0].entrezGeneId, 2);
+            })
+        ]);
+    });
+});

--- a/src/shared/cache/GenesetCorrelatedGeneCache.ts
+++ b/src/shared/cache/GenesetCorrelatedGeneCache.ts
@@ -1,0 +1,90 @@
+import {GenesetCorrelation} from "../api/generated/CBioPortalAPIInternal";
+import client from "shared/api/cbioportalInternalClientInstance";
+import _ from "lodash";
+import {IDataQueryFilter} from "../lib/StoreUtils";
+
+interface IQuery {
+    genesetId: string;
+    molecularProfileId: string;
+}
+
+type SampleFilterByProfile = {
+    [molecularProfileId: string]: IDataQueryFilter
+};
+
+async function fetch(
+    {genesetId, molecularProfileId}: IQuery,
+    sampleFilterByProfile: SampleFilterByProfile
+): Promise<GenesetCorrelation[]> {
+    const param = {
+        genesetId,
+        geneticProfileId: molecularProfileId,
+        ...sampleFilterByProfile[molecularProfileId]
+    };
+    return client.fetchCorrelatedGenesUsingPOST(param);
+}
+
+class GenesetCorrelatedGeneIteration {
+    private query: IQuery;
+    private sampleFilterByProfile: SampleFilterByProfile;
+    private nextGeneIndex = 0;
+    private data: undefined | GenesetCorrelation[] = undefined;
+
+    constructor(query: IQuery, sampleFilterByProfile: SampleFilterByProfile) {
+        this.query = query;
+        this.sampleFilterByProfile = sampleFilterByProfile;
+    }
+
+    async next(maxNumber: number) {
+        if (this.data === undefined) {
+            this.data = await fetch(this.query, this.sampleFilterByProfile);
+        }
+        // select the first 5 genes starting from the index,
+        // up to the end of the array
+        const nextGenes = this.data.slice(
+            this.nextGeneIndex,
+            this.nextGeneIndex + maxNumber
+        );
+        this.nextGeneIndex += nextGenes.length;
+        return nextGenes;
+    }
+
+    /**
+     * Resets the iteration so that next() will start from the beginning.
+     */
+    reset(): void {
+        this.nextGeneIndex = 0;
+    }
+}
+
+export default class GenesetCorrelatedGeneCache  {
+
+    private sampleFilterByProfile: SampleFilterByProfile;
+    private iterations: {
+        [iterationKey: string]: GenesetCorrelatedGeneIteration
+    } = {};
+
+    constructor(sampleFilterByProfile: SampleFilterByProfile) {
+        this.sampleFilterByProfile = sampleFilterByProfile;
+    }
+
+    initIteration(iterationKey: string, query: IQuery) {
+        if (!Object.prototype.hasOwnProperty.call(this.iterations, iterationKey)) {
+            this.iterations[iterationKey] = new GenesetCorrelatedGeneIteration(
+                query, this.sampleFilterByProfile
+            );
+        }
+    }
+
+    async next(
+        iterationKey: string,
+        maxNumber: number
+    ): Promise<GenesetCorrelation[]> {
+        return this.iterations[iterationKey].next(maxNumber);
+    }
+
+    reset(iterationKey: string): void {
+        this.iterations[iterationKey].reset();
+    }
+
+}

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -94,10 +94,13 @@ interface IBaseHeatmapTrackSpec {
 export interface IGeneHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     data: IGeneHeatmapTrackDatum[];
     onRemove: () => void;
+    info?: string;
 }
 export interface IGenesetHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     data: IGenesetHeatmapTrackDatum[];
     trackLinkUrl: string | undefined;
+    expansionTrackList: IGeneHeatmapTrackSpec[];
+    expansionCallback: () => void;
 }
 
 export const GENETIC_TRACK_GROUP_INDEX = 1;

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -51,10 +51,10 @@ function makeGenesetHeatmapExpandHandler(
         );
         runInAction('genesetHeatmapExpansion', () => {
             const list = (
-                oncoprint.genesetHeatmapTrackExpansionGenes.get(track_key)
+                oncoprint.expansionsByGenesetHeatmapTrackKey.get(track_key)
                 || []
             );
-            oncoprint.genesetHeatmapTrackExpansionGenes.set(
+            oncoprint.expansionsByGenesetHeatmapTrackKey.set(
                 track_key, list.concat(new_genes)
             );
         });
@@ -69,7 +69,7 @@ function makeGenesetHeatmapUnexpandHandler(
     onRemoveLast: () => void
 ) {
     return action('genesetHeatmapUnexpansion', () => {
-        const list = oncoprint.genesetHeatmapTrackExpansionGenes.get(parentKey);
+        const list = oncoprint.expansionsByGenesetHeatmapTrackKey.get(parentKey);
         if (list) {
             // only remove if the expansion if it isn't needed in another track
             // group than the one this track is being removed from; keep the
@@ -396,7 +396,7 @@ export function makeGenesetHeatmapExpansionsMobxPromise(oncoprint:ResultsViewOnc
             const genesetGeneCache = oncoprint.props.store.genesetCorrelatedGeneCache.result!;
 
             const trackGroup = oncoprint.genesetHeatmapTrackGroup;
-            const expansionsByGenesetTrack = oncoprint.genesetHeatmapTrackExpansionGenes;
+            const expansionsByGenesetTrack = oncoprint.expansionsByGenesetHeatmapTrackKey;
 
             // list all the genes in an array of plain, non-observable objects,
             // as observable arrays cannot be safely passed to external libs

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -402,7 +402,7 @@ export function makeGenesetHeatmapExpansionsMobxPromise(oncoprint:ResultsViewOnc
                             const data = dataCache.get({entrezGeneId, molecularProfileId})!.data!;
                             const profile = molecularProfileIdToMolecularProfile[molecularProfileId];
                             return {
-                                key: `EXPANSIONTRACK_${gsTrack},${hugoGeneSymbol}`,
+                                key: `EXPANSIONTRACK_${gsTrack},${hugoGeneSymbol},GROUP${trackGroup}`,
                                 label: hugoGeneSymbol,
                                 info: correlationValue.toFixed(2),
                                 molecularProfileId: molecularProfileId,
@@ -473,9 +473,9 @@ export function makeGenesetHeatmapTracksMobxPromise(
             await dataCache.getPromise(cacheQueries, true);
 
             return genesetIds.map((genesetId) => {
-                const track_key = `GENESETHEATMAPTRACK_${molecularProfileId},${genesetId},GROUP${trackGroup}`;
+                const expansionMapKey = `GENESETHEATMAPTRACK_${molecularProfileId},${genesetId}`;
                 return {
-                    key: track_key,
+                    key: `GENESETHEATMAPTRACK_${molecularProfileId},${genesetId},GROUP${trackGroup}`,
                     label: genesetId,
                     molecularProfileId,
                     molecularAlterationType: molecularProfile.value.molecularAlterationType,
@@ -490,11 +490,11 @@ export function makeGenesetHeatmapTracksMobxPromise(
                     trackGroupIndex: trackGroup,
                     expansionCallback: makeGenesetHeatmapExpandHandler(
                         oncoprint,
-                        track_key,
+                        expansionMapKey,
                         {molecularProfileId, genesetId},
                         correlatedGeneCache
                     ),
-                    expansionTrackList: expansions[track_key]
+                    expansionTrackList: expansions[expansionMapKey]
                 };
             });
         },

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -16,8 +16,8 @@ import {ResultsViewPageStore} from "../../../pages/resultsView/ResultsViewPageSt
 import {ClinicalAttribute, Gene, MolecularProfile, Mutation, Sample} from "../../api/generated/CBioPortalAPI";
 import {
     percentAltered, makeGeneticTracksMobxPromise,
-    makeGenesetHeatmapTracksMobxPromise, makeHeatmapTracksMobxPromise,
-    makeClinicalTracksMobxPromise
+    makeGenesetHeatmapExpansionsMobxPromise, makeGenesetHeatmapTracksMobxPromise,
+    makeHeatmapTracksMobxPromise, makeClinicalTracksMobxPromise
 } from "./OncoprintUtils";
 import _ from "lodash";
 import onMobxPromise from "shared/lib/onMobxPromise";
@@ -51,6 +51,13 @@ export type SortMode = (
     {type:"data"|"alphabetical"|"caseList", clusteredHeatmapProfile?:undefined} |
     {type:"heatmap", clusteredHeatmapProfile:string}
 );
+
+export interface IGenesetExpansionRecord {
+    entrezGeneId: number;
+    hugoGeneSymbol: string;
+    molecularProfileId: string;
+    correlationValue: number;
+}
 
 const specialClinicalAttributes:OncoprintClinicalAttribute[] = [
     {
@@ -123,6 +130,8 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
     private heatmapGeneInputValueUpdater:IReactionDisposer;
 
     public selectedClinicalAttributeIds = observable.shallowMap<boolean>();
+    public genesetHeatmapTrackExpansionGenes =
+        observable.map<IGenesetExpansionRecord[]>();
     public molecularProfileIdToHeatmapTracks =
         observable.map<HeatmapTrackGroupRecord>();
 
@@ -768,7 +777,9 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         );
     }
 
+    readonly sampleGenesetHeatmapExpansionTracks = makeGenesetHeatmapExpansionsMobxPromise(this, true);
     readonly sampleGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, true);
+    readonly patientGenesetHeatmapExpansionTracks = makeGenesetHeatmapExpansionsMobxPromise(this, false);
     readonly patientGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, false);
     @computed get genesetHeatmapTracks() {
         return (this.columnMode === "sample" ? this.sampleGenesetHeatmapTracks : this.patientGenesetHeatmapTracks);

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -777,10 +777,14 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         );
     }
 
-    readonly sampleGenesetHeatmapExpansionTracks = makeGenesetHeatmapExpansionsMobxPromise(this, true);
-    readonly sampleGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, true);
-    readonly patientGenesetHeatmapExpansionTracks = makeGenesetHeatmapExpansionsMobxPromise(this, false);
-    readonly patientGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, false);
+    readonly sampleGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(
+            this, true,
+            makeGenesetHeatmapExpansionsMobxPromise(this, true)
+    );
+    readonly patientGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(
+            this, false,
+            makeGenesetHeatmapExpansionsMobxPromise(this, false)
+    );
     @computed get genesetHeatmapTracks() {
         return (this.columnMode === "sample" ? this.sampleGenesetHeatmapTracks : this.patientGenesetHeatmapTracks);
     }

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -130,7 +130,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
     private heatmapGeneInputValueUpdater:IReactionDisposer;
 
     public selectedClinicalAttributeIds = observable.shallowMap<boolean>();
-    public genesetHeatmapTrackExpansionGenes =
+    public expansionsByGenesetHeatmapTrackKey =
         observable.map<IGenesetExpansionRecord[]>();
     public molecularProfileIdToHeatmapTracks =
         observable.map<HeatmapTrackGroupRecord>();


### PR DESCRIPTION
Register callbacks to enable expansion options in the track menu of gene
set heatmap tracks in the Oncoprint. When these are clicked, retrieve
the list of correlated genes for the gene set and render these tracks as
the expansions of the gene set tracks. Tweak the colour of the gene set
tracks' labels in order to clearly distinguish them from gene tracks in
the same group.

This is a rewrite of the functionality originally reviewed in pull request
cBioPortal/cbioportal#2190, using the functionality I later ported to
the new stack via cBioPortal/oncoprintjs#34 and
cBioPortal/cbioportal-frontend#898.

## Screenshot ##
![Screenshot showing a gene set heatmap with grey track labels, also containing five gene expression heatmaps in the regular colours under one of the tracks and showing the words ‘Show genes’ in the track menu for another](https://user-images.githubusercontent.com/4929431/35990288-d13c8536-0d03-11e8-80e5-3810be8426ee.png)