### PR TITLE
Reduce debounce length in oncoprint, fix small bug in oncoprint

### DIFF
--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -147,7 +147,7 @@ export default class Oncoprint extends React.Component<IOncoprintProps, {}> {
 
         this.trackSpecKeyToTrackId = {};
         this.divRefHandler = this.divRefHandler.bind(this);
-        this.refreshOncoprint = _.debounce(this.refreshOncoprint, 50);
+        this.refreshOncoprint = _.debounce(this.refreshOncoprint.bind(this),  0);
     }
 
     private divRefHandler(div:HTMLDivElement) {
@@ -178,7 +178,7 @@ export default class Oncoprint extends React.Component<IOncoprintProps, {}> {
         }
         if (!this.oncoprint.webgl_unavailable) {
             transition(props, this.lastTransitionProps || {}, this.oncoprint, ()=>this.trackSpecKeyToTrackId);
-            this.lastTransitionProps = _.clone(this.props);
+            this.lastTransitionProps = _.clone(props);
         }
     }
 


### PR DESCRIPTION
(1) Reduce debounce time from 50ms to 0ms (i.e. just wait until no more in-serial repeated oncoprint refresh calls), which fixes a timing condition that was causing double-flash when sample/patient mode switched in oncoprint (dynamic where isLoading switches to true, causing onSuppressRendering to fire and change renderingComplete to false, by which time isLoading has already switched back to false. The effect is causing the first flash due to isLoading false->true->false, then the second one, disjoint in time, due to renderingComplete true->false->true. Instead we should get a single flash: (isLoading true)->(renderingComplete false), then eventually (isLoading false) and (renderingComplete true) which makes a single fade out and in.)

(2) Fix small bug in oncoprint which may have been causing an extra render cycle.