### PR TITLE
Update to new version of oncoprint to fix download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12028,9 +12028,9 @@
       }
     },
     "oncoprintjs": {
-      "version": "1.0.92",
-      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.0.92.tgz",
-      "integrity": "sha1-rSiQxZMaBbjpKny4BSaZdcHtBpo=",
+      "version": "1.0.94",
+      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.0.94.tgz",
+      "integrity": "sha1-rWHk1oIdZMZ4nC4a4D+s+6+v+/g=",
       "requires": {
         "express": "4.15.4",
         "gl-matrix": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "mobx-utils": "^2.0.1",
     "mobxpromise": "^1.2.0",
     "node-sass": "^4.3.0",
-    "oncoprintjs": "^1.0.92",
+    "oncoprintjs": "^1.0.94",
     "parameter-validator": "^1.0.2",
     "pdfobject": "^2.0.201604172",
     "plotly.js": "^1.31.2",


### PR DESCRIPTION
Legend with new base rectangle was downloading black because the svg->pdf engine we use can't handle rgba. So I fixed the oncoprint library to use rgb and opacity instead of rgba, and this PR updates to that.