### PR TITLE
Moved Copied! text into the tooltip for Copy/Download controls

### DIFF
--- a/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
@@ -22,13 +22,17 @@ export class CopyDownloadButtons extends React.Component<ICopyDownloadButtonsPro
     public render() {
         return (
             <span className={this.props.className}>
-                <If condition={this.props.showCopyMessage}>
-                    <span style={{marginLeft: 10}} className="alert-success">Copied!</span>
-                </If>
                 <ButtonGroup style={{ marginLeft:10 }} className={this.props.className}>
                     <If condition={this.props.showCopy}>
                         <DefaultTooltip
-                            overlay={<span>Copy</span>}
+                            overlay={() => {
+                                if (this.props.showCopyMessage) {
+                                    return <span className="alert-success">Copied!</span>;
+                                }
+                                else {
+                                    return <span>Copy</span>;
+                                }
+                            }}
                             placement="top"
                             mouseLeaveDelay={0}
                             mouseEnterDelay={0.5}


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/4115.

![copied](https://user-images.githubusercontent.com/3604198/39379017-01ceb866-4a28-11e8-90e2-d26604cc5c12.png)

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)