### PR TITLE
Include reference links in Oncoprint gene set track tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12028,9 +12028,9 @@
       }
     },
     "oncoprintjs": {
-      "version": "1.0.82",
-      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.0.82.tgz",
-      "integrity": "sha1-eQGtqQhQQmAXV0qrdf9zMdgrRWc=",
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.0.83.tgz",
+      "integrity": "sha1-/g5MW9XMH2DTg9hNFhs+rI/tY6s=",
       "requires": {
         "express": "4.15.4",
         "gl-matrix": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "mobx-utils": "^2.0.1",
     "mobxpromise": "^1.2.0",
     "node-sass": "^4.3.0",
-    "oncoprintjs": "^1.0.82",
+    "oncoprintjs": "^1.0.83",
     "parameter-validator": "^1.0.2",
     "pdfobject": "^2.0.201604172",
     "plotly.js": "^1.31.2",

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1365,6 +1365,23 @@ export class ResultsViewPageStore {
         }
     });
 
+    readonly genesetLinkMap = remoteData<{[genesetId: string]: string}>({
+        invoke: async () => {
+            if (this.genesetIds && this.genesetIds.length) {
+                const genesets = await internalClient.fetchGenesetsUsingPOST(
+                    {genesetIds: this.genesetIds.slice()}
+                );
+                const linkMap: {[genesetId: string]: string} = {};
+                genesets.forEach(({genesetId, refLink}) => {
+                    linkMap[genesetId] = refLink;
+                });
+                return linkMap;
+            } else {
+                return {};
+            }
+        }
+    });
+
     readonly customDriverAnnotationReport = remoteData<{ hasBinary:boolean, tiers:string[] }>({
         await:()=>[
             this.mutations

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -11,7 +11,10 @@ import {
     getGenesetHeatmapTrackRuleSetParams, getHeatmapTrackRuleSetParams
 } from "./OncoprintUtils";
 import {getClinicalTrackSortComparator, getGeneticTrackSortComparator, heatmapTrackSortComparator} from "./SortUtils";
-import {makeClinicalTrackTooltip, makeGeneticTrackTooltip, makeHeatmapTrackTooltip} from "./TooltipUtils";
+import {
+    makeClinicalTrackTooltip, makeGeneticTrackTooltip, makeHeatmapTrackTooltip,
+    linebreakGenesetId
+} from "./TooltipUtils";
 import {MolecularProfile} from "../../api/generated/CBioPortalAPI";
 
 export function transition(
@@ -561,11 +564,12 @@ function transitionGenesetHeatmapTrack(
             has_column_spacing: false,
             track_padding: 0,
             label: nextSpec.label,
+            html_label: linebreakGenesetId(nextSpec.label),
             target_group: nextSpec.trackGroupIndex,
             sort_direction_changeable: true,
             sortCmpFn: heatmapTrackSortComparator,
             init_sort_direction: 0 as 0,
-            description: `${nextSpec.label} data from ${nextSpec.molecularProfileId}`,
+            description: `Gene set scores from ${nextSpec.molecularProfileId}`,
             link_url: nextSpec.trackLinkUrl,
             tooltipFn: makeHeatmapTrackTooltip(nextSpec.molecularAlterationType, true),
             onSortDirectionChange: nextProps.onTrackSortDirectionChange

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -566,6 +566,7 @@ function transitionGenesetHeatmapTrack(
             sortCmpFn: heatmapTrackSortComparator,
             init_sort_direction: 0 as 0,
             description: `${nextSpec.label} data from ${nextSpec.molecularProfileId}`,
+            link_url: nextSpec.trackLinkUrl,
             tooltipFn: makeHeatmapTrackTooltip(nextSpec.molecularAlterationType, true),
             onSortDirectionChange: nextProps.onTrackSortDirectionChange
         };

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -97,6 +97,7 @@ export interface IGeneHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
 }
 export interface IGenesetHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     data: IGenesetHeatmapTrackDatum[];
+    trackLinkUrl: string | undefined;
 }
 
 export const GENETIC_TRACK_GROUP_INDEX = 1;

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -307,6 +307,7 @@ export function makeGenesetHeatmapTracksMobxPromise(
             oncoprint.props.store.patients,
             oncoprint.props.store.genesetMolecularProfile,
             oncoprint.props.store.genesetMolecularDataCache,
+            oncoprint.props.store.genesetLinkMap,
             oncoprint.genesetHeatmapTrackGroup
         ],
         invoke: async () => {
@@ -314,6 +315,7 @@ export function makeGenesetHeatmapTracksMobxPromise(
             const patients = oncoprint.props.store.patients.result!;
             const molecularProfile = oncoprint.props.store.genesetMolecularProfile.result!;
             const dataCache = oncoprint.props.store.genesetMolecularDataCache.result!;
+            const genesetLinkMap = oncoprint.props.store.genesetLinkMap.result!;
             const trackGroup = oncoprint.genesetHeatmapTrackGroup.result!;
 
             if (!molecularProfile.isApplicable) {
@@ -331,6 +333,7 @@ export function makeGenesetHeatmapTracksMobxPromise(
                 molecularProfileId,
                 molecularAlterationType: molecularProfile.value.molecularAlterationType,
                 datatype: molecularProfile.value.datatype,
+                trackLinkUrl: genesetLinkMap[genesetId],
                 data: makeHeatmapTrackData<IGenesetHeatmapTrackDatum, 'geneset_id'>(
                     'geneset_id',
                     genesetId,

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -39,6 +39,20 @@ function makeGenePanelPopupLink(gene_panel_id:string) {
     });
     return anchor;
 }
+
+export function linebreakGenesetId(
+    genesetId: string
+): string {
+    return (
+        // encode the string as the textual contents of an HTML element
+        $('<div>').text(genesetId).html()
+        // Include zero-width spaces to allow line breaks after punctuation in
+        // (typically long) gs names
+        .replace(/_/g, '_&#8203;')
+        .replace(/\./g, '.&#8203;')
+    );
+}
+
 export function makeClinicalTrackTooltip(track:ClinicalTrackSpec, link_id?:boolean) {
     return function(d:any) {
         let ret = '';


### PR DESCRIPTION
When exploring the relevance of gene sets through the heatmap functionality in the Oncoprint, users sometimes want to look up what a gene set is actually about. The metadata known to cBioPortal include the URL of the main reference for the gene set. By making the Oncoprint setup retrieve this URL via the web API, a hyperlink can be presented to the user in the track tooltip.

In addition, mark word breaks to allow browsers to split the line after punctuation commonly found in long MSigDB gene set names, in case the name overflows the width of the tooltip.

This is a translation of the code originally reviewed in pull request thehyve/cbioportal#19,
using the functionality I later ported to the new stack via cBioPortal/oncoprintjs#34 and cBioPortal/cbioportal-frontend#898.

## Screenshot ##
![Screenshot of a gene set track mouseover starting with the track label marked in blue and split over two lines](https://user-images.githubusercontent.com/4929431/35989661-0c1a61f2-0d02-11e8-842a-2c5d95401e66.png)