### PR TITLE
 Adapt some functions to deal with queries with only gene sets

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -133,7 +133,7 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
 
         // hide mutex tab
         $(document).ready(()=>{
-            if (genes((window as any).serverVars.theQuery).length <= 1) {
+            if (!(window as any).serverVars.theQuery.trim().length || genes((window as any).serverVars.theQuery).length <= 1) {
                 $('a#mutex-result-tab').parent().hide();
             }
         });

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -136,7 +136,7 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
             if (!(window as any).serverVars.theQuery.trim().length || genes((window as any).serverVars.theQuery).length <= 1) {
                 $('a#mutex-result-tab').parent().hide();
             }
-            //hide gene-specific tabs when no genes are queried
+            //hide gene-specific tabs when we only query gene sets (and no genes are queried)
             if (!(window as any).serverVars.theQuery.trim().length || genes((window as any).serverVars.theQuery).length == 0) {
                 $('a#cancer-types-result-tab').parent().hide();
                 $('a#plots-result-tab').parent().hide();

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -136,6 +136,18 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
             if (!(window as any).serverVars.theQuery.trim().length || genes((window as any).serverVars.theQuery).length <= 1) {
                 $('a#mutex-result-tab').parent().hide();
             }
+            //hide gene-specific tabs when no genes are queried
+            if (!(window as any).serverVars.theQuery.trim().length || genes((window as any).serverVars.theQuery).length == 0) {
+                $('a#cancer-types-result-tab').parent().hide();
+                $('a#plots-result-tab').parent().hide();
+                $('a#mutation-result-tab').parent().hide();
+                $('a#coexp-result-tab').parent().hide();
+                $('a#enrichments-result-tab').parent().hide();
+                $('a#survival-result-tab').parent().hide();
+                $('a#network-result-tab').parent().hide();
+                $('a#igv-result-tab').parent().hide();
+                $('a#data-download-result-tab').parent().hide();
+            }
         });
     }
 

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -298,8 +298,9 @@ export class ResultsViewPageStore {
 
             // we get mutations with mutations endpoint, all other alterations with this one, so filter out mutation genetic profile
             const profilesWithoutMutationProfile = _.filter(this.selectedMolecularProfiles.result, (profile: MolecularProfile) => profile.molecularAlterationType !== 'MUTATION_EXTENDED');
+            const genes = this.genes.result;
 
-            if (profilesWithoutMutationProfile.length) {
+            if (profilesWithoutMutationProfile.length && genes != undefined && genes.length) {
 
                 const identifiers : SampleMolecularIdentifier[] = [];
 
@@ -369,9 +370,13 @@ export class ResultsViewPageStore {
             this.defaultOQLQuery
         ],
         invoke:()=>{
-            return Promise.resolve(
-                filterCBioPortalWebServiceData(this.oqlQuery, this.unfilteredAlterations.result!, (new accessors(this.selectedMolecularProfiles.result!)), this.defaultOQLQuery.result!)
-            );
+            if (this.oqlQuery.trim() != "") {
+                return Promise.resolve(
+                        filterCBioPortalWebServiceData(this.oqlQuery, this.unfilteredAlterations.result!, (new accessors(this.selectedMolecularProfiles.result!)), this.defaultOQLQuery.result!)
+                );
+            } else {
+                return Promise.resolve([]);
+            }
         }
     });
 
@@ -433,21 +438,25 @@ export class ResultsViewPageStore {
             unfilteredAlterations = unfilteredAlterations.concat(this.putativeDriverAnnotatedMutations.result!);
             unfilteredAlterations = unfilteredAlterations.concat(this.annotatedMolecularData.result!);
 
-            const filteredAlterationsByOQLLine:OQLLineFilterOutput<AnnotatedExtendedAlteration>[] = filterCBioPortalWebServiceDataByOQLLine(this.oqlQuery, unfilteredAlterations,
-                (new accessors(this.selectedMolecularProfiles.result!)), this.defaultOQLQuery.result!);
+            if (this.oqlQuery.trim() != "") {
+                const filteredAlterationsByOQLLine:OQLLineFilterOutput<AnnotatedExtendedAlteration>[] = filterCBioPortalWebServiceDataByOQLLine(this.oqlQuery, unfilteredAlterations,
+                        (new accessors(this.selectedMolecularProfiles.result!)), this.defaultOQLQuery.result!);
 
-            return Promise.resolve(filteredAlterationsByOQLLine.map(oql=>{
-                const cases:CaseAggregatedData<AnnotatedExtendedAlteration> = {
-                    samples:
-                        groupBy(oql.data, datum=>datum.uniqueSampleKey, this.samples.result!.map(sample=>sample.uniqueSampleKey)),
-                    patients:
-                        groupBy(oql.data, datum=>datum.uniquePatientKey, this.patients.result!.map(sample=>sample.uniquePatientKey))
-                };
-                return {
-                    cases,
-                    oql
-                };
-            }));
+                    return Promise.resolve(filteredAlterationsByOQLLine.map(oql=>{
+                        const cases:CaseAggregatedData<AnnotatedExtendedAlteration> = {
+                            samples:
+                                groupBy(oql.data, datum=>datum.uniqueSampleKey, this.samples.result!.map(sample=>sample.uniqueSampleKey)),
+                            patients:
+                                groupBy(oql.data, datum=>datum.uniquePatientKey, this.patients.result!.map(sample=>sample.uniquePatientKey))
+                        };
+                        return {
+                            cases,
+                            oql
+                        };
+                    }));
+            } else {
+                return Promise.resolve([]);
+            }
         }
     });
 

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -891,7 +891,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         const alteredIdsPromise = (this.columnMode === "sample" ? this.props.store.alteredSampleKeys : this.props.store.alteredPatientKeys);
         const sequencedIdsPromise = (this.columnMode === "sample" ? this.props.store.sequencedSampleKeys: this.props.store.sequencedPatientKeys);
         const allIdsPromise = (this.columnMode === "sample" ? this.props.store.samples : this.props.store.patients);
-        if (allIdsPromise.isComplete && alteredIdsPromise.isComplete && sequencedIdsPromise.isComplete) {
+        if (allIdsPromise.isComplete && alteredIdsPromise.isComplete && sequencedIdsPromise.isComplete && sequencedIdsPromise.result.length != 0) {
             return (
                 <span style={{marginTop:"15px", marginBottom:"15px", display: "block"}}>
                     {`Altered in ${alteredIdsPromise.result.length} `+

--- a/src/shared/components/query/GenesetsValidator.tsx
+++ b/src/shared/components/query/GenesetsValidator.tsx
@@ -23,20 +23,20 @@ export default class GenesetsValidator extends QueryStoreComponent<{}, {}>
 {
     render()
     {
-        if (this.store.genesetIdsOQL.error)
+        if (this.store.genesetIdsQuery.error)
             return (
                     <div className={styles.GeneSymbolValidator}>
                     <span className={styles.errorMessage}>
                     {`Cannot validate gene sets because of invalid OQL. ${
                         this.store.genesetQueryErrorDisplayStatus === 'unfocused'
                         ? "Please click 'Submit' to see location of error."
-                        : this.store.genesetIdsOQL.error.message
+                        : this.store.genesetIdsQuery.error.message
                     }`}
                     </span>
                     </div>
             );
         
-        if (!this.store.genesetIdsOQL.query.length)
+        if (!this.store.genesetIdsQuery.query.length)
             return null;
         
         if (this.store.genesets.isError)

--- a/src/shared/components/query/QueryStore.spec.ts
+++ b/src/shared/components/query/QueryStore.spec.ts
@@ -10,6 +10,7 @@ describe("QueryStore", ()=>{
                         study1: ["sample1", "sample2", "sample3"]
                     },
                     theQuery:"",
+                    genesetIds: "",
                     caseSetProperties:{
                         case_set_id: CUSTOM_CASE_LIST_ID
                     }
@@ -29,6 +30,7 @@ describe("QueryStore", ()=>{
                                 study2: ["sample4", "sample5", "sample6"]
                         },
                         theQuery:"",
+                        genesetIds: "",
                         caseSetProperties:{
                             case_set_id: CUSTOM_CASE_LIST_ID
                         }

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1273,6 +1273,7 @@ export class QueryStore
 		if ((_window as any).serverVars) {
 			// Populate OQL
 			this.geneQuery = normalizeQuery((_window as any).serverVars.theQuery);
+			this.genesetQuery = normalizeQuery((_window as any).serverVars.genesetIds);
 			const dataPriority = (_window as any).serverVars.dataPriority;
 			if (typeof dataPriority !== "undefined") {
 				this.dataTypePriorityCode = (dataPriority + '') as '0'|'1'|'2';

--- a/src/shared/lib/oql/oql-parser.d.ts
+++ b/src/shared/lib/oql/oql-parser.d.ts
@@ -12,7 +12,6 @@ export declare class SyntaxError
 }
 
 export declare function parse(str:string):OQLQuery | undefined;
-export declare function parseGeneset(str:string):OQLGenesetQuery | undefined;
 
 // start
 // 	= Query
@@ -53,7 +52,6 @@ export declare type AminoAcid = 'G'|'P'|'A'|'V'|'L'|'I'|'M'|'C'|'F'|'Y'|'W'|'H'|
 // 	/ msp first:SingleGeneQuery msp br { return [first]; }
 // 	/ msp first:SingleGeneQuery msp { return [first]; }
 export declare type OQLQuery = SingleGeneQuery[];
-export declare type OQLGenesetQuery = SingleGenesetQuery[];
 //
 // ListOfGenes
 // 	= msp geneName:String msp rest:ListOfGenes { return [geneName].concat(rest);}
@@ -63,7 +61,6 @@ export declare type OQLGenesetQuery = SingleGenesetQuery[];
 // 	= geneName:String msp ":" msp alts:Alterations { return {"gene": geneName, "alterations": alts}; }
 // 	/ geneName:String { return {"gene": geneName, "alterations":false}; }
 export declare type SingleGeneQuery = {gene:string, alterations:false|Alteration[]};
-export declare type SingleGenesetQuery = {geneset:string, alterations:false|Alteration[]};
 //
 // Alterations
 // 	= a1:Alteration sp a2:Alterations { return [a1].concat(a2);}


### PR DESCRIPTION
This PR makes some fixes to functions so that they don't crash when queries with only gene sets are submitted, including hiding gene-related tabs in the result page. 

Note: the first two commits are also present in PR #1003 (bugfixes). This last PR should be merged first, and then rebase the PR explained here.
