### PR TITLE
Fix SVG for Adobe Illustrator

### DIFF
--- a/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
@@ -263,7 +263,7 @@ export class CancerSummaryChart extends React.Component<CancerSummaryChartProps,
         return (
             <div data-test="cancerTypeSummaryChart">
                 <div style={this.overflowStyle} className="borderedChart">
-                    <div ref={(el:HTMLDivElement)=>this.scrollPane=el} style={{overflowX:'auto', overflowY:'hidden'}}>
+                    <div ref={(el:HTMLDivElement)=>this.scrollPane=el} style={{fontFamily:"Arial, Helvetica", overflowX:'auto', overflowY:'hidden'}}>
                     {
                         (this.tooltipModel) && (this.buildTooltip(this.tooltipModel))
                     }

--- a/src/shared/theme/cBioPoralTheme.ts
+++ b/src/shared/theme/cBioPoralTheme.ts
@@ -24,7 +24,7 @@ const grey900 = "#212121";
 // *
 // * Typography
 // *
-const sansSerif = "Verdana, sans-serif";
+const sansSerif = "Arial, Helvetica";
 const letterSpacing = "normal";
 const fontSize = 12;
 // *
@@ -32,6 +32,7 @@ const fontSize = 12;
 // *
 const padding = 8;
 const baseProps = {
+    fontFamily: sansSerif,
     width: 350,
     height: 350,
     padding: 50


### PR DESCRIPTION
Fix  https://github.com/cBioPortal/cbioportal/issues/3944

Only works when font-family does not contain the word sans-serif in SVG. When
downloading the SVG it applies all the styles to the main svg element (not just
the ones specified in theme). Therefore it's necessary to specify the font
family in the div surrounding the svg as well. It would be better if there was
a way to apply the style directly to the SVG in Victory, but didn't see a way
to do this.