### PR TITLE
Added support for custom header content when downloading

### DIFF
--- a/src/pages/resultsView/download/CaseAlterationTable.tsx
+++ b/src/pages/resultsView/download/CaseAlterationTable.tsx
@@ -1,6 +1,6 @@
 import {observer} from "mobx-react";
 import * as React from 'react';
-import LazyMobXTable from "shared/components/lazyMobXTable/LazyMobXTable";
+import {default as LazyMobXTable, Column} from "shared/components/lazyMobXTable/LazyMobXTable";
 import {OQLLineFilterOutput} from "shared/lib/oql/oqlfilter";
 import {AnnotatedExtendedAlteration} from "../ResultsViewPageStore";
 
@@ -88,7 +88,7 @@ class CaseAlterationTableComponent extends LazyMobXTable<ICaseAlteration> {}
 export default class CaseAlterationTable extends React.Component<ICaseAlterationTableProps, {}> {
     public render()
     {
-        const columns = [
+        const columns: Column<ICaseAlteration>[] = [
             {
                 name: 'Study ID',
                 render: (data: ICaseAlteration) => <span style={{whiteSpace: "nowrap"}}>{data.studyId}</span>,
@@ -129,6 +129,7 @@ export default class CaseAlterationTable extends React.Component<ICaseAlteration
             columns.push({
                 name: oql.gene,
                 tooltip: <span>{oql.oql_line}</span>,
+                headerDownload: (name: string) => oql.oql_line,
                 render: (data: ICaseAlteration) =>
                     <span style={{whiteSpace: "nowrap"}}>{data.oqlData ? generateOqlValue(data.oqlData[oql.oql_line]) : ""}</span>,
                 download: (data: ICaseAlteration) =>

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -1104,6 +1104,22 @@ describe('LazyMobXTable', ()=>{
                 "3\t-1\tzijxcpo\t\t3HELLO123456\t\t\r\n"+
                 "4\t90\tzkzxc\t\t4HELLO123456\t\t\r\n");
         });
+
+        it("gives the correct column names when headerDownload is defined", async () => {
+            const cols = [{
+                name: "Myth",
+                render:(d:any)=><span/>
+            },{
+                name: "Science",
+                render:(d:any)=><span/>,
+                headerDownload:(name:string) => `${name}: Ruining everything since 1543`
+            }];
+
+            const table = mount(<Table columns={cols} data={[]}/>);
+
+            assert.deepEqual((await (table.instance() as LazyMobXTable<any>).getDownloadDataPromise()).text,
+                "Myth\tScience: Ruining everything since 1543\r\n");
+        });
     });
     describe('pagination', ()=>{
         it("starts with 50 items per page", ()=>{

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -28,6 +28,7 @@ export type SortDirection = 'asc' | 'desc';
 export type Column<T> = {
     name: string;
     headerRender?:(name:string)=>JSX.Element;
+    headerDownload?:(name:string)=>string;
     align?:"left"|"center"|"right";
     filter?:(data:T, filterString:string, filterStringUpper?:string, filterStringLower?:string)=>boolean;
     visible?:boolean;
@@ -266,7 +267,7 @@ class LazyMobXTableStore<T> {
         // add header (including hidden columns)
         tableDownloadData[0] = [];
         this.columns.forEach((column:Column<T>) => {
-            tableDownloadData[0].push(column.name);
+            tableDownloadData[0].push(column.headerDownload ? column.headerDownload(column.name) : column.name);
         });
 
         // add rows (including hidden columns). The purpose of this part is to ensure that


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/3966.

Changes proposed in this pull request:
- Added a new `LazyMobXTable`propery called `headerDownload` which allows customization of the column name for the copy/download functionality
- Updated `CaseAlterationTable` to include OQL lines as column names in the download file

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)