### PR TITLE
Move cancerhotspots.org to www.cancerhotspots.org (+3d)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fetchAPI": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && curl ${CBIOPORTAL_URL}/api/api-docs | json | grep -v basePath | grep -v termsOfService | grep -v host > src/shared/api/generated/CBioPortalAPI-docs.json && curl ${CBIOPORTAL_URL}/api/api-docs?group=internal | json | grep -v host | grep -v basePath | grep -v termsOfService > src/shared/api/generated/CBioPortalAPIInternal-docs.json",
     "buildAPI": "node scripts/generate-api.js src/shared/api/generated CBioPortalAPI CBioPortalAPIInternal",
     "updateHotspotsAPI": "npm run fetchHotspotsAPI && npm run buildHotspotsAPI",
-    "fetchHotspotsAPI": "curl http://cancerhotspots.org/v2/api-docs?group=cancer_hotspots | json > src/shared/api/generated/CancerHotspotsAPI-docs.json",
+    "fetchHotspotsAPI": "curl http://www.cancerhotspots.org/v2/api-docs?group=cancer_hotspots | json > src/shared/api/generated/CancerHotspotsAPI-docs.json",
     "buildHotspotsAPI": "node scripts/generate-api.js src/shared/api/generated CancerHotspotsAPI",
     "updateOncoKbAPI": "npm run fetchOncoKbAPI && npm run buildOncoKbAPI",
     "fetchOncoKbAPI": "curl http://oncokb.org/api/v1/v2/api-docs | json > src/shared/api/generated/OncoKbAPI-docs.json",

--- a/src/shared/api/generated/CancerHotspotsAPI-docs.json
+++ b/src/shared/api/generated/CancerHotspotsAPI-docs.json
@@ -12,7 +12,7 @@
       "url": "https://github.com/cBioPortal/cancerhotspots/blob/master/LICENSE"
     }
   },
-  "host": "cancerhotspots.org",
+  "host": "www.cancerhotspots.org",
   "basePath": "/",
   "tags": [
     {

--- a/src/shared/api/generated/GenomeNexusAPI-docs.json
+++ b/src/shared/api/generated/GenomeNexusAPI-docs.json
@@ -265,6 +265,13 @@
             "description": "An Ensembl protein ID. For example ENSP00000439985",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "hugoSymbol",
+            "in": "query",
+            "description": "A Hugo Symbol For example ARF5",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {
@@ -283,7 +290,7 @@
         "tags": [
           "ensembl-controller"
         ],
-        "summary": "Retrieves Ensembl Transcripts by Ensembl transcript IDs, protein IDs, or gene IDs",
+        "summary": "Retrieves Ensembl Transcripts by Ensembl transcript IDs, hugo Symbols, protein IDs, or gene IDs",
         "operationId": "fetchEnsemblTranscriptsByEnsemblFilterPOST",
         "consumes": [
           "application/json"
@@ -295,7 +302,7 @@
           {
             "in": "body",
             "name": "ensemblFilter",
-            "description": "List of Ensembl transcript IDs. For example [\"ENST00000361390\", \"ENST00000361453\", \"ENST00000361624\"]<br>OR<br>List of Ensembl protein IDs. For example [\"ENSP00000439985\", \"ENSP00000478460\", \"ENSP00000346196\"]<br>OR<br>List of Ensembl gene IDs. For example [\"ENSG00000136999\", \"ENSG00000272398\", \"ENSG00000198695\"]",
+            "description": "List of Ensembl transcript IDs. For example [\"ENST00000361390\", \"ENST00000361453\", \"ENST00000361624\"]<br>OR<br>List of Hugo Symbols. For example [\"TP53\", \"PIK3CA\", \"BRCA1\"]<br>OR<br>List of Ensembl protein IDs. For example [\"ENSP00000439985\", \"ENSP00000478460\", \"ENSP00000346196\"]<br>OR<br>List of Ensembl gene IDs. For example [\"ENSG00000136999\", \"ENSG00000272398\", \"ENSG00000198695\"]",
             "required": true,
             "schema": {
               "$ref": "#/definitions/EnsemblFilter"
@@ -585,6 +592,13 @@
             "type": "string"
           }
         },
+        "hugoSymbols": {
+          "type": "array",
+          "description": "List of Hugo Symbols. For example [\"TP53\", \"PIK3CA\", \"BRCA1\"]",
+          "items": {
+            "type": "string"
+          }
+        },
         "proteinIds": {
           "type": "array",
           "description": "List of Ensembl protein IDs. For example [\"ENSP00000439985\", \"ENSP00000478460\", \"ENSP00000346196\"]",
@@ -632,6 +646,62 @@
           "items": {
             "$ref": "#/definitions/PfamDomainRange"
           }
+        },
+        "exons": {
+          "type": "array",
+          "description": "Exon information",
+          "items": {
+            "$ref": "#/definitions/ExonRange"
+          }
+        },
+        "hugoSymbols": {
+          "type": "array",
+          "description": "Hugo symbols",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExonRange": {
+      "type": "object",
+      "required": [
+        "exonEnd",
+        "exonId",
+        "exonStart",
+        "rank",
+        "strand",
+        "version"
+      ],
+      "properties": {
+        "exonId": {
+          "type": "string",
+          "description": "Exon id"
+        },
+        "exonStart": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Start position of exon"
+        },
+        "exonEnd": {
+          "type": "integer",
+          "format": "int32",
+          "description": "End position of exon"
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of exon in transcript"
+        },
+        "strand": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Strand exon is on, -1 for - and 1 for +"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Exon version"
         }
       }
     },
@@ -789,7 +859,8 @@
           "description": "Hugo gene symbol"
         },
         "hgnc_id": {
-          "type": "string",
+          "type": "integer",
+          "format": "int32",
           "description": "HGNC id"
         },
         "hgvsc": {
@@ -805,11 +876,13 @@
           "description": "Polyphen Prediction"
         },
         "polyphen_score": {
-          "type": "string",
+          "type": "number",
+          "format": "double",
           "description": "Polyphen Score"
         },
         "protein_end": {
-          "type": "string",
+          "type": "integer",
+          "format": "int32",
           "description": "Protein end position"
         },
         "protein_id": {
@@ -817,7 +890,8 @@
           "description": "Ensembl protein id"
         },
         "protein_start": {
-          "type": "string",
+          "type": "integer",
+          "format": "int32",
           "description": "Protein start position"
         },
         "refseq_transcript_ids": {
@@ -832,7 +906,8 @@
           "description": "Sift Prediction"
         },
         "sift_score": {
-          "type": "string",
+          "type": "number",
+          "format": "double",
           "description": "Sift Score"
         },
         "transcript_id": {
@@ -848,7 +923,6 @@
     "VariantAnnotation": {
       "type": "object",
       "required": [
-        "annotationJSON",
         "id",
         "variant"
       ],

--- a/src/shared/api/generated/GenomeNexusAPI.ts
+++ b/src/shared/api/generated/GenomeNexusAPI.ts
@@ -4,6 +4,8 @@ type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type EnsemblFilter = {
     'geneIds': Array < string >
 
+        'hugoSymbols': Array < string >
+
         'proteinIds': Array < string >
 
         'transcriptIds': Array < string >
@@ -19,6 +21,24 @@ export type EnsemblTranscript = {
         'proteinLength': number
 
         'pfamDomains': Array < PfamDomainRange >
+
+        'exons': Array < ExonRange >
+
+        'hugoSymbols': Array < string >
+
+};
+export type ExonRange = {
+    'exonId': string
+
+        'exonStart': number
+
+        'exonEnd': number
+
+        'rank': number
+
+        'strand': number
+
+        'version': number
 
 };
 export type GeneXref = {
@@ -80,7 +100,7 @@ export type TranscriptConsequence = {
 
         'gene_symbol': string
 
-        'hgnc_id': string
+        'hgnc_id': number
 
         'hgvsc': string
 
@@ -88,19 +108,19 @@ export type TranscriptConsequence = {
 
         'polyphen_prediction': string
 
-        'polyphen_score': string
+        'polyphen_score': number
 
-        'protein_end': string
+        'protein_end': number
 
         'protein_id': string
 
-        'protein_start': string
+        'protein_start': number
 
         'refseq_transcript_ids': Array < string >
 
         'sift_prediction': string
 
-        'sift_score': string
+        'sift_score': number
 
         'transcript_id': string
 
@@ -511,6 +531,7 @@ export default class GenomeNexusAPI {
     fetchEnsemblTranscriptsGETURL(parameters: {
         'geneId' ? : string,
         'proteinId' ? : string,
+        'hugoSymbol' ? : string,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
@@ -521,6 +542,10 @@ export default class GenomeNexusAPI {
 
         if (parameters['proteinId'] !== undefined) {
             queryParameters['proteinId'] = parameters['proteinId'];
+        }
+
+        if (parameters['hugoSymbol'] !== undefined) {
+            queryParameters['hugoSymbol'] = parameters['hugoSymbol'];
         }
 
         if (parameters.$queryParameters) {
@@ -539,10 +564,12 @@ export default class GenomeNexusAPI {
      * @name GenomeNexusAPI#fetchEnsemblTranscriptsGET
      * @param {string} geneId - An Ensembl gene ID. For example ENSG00000136999
      * @param {string} proteinId - An Ensembl protein ID. For example ENSP00000439985
+     * @param {string} hugoSymbol - A Hugo Symbol For example ARF5
      */
     fetchEnsemblTranscriptsGET(parameters: {
             'geneId' ? : string,
             'proteinId' ? : string,
+            'hugoSymbol' ? : string,
             $queryParameters ? : any,
                 $domain ? : string
         }): Promise < Array < EnsemblTranscript >
@@ -565,6 +592,10 @@ export default class GenomeNexusAPI {
 
                 if (parameters['proteinId'] !== undefined) {
                     queryParameters['proteinId'] = parameters['proteinId'];
+                }
+
+                if (parameters['hugoSymbol'] !== undefined) {
+                    queryParameters['hugoSymbol'] = parameters['hugoSymbol'];
                 }
 
                 if (parameters.$queryParameters) {
@@ -599,10 +630,10 @@ export default class GenomeNexusAPI {
     };
 
     /**
-     * Retrieves Ensembl Transcripts by Ensembl transcript IDs, protein IDs, or gene IDs
+     * Retrieves Ensembl Transcripts by Ensembl transcript IDs, hugo Symbols, protein IDs, or gene IDs
      * @method
      * @name GenomeNexusAPI#fetchEnsemblTranscriptsByEnsemblFilterPOST
-     * @param {} ensemblFilter - List of Ensembl transcript IDs. For example ["ENST00000361390", "ENST00000361453", "ENST00000361624"]<br>OR<br>List of Ensembl protein IDs. For example ["ENSP00000439985", "ENSP00000478460", "ENSP00000346196"]<br>OR<br>List of Ensembl gene IDs. For example ["ENSG00000136999", "ENSG00000272398", "ENSG00000198695"]
+     * @param {} ensemblFilter - List of Ensembl transcript IDs. For example ["ENST00000361390", "ENST00000361453", "ENST00000361624"]<br>OR<br>List of Hugo Symbols. For example ["TP53", "PIK3CA", "BRCA1"]<br>OR<br>List of Ensembl protein IDs. For example ["ENSP00000439985", "ENSP00000478460", "ENSP00000346196"]<br>OR<br>List of Ensembl gene IDs. For example ["ENSG00000136999", "ENSG00000272398", "ENSG00000198695"]
      */
     fetchEnsemblTranscriptsByEnsemblFilterPOST(parameters: {
             'ensemblFilter': EnsemblFilter,

--- a/src/shared/api/generated/GenomeNexusAPIInternal-docs.json
+++ b/src/shared/api/generated/GenomeNexusAPIInternal-docs.json
@@ -36,13 +36,88 @@
     "https"
   ],
   "paths": {
-    "/cancer_hotspots": {
+    "/cancer_hotspots/genomic": {
       "post": {
         "tags": [
           "cancer-hotspots-controller"
         ],
-        "summary": "Retrieves hotspot annotation for the provided list of variants",
-        "operationId": "fetchHotspotAnnotationPOST",
+        "summary": "Retrieves hotspot annotations for the provided list of genomic locations",
+        "operationId": "fetchHotspotAnnotationByGenomicLocationPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "genomicLocations",
+            "description": "List of genomic locations.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GenomicLocation"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AggregatedHotspots"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cancer_hotspots/genomic/{genomicLocation}": {
+      "get": {
+        "tags": [
+          "cancer-hotspots-controller"
+        ],
+        "summary": "Retrieves hotspot annotations for a specific genomic location",
+        "operationId": "fetchHotspotAnnotationByGenomicLocationGET",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "genomicLocation",
+            "in": "path",
+            "description": "A genomic location. For example 7,140453136,140453136,A,T",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Hotspot"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cancer_hotspots/hgvs": {
+      "post": {
+        "tags": [
+          "cancer-hotspots-controller"
+        ],
+        "summary": "Retrieves hotspot annotations for the provided list of variants",
+        "operationId": "fetchHotspotAnnotationByHgvsPOST",
         "consumes": [
           "application/json"
         ],
@@ -69,20 +144,20 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Hotspot"
+                "$ref": "#/definitions/AggregatedHotspots"
               }
             }
           }
         }
       }
     },
-    "/cancer_hotspots/{variant}": {
+    "/cancer_hotspots/hgvs/{variant}": {
       "get": {
         "tags": [
           "cancer-hotspots-controller"
         ],
-        "summary": "Retrieves hotspot annotation for a specific variant",
-        "operationId": "fetchHotspotAnnotationGET",
+        "summary": "Retrieves hotspot annotations for a specific variant",
+        "operationId": "fetchHotspotAnnotationByHgvsGET",
         "consumes": [
           "application/json"
         ],
@@ -368,6 +443,31 @@
     }
   },
   "definitions": {
+    "AggregatedHotspots": {
+      "type": "object",
+      "required": [
+        "genomicLocation",
+        "hotspots",
+        "variant"
+      ],
+      "properties": {
+        "genomicLocation": {
+          "description": "Genomic Location",
+          "$ref": "#/definitions/GenomicLocation"
+        },
+        "hotspots": {
+          "type": "array",
+          "description": "Hotspots",
+          "items": {
+            "$ref": "#/definitions/Hotspot"
+          }
+        },
+        "variant": {
+          "type": "string",
+          "description": "HGVS notation"
+        }
+      }
+    },
     "GeneXref": {
       "type": "object",
       "required": [
@@ -420,27 +520,53 @@
         }
       }
     },
+    "GenomicLocation": {
+      "type": "object",
+      "required": [
+        "chromosome",
+        "end",
+        "referenceAllele",
+        "start",
+        "variantAllele"
+      ],
+      "properties": {
+        "chromosome": {
+          "type": "string",
+          "description": "Chromosome"
+        },
+        "start": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Start Position"
+        },
+        "end": {
+          "type": "integer",
+          "format": "int32",
+          "description": "End Position"
+        },
+        "referenceAllele": {
+          "type": "string",
+          "description": "Reference Allele"
+        },
+        "variantAllele": {
+          "type": "string",
+          "description": "Variant Allele"
+        }
+      }
+    },
     "Hotspot": {
       "type": "object",
       "required": [
         "transcriptId"
       ],
       "properties": {
-        "geneId": {
-          "type": "string",
-          "description": "Ensembl gene id"
+        "aminoAcidPosition": {
+          "description": "Amino acid position (start - end)",
+          "$ref": "#/definitions/IntegerRange"
         },
         "hugoSymbol": {
           "type": "string",
           "description": "Hugo gene symbol"
-        },
-        "proteinEnd": {
-          "type": "string",
-          "description": "Protein end position"
-        },
-        "proteinStart": {
-          "type": "string",
-          "description": "Protein start position"
         },
         "residue": {
           "type": "string",
@@ -449,6 +575,33 @@
         "transcriptId": {
           "type": "string",
           "description": "Transcript id"
+        },
+        "tumorCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tumor count"
+        },
+        "tumorTypeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tumor type count"
+        },
+        "type": {
+          "type": "string",
+          "description": "Hotspot type"
+        }
+      }
+    },
+    "IntegerRange": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "start": {
+          "type": "integer",
+          "format": "int32"
         }
       }
     },
@@ -499,6 +652,9 @@
           "type": "number",
           "format": "double",
           "description": "Functional impact score"
+        },
+        "hgvs": {
+          "type": "string"
         },
         "hugoSymbol": {
           "type": "string",

--- a/src/shared/api/generated/GenomeNexusAPIInternal.ts
+++ b/src/shared/api/generated/GenomeNexusAPIInternal.ts
@@ -1,6 +1,14 @@
 import * as request from "superagent";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
+export type AggregatedHotspots = {
+    'genomicLocation': GenomicLocation
+
+        'hotspots': Array < Hotspot >
+
+        'variant': string
+
+};
 export type GeneXref = {
     'db_display_name': string
 
@@ -21,18 +29,38 @@ export type GeneXref = {
         'version': string
 
 };
+export type GenomicLocation = {
+    'chromosome': string
+
+        'start': number
+
+        'end': number
+
+        'referenceAllele': string
+
+        'variantAllele': string
+
+};
 export type Hotspot = {
-    'geneId': string
+    'aminoAcidPosition': IntegerRange
 
         'hugoSymbol': string
-
-        'proteinEnd': string
-
-        'proteinStart': string
 
         'residue': string
 
         'transcriptId': string
+
+        'tumorCount': number
+
+        'tumorTypeCount': number
+
+        'type': string
+
+};
+export type IntegerRange = {
+    'end': number
+
+        'start': number
 
 };
 export type IsoformOverride = {
@@ -53,6 +81,8 @@ export type MutationAssessor = {
         'functionalImpact': string
 
         'functionalImpactScore': number
+
+        'hgvs': string
 
         'hugoSymbol': string
 
@@ -148,12 +178,12 @@ export default class GenomeNexusAPIInternal {
         });
     }
 
-    fetchHotspotAnnotationPOSTURL(parameters: {
-        'variants': Array < string > ,
+    fetchHotspotAnnotationByGenomicLocationPOSTURL(parameters: {
+        'genomicLocations': Array < GenomicLocation > ,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
-        let path = '/cancer_hotspots';
+        let path = '/cancer_hotspots/genomic';
 
         if (parameters.$queryParameters) {
             Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
@@ -166,13 +196,79 @@ export default class GenomeNexusAPIInternal {
     };
 
     /**
-     * Retrieves hotspot annotation for the provided list of variants
+     * Retrieves hotspot annotations for the provided list of genomic locations
      * @method
-     * @name GenomeNexusAPIInternal#fetchHotspotAnnotationPOST
-     * @param {} variants - List of variants. For example ["7:g.140453136A>T","12:g.25398285C>A"]
+     * @name GenomeNexusAPIInternal#fetchHotspotAnnotationByGenomicLocationPOST
+     * @param {} genomicLocations - List of genomic locations.
      */
-    fetchHotspotAnnotationPOST(parameters: {
-            'variants': Array < string > ,
+    fetchHotspotAnnotationByGenomicLocationPOST(parameters: {
+            'genomicLocations': Array < GenomicLocation > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < AggregatedHotspots >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/cancer_hotspots/genomic';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                if (parameters['genomicLocations'] !== undefined) {
+                    body = parameters['genomicLocations'];
+                }
+
+                if (parameters['genomicLocations'] === undefined) {
+                    reject(new Error('Missing required  parameter: genomicLocations'));
+                    return;
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchHotspotAnnotationByGenomicLocationGETURL(parameters: {
+        'genomicLocation': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/cancer_hotspots/genomic/{genomicLocation}';
+
+        path = path.replace('{genomicLocation}', parameters['genomicLocation'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves hotspot annotations for a specific genomic location
+     * @method
+     * @name GenomeNexusAPIInternal#fetchHotspotAnnotationByGenomicLocationGET
+     * @param {string} genomicLocation - A genomic location. For example 7,140453136,140453136,A,T
+     */
+    fetchHotspotAnnotationByGenomicLocationGET(parameters: {
+            'genomicLocation': string,
             $queryParameters ? : any,
             $domain ? : string
         }): Promise < Array < Hotspot >
@@ -180,7 +276,69 @@ export default class GenomeNexusAPIInternal {
             const domain = parameters.$domain ? parameters.$domain : this.domain;
             const errorHandlers = this.errorHandlers;
             const request = this.request;
-            let path = '/cancer_hotspots';
+            let path = '/cancer_hotspots/genomic/{genomicLocation}';
+            let body: any;
+            let queryParameters: any = {};
+            let headers: any = {};
+            let form: any = {};
+            return new Promise(function(resolve, reject) {
+                headers['Accept'] = 'application/json';
+                headers['Content-Type'] = 'application/json';
+
+                path = path.replace('{genomicLocation}', parameters['genomicLocation'] + '');
+
+                if (parameters['genomicLocation'] === undefined) {
+                    reject(new Error('Missing required  parameter: genomicLocation'));
+                    return;
+                }
+
+                if (parameters.$queryParameters) {
+                    Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                        var parameter = parameters.$queryParameters[parameterName];
+                        queryParameters[parameterName] = parameter;
+                    });
+                }
+
+                request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+            }).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    fetchHotspotAnnotationByHgvsPOSTURL(parameters: {
+        'variants': Array < string > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/cancer_hotspots/hgvs';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Retrieves hotspot annotations for the provided list of variants
+     * @method
+     * @name GenomeNexusAPIInternal#fetchHotspotAnnotationByHgvsPOST
+     * @param {} variants - List of variants. For example ["7:g.140453136A>T","12:g.25398285C>A"]
+     */
+    fetchHotspotAnnotationByHgvsPOST(parameters: {
+            'variants': Array < string > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < AggregatedHotspots >
+        > {
+            const domain = parameters.$domain ? parameters.$domain : this.domain;
+            const errorHandlers = this.errorHandlers;
+            const request = this.request;
+            let path = '/cancer_hotspots/hgvs';
             let body: any;
             let queryParameters: any = {};
             let headers: any = {};
@@ -212,12 +370,12 @@ export default class GenomeNexusAPIInternal {
             });
         };
 
-    fetchHotspotAnnotationGETURL(parameters: {
+    fetchHotspotAnnotationByHgvsGETURL(parameters: {
         'variant': string,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
-        let path = '/cancer_hotspots/{variant}';
+        let path = '/cancer_hotspots/hgvs/{variant}';
 
         path = path.replace('{variant}', parameters['variant'] + '');
 
@@ -232,12 +390,12 @@ export default class GenomeNexusAPIInternal {
     };
 
     /**
-     * Retrieves hotspot annotation for a specific variant
+     * Retrieves hotspot annotations for a specific variant
      * @method
-     * @name GenomeNexusAPIInternal#fetchHotspotAnnotationGET
+     * @name GenomeNexusAPIInternal#fetchHotspotAnnotationByHgvsGET
      * @param {string} variant - A variant. For example 7:g.140453136A>T
      */
-    fetchHotspotAnnotationGET(parameters: {
+    fetchHotspotAnnotationByHgvsGET(parameters: {
             'variant': string,
             $queryParameters ? : any,
             $domain ? : string
@@ -246,7 +404,7 @@ export default class GenomeNexusAPIInternal {
             const domain = parameters.$domain ? parameters.$domain : this.domain;
             const errorHandlers = this.errorHandlers;
             const request = this.request;
-            let path = '/cancer_hotspots/{variant}';
+            let path = '/cancer_hotspots/hgvs/{variant}';
             let body: any;
             let queryParameters: any = {};
             let headers: any = {};

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -65,10 +65,10 @@ export function getOncoQueryDocUrl() {
     return cbioUrl('onco_query_lang_desc.jsp');
 }
 export function getHotspotsApiUrl() {
-    return cbioUrl('proxy/cancerhotspots.org');
+    return cbioUrl('proxy/www.cancerhotspots.org');
 }
 export function getHotspots3DApiUrl() {
-    return cbioUrl('proxy/3dhotspots.org/3d');
+    return cbioUrl('proxy/www.3dhotspots.org');
 }
 export function getOncoKbApiUrl() {
     let url = AppConfig.oncoKBApiUrl;

--- a/src/shared/components/annotation/CancerHotspots.tsx
+++ b/src/shared/components/annotation/CancerHotspots.tsx
@@ -89,7 +89,7 @@ export default class CancerHotspots extends React.Component<ICancerHotspotsProps
     public static link(isHotspot:boolean, is3dHotspot:boolean)
     {
         const recurrentLink = isHotspot ? (
-                <a href="http://cancerhotspots.org/" target="_blank">
+                <a href="http://www.cancerhotspots.org/" target="_blank">
                     http://cancerhotspots.org/
                 </a>
             ) : "";
@@ -97,7 +97,7 @@ export default class CancerHotspots extends React.Component<ICancerHotspotsProps
         const maybeAnd = isHotspot && is3dHotspot ? "and" : "";
 
         const clusteredLink = is3dHotspot ? (
-                <a href="http://3dhotspots.org/" target="_blank">
+                <a href="http://www.3dhotspots.org/" target="_blank">
                     http://3dhotspots.org/
                 </a>
             ) : "";

--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -271,9 +271,9 @@ export default class FunctionalImpactColumnFormatter {
 
         // TODO: handle multiple transcripts instead of just picking the first one
         const mutationAssessor = genomeNexusData.data.mutation_assessor && genomeNexusData.data.mutation_assessor.annotation;
-        const siftScore = parseFloat(genomeNexusData.data.transcript_consequences[0].sift_score);
+        const siftScore = genomeNexusData.data.transcript_consequences[0].sift_score;
         const siftPrediction = genomeNexusData.data.transcript_consequences[0].sift_prediction;
-        const polyPhenScore = parseFloat(genomeNexusData.data.transcript_consequences[0].polyphen_score);
+        const polyPhenScore = genomeNexusData.data.transcript_consequences[0].polyphen_score;
         const polyPhenPrediction = genomeNexusData.data.transcript_consequences[0].polyphen_prediction;
 
         return {

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -592,7 +592,7 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
                                 /> Hotspots
                                 <DefaultTooltip
                                     overlay={<div style={{maxWidth:"400px"}}>Identified as a recurrent hotspot (statistically significant) in a population-scale cohort of tumor samples of various cancer types using methodology based in part on <a href="http://www.ncbi.nlm.nih.gov/pubmed/26619011" target="_blank">Chang et al., Nat Biotechnol, 2016.</a>
-                                        Explore all mutations at <a href="http://cancerhotspots.org" target="_blank">http://cancerhotspots.org</a></div>}
+                                        Explore all mutations at <a href="http://www.cancerhotspots.org" target="_blank">http://cancerhotspots.org</a></div>}
                                     placement="top"
                                 >
                                     <img


### PR DESCRIPTION
Unfortunately google domains can't forward A domain record to another domain
(has to be ip). Now that cancerhotspots is on Heroku this breaks the client if
they don't point to the prefixed www. URL. Same goes for 3d hotspots.