### PR TITLE
Ignore https/http switch in package-lock circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
           - v1-dependencies-
       - run: npm install
       - run:
+		  name: "Ignore https to http switches in package lock (not sure why this happens)"
+		  command: "sed -i 's/http:/https:/g' package-lock.json"
+      - run:
           name: "Make sure lock file is still the same"
           command: 'git diff --exit-code package-lock.json || (echo -e "New package lock file at $(cat package-lock.json | curl -F c=@- https://ptpb.pw | grep url) (include this file in your PR to fix this test)" && exit 1)'
       - save_cache:


### PR DESCRIPTION
Somehow circle ci switches the onetime to package to use http npm registry instead of https. Obviously should be using ssl if possible, so let's ignore this change instead.