### PR TITLE
Enable clustering for gene set heatmaps

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1265,15 +1265,16 @@ export class ResultsViewPageStore {
     }, {});
 
     readonly heatmapMolecularProfiles = remoteData<MolecularProfile[]>({
-        await: ()=>[
-            this.molecularProfilesInStudies
+        await: () => [
+            this.molecularProfilesInStudies,
+            this.genesetMolecularProfile
         ],
-        invoke:()=>{
+        invoke: () => {
             const MRNA_EXPRESSION = "MRNA_EXPRESSION";
             const PROTEIN_LEVEL = "PROTEIN_LEVEL";
             const selectedMolecularProfileIds = stringListToSet(this.selectedMolecularProfileIds);
 
-            return Promise.resolve(_.sortBy(_.filter(this.molecularProfilesInStudies.result!, profile=>{
+            const expressionHeatmaps = _.sortBy(_.filter(this.molecularProfilesInStudies.result!, profile=>{
                 return (profile.molecularAlterationType === MRNA_EXPRESSION ||
                         profile.molecularAlterationType === PROTEIN_LEVEL) && profile.showProfileInAnalysisTab;
             }), profile=>{
@@ -1291,7 +1292,14 @@ export class ResultsViewPageStore {
                         return 3;
                     }
                 }
-            }));
+            });
+            const genesetMolecularProfile = this.genesetMolecularProfile.result!;
+            const genesetHeatmaps = (
+                genesetMolecularProfile.isApplicable
+                ? [genesetMolecularProfile.value]
+                : []
+            );
+            return Promise.resolve(expressionHeatmaps.concat(genesetHeatmaps));
         }
     });
 

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1274,25 +1274,33 @@ export class ResultsViewPageStore {
             const PROTEIN_LEVEL = "PROTEIN_LEVEL";
             const selectedMolecularProfileIds = stringListToSet(this.selectedMolecularProfileIds);
 
-            const expressionHeatmaps = _.sortBy(_.filter(this.molecularProfilesInStudies.result!, profile=>{
-                return (profile.molecularAlterationType === MRNA_EXPRESSION ||
-                        profile.molecularAlterationType === PROTEIN_LEVEL) && profile.showProfileInAnalysisTab;
-            }), profile=>{
-                // Sort order: selected and mrna, selected and protein, unselected and mrna, unselected and protein
-                if (profile.molecularProfileId in selectedMolecularProfileIds) {
-                    if (profile.molecularAlterationType === MRNA_EXPRESSION) {
-                        return 0;
-                    } else if (profile.molecularAlterationType === PROTEIN_LEVEL) {
-                        return 1;
-                    }
-                } else {
-                    if (profile.molecularAlterationType === MRNA_EXPRESSION) {
-                        return 2;
-                    } else if (profile.molecularAlterationType === PROTEIN_LEVEL) {
-                        return 3;
+            const expressionHeatmaps = _.sortBy(
+                _.filter(
+                    this.molecularProfilesInStudies.result!,
+                    ({showProfileInAnalysisTab, molecularAlterationType}) => (
+                        showProfileInAnalysisTab && (
+                            molecularAlterationType === MRNA_EXPRESSION ||
+                            molecularAlterationType === PROTEIN_LEVEL
+                        )
+                    )
+                ),
+                profile => {
+                    // Sort order: selected and mrna, selected and protein, unselected and mrna, unselected and protein
+                    if (profile.molecularProfileId in selectedMolecularProfileIds) {
+                        if (profile.molecularAlterationType === MRNA_EXPRESSION) {
+                            return 0;
+                        } else if (profile.molecularAlterationType === PROTEIN_LEVEL) {
+                            return 1;
+                        }
+                    } else {
+                        if (profile.molecularAlterationType === MRNA_EXPRESSION) {
+                            return 2;
+                        } else if (profile.molecularAlterationType === PROTEIN_LEVEL) {
+                            return 3;
+                        }
                     }
                 }
-            });
+            );
             const genesetMolecularProfile = this.genesetMolecularProfile.result!;
             const genesetHeatmaps = (
                 genesetMolecularProfile.isApplicable

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -32,11 +32,11 @@ export function transition(
         oncoprint.keepSorted(false);
     }
     trySuppressRendering(nextProps, prevProps, oncoprint);
-    transitionSortConfig(nextProps, prevProps, oncoprint);
     transitionWhitespaceBetweenColumns(nextProps, prevProps, oncoprint);
     transitionShowMinimap(nextProps, prevProps, oncoprint);
     transitionOnMinimapCloseCallback(nextProps, prevProps, oncoprint);
     transitionTracks(nextProps, prevProps, oncoprint, getTrackSpecKeyToTrackId);
+    transitionSortConfig(nextProps, prevProps, oncoprint);
     transitionTrackGroupSortPriority(nextProps, prevProps, oncoprint);
     transitionHiddenIds(nextProps, prevProps, oncoprint);
     transitionHorzZoomToFit(nextProps, prevProps, oncoprint);
@@ -162,7 +162,7 @@ function shouldNotKeepSorted_ClinicalTracksHelper(
     // Check if
     // (1) A track added/removed
     // (2) Track data changed
-    if (differentTracksOrChangedData(nextProps.geneticTracks || [], prevProps.geneticTracks || [])) {
+    if (differentTracksOrChangedData(nextProps.clinicalTracks || [], prevProps.clinicalTracks || [])) {
         return true;
     }
 }
@@ -174,7 +174,10 @@ function shouldNotKeepSorted_HeatmapTracksHelper(
     // Check if
     // (1) A track added/removed
     // (2) Track data changed
-    if (differentTracksOrChangedData(nextProps.geneticTracks || [], prevProps.geneticTracks || [])) {
+    if (
+        differentTracksOrChangedData(nextProps.heatmapTracks, prevProps.heatmapTracks || [] )
+        || differentTracksOrChangedData(nextProps.genesetHeatmapTracks, prevProps.genesetHeatmapTracks || [])
+    ) {
         return true;
     }
 }

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -285,10 +285,13 @@ export function makeHeatmapTracksMobxPromise(oncoprint:ResultsViewOncoprint, sam
                             trackGroup.genes.delete(gene);
                             if (!trackGroup.genes.size) {
                                 molecularProfileIdToHeatmapTracks.delete(molecularProfileId);
-                                if (oncoprint.sortMode.type === "heatmap" && oncoprint.sortMode.clusteredHeatmapProfile === molecularProfileId) {
-                                    oncoprint.sortByData();
-                                }
                             }
+                        }
+                        if (!molecularProfileIdToHeatmapTracks.has(molecularProfileId)
+                            && oncoprint.sortMode.type === "heatmap"
+                            && oncoprint.sortMode.clusteredHeatmapProfile === molecularProfileId
+                        ) {
+                            oncoprint.sortByData();
                         }
                     })
                 };

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -310,8 +310,7 @@ export function makeGenesetHeatmapTracksMobxPromise(
             oncoprint.props.store.patients,
             oncoprint.props.store.genesetMolecularProfile,
             oncoprint.props.store.genesetMolecularDataCache,
-            oncoprint.props.store.genesetLinkMap,
-            oncoprint.genesetHeatmapTrackGroup
+            oncoprint.props.store.genesetLinkMap
         ],
         invoke: async () => {
             const samples = oncoprint.props.store.samples.result!;
@@ -319,7 +318,9 @@ export function makeGenesetHeatmapTracksMobxPromise(
             const molecularProfile = oncoprint.props.store.genesetMolecularProfile.result!;
             const dataCache = oncoprint.props.store.genesetMolecularDataCache.result!;
             const genesetLinkMap = oncoprint.props.store.genesetLinkMap.result!;
-            const trackGroup = oncoprint.genesetHeatmapTrackGroup.result!;
+
+            // observe computed property based on other tracks
+            const trackGroup = oncoprint.genesetHeatmapTrackGroup;
 
             if (!molecularProfile.isApplicable) {
                 return [];

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -47,7 +47,10 @@ export type OncoprintClinicalAttribute =
         clinicalAttributeId: string|SpecialAttribute;
     };
 
-export type SortMode = {type:"data"|"alphabetical"|"caseList"|"heatmap", clusteredHeatmapProfile?:string};
+export type SortMode = (
+    {type:"data"|"alphabetical"|"caseList", clusteredHeatmapProfile?:undefined} |
+    {type:"heatmap", clusteredHeatmapProfile:string}
+);
 
 const specialClinicalAttributes:OncoprintClinicalAttribute[] = [
     {
@@ -110,8 +113,8 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
     @observable showClinicalTrackLegends:boolean = true;
     @observable showMinimap:boolean = false;
 
-    @observable selectedHeatmapProfile:string = "";
-    @observable heatmapGeneInputValue:string = "";
+    @observable selectedHeatmapProfile = "";
+    @observable heatmapGeneInputValue = "";
 
     @observable horzZoom:number = 0.5;
 
@@ -263,12 +266,23 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
             get selectedHeatmapProfile() {
                 return self.selectedHeatmapProfile;
             },
+            get heatmapIsDynamicallyQueried () {
+                return self.heatmapIsDynamicallyQueried;
+            },
             get clusterHeatmapButtonDisabled() {
                 return (self.sortMode.type === "heatmap" &&
                     self.selectedHeatmapProfile === self.sortMode.clusteredHeatmapProfile);
             },
             get hideClusterHeatmapButton() {
-                return !self.molecularProfileIdToHeatmapTracks.get(self.selectedHeatmapProfile);
+                const genesetHeatmapProfile: string | undefined = (
+                    self.props.store.genesetMolecularProfile.result &&
+                    self.props.store.genesetMolecularProfile.result.value &&
+                    self.props.store.genesetMolecularProfile.result.value.molecularProfileId
+                );
+                return !(
+                    self.molecularProfileIdToHeatmapTracks.get(self.selectedHeatmapProfile) ||
+                    self.selectedHeatmapProfile === genesetHeatmapProfile
+                );
             },
             get heatmapGeneInputValue() {
                 return self.heatmapGeneInputValue;
@@ -435,11 +449,8 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
             onClickAddGenesToHeatmap:()=>{
                 this.addHeatmapTracks(this.selectedHeatmapProfile, this.heatmapGeneInputValue.toUpperCase().trim().split(/\s+/));
             },
-            onClickRemoveHeatmap:action(()=>{
+            onClickRemoveHeatmap:action(() => {
                 this.molecularProfileIdToHeatmapTracks.clear();
-                if (this.sortMode.type === "heatmap") {
-                    this.sortByData();
-                }
             }),
             onClickClusterHeatmap:()=>{
                 this.sortMode = {type: "heatmap", clusteredHeatmapProfile: this.selectedHeatmapProfile};
@@ -527,7 +538,21 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
             }
         };
     }
-    
+
+    /**
+     * Indicates whether dynamic heatmap querying controls are relevant.
+     *
+     * They are if a non-geneset heatmap profile is currently selected; gene set
+     * heatmaps are queried from the query page.
+     */
+    @computed get heatmapIsDynamicallyQueried(): boolean {
+        const profileMap = this.props.store.molecularProfileIdToMolecularProfile.result;
+        return (
+            profileMap.hasOwnProperty(this.selectedHeatmapProfile) &&
+            profileMap[this.selectedHeatmapProfile].molecularAlterationType !== 'GENESET_SCORE'
+        );
+    }
+
     @action private initFromUrlParams(paramsMap:any) {
         if (paramsMap[SAMPLE_MODE_URL_PARAM]) {
             this.columnMode = (paramsMap[SAMPLE_MODE_URL_PARAM] && paramsMap[SAMPLE_MODE_URL_PARAM]==="true") ? "sample" : "patient";
@@ -752,10 +777,20 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
 
     @computed get clusterHeatmapTrackGroupIndex() {
         if (this.sortMode.type === "heatmap") {
-            return this.molecularProfileIdToHeatmapTracks.get(this.sortMode.clusteredHeatmapProfile!)!.trackGroupIndex;
-        } else {
-            return undefined;
+            const clusteredHeatmapProfile: string = this.sortMode.clusteredHeatmapProfile;
+            const genesetHeatmapProfile: string | undefined = (
+                this.props.store.genesetMolecularProfile.result &&
+                this.props.store.genesetMolecularProfile.result.value &&
+                this.props.store.genesetMolecularProfile.result.value.molecularProfileId
+            );
+            if (clusteredHeatmapProfile === genesetHeatmapProfile) {
+                return this.genesetHeatmapTrackGroup.result;
+            } else {
+                const heatmapGroup = this.molecularProfileIdToHeatmapTracks.get(clusteredHeatmapProfile);
+                return (heatmapGroup && heatmapGroup.trackGroupIndex);
+            }
         }
+        return undefined;
     }
 
     @computed get sortConfig() {

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -7,7 +7,7 @@ import {
     reaction
 } from "mobx";
 import {remoteData} from "../../api/remoteData";
-import {default as Oncoprint, GENETIC_TRACK_GROUP_INDEX} from "./Oncoprint";
+import Oncoprint, {GENETIC_TRACK_GROUP_INDEX} from "./Oncoprint";
 import OncoprintControls, {
     IOncoprintControlsHandlers,
     IOncoprintControlsState
@@ -760,13 +760,13 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         return (this.columnMode === "sample" ? this.sampleHeatmapTracks : this.patientHeatmapTracks);
     }
 
-    readonly genesetHeatmapTrackGroup = remoteData<number>({
-        await: () => [this.heatmapTracks],
-        invoke: () => Promise.resolve(1 + Math.max(
+    @computed get genesetHeatmapTrackGroup(): number {
+        return 1 + Math.max(
             GENETIC_TRACK_GROUP_INDEX,
-            ...(this.heatmapTracks.result!.map(hmTrack => hmTrack.trackGroupIndex))
-        ))
-    });
+            // observe the heatmap tracks to render in the very next group
+            ...(this.heatmapTracks.result.map(hmTrack => hmTrack.trackGroupIndex))
+        );
+    }
 
     readonly sampleGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, true);
     readonly patientGenesetHeatmapTracks = makeGenesetHeatmapTracksMobxPromise(this, false);
@@ -784,7 +784,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                 this.props.store.genesetMolecularProfile.result.value.molecularProfileId
             );
             if (clusteredHeatmapProfile === genesetHeatmapProfile) {
-                return this.genesetHeatmapTrackGroup.result;
+                return this.genesetHeatmapTrackGroup;
             } else {
                 const heatmapGroup = this.molecularProfileIdToHeatmapTracks.get(clusteredHeatmapProfile);
                 return (heatmapGroup && heatmapGroup.trackGroupIndex);

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -82,6 +82,7 @@ export interface IOncoprintControlsState {
     selectedClinicalAttributeIds?:string[],
     heatmapProfilesPromise?:MobxPromise<MolecularProfile[]>,
     selectedHeatmapProfile?:string;
+    heatmapIsDynamicallyQueried:boolean;
     heatmapGeneInputValue?: string;
     clusterHeatmapButtonDisabled?:boolean;
     hideClusterHeatmapButton?:boolean;
@@ -426,24 +427,30 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
                             value={this.props.state.selectedHeatmapProfile}
                             options={this.heatmapProfileOptions}
                         />
-                        <textarea
-                            placeholder="Type space- or comma-separated genes here, then click 'Add Genes to Heatmap'"
-                            name={EVENT_KEY.heatmapGeneInput}
-                            onChange={this.onType}
-                            value={this.props.state.heatmapGeneInputValue}
-                        >
-                        </textarea>
+                        {this.props.state.heatmapIsDynamicallyQueried && [
+                            <textarea
+                                key="heatmapGeneInputArea"
+                                placeholder="Type space- or comma-separated genes here, then click 'Add Genes to Heatmap'"
+                                name={EVENT_KEY.heatmapGeneInput}
+                                onChange={this.onType}
+                                value={this.props.state.heatmapGeneInputValue}
+                            >
+                            </textarea>,
 
-                        <button className="btn btn-sm btn-default"
-                             name={EVENT_KEY.addGenesToHeatmap}
-                             onClick={this.onButtonClick}
-                         >Add Genes to Heatmap</button>
+                            <button
+                                key="addGenesToHeatmapButton"
+                                className="btn btn-sm btn-default"
+                                name={EVENT_KEY.addGenesToHeatmap}
+                                onClick={this.onButtonClick}
+                             >Add Genes to Heatmap</button>,
 
-                        <button
-                            className="btn btn-sm btn-default"
-                            name={EVENT_KEY.removeHeatmap}
-                            onClick={this.onButtonClick}
-                        >Remove Heatmap</button>
+                            <button
+                                key="removeHeatmapButton"
+                                className="btn btn-sm btn-default"
+                                name={EVENT_KEY.removeHeatmap}
+                                onClick={this.onButtonClick}
+                            >Remove Heatmap</button>
+                        ]}
 
                         {!this.props.state.hideClusterHeatmapButton &&
                             (<button


### PR DESCRIPTION
List any queried gene set profile in the heatmap menu, displaying only
the clustering button as it's queried via the query page and the ‘Add
Genes’ and ‘Remove Heatmap’ buttons do not apply to it.

Collapse expansion tracks before clustering a heatmap, as these are
generally not of the same data type as the main tracks of the heatmap,
and including them when clustering would not make sense. 

This is a rewrite of functionality originally reviewed in pull request
cBioPortal/cbioportal#2186, using the functionality I later ported to
the new stack via cBioPortal/oncoprintjs#34 and
cBioPortal/cbioportal-frontend#898.

## Screenshot ##

![Screenshot showing an Oncoprint with a clustered gene set heatmap and a heatmap menu containing only the cluster button for this profile](https://user-images.githubusercontent.com/4929431/36312041-7bb94dee-132d-11e8-91a1-50fed3979e43.png)