### PR TITLE
Cancer hotspots data doesn't block mutations tab anymore

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -366,7 +366,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         downloadDataFetcher={patientViewPageStore.downloadDataFetcher}
                                         mutSigData={patientViewPageStore.mutSigData.result}
                                         myCancerGenomeData={patientViewPageStore.myCancerGenomeData}
-                                        hotspots={patientViewPageStore.indexedHotspotData}
+                                        hotspotData={patientViewPageStore.indexedHotspotData}
                                         cosmicData={patientViewPageStore.cosmicData.result}
                                         oncoKbData={patientViewPageStore.oncoKbData}
                                         oncoKbAnnotatedGenes={patientViewPageStore.oncoKbAnnotatedGenes.result}

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -608,10 +608,12 @@ export class PatientViewPageStore {
         return [];
     }
 
-    @computed get indexedHotspotData(): IHotspotIndex|undefined
-    {
-        return indexHotspotsData(this.hotspotData);
-    }
+    readonly indexedHotspotData = remoteData<IHotspotIndex|undefined>({
+        await:()=>[
+            this.hotspotData
+        ],
+        invoke: ()=>Promise.resolve(indexHotspotsData(this.hotspotData))
+    });
 
     @computed get mergedMutationData(): Mutation[][] {
         return mergeMutations(this.mutationData);

--- a/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
@@ -53,6 +53,7 @@ export default class AnnotationColumnFormatter
                 hasCivicVariants: civicGenes && civicGenes.result && civicVariants && civicVariants.result ?
                     AnnotationColumnFormatter.hasCivicVariants(copyNumberData, civicGenes.result, civicVariants.result) : true,
                 myCancerGenomeLinks: [],
+                hotspotStatus: "complete",
                 isHotspot: false,
                 is3dHotspot: false
             };

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -880,7 +880,7 @@ export class ResultsViewPageStore {
     }
 
     readonly mutationMapperStores = remoteData<{ [hugoGeneSymbol: string]: MutationMapperStore }>({
-        await: () => [this.genes, this.oncoKbAnnotatedGenes, this.indexedHotspotData, this.uniqueSampleKeyToTumorType, this.mutations],
+        await: () => [this.genes, this.oncoKbAnnotatedGenes, this.uniqueSampleKeyToTumorType, this.mutations],
         invoke: () => {
             if (this.genes.result) {
                 // we have to use _.reduce, otherwise this.genes.result (Immutable, due to remoteData) will return

--- a/src/pages/resultsView/mutation/MutationMapper.tsx
+++ b/src/pages/resultsView/mutation/MutationMapper.tsx
@@ -230,7 +230,7 @@ export default class MutationMapper extends React.Component<IMutationMapperProps
                                     itemsLabelPlural={this.itemsLabelPlural}
                                     downloadDataFetcher={this.props.store.downloadDataFetcher}
                                     myCancerGenomeData={this.props.myCancerGenomeData}
-                                    hotspots={this.props.store.indexedHotspotData.result}
+                                    hotspotData={this.props.store.indexedHotspotData}
                                     cosmicData={this.props.store.cosmicData.result}
                                     oncoKbData={this.props.store.oncoKbData}
                                     civicGenes={this.props.store.civicGenes}

--- a/src/shared/components/annotation/CancerHotspots.tsx
+++ b/src/shared/components/annotation/CancerHotspots.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import {Circle} from "better-react-spinkit";
 import DefaultTooltip from 'shared/components/defaultTooltip/DefaultTooltip';
 import annotationStyles from "./styles/annotation.module.scss";
 import hotspotStyles from "./styles/cancerHotspots.module.scss";
 
 export interface ICancerHotspotsProps {
+    status: "pending" | "error" | "complete";
     isHotspot: boolean;
     is3dHotspot: boolean;
 }
@@ -115,6 +117,13 @@ export default class CancerHotspots extends React.Component<ICancerHotspotsProps
         this.state = {};
     }
 
+    public loaderIcon()
+    {
+        return (
+            <Circle size={18} scaleEnd={0.5} scaleStart={0.2} color="#aaa" className="pull-left"/>
+        );
+    }
+
     public render()
     {
         const {isHotspot, is3dHotspot} = this.props;
@@ -123,7 +132,10 @@ export default class CancerHotspots extends React.Component<ICancerHotspotsProps
             <span className={`${annotationStyles["annotation-item"]}`} />
         );
 
-        if (isHotspot || is3dHotspot)
+        if (this.props.status === "pending") {
+            hotspotContent = this.loaderIcon();
+        }
+        else if (isHotspot || is3dHotspot)
         {
             const hotspotsImgWidth:number = 14;
             let hotspotsImgHeight:number = 14;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -24,7 +24,7 @@ import ValidationStatusColumnFormatter from "./column/ValidationStatusColumnForm
 import {ICosmicData} from "shared/model/Cosmic";
 import AnnotationColumnFormatter from "./column/AnnotationColumnFormatter";
 import {IMyCancerGenomeData} from "shared/model/MyCancerGenome";
-import {IHotspotIndex} from "shared/model/CancerHotspots";
+import {IHotspotDataWrapper} from "shared/model/CancerHotspots";
 import {IOncoKbDataWrapper} from "shared/model/OncoKB";
 import {ICivicVariantDataWrapper, ICivicGeneDataWrapper} from "shared/model/Civic";
 import {IMutSigData} from "shared/model/MutSig";
@@ -60,7 +60,7 @@ export interface IMutationTableProps {
     enableCivic?: boolean;
     enableFunctionalImpact?: boolean;
     myCancerGenomeData?: IMyCancerGenomeData;
-    hotspots?: IHotspotIndex;
+    hotspotData?: IHotspotDataWrapper;
     cosmicData?:ICosmicData;
     oncoKbData?: IOncoKbDataWrapper;
     oncoKbAnnotatedGenes:{[entrezGeneId:number]:boolean};
@@ -435,7 +435,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
         this._columns[MutationTableColumnType.ANNOTATION] = {
             name: "Annotation",
             render: (d:Mutation[]) => (AnnotationColumnFormatter.renderFunction(d, {
-                hotspots: this.props.hotspots,
+                hotspotData: this.props.hotspotData,
                 myCancerGenomeData: this.props.myCancerGenomeData,
                 oncoKbData: this.props.oncoKbData,
                 oncoKbEvidenceCache: this.props.oncoKbEvidenceCache,
@@ -452,7 +452,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
             download:(d:Mutation[])=>{
                 return AnnotationColumnFormatter.download(d,
                     this.props.oncoKbAnnotatedGenes,
-                    this.props.hotspots,
+                    this.props.hotspotData,
                     this.props.myCancerGenomeData,
                     this.props.oncoKbData,
                     this.props.civicGenes,
@@ -461,7 +461,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
             sortBy:(d:Mutation[])=>{
                 return AnnotationColumnFormatter.sortValue(d,
                     this.props.oncoKbAnnotatedGenes,
-                    this.props.hotspots,
+                    this.props.hotspotData,
                     this.props.myCancerGenomeData,
                     this.props.oncoKbData,
                     this.props.civicGenes,

--- a/src/shared/lib/CancerHotspotsUtils.ts
+++ b/src/shared/lib/CancerHotspotsUtils.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import MobxPromise from "mobxpromise";
 import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import {
@@ -6,7 +5,7 @@ import {
 } from "shared/api/generated/GenomeNexusAPIInternal";
 import genomeNexusInternalClient from "shared/api/genomeNexusInternalClientInstance";
 import {concatMutationData} from "./StoreUtils";
-import {extractGenomicLocation} from "./MutationUtils";
+import {extractGenomicLocation, genomicLocationString, uniqueGenomicLocations} from "./MutationUtils";
 import {IHotspotIndex} from "shared/model/CancerHotspots";
 
 export async function fetchHotspotsData(mutationData: MobxPromise<Mutation[]>,
@@ -19,7 +18,7 @@ export async function fetchHotspotsData(mutationData: MobxPromise<Mutation[]>,
         return [];
     }
 
-    const genomicLocations: GenomicLocation[] = _.uniq(_.map(mutationDataResult, extractGenomicLocation));
+    const genomicLocations: GenomicLocation[] = uniqueGenomicLocations(mutationDataResult);
 
     return await client.fetchHotspotAnnotationByGenomicLocationPOST({genomicLocations: genomicLocations});
 }
@@ -43,11 +42,6 @@ export function indexHotspots(hotspots: AggregatedHotspots[]): IHotspotIndex
     });
 
     return index;
-}
-
-export function genomicLocationString(genomicLocation: GenomicLocation)
-{
-    return `${genomicLocation.chromosome},${genomicLocation.start},${genomicLocation.end},${genomicLocation.referenceAllele},${genomicLocation.variantAllele}`;
 }
 
 export function isHotspot(mutation: Mutation, index: IHotspotIndex, filter?: (hotspot: Hotspot) => boolean): boolean

--- a/src/shared/lib/MutationUtils.spec.ts
+++ b/src/shared/lib/MutationUtils.spec.ts
@@ -1,6 +1,6 @@
 import {
     somaticMutationRate, germlineMutationRate, countUniqueMutations, groupMutationsByGeneAndPatientAndProteinChange,
-    countDuplicateMutations
+    countDuplicateMutations, uniqueGenomicLocations
 } from "./MutationUtils";
 import * as _ from 'lodash';
 import { assert, expect } from 'chai';
@@ -280,6 +280,63 @@ describe('MutationUtils', () => {
                     [{studyId:'STUDY1', sampleId:'PATIENT1'}, {studyId:'STUDY1', sampleId:'PATIENT2'}]
                 );
             assert.equal(result, 0);
+        });
+    });
+
+    describe('uniqueGenomicLocations', () => {
+        it('extracts unique genomic locations', () => {
+            const mutations = [
+                initMutation({
+                    gene: {
+                        chromosome: "7"
+                    },
+                    startPosition: 111,
+                    endPosition: 111,
+                    referenceAllele: "T",
+                    variantAllele: "C",
+                }),
+                initMutation({
+                    gene: {
+                        chromosome: "7"
+                    },
+                    startPosition: 111,
+                    endPosition: 111,
+                    referenceAllele: "T",
+                    variantAllele: "C",
+                }),
+                initMutation({
+                    gene: {
+                        chromosome: "17"
+                    },
+                    startPosition: 66,
+                    endPosition: 66,
+                    referenceAllele: "T",
+                    variantAllele: "A",
+                }),
+                initMutation({
+                    gene: {
+                        chromosome: "17"
+                    },
+                    startPosition: 66,
+                    endPosition: 66,
+                    referenceAllele: "T",
+                    variantAllele: "A",
+                }),
+                initMutation({
+                    gene: {
+                        chromosome: "4"
+                    },
+                    startPosition: 11,
+                    endPosition: 11,
+                    referenceAllele: "-",
+                    variantAllele: "G",
+                }),
+            ];
+
+            const genomicLocations = uniqueGenomicLocations(mutations);
+
+            assert.equal(genomicLocations.length, 3,
+                "Duplicate genomic locations should be removed (5 - 2 = 3)");
         });
     });
 });

--- a/src/shared/lib/MutationUtils.ts
+++ b/src/shared/lib/MutationUtils.ts
@@ -4,6 +4,7 @@ import {
     ProteinImpactType, getProteinImpactTypeFromCanonical
 } from "./getCanonicalMutationType";
 import {MolecularProfile, Mutation, SampleIdentifier} from "shared/api/generated/CBioPortalAPI";
+import {GenomicLocation} from "shared/api/generated/GenomeNexusAPIInternal";
 import {MUTATION_STATUS_GERMLINE, MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX} from "shared/constants";
 import {findFirstMostCommonElt} from "./findFirstMostCommonElt";
 import {toSampleUuid} from "./UuidUtils";
@@ -240,4 +241,21 @@ export function extractGenomicLocation(mutation: Mutation)
         referenceAllele: mutation.referenceAllele,
         variantAllele: mutation.variantAllele
     };
+}
+
+export function genomicLocationString(genomicLocation: GenomicLocation)
+{
+    return `${genomicLocation.chromosome},${genomicLocation.start},${genomicLocation.end},${genomicLocation.referenceAllele},${genomicLocation.variantAllele}`;
+}
+
+export function uniqueGenomicLocations(mutations: Mutation[]): GenomicLocation[]
+{
+    const genomicLocationMap: {[key: string]: GenomicLocation} = {};
+
+    mutations.map((mutaiton: Mutation) => {
+        const genomicLocation: GenomicLocation = extractGenomicLocation(mutaiton);
+        genomicLocationMap[genomicLocationString(genomicLocation)] = genomicLocation;
+    });
+
+    return _.values(genomicLocationMap);
 }

--- a/src/shared/model/CancerHotspots.ts
+++ b/src/shared/model/CancerHotspots.ts
@@ -3,3 +3,8 @@ import {AggregatedHotspots} from "shared/api/generated/GenomeNexusAPIInternal";
 export interface IHotspotIndex {
     [genomicLocation: string]: AggregatedHotspots;
 }
+
+export interface IHotspotDataWrapper {
+    status: "pending" | "error" | "complete";
+    result?: IHotspotIndex;
+}


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/3956

Changes proposed in this pull request:
- Mutations tab does not wait for Cancer Hotspots data for initialization anymore
- Added loader icon for hotspot annotation (for the `Annotation` column)
- Removed duplicate genomic locations from genome nexus cancer hotspots query

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)