### PR TITLE
Use hardcoded version pathology reports datahub

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -230,7 +230,7 @@ export class PatientViewPageStore {
             // only check path report for tcga studies
             if (this.studyId.toLowerCase().indexOf('tcga') > -1) {
                 const pathLinkUrl = "https://raw.githubusercontent.com/inodb/datahub/a0d36d77b242e32cda3175127de73805b028f595/tcga/pathology_reports/symlink_by_patient";
-                const rawPdfUrl = "https://github.com/cBioPortal/datahub/raw/master/tcga/pathology_reports";
+                const rawPdfUrl = "https://github.com/inodb/datahub/raw/a0d36d77b242e32cda3175127de73805b028f595/tcga/pathology_reports";
                 const reports: PathologyReportPDF[] = [];
 
                 // keep checking if patient has more reports recursively


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/4079. Use the same commit that is used for the symlinking of TCGA id to
pathology report to get the PDFs (instead of `cBioPortal/datahub/master`). This way there's only one dependency. Since the TCGA path reports
won't change anymore this should work fine