### PR TITLE
Preserving the column visibility state when navigating across patients

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -13,13 +13,15 @@ import SelectCallback = ReactBootstrap.SelectCallback;
 import {ThreeBounce} from 'better-react-spinkit';
 import PatientHeader from './patientHeader/PatientHeader';
 import {PaginationControls} from "../../shared/components/paginationControls/PaginationControls";
+import {IColumnVisibilityDef} from "shared/components/columnVisibilityControls/ColumnVisibilityControls";
+import {toggleColumnVisibility} from "shared/components/lazyMobXTable/ColumnVisibilityResolver";
 import { PatientViewPageStore } from './clinicalInformation/PatientViewPageStore';
 import ClinicalInformationPatientTable from "./clinicalInformation/ClinicalInformationPatientTable";
 import ClinicalInformationSamples from "./clinicalInformation/ClinicalInformationSamplesTable";
 import {observer, inject } from "mobx-react";
 import {getSpanElementsFromCleanData} from './clinicalInformation/lib/clinicalAttributesUtil.js';
 import CopyNumberTableWrapper from "./copyNumberAlterations/CopyNumberTableWrapper";
-import {reaction, computed, autorun, IReactionDisposer} from "mobx";
+import {reaction, computed, autorun, IReactionDisposer, observable, action} from "mobx";
 import Timeline from "./timeline/Timeline";
 import {default as PatientViewMutationTable} from "./mutation/PatientViewMutationTable";
 import PathologyReport from "./pathologyReport/PathologyReport";
@@ -52,6 +54,9 @@ export interface IPatientViewPageProps {
 @inject('routing')
 @observer
 export default class PatientViewPage extends React.Component<IPatientViewPageProps, {}> {
+
+    @observable private mutationTableColumnVisibility: {[columnId: string]: boolean}|undefined;
+    @observable private cnaTableColumnVisibility: {[columnId: string]: boolean}|undefined;
 
     private updatePageTitleReaction: IReactionDisposer;
 
@@ -97,8 +102,10 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
             () => patientViewPageStore.pageTitle,
             (title:string) => ((window as any).document.title = title),
             { fireImmediately:true }
-        )
+        );
 
+        this.onMutationTableColumnVisibilityToggled = this.onMutationTableColumnVisibilityToggled.bind(this);
+        this.onCnaTableColumnVisibilityToggled = this.onCnaTableColumnVisibilityToggled.bind(this);
     }
 
     public componentDidMount() {
@@ -164,6 +171,18 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
         } else {
             return "loading";
         }
+    }
+
+    @action private onCnaTableColumnVisibilityToggled(columnId: string, columnVisibility?: IColumnVisibilityDef[])
+    {
+        this.cnaTableColumnVisibility = toggleColumnVisibility(
+            this.cnaTableColumnVisibility, columnId, columnVisibility);
+    }
+
+    @action private onMutationTableColumnVisibilityToggled(columnId: string, columnVisibility?: IColumnVisibilityDef[])
+    {
+        this.mutationTableColumnVisibility = toggleColumnVisibility(
+            this.mutationTableColumnVisibility, columnId, columnVisibility);
     }
 
     private shouldShowPathologyReport(patientViewPageStore: PatientViewPageStore): boolean {
@@ -378,6 +397,10 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         enableHotspot={AppConfig.showHotspot}
                                         enableMyCancerGenome={AppConfig.showMyCancerGenome}
                                         enableCivic={AppConfig.showCivic}
+                                        columnVisibility={this.mutationTableColumnVisibility}
+                                        columnVisibilityProps={{
+                                            onColumnToggled: this.onMutationTableColumnVisibilityToggled
+                                        }}
                                     />
                                 )
                             }
@@ -404,6 +427,10 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                 gisticData={patientViewPageStore.gisticData.result}
                                 mrnaExprRankMolecularProfileId={patientViewPageStore.mrnaRankMolecularProfileId.result || undefined}
                                 status={this.cnaTableStatus}
+                                columnVisibility={this.cnaTableColumnVisibility}
+                                columnVisibilityProps={{
+                                    onColumnToggled: this.onCnaTableColumnVisibilityToggled
+                                }}
                             />
                         </MSKTab>
 

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import {observer} from "mobx-react";
+import * as _ from 'lodash';
 import LazyMobXTable from "shared/components/lazyMobXTable/LazyMobXTable";
 import {DiscreteCopyNumberData} from "shared/api/generated/CBioPortalAPI";
 import {Column} from "shared/components/lazyMobXTable/LazyMobXTable";
-import * as _ from 'lodash';
 import MrnaExprColumnFormatter from "shared/components/mutationTable/column/MrnaExprColumnFormatter";
+import {IColumnVisibilityControlsProps} from "shared/components/columnVisibilityControls/ColumnVisibilityControls";
 import CohortColumnFormatter from "./column/CohortColumnFormatter";
 import CnaColumnFormatter from "./column/CnaColumnFormatter";
 import AnnotationColumnFormatter from "./column/AnnotationColumnFormatter";
@@ -41,6 +42,8 @@ type ICopyNumberTableWrapperProps = {
     gisticData:IGisticData;
     userEmailAddress?:string;
     mrnaExprRankMolecularProfileId?:string;
+    columnVisibility?: {[columnId: string]: boolean};
+    columnVisibilityProps?: IColumnVisibilityControlsProps;
     status:"loading"|"available"|"unavailable";
 };
 
@@ -171,6 +174,8 @@ export default class CopyNumberTableWrapper extends React.Component<ICopyNumberT
                         itemsLabel="Copy Number Alteration"
                         itemsLabelPlural="Copy Number Alterations"
                         showCountHeader={true}
+                        columnVisibility={this.props.columnVisibility}
+                        columnVisibilityProps={this.props.columnVisibilityProps}
                     />
                 )
             }

--- a/src/shared/components/columnVisibilityControls/ColumnVisibilityControls.tsx
+++ b/src/shared/components/columnVisibilityControls/ColumnVisibilityControls.tsx
@@ -13,7 +13,7 @@ export interface IColumnVisibilityControlsProps {
     className?: string;
     buttonText?: string | JSX.Element;
     columnVisibility?: IColumnVisibilityDef[];
-    onColumnToggled?: (columnId: string) => void;
+    onColumnToggled?: (columnId: string, columnVisibility?: IColumnVisibilityDef[]) => void;
 }
 
 /**
@@ -70,7 +70,7 @@ export class ColumnVisibilityControls extends React.Component<IColumnVisibilityC
         const id = evt.currentTarget.getAttribute("data-id");
 
         if (this.props.onColumnToggled && id) {
-            this.props.onColumnToggled(id);
+            this.props.onColumnToggled(id, this.props.columnVisibility);
         }
     }
 }

--- a/src/shared/components/lazyMobXTable/ColumnVisibilityResolver.spec.ts
+++ b/src/shared/components/lazyMobXTable/ColumnVisibilityResolver.spec.ts
@@ -1,6 +1,9 @@
 import {assert} from 'chai';
 import * as _ from 'lodash';
-import {resolveColumnVisibility, resolveColumnVisibilityByColumnDefinition} from "./ColumnVisibilityResolver";
+import {
+    ISimpleColumnVisibilityDef, resolveColumnVisibility,
+    resolveColumnVisibilityByColumnDefinition, toggleColumnVisibility
+} from "./ColumnVisibilityResolver";
 
 function getVisibleColumnIds(columnVisibility: {[columnId: string]: boolean}): string[]
 {
@@ -9,7 +12,7 @@ function getVisibleColumnIds(columnVisibility: {[columnId: string]: boolean}): s
 
 describe('ColumnVisibilityResolver', () => {
 
-    let columns:any[];
+    let columns: ISimpleColumnVisibilityDef[];
 
     beforeEach(() => {
         columns = [
@@ -111,6 +114,76 @@ describe('ColumnVisibilityResolver', () => {
 
             assert.deepEqual(getVisibleColumnIds(colVis), ["2nd", "3rd", "5th", "6th"],
                 "2nd, 3rd, 5th, and 6th columns should be visible");
+        });
+    });
+
+    describe('toggleColumnVisibility', () => {
+        it("properly initializes and toggles column visibility multiple times", () => {
+            const columnVisibilityDef: ISimpleColumnVisibilityDef[] = [
+                {
+                    id: "1st",
+                    name: "1st: doesn't have to be same as the id",
+                    visible: false
+                },
+                {
+                    id: "2nd",
+                    name: "2nd: doesn't have to be same as the id",
+                    visible: false
+                },
+                {
+                    id: "3rd",
+                    name: "3rd: doesn't have to be same as the id",
+                    visible: true
+                },
+                {
+                    id: "4th",
+                    name: "4th: doesn't have to be same as the id",
+                    visible: true
+                },
+                {
+                    id: "5th",
+                    name: "5th: doesn't have to be same as the id",
+                    visible: false
+                }
+            ];
+
+            // init with column visibility def
+            let colVis = toggleColumnVisibility(undefined, "5th", columnVisibilityDef);
+
+            assert.deepEqual(getVisibleColumnIds(colVis), ["3rd", "4th", "5th"],
+                "3rd and 4th initially visible, 5th toggled to be visible");
+
+            // toggle 4th column
+            colVis = toggleColumnVisibility(colVis, "4th", columnVisibilityDef);
+
+            assert.deepEqual(getVisibleColumnIds(colVis), ["3rd", "5th"],
+                "3rd and 5th visible, columnVisibilityDef should be ignored this time");
+
+            // toggle 3rd column
+            colVis = toggleColumnVisibility(colVis, "3rd");
+
+            assert.deepEqual(getVisibleColumnIds(colVis), ["5th"],
+                "only 5th visible");
+
+            // toggle 1st column
+            colVis = toggleColumnVisibility(colVis, "1st");
+
+            assert.deepEqual(getVisibleColumnIds(colVis), ["1st", "5th"],
+                "1st and 5th visible");
+
+            // toggle 1st and 5th columns
+            colVis = toggleColumnVisibility(colVis, "1st");
+            colVis = toggleColumnVisibility(colVis, "5th");
+
+            assert.equal(getVisibleColumnIds(colVis).length, 0,
+                "none visible");
+
+            // toggle 2nd and 3rd columns
+            colVis = toggleColumnVisibility(colVis, "2nd");
+            colVis = toggleColumnVisibility(colVis, "3rd");
+
+            assert.deepEqual(getVisibleColumnIds(colVis), ["2nd", "3rd"],
+                "2nd and 3rd visible");
         });
     });
 });

--- a/src/shared/components/lazyMobXTable/ColumnVisibilityResolver.ts
+++ b/src/shared/components/lazyMobXTable/ColumnVisibilityResolver.ts
@@ -1,10 +1,14 @@
-import {Column} from "./LazyMobXTable";
+export interface ISimpleColumnVisibilityDef {
+    name: string;
+    id?: string;
+    visible?: boolean;
+}
 
-export function resolveColumnVisibilityByColumnDefinition<T>(columns: Column<T>[]): {[columnId: string]: boolean}
+export function resolveColumnVisibilityByColumnDefinition(columns: ISimpleColumnVisibilityDef[] = []): {[columnId: string]: boolean}
 {
     const colVis:{[columnId: string]: boolean} = {};
 
-    columns.forEach((column:Column<T>) => {
+    columns.forEach((column: ISimpleColumnVisibilityDef) => {
         // every column is visible by default unless it is flagged otherwise
         let visible = true;
 
@@ -12,7 +16,10 @@ export function resolveColumnVisibilityByColumnDefinition<T>(columns: Column<T>[
             visible = column.visible;
         }
 
-        colVis[column.name] = visible;
+        // if no id exists, just use name for key
+        const key = column.id || column.name;
+
+        colVis[key] = visible;
     });
 
     return colVis;
@@ -36,6 +43,24 @@ export function resolveColumnVisibility(columnVisibilityByColumnDefinition: {[co
             ...(columnVisibilityOverride || {})
         };
     }
+
+    return colVis;
+}
+
+export function toggleColumnVisibility(columnVisibility: {[columnId: string]: boolean}|undefined,
+                                       columnId: string,
+                                       columnVisibilityDefs?: ISimpleColumnVisibilityDef[]): {[columnId: string]: boolean}
+{
+    let colVis = columnVisibility;
+
+    // if not init yet: it means that no prior user action on column visibility
+    // just copy the contents from the provided columnVisibility definition
+    if (!colVis) {
+        colVis = resolveColumnVisibilityByColumnDefinition(columnVisibilityDefs);
+    }
+
+    // toggle column visibility
+    colVis[columnId] = !colVis[columnId];
 
     return colVis;
 }

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -21,6 +21,7 @@ import MutationCountColumnFormatter from "./column/MutationCountColumnFormatter"
 import CancerTypeColumnFormatter from "./column/CancerTypeColumnFormatter";
 import MutationStatusColumnFormatter from "./column/MutationStatusColumnFormatter";
 import ValidationStatusColumnFormatter from "./column/ValidationStatusColumnFormatter";
+import StudyColumnFormatter from "./column/StudyColumnFormatter";
 import {ICosmicData} from "shared/model/Cosmic";
 import AnnotationColumnFormatter from "./column/AnnotationColumnFormatter";
 import {IMyCancerGenomeData} from "shared/model/MyCancerGenome";
@@ -40,7 +41,7 @@ import {IMobXApplicationLazyDownloadDataFetcher} from "shared/lib/IMobXApplicati
 import generalStyles from "./column/styles.module.scss";
 import classnames from 'classnames';
 import {IPaginationControlsProps} from "../paginationControls/PaginationControls";
-import StudyColumnFormatter from "./column/StudyColumnFormatter";
+import {IColumnVisibilityControlsProps} from "../columnVisibilityControls/ColumnVisibilityControls";
 
 export interface IMutationTableProps {
     studyIdToStudy?: {[studyId:string]:CancerStudy};
@@ -81,6 +82,7 @@ export interface IMutationTableProps {
     paginationProps?:IPaginationControlsProps;
     showCountHeader?:boolean;
     columnVisibility?: {[columnId: string]: boolean};
+    columnVisibilityProps?: IColumnVisibilityControlsProps;
 }
 
 export enum MutationTableColumnType {
@@ -535,6 +537,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
                 paginationProps={this.props.paginationProps}
                 showCountHeader={this.props.showCountHeader}
                 columnVisibility={this.props.columnVisibility}
+                columnVisibilityProps={this.props.columnVisibilityProps}
             />
         );
     }


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/4026.

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)