### PR TITLE
Revert "using Genome Nexus hotspot data for oncoprint instead of OncoKB"

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -55,7 +55,6 @@ import {CosmicMutation} from "../../shared/api/generated/CBioPortalAPIInternal";
 import internalClient from "../../shared/api/cbioportalInternalClientInstance";
 import {IndicatorQueryResp} from "../../shared/api/generated/OncoKbAPI";
 import {getAlterationString} from "../../shared/lib/CopyNumberUtils";
-import {isRecurrentHotspot} from "../../shared/lib/AnnotationUtils";
 import memoize from "memoize-weak-decorator";
 import request from 'superagent';
 import {countMutations, mutationCountByPositionKey} from "./mutationCountHelpers";
@@ -1447,7 +1446,7 @@ export class ResultsViewPageStore {
                 toAwait.push(this.getOncoKbMutationAnnotationForOncoprint);
             }
             if (this.mutationAnnotationSettings.hotspots) {
-                toAwait.push(this.indexedHotspotData);
+                toAwait.push(this.isHotspot);
             }
             if (this.mutationAnnotationSettings.cbioportalCount) {
                 toAwait.push(this.getCBioportalCount);
@@ -1471,8 +1470,8 @@ export class ResultsViewPageStore {
 
                 const hotspots:boolean =
                     (this.mutationAnnotationSettings.hotspots &&
-                    this.indexedHotspotData.isComplete &&
-                    isRecurrentHotspot(mutation, this.indexedHotspotData.result!));
+                    this.isHotspot.isComplete &&
+                    this.isHotspot.result(mutation));
 
                 const cbioportalCount:boolean =
                     (this.mutationAnnotationSettings.cbioportalCount &&
@@ -1523,6 +1522,17 @@ export class ResultsViewPageStore {
         invoke: ()=>Promise.resolve(indexHotspotsData(this.hotspotData))
     });
 
+    public readonly isHotspot = remoteData({
+        await:()=>[
+            this.getOncoKbMutationAnnotationForOncoprint
+        ],
+        invoke:()=>{
+            return Promise.resolve((mutation:Mutation)=>{
+                const oncokbAnnotation = this.getOncoKbMutationAnnotationForOncoprint.result!(mutation);
+                return (oncokbAnnotation ? !!oncokbAnnotation.hotspot : false);
+            });
+        }
+    });
     //OncoKb
     readonly uniqueSampleKeyToTumorType = remoteData<{[uniqueSampleKey: string]: string}>({
         await:()=>[

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1528,7 +1528,7 @@ export class ResultsViewPageStore {
         ],
         invoke:()=>{
             return Promise.resolve((mutation:Mutation)=>{
-                const oncokbAnnotation = this.getOncoKbMutationAnnotationForOncoprint.result!(mutation);
+                const oncokbAnnotation = typeof this.getOncoKbMutationAnnotationForOncoprint.result === "function" && this.getOncoKbMutationAnnotationForOncoprint.result!(mutation);
                 return (oncokbAnnotation ? !!oncokbAnnotation.hotspot : false);
             });
         }


### PR DESCRIPTION
This reverts commit 7c3ccfcd5845ffa33d45e21d2373c4fd7f28189c