### PR TITLE
Render merged track queries as single Oncoprint tracks

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -48,7 +48,6 @@ import {
     filterCBioPortalWebServiceDataByUnflattenedOQLLine,
     OQLLineFilterOutput,
     UnflattenedOQLLineFilterOutput,
-    isMergedTrackFilter
 } from "../../shared/lib/oql/oqlfilter";
 import GeneMolecularDataCache from "../../shared/cache/GeneMolecularDataCache";
 import GenesetMolecularDataCache from "../../shared/cache/GenesetMolecularDataCache";

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -33,7 +33,6 @@ import {stringListToIndexSet, stringListToSet} from "../../shared/lib/StringUtil
 import {toSampleUuid} from "../../shared/lib/UuidUtils";
 import MutationDataCache from "../../shared/cache/MutationDataCache";
 import accessors, {getSimplifiedMutationType, SimplifiedMutationType} from "../../shared/lib/oql/accessors";
-import {filterCBioPortalWebServiceData} from "../../shared/lib/oql/oqlfilter.js";
 import {keepAlive} from "mobx-utils";
 import MutationMapper from "./mutation/MutationMapper";
 import {CacheData} from "../../shared/lib/LazyMobXCache";
@@ -43,7 +42,14 @@ import {
 } from "./cancerSummary/CancerSummaryContent";
 import {writeTest} from "../../shared/lib/writeTest";
 import {PatientSurvival} from "../../shared/model/PatientSurvival";
-import {filterCBioPortalWebServiceDataByOQLLine, OQLLineFilterOutput} from "../../shared/lib/oql/oqlfilter";
+import {
+    filterCBioPortalWebServiceData,
+    filterCBioPortalWebServiceDataByOQLLine,
+    filterCBioPortalWebServiceDataByUnflattenedOQLLine,
+    OQLLineFilterOutput,
+    UnflattenedOQLLineFilterOutput,
+    isMergedTrackFilter
+} from "../../shared/lib/oql/oqlfilter";
 import GeneMolecularDataCache from "../../shared/cache/GeneMolecularDataCache";
 import GenesetMolecularDataCache from "../../shared/cache/GenesetMolecularDataCache";
 import GenesetCorrelatedGeneCache from "../../shared/cache/GenesetCorrelatedGeneCache";
@@ -61,7 +67,7 @@ import {countMutations, mutationCountByPositionKey} from "./mutationCountHelpers
 import {getPatientSurvivals} from "./SurvivalStoreHelper";
 import {QueryStore} from "shared/components/query/QueryStore";
 import {
-    annotateMolecularDatum, getOncoKbOncogenic,
+    annotateMolecularDatum, getOncoKbOncogenic, groupDataByCase,
     computeCustomDriverAnnotationReport, computePutativeDriverAnnotatedMutations,
     initializeCustomDriverAnnotationSettings, computeGenePanelInformation,
     fetchQueriedStudies, CoverageInformation
@@ -464,6 +470,41 @@ export class ResultsViewPageStore {
         }
     });
 
+    readonly putativeDriverFilteredCaseAggregatedDataByUnflattenedOQLLine = remoteData<{
+        cases: CaseAggregatedData<AnnotatedExtendedAlteration>,
+        oql: UnflattenedOQLLineFilterOutput<AnnotatedExtendedAlteration>
+    }[]>({
+        await: () => [
+            this.putativeDriverAnnotatedMutations,
+            this.annotatedMolecularData,
+            this.selectedMolecularProfiles,
+            this.defaultOQLQuery,
+            this.samples,
+            this.patients
+        ],
+        invoke: () => {
+            if (this.oqlQuery.trim() === '') {
+                return Promise.resolve([]);
+            } else {
+                const filteredAlterationsByOQLLine: UnflattenedOQLLineFilterOutput<AnnotatedExtendedAlteration>[] = (
+                    filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+                        this.oqlQuery,
+                        [...(this.putativeDriverAnnotatedMutations.result!), ...(this.annotatedMolecularData.result!)],
+                        (new accessors(this.selectedMolecularProfiles.result!)),
+                        this.defaultOQLQuery.result!
+                    )
+                );
+
+                return Promise.resolve(filteredAlterationsByOQLLine.map(
+                    (oql) => ({
+                        cases: groupDataByCase(oql, this.samples.result!, this.patients.result!),
+                        oql
+                    })
+                ));
+            }
+        }
+    });
+
     readonly putativeDriverFilteredCaseAggregatedDataByOQLLine = remoteData<{cases:CaseAggregatedData<AnnotatedExtendedAlteration>, oql:OQLLineFilterOutput<AnnotatedExtendedAlteration>}[]>({
         await:()=>[
             this.putativeDriverAnnotatedMutations,
@@ -473,29 +514,23 @@ export class ResultsViewPageStore {
             this.samples,
             this.patients
         ],
-        invoke:()=>{
-            let unfilteredAlterations:(AnnotatedMutation | AnnotatedNumericGeneMolecularData)[] = [];
-            unfilteredAlterations = unfilteredAlterations.concat(this.putativeDriverAnnotatedMutations.result!);
-            unfilteredAlterations = unfilteredAlterations.concat(this.annotatedMolecularData.result!);
-
-            if (this.oqlQuery.trim() != "") {
-                const filteredAlterationsByOQLLine:OQLLineFilterOutput<AnnotatedExtendedAlteration>[] = filterCBioPortalWebServiceDataByOQLLine(this.oqlQuery, unfilteredAlterations,
-                        (new accessors(this.selectedMolecularProfiles.result!)), this.defaultOQLQuery.result!);
-
-                    return Promise.resolve(filteredAlterationsByOQLLine.map(oql=>{
-                        const cases:CaseAggregatedData<AnnotatedExtendedAlteration> = {
-                            samples:
-                                groupBy(oql.data, datum=>datum.uniqueSampleKey, this.samples.result!.map(sample=>sample.uniqueSampleKey)),
-                            patients:
-                                groupBy(oql.data, datum=>datum.uniquePatientKey, this.patients.result!.map(sample=>sample.uniquePatientKey))
-                        };
-                        return {
-                            cases,
-                            oql
-                        };
-                    }));
-            } else {
+        invoke: () => {
+            if (this.oqlQuery.trim() === '') {
                 return Promise.resolve([]);
+            } else {
+                const filteredAlterationsByOQLLine:OQLLineFilterOutput<AnnotatedExtendedAlteration>[] = filterCBioPortalWebServiceDataByOQLLine(
+                    this.oqlQuery,
+                    [...(this.putativeDriverAnnotatedMutations.result!), ...(this.annotatedMolecularData.result!)],
+                    (new accessors(this.selectedMolecularProfiles.result!)),
+                    this.defaultOQLQuery.result!
+                );
+
+                return Promise.resolve(filteredAlterationsByOQLLine.map(
+                    (oql) => ({
+                        cases: groupDataByCase(oql, this.samples.result!, this.patients.result!),
+                        oql
+                    })
+                ));
             }
         }
     });

--- a/src/pages/resultsView/download/DownloadUtils.spec.ts
+++ b/src/pages/resultsView/download/DownloadUtils.spec.ts
@@ -318,12 +318,11 @@ describe('DownloadUtils', () => {
 
         it('generates empty oql data for a sample with no alteration data', () => {
 
-            const geneticTrackDatum = {
+            const geneticTrackDatum: GeneticTrackDatum = {
                 sample: "TCGA-BF-A1PV-01",
                 study_id: "skcm_tcga",
                 uid: "VENHQS1CRi1BMVBWLTAxOnNrY21fdGNnYQ",
-                coverage:[],
-                gene: "PTEN",
+                trackLabel: "PTEN",
                 data: sampleDataWithNoAlteration
             };
 
@@ -343,19 +342,17 @@ describe('DownloadUtils', () => {
                 "protein level data is empty for the sample with no alteration");
         });
 
-
         it('generates oql data properly for samples with multiple alteration types', () => {
 
-            const geneticTrackDatum = {
+            const geneticTrackDatum: GeneticTrackDatum = {
                 sample: "TCGA-EE-A20C-06",
                 study_id: "skcm_tcga",
                 uid: "VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ",
-                coverage:[],
-                gene: "PTEN",
+                trackLabel: "PTEN",
                 data: [mrnaDataForTCGAEEA20C, proteinDataForTCGAEEA20C] as any[],
                 disp_mrna: "up",
                 disp_prot: "up"
-            } as GeneticTrackDatum;
+            };
 
             const oqlData = generateOqlData(geneticTrackDatum);
 
@@ -381,17 +378,16 @@ describe('DownloadUtils', () => {
 
         it('generates oql data properly for samples with multiple mutations/fusions', () => {
 
-            const geneticTrackDatum = {
+            const geneticTrackDatum: GeneticTrackDatum = {
                 sample: "P-0000378-T01-IM3",
                 study_id: "msk_impact_2017",
                 uid: "UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3",
-                coverage:[],
-                gene: "EGFR",
+                trackLabel: "EGFR",
                 data: sampleDataWithBothMutationAndFusion,
                 disp_fusion: true,
                 disp_cna: "amp",
                 disp_mut: "missense_rec"
-            } as GeneticTrackDatum;
+            };
 
             const oqlData = generateOqlData(geneticTrackDatum);
 

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -74,10 +74,14 @@ export function generateOqlData(datum: GeneticTrackDatum,
     }
 
     return ({
-        // by default assume it is sequenced if no gene alteration data exists for a particular gene
-        sequenced: geneAlterationDataByGene && geneAlterationDataByGene[datum.gene] ?
-            geneAlterationDataByGene[datum.gene].sequenced > 0 : true,
-        geneSymbol: datum.gene,
+        // by default assume it is sequenced if the label is not a recognised
+        // gene symbol or if no gene alteration data exists for the gene; it
+        // should always be a gene symbol as long as the download tab doesn't
+        // use multi-gene tracks
+        sequenced: geneAlterationDataByGene && geneAlterationDataByGene[datum.trackLabel]
+            ? geneAlterationDataByGene[datum.trackLabel].sequenced > 0
+            : true,
+        geneSymbol: datum.trackLabel,
         mutation: proteinChanges,
         fusion: fusions,
         cna: cnaAlterations,

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -503,14 +503,14 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", []),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: [],
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any);
+               });
        });
        it("fills a datum w one mutation data correctly", ()=>{
            let data = [
@@ -522,14 +522,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               } as any, "missense driver with no germline");
+               },
+               "missense driver with no germline");
 
            data = [{
                mutationType: "in_frame_del",
@@ -539,14 +540,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "inframe",
                    disp_germ: false
-               } as any, "inframe non-driver");
+               },
+               "inframe non-driver");
 
            data = [{
                mutationType: "truncating",
@@ -556,14 +558,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "trunc",
                    disp_germ: false
-               } as any, "truncating non-driver");
+               },
+               "truncating non-driver");
 
            data = [{
                mutationType: "fusion",
@@ -573,7 +576,7 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
@@ -581,7 +584,8 @@ describe("DataUtils", ()=>{
                    disp_mut: undefined,
                    disp_fusion: true,
                    disp_germ: undefined
-               } as any, "fusion non-driver");
+               },
+               "fusion non-driver");
        });
 
 
@@ -593,14 +597,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "amp",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "amplification");
+               },
+               "amplification");
 
            data = [{
                value: 1,
@@ -609,14 +614,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "gain",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "gain");
+               },
+               "gain");
 
            data = [{
                value: -1,
@@ -626,14 +632,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "hetloss",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "hetloss");
+               },
+               "hetloss");
 
            data = [{
                value: -2,
@@ -643,14 +650,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "homdel");
+               },
+               "homdel");
 
            data = [{
                value: 0,
@@ -659,14 +667,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "diploid");
+               },
+               "diploid");
        });
 
        it("fills a datum w one germline data correctly", ()=>{
@@ -679,14 +688,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: true
-               } as any, "missense driver with germline");
+               },
+               "missense driver with germline");
 
             data = [{
                mutationType: "missense",
@@ -696,14 +706,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               } as any, "missense driver without germline");
+               },
+               "missense driver without germline");
        });
 
        it("fills a datum w one germline and one non-germline data correctly", ()=>{
@@ -721,14 +732,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: true
-               } as any, "missense driver with germline is stronger than missense passenger");
+               },
+               "missense driver with germline is stronger than missense passenger");
 
            data = [{
                mutationType: "missense",
@@ -744,14 +756,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               } as any, "trunc driver is stronger than missense passenger w germline");
+               },
+               "trunc driver is stronger than missense passenger w germline");
        });
 
        it("fills a datum w one mrna data correctly", ()=>{
@@ -762,14 +775,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: "up",
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "up");
+               },
+               "up");
 
            data = [{
                alterationSubType:"down",
@@ -778,14 +792,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: "down",
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "down");
+               },
+               "down");
        });
        it("fills a datum w one protein data correctly", ()=>{
            let data = [{
@@ -795,14 +810,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: "up",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "up");
+               },
+               "up");
 
            data = [{
                alterationSubType:"down",
@@ -811,14 +827,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: "down",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "down");
+               },
+               "down");
        });
        it("fills a datum w two mutation data w correct priority", ()=>{
            let data = [{
@@ -833,14 +850,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               } as any, "truncating driver beats missense driver");
+               },
+               "truncating driver beats missense driver");
 
            data = [{
                mutationType: "missense",
@@ -854,14 +872,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               } as any, "missense driver beats truncating non-driver");
+               },
+               "missense driver beats truncating non-driver");
 
            data = [{
                mutationType: "missense",
@@ -875,14 +894,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: "trunc",
                    disp_germ: false
-               } as any, "truncating non-driver beats missense non-driver");
+               },
+               "truncating non-driver beats missense non-driver");
        });
        it("fills a datum w multiple cna data w correct priority", ()=>{
            let data = [{
@@ -895,14 +915,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "amp",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "amplification beats gain");
+               },
+               "amplification beats gain");
 
            data = [{
                value: -2,
@@ -914,14 +935,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "homdel beats diploid");
+               },
+               "homdel beats diploid");
 
            data = [{
                value: -2,
@@ -936,14 +958,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two homdels beats one amp");
+               },
+               "two homdels beats one amp");
 
            data = [{
                value: -2,
@@ -958,14 +981,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "amp",
                    disp_mrna: undefined,
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two amps beats one homdel");
+               },
+               "two amps beats one homdel");
        });
        it("fills a datum w multiple mrna data w correct priority", ()=>{
            let data = [{
@@ -981,14 +1005,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: "down",
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two downs beats one up");
+               },
+               "two downs beats one up");
 
            data = [{
                alterationSubType:"up",
@@ -1003,14 +1028,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: "up",
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two ups beats one down");
+               },
+               "two ups beats one down");
        });
        it("fills a datum w multiple protein data w correct priority", ()=>{
            let data = [{
@@ -1026,14 +1052,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: "down",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two downs beats one up");
+               },
+               "two downs beats one up");
 
            data = [{
                alterationSubType:"up",
@@ -1048,14 +1075,15 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
                    disp_mrna: undefined,
                    disp_prot: "up",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two ups beats one down");
+               },
+               "two ups beats one down");
        });
        it("fills a datum w several data of different types correctly", ()=>{
            let data = [{
@@ -1097,14 +1125,14 @@ describe("DataUtils", ()=>{
            assert.deepEqual(
                fillGeneticTrackDatum({}, "gene", data),
                {
-                   gene:"gene",
+                   trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",
                    disp_mrna: "up",
                    disp_prot: "down",
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               } as any);
+               });
        });
    });
 
@@ -1220,7 +1248,6 @@ describe("DataUtils", ()=>{
                {sampleId:"sample", studyId:"study"} as Sample,
                [{value: 7}]
            );
-           console.log(partialTrackDatum);
            assert.deepEqual(
                partialTrackDatum,
                {geneset_id:"MY_FAVORITE_GENE_SET-3", study:"study", profile_data:7}

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -510,7 +510,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any);
+               });
        });
        it("fills a datum w one mutation data correctly", ()=>{
            let data = [
@@ -529,7 +529,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               } as any, "missense driver with no germline");
+               },
+               "missense driver with no germline"
+           );
 
            data = [{
                mutationType: "in_frame_del",
@@ -546,7 +548,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "inframe",
                    disp_germ: false
-               } as any, "inframe non-driver");
+               },
+               "inframe non-driver"
+           );
 
            data = [{
                mutationType: "truncating",
@@ -563,7 +567,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc",
                    disp_germ: false
-               } as any, "truncating non-driver");
+               },
+               "truncating non-driver"
+           );
 
            data = [{
                mutationType: "fusion",
@@ -581,7 +587,9 @@ describe("DataUtils", ()=>{
                    disp_mut: undefined,
                    disp_fusion: true,
                    disp_germ: undefined
-               } as any, "fusion non-driver");
+               },
+               "fusion non-driver"
+           );
        });
 
 
@@ -600,7 +608,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "amplification");
+               },
+               "amplification"
+           );
 
            data = [{
                value: 1,
@@ -616,7 +626,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "gain");
+               },
+               "gain"
+           );
 
            data = [{
                value: -1,
@@ -633,7 +645,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "hetloss");
+               },
+               "hetloss"
+           );
 
            data = [{
                value: -2,
@@ -650,7 +664,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "homdel");
+               },
+               "homdel"
+           );
 
            data = [{
                value: 0,
@@ -666,7 +682,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "diploid");
+               },
+               "diploid"
+           );
        });
 
        it("fills a datum w one germline data correctly", ()=>{
@@ -686,7 +704,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: true
-               } as any, "missense driver with germline");
+               },
+               "missense driver with germline"
+           );
 
             data = [{
                mutationType: "missense",
@@ -703,7 +723,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               } as any, "missense driver without germline");
+               },
+               "missense driver without germline"
+           );
        });
 
        it("fills a datum w one germline and one non-germline data correctly", ()=>{
@@ -728,7 +750,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: true
-               } as any, "missense driver with germline is stronger than missense passenger");
+               },
+               "missense driver with germline is stronger than missense passenger"
+           );
 
            data = [{
                mutationType: "missense",
@@ -751,7 +775,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               } as any, "trunc driver is stronger than missense passenger w germline");
+               },
+               "trunc driver is stronger than missense passenger w germline"
+           );
        });
 
        it("fills a datum w one mrna data correctly", ()=>{
@@ -769,7 +795,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "up");
+               },
+               "up"
+           );
 
            data = [{
                alterationSubType:"down",
@@ -785,7 +813,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "down");
+               },
+               "down"
+           );
        });
        it("fills a datum w one protein data correctly", ()=>{
            let data = [{
@@ -802,7 +832,9 @@ describe("DataUtils", ()=>{
                    disp_prot: "up",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "up");
+               },
+               "up"
+           );
 
            data = [{
                alterationSubType:"down",
@@ -818,7 +850,9 @@ describe("DataUtils", ()=>{
                    disp_prot: "down",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "down");
+               },
+               "down"
+           );
        });
        it("fills a datum w two mutation data w correct priority", ()=>{
            let data = [{
@@ -840,7 +874,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               } as any, "truncating driver beats missense driver");
+               },
+               "truncating driver beats missense driver"
+           );
 
            data = [{
                mutationType: "missense",
@@ -861,7 +897,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               } as any, "missense driver beats truncating non-driver");
+               },
+               "missense driver beats truncating non-driver"
+           );
 
            data = [{
                mutationType: "missense",
@@ -882,7 +920,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc",
                    disp_germ: false
-               } as any, "truncating non-driver beats missense non-driver");
+               },
+               "truncating non-driver beats missense non-driver"
+           );
        });
        it("fills a datum w multiple cna data w correct priority", ()=>{
            let data = [{
@@ -902,7 +942,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "amplification beats gain");
+               },
+               "amplification beats gain"
+           );
 
            data = [{
                value: -2,
@@ -921,7 +963,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "homdel beats diploid");
+               },
+               "homdel beats diploid"
+           );
 
            data = [{
                value: -2,
@@ -943,7 +987,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two homdels beats one amp");
+               },
+               "two homdels beats one amp"
+           );
 
            data = [{
                value: -2,
@@ -965,7 +1011,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two amps beats one homdel");
+               },
+               "two amps beats one homdel"
+           );
        });
        it("fills a datum w multiple mrna data w correct priority", ()=>{
            let data = [{
@@ -988,7 +1036,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two downs beats one up");
+               },
+               "two downs beats one up"
+           );
 
            data = [{
                alterationSubType:"up",
@@ -1010,7 +1060,9 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two ups beats one down");
+               },
+               "two ups beats one down"
+           );
        });
        it("fills a datum w multiple protein data w correct priority", ()=>{
            let data = [{
@@ -1033,7 +1085,9 @@ describe("DataUtils", ()=>{
                    disp_prot: "down",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two downs beats one up");
+               },
+               "two downs beats one up"
+           );
 
            data = [{
                alterationSubType:"up",
@@ -1055,7 +1109,9 @@ describe("DataUtils", ()=>{
                    disp_prot: "up",
                    disp_mut: undefined,
                    disp_germ: undefined
-               } as any, "two ups beats one down");
+               },
+               "two ups beats one down"
+           );
        });
        it("fills a datum w several data of different types correctly", ()=>{
            let data = [{
@@ -1104,7 +1160,7 @@ describe("DataUtils", ()=>{
                    disp_prot: "down",
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               } as any);
+               });
        });
    });
 
@@ -1220,7 +1276,6 @@ describe("DataUtils", ()=>{
                {sampleId:"sample", studyId:"study"} as Sample,
                [{value: 7}]
            );
-           console.log(partialTrackDatum);
            assert.deepEqual(
                partialTrackDatum,
                {geneset_id:"MY_FAVORITE_GENE_SET-3", study:"study", profile_data:7}

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -499,10 +499,15 @@ describe("DataUtils", ()=>{
    });
 
    describe("fillGeneticTrackDatum", ()=>{
+       const makeMinimalUnfilledDatum = () => ({
+           study_id: 'study1',
+           uid: 'SAMPLE1=='
+       });
        it("fills a datum w no data correctly", ()=>{
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", []),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", []),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: [],
                    disp_cna: undefined,
@@ -520,8 +525,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
                 } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -538,8 +544,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -556,8 +563,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -574,8 +582,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -595,8 +604,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "amp",
@@ -612,8 +622,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "gain",
@@ -630,8 +641,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "hetloss",
@@ -648,8 +660,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",
@@ -665,8 +678,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -686,8 +700,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -704,8 +719,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -730,8 +746,9 @@ describe("DataUtils", ()=>{
            } as AnnotatedExtendedAlteration];
 
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -754,8 +771,9 @@ describe("DataUtils", ()=>{
            } as AnnotatedExtendedAlteration];
 
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -773,8 +791,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -790,8 +809,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -808,8 +828,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -825,8 +846,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -848,8 +870,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -870,8 +893,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -892,8 +916,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -913,8 +938,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "amp",
@@ -933,8 +959,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",
@@ -956,8 +983,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",
@@ -979,8 +1007,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.COPY_NUMBER_ALTERATION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "amp",
@@ -1003,8 +1032,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -1026,8 +1056,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MRNA_EXPRESSION
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -1050,8 +1081,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -1073,8 +1105,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.PROTEIN_LEVEL
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: undefined,
@@ -1123,8 +1156,9 @@ describe("DataUtils", ()=>{
                molecularProfileAlterationType: AlterationTypeConstants.MUTATION_EXTENDED
            } as AnnotatedExtendedAlteration];
            assert.deepEqual(
-               fillGeneticTrackDatum({}, "gene", data),
+               fillGeneticTrackDatum(makeMinimalUnfilledDatum(), "gene", data),
                {
+                   ...makeMinimalUnfilledDatum(),
                    trackLabel: "gene",
                    data: data,
                    disp_cna: "homdel",

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -510,7 +510,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               });
+               } as any);
        });
        it("fills a datum w one mutation data correctly", ()=>{
            let data = [
@@ -529,9 +529,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               },
-               "missense driver with no germline"
-           );
+               } as any, "missense driver with no germline");
 
            data = [{
                mutationType: "in_frame_del",
@@ -548,9 +546,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "inframe",
                    disp_germ: false
-               },
-               "inframe non-driver"
-           );
+               } as any, "inframe non-driver");
 
            data = [{
                mutationType: "truncating",
@@ -567,9 +563,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc",
                    disp_germ: false
-               },
-               "truncating non-driver"
-           );
+               } as any, "truncating non-driver");
 
            data = [{
                mutationType: "fusion",
@@ -587,9 +581,7 @@ describe("DataUtils", ()=>{
                    disp_mut: undefined,
                    disp_fusion: true,
                    disp_germ: undefined
-               },
-               "fusion non-driver"
-           );
+               } as any, "fusion non-driver");
        });
 
 
@@ -608,9 +600,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "amplification"
-           );
+               } as any, "amplification");
 
            data = [{
                value: 1,
@@ -626,9 +616,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "gain"
-           );
+               } as any, "gain");
 
            data = [{
                value: -1,
@@ -645,9 +633,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "hetloss"
-           );
+               } as any, "hetloss");
 
            data = [{
                value: -2,
@@ -664,9 +650,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "homdel"
-           );
+               } as any, "homdel");
 
            data = [{
                value: 0,
@@ -682,9 +666,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "diploid"
-           );
+               } as any, "diploid");
        });
 
        it("fills a datum w one germline data correctly", ()=>{
@@ -704,9 +686,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: true
-               },
-               "missense driver with germline"
-           );
+               } as any, "missense driver with germline");
 
             data = [{
                mutationType: "missense",
@@ -723,9 +703,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               },
-               "missense driver without germline"
-           );
+               } as any, "missense driver without germline");
        });
 
        it("fills a datum w one germline and one non-germline data correctly", ()=>{
@@ -750,9 +728,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: true
-               },
-               "missense driver with germline is stronger than missense passenger"
-           );
+               } as any, "missense driver with germline is stronger than missense passenger");
 
            data = [{
                mutationType: "missense",
@@ -775,9 +751,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               },
-               "trunc driver is stronger than missense passenger w germline"
-           );
+               } as any, "trunc driver is stronger than missense passenger w germline");
        });
 
        it("fills a datum w one mrna data correctly", ()=>{
@@ -795,9 +769,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "up"
-           );
+               } as any, "up");
 
            data = [{
                alterationSubType:"down",
@@ -813,9 +785,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "down"
-           );
+               } as any, "down");
        });
        it("fills a datum w one protein data correctly", ()=>{
            let data = [{
@@ -832,9 +802,7 @@ describe("DataUtils", ()=>{
                    disp_prot: "up",
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "up"
-           );
+               } as any, "up");
 
            data = [{
                alterationSubType:"down",
@@ -850,9 +818,7 @@ describe("DataUtils", ()=>{
                    disp_prot: "down",
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "down"
-           );
+               } as any, "down");
        });
        it("fills a datum w two mutation data w correct priority", ()=>{
            let data = [{
@@ -874,9 +840,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               },
-               "truncating driver beats missense driver"
-           );
+               } as any, "truncating driver beats missense driver");
 
            data = [{
                mutationType: "missense",
@@ -897,9 +861,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "missense_rec",
                    disp_germ: false
-               },
-               "missense driver beats truncating non-driver"
-           );
+               } as any, "missense driver beats truncating non-driver");
 
            data = [{
                mutationType: "missense",
@@ -920,9 +882,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: "trunc",
                    disp_germ: false
-               },
-               "truncating non-driver beats missense non-driver"
-           );
+               } as any, "truncating non-driver beats missense non-driver");
        });
        it("fills a datum w multiple cna data w correct priority", ()=>{
            let data = [{
@@ -942,9 +902,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "amplification beats gain"
-           );
+               } as any, "amplification beats gain");
 
            data = [{
                value: -2,
@@ -963,9 +921,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "homdel beats diploid"
-           );
+               } as any, "homdel beats diploid");
 
            data = [{
                value: -2,
@@ -987,9 +943,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "two homdels beats one amp"
-           );
+               } as any, "two homdels beats one amp");
 
            data = [{
                value: -2,
@@ -1011,9 +965,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "two amps beats one homdel"
-           );
+               } as any, "two amps beats one homdel");
        });
        it("fills a datum w multiple mrna data w correct priority", ()=>{
            let data = [{
@@ -1036,9 +988,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "two downs beats one up"
-           );
+               } as any, "two downs beats one up");
 
            data = [{
                alterationSubType:"up",
@@ -1060,9 +1010,7 @@ describe("DataUtils", ()=>{
                    disp_prot: undefined,
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "two ups beats one down"
-           );
+               } as any, "two ups beats one down");
        });
        it("fills a datum w multiple protein data w correct priority", ()=>{
            let data = [{
@@ -1085,9 +1033,7 @@ describe("DataUtils", ()=>{
                    disp_prot: "down",
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "two downs beats one up"
-           );
+               } as any, "two downs beats one up");
 
            data = [{
                alterationSubType:"up",
@@ -1109,9 +1055,7 @@ describe("DataUtils", ()=>{
                    disp_prot: "up",
                    disp_mut: undefined,
                    disp_germ: undefined
-               },
-               "two ups beats one down"
-           );
+               } as any, "two ups beats one down");
        });
        it("fills a datum w several data of different types correctly", ()=>{
            let data = [{
@@ -1160,7 +1104,7 @@ describe("DataUtils", ()=>{
                    disp_prot: "down",
                    disp_mut: "trunc_rec",
                    disp_germ: false
-               });
+               } as any);
        });
    });
 
@@ -1276,6 +1220,7 @@ describe("DataUtils", ()=>{
                {sampleId:"sample", studyId:"study"} as Sample,
                [{value: 7}]
            );
+           console.log(partialTrackDatum);
            assert.deepEqual(
                partialTrackDatum,
                {geneset_id:"MY_FAVORITE_GENE_SET-3", study:"study", profile_data:7}

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -98,22 +98,11 @@ export function selectDisplayValue(counts:{[value:string]:number}, priority:{[va
     }
 };
 
-type FilledGeneticTrackDatum<T> = T & Pick<GeneticTrackDatum, (
-    'gene'
-    | 'data'
-    | 'disp_fusion'
-    | 'disp_cna'
-    | 'disp_mrna'
-    | 'disp_prot'
-    | 'disp_mut'
-    | 'disp_germ'
-)>;
-export function fillGeneticTrackDatum<T>(
-    oldDatum: T,
+export function fillGeneticTrackDatum(
+    newDatum:Partial<GeneticTrackDatum>,
     hugoGeneSymbol:string,
     data:AnnotatedExtendedAlteration[]
-): FilledGeneticTrackDatum<T> {
-    const newDatum: Partial<FilledGeneticTrackDatum<T>> = oldDatum;
+):GeneticTrackDatum {
     newDatum.gene = hugoGeneSymbol;
     newDatum.data = data;
 
@@ -171,11 +160,10 @@ export function fillGeneticTrackDatum<T>(
     newDatum.disp_cna = selectDisplayValue(dispCnaCounts, cnaRenderPriority);
     newDatum.disp_mrna = selectDisplayValue(dispMrnaCounts, mrnaRenderPriority);
     newDatum.disp_prot = selectDisplayValue(dispProtCounts, protRenderPriority);
-    const disp_mut = selectDisplayValue(dispMutCounts, mutRenderPriority);
-    newDatum.disp_mut = disp_mut;
-    newDatum.disp_germ = disp_mut ? dispGermline[disp_mut] : undefined;
+    newDatum.disp_mut = selectDisplayValue(dispMutCounts, mutRenderPriority);
+    newDatum.disp_germ = newDatum.disp_mut ? dispGermline[newDatum.disp_mut] : undefined;
 
-    return newDatum as FilledGeneticTrackDatum<T>;
+    return newDatum as GeneticTrackDatum; // return for convenience, even though changes made in place
 }
 
 export function makeGeneticTrackData(

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -168,7 +168,7 @@ export function fillGeneticTrackDatum(
 
 export function makeGeneticTrackData(
     caseAggregatedAlterationData:CaseAggregatedData<AnnotatedExtendedAlteration>["samples"],
-    hugoGeneSymbol:string,
+    hugoGeneSymbols:string|string[],
     samples:Sample[],
     genePanelInformation:CoverageInformation,
     selectedMolecularProfiles:MolecularProfile[]
@@ -176,7 +176,7 @@ export function makeGeneticTrackData(
 
 export function makeGeneticTrackData(
     caseAggregatedAlterationData:CaseAggregatedData<AnnotatedExtendedAlteration>["patients"],
-    hugoGeneSymbol:string,
+    hugoGeneSymbols:string|string[],
     patients:Patient[],
     genePanelInformation:CoverageInformation,
     selectedMolecularProfiles:MolecularProfile[]
@@ -184,7 +184,7 @@ export function makeGeneticTrackData(
 
 export function makeGeneticTrackData(
     caseAggregatedAlterationData:CaseAggregatedData<AnnotatedExtendedAlteration>["samples"]|CaseAggregatedData<AnnotatedExtendedAlteration>["patients"],
-    hugoGeneSymbol:string,
+    hugoGeneSymbols:string|string[],
     cases:Sample[]|Patient[],
     genePanelInformation:CoverageInformation,
     selectedMolecularProfiles:MolecularProfile[]
@@ -192,6 +192,7 @@ export function makeGeneticTrackData(
     if (!cases.length) {
         return [];
     }
+    const geneSymbolArray = hugoGeneSymbols instanceof Array ? hugoGeneSymbols : [hugoGeneSymbols];
     const _selectedMolecularProfiles = _.keyBy(selectedMolecularProfiles, p=>p.molecularProfileId);
     const ret:GeneticTrackDatum[] = [];
     if (isSampleList(cases)) {
@@ -203,16 +204,23 @@ export function makeGeneticTrackData(
             newDatum.uid = sample.uniqueSampleKey;
 
             const sampleSequencingInfo = genePanelInformation.samples[sample.uniqueSampleKey];
-            newDatum.profiled_in = sampleSequencingInfo.byGene[hugoGeneSymbol] || [];
+            newDatum.profiled_in = _.flatMap(
+                geneSymbolArray,
+                hugoGeneSymbol => sampleSequencingInfo.byGene[hugoGeneSymbol] || []
+            );
             newDatum.profiled_in = newDatum.profiled_in.concat(sampleSequencingInfo.allGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
             if (!newDatum.profiled_in.length) {
                 newDatum.na = true;
             }
-            newDatum.not_profiled_in = sampleSequencingInfo.notProfiledByGene[hugoGeneSymbol] || [];
+            newDatum.not_profiled_in = _.flatMap(
+                geneSymbolArray,
+                hugoGeneSymbol => sampleSequencingInfo.notProfiledByGene[hugoGeneSymbol] || []
+            );
             newDatum.not_profiled_in = newDatum.not_profiled_in.concat(sampleSequencingInfo.notProfiledAllGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
 
             fillGeneticTrackDatum(
-                newDatum, hugoGeneSymbol,
+                newDatum,
+                geneSymbolArray.join(' / '),
                 caseAggregatedAlterationData[sample.uniqueSampleKey]
             );
             ret.push(newDatum as GeneticTrackDatum);
@@ -226,16 +234,23 @@ export function makeGeneticTrackData(
             newDatum.uid = patient.uniquePatientKey;
 
             const patientSequencingInfo = genePanelInformation.patients[patient.uniquePatientKey];
-            newDatum.profiled_in = patientSequencingInfo.byGene[hugoGeneSymbol] || [];
+            newDatum.profiled_in = _.flatMap(
+                geneSymbolArray,
+                hugoGeneSymbol => patientSequencingInfo.byGene[hugoGeneSymbol] || []
+            );
             newDatum.profiled_in = newDatum.profiled_in.concat(patientSequencingInfo.allGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
             if (!newDatum.profiled_in.length) {
                 newDatum.na = true;
             }
-            newDatum.not_profiled_in = patientSequencingInfo.notProfiledByGene[hugoGeneSymbol] || [];
+            newDatum.not_profiled_in = _.flatMap(
+                geneSymbolArray,
+                hugoGeneSymbol => patientSequencingInfo.notProfiledByGene[hugoGeneSymbol] || []
+            );
             newDatum.not_profiled_in = newDatum.not_profiled_in.concat(patientSequencingInfo.notProfiledAllGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
 
             fillGeneticTrackDatum(
-                newDatum, hugoGeneSymbol,
+                newDatum,
+                geneSymbolArray.join(' / '),
                 caseAggregatedAlterationData[patient.uniquePatientKey]
             );
             ret.push(newDatum as GeneticTrackDatum);

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -100,10 +100,10 @@ export function selectDisplayValue(counts:{[value:string]:number}, priority:{[va
 
 export function fillGeneticTrackDatum(
     newDatum:Partial<GeneticTrackDatum>,
-    hugoGeneSymbol:string,
+    trackLabel:string,
     data:AnnotatedExtendedAlteration[]
 ): Partial<GeneticTrackDatum> {
-    newDatum.trackLabel = hugoGeneSymbol;
+    newDatum.trackLabel = trackLabel;
     newDatum.data = data;
 
     let dispFusion = false;

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -102,8 +102,8 @@ export function fillGeneticTrackDatum(
     newDatum:Partial<GeneticTrackDatum>,
     hugoGeneSymbol:string,
     data:AnnotatedExtendedAlteration[]
-):GeneticTrackDatum {
-    newDatum.gene = hugoGeneSymbol;
+): Partial<GeneticTrackDatum> {
+    newDatum.trackLabel = hugoGeneSymbol;
     newDatum.data = data;
 
     let dispFusion = false;
@@ -163,7 +163,7 @@ export function fillGeneticTrackDatum(
     newDatum.disp_mut = selectDisplayValue(dispMutCounts, mutRenderPriority);
     newDatum.disp_germ = newDatum.disp_mut ? dispGermline[newDatum.disp_mut] : undefined;
 
-    return newDatum as GeneticTrackDatum; // return for convenience, even though changes made in place
+    return newDatum; // return for convenience, even though changes made in place
 }
 
 export function makeGeneticTrackData(

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -96,13 +96,14 @@ export function selectDisplayValue(counts:{[value:string]:number}, priority:{[va
     } else {
         return undefined;
     }
-};
+}
 
 export function fillGeneticTrackDatum(
+    // must already have all non-disp* fields except trackLabel and data
     newDatum:Partial<GeneticTrackDatum>,
     trackLabel:string,
     data:AnnotatedExtendedAlteration[]
-): Partial<GeneticTrackDatum> {
+): GeneticTrackDatum {
     newDatum.trackLabel = trackLabel;
     newDatum.data = data;
 
@@ -163,7 +164,7 @@ export function fillGeneticTrackDatum(
     newDatum.disp_mut = selectDisplayValue(dispMutCounts, mutRenderPriority);
     newDatum.disp_germ = newDatum.disp_mut ? dispGermline[newDatum.disp_mut] : undefined;
 
-    return newDatum; // return for convenience, even though changes made in place
+    return newDatum as GeneticTrackDatum; // return for convenience, even though changes made in place
 }
 
 export function makeGeneticTrackData(
@@ -218,12 +219,11 @@ export function makeGeneticTrackData(
             );
             newDatum.not_profiled_in = newDatum.not_profiled_in.concat(sampleSequencingInfo.notProfiledAllGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
 
-            _.assign(newDatum, fillGeneticTrackDatum(
-                {},
+            ret.push(fillGeneticTrackDatum(
+                newDatum,
                 geneSymbolArray.join(' / '),
                 caseAggregatedAlterationData[sample.uniqueSampleKey]
             ));
-            ret.push(newDatum as GeneticTrackDatum);
         }
     } else {
         // case: Patients
@@ -248,12 +248,11 @@ export function makeGeneticTrackData(
             );
             newDatum.not_profiled_in = newDatum.not_profiled_in.concat(patientSequencingInfo.notProfiledAllGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
 
-            _.assign(newDatum, fillGeneticTrackDatum(
-                {},
+            ret.push(fillGeneticTrackDatum(
+                newDatum,
                 geneSymbolArray.join(' / '),
                 caseAggregatedAlterationData[patient.uniquePatientKey]
             ));
-            ret.push(newDatum as GeneticTrackDatum);
         }
     }
     return ret;

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -53,7 +53,7 @@ export interface IGenesetHeatmapTrackDatum extends IBaseHeatmapTrackDatum {
 }
 
 export type GeneticTrackDatum = {
-    gene: string;
+    trackLabel: string;
     sample?:string;
     patient?:string;
     study_id:string;

--- a/src/shared/components/oncoprint/OncoprintUtils.spec.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.spec.ts
@@ -1,8 +1,71 @@
+import {
+    makeGeneticTrackWith,
+    percentAltered
+} from "./OncoprintUtils";
+import * as _ from 'lodash';
 import {assert} from 'chai';
-import {percentAltered} from "./OncoprintUtils";
 
-describe('OncoprintUtils', ()=>{
-    describe('percentAltered',()=>{
+describe('OncoprintUtils', () => {
+    describe('makeGeneticTrackWith', () => {
+        const makeMinimalCoverageRecord = () => ({
+            byGene: {}, allGenes: [],
+            notProfiledByGene: {}, notProfiledAllGenes: []
+        });
+        const makeMinimal3Patient3GeneStoreProperties = () => ({
+            samples: [],
+            patients: [
+                { 'patientId': 'TCGA-02-0001', 'studyId': 'gbm_tcga', 'uniquePatientKey': 'VENHQS0wMi0wMDAxOmdibV90Y2dh' },
+                { 'patientId': 'TCGA-02-0003', 'studyId': 'gbm_tcga', 'uniquePatientKey': 'VENHQS0wMi0wMDAzOmdibV90Y2dh' },
+                { 'patientId': 'TCGA-02-0006', 'studyId': 'gbm_tcga', 'uniquePatientKey': 'VENHQS0wMi0wMDA2OmdibV90Y2dh' }
+            ],
+            coverageInformation: {
+                samples: {},
+                patients: {
+                    'VENHQS0wMi0wMDAxOmdibV90Y2dh': makeMinimalCoverageRecord(),
+                    'VENHQS0wMi0wMDAzOmdibV90Y2dh': makeMinimalCoverageRecord(),
+                    'VENHQS0wMi0wMDA2OmdibV90Y2dh': makeMinimalCoverageRecord()
+                }
+            },
+            sequencedSampleKeysByGene: {},
+            sequencedPatientKeysByGene: {'BRCA1': [], 'PTEN': [], 'TP53': []},
+            selectedMolecularProfiles: []
+        });
+        const makeMinimal3Patient3GeneCaseData = () => ({
+            samples: {},
+            patients: {
+                'VENHQS0wMi0wMDAxOmdibV90Y2dh': [],
+                'VENHQS0wMi0wMDAzOmdibV90Y2dh': [],
+                'VENHQS0wMi0wMDA2OmdibV90Y2dh': []
+            }
+        });
+        const MINIMAL_TRACK_INDEX = 0;
+
+        it('if queried for a plain gene, labels the track based on that query', () => {
+            // given store properties for three patients and query data for
+            // a single gene
+            const storeProperties = makeMinimal3Patient3GeneStoreProperties();
+            const queryData = {
+                cases: makeMinimal3Patient3GeneCaseData(),
+                oql: {
+                    gene: 'TP53',
+                    oql_line: 'TP53;',
+                    parsed_oql_line: {gene: 'TP53', alterations: []},
+                    data: []
+                }
+            };
+            // when the track formatting function is called with this query
+            const trackFunction = makeGeneticTrackWith({
+                sampleMode: false,
+                ...storeProperties
+            });
+            const track = trackFunction(queryData, MINIMAL_TRACK_INDEX);
+            // then it returns a track with the same label and OQL
+            assert.equal(track.label, 'TP53');
+            assert.equal(track.oql, 'TP53;');
+        });
+    });
+
+    describe('percentAltered', () => {
         it("returns the percentage with no decimal digits, for percentages >= 3", ()=>{
             assert.equal(percentAltered(3,100), "3%");
             assert.equal(percentAltered(20,100), "20%");

--- a/src/shared/components/oncoprint/OncoprintUtils.spec.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.spec.ts
@@ -63,6 +63,53 @@ describe('OncoprintUtils', () => {
             assert.equal(track.label, 'TP53');
             assert.equal(track.oql, 'TP53;');
         });
+
+        it('if queried for a merged track without a label, labels the track based on the genes inside', () => {
+            // given store properties for three patients and query data
+            // for a two-gene merged track
+            const storeProperties = makeMinimal3Patient3GeneStoreProperties();
+            const queryData = {
+                cases: makeMinimal3Patient3GeneCaseData(),
+                oql: {list: [
+                    {gene: 'BRCA1', oql_line: 'BRCA1;', parsed_oql_line: {gene: 'BRCA1', alterations: []}, data: []},
+                    {gene: 'PTEN', oql_line: 'PTEN;', parsed_oql_line: {gene: 'PTEN', alterations: []}, data: []}
+                ]}
+            };
+            // when the track formatting function is called with this query
+            const trackFunction = makeGeneticTrackWith({
+                sampleMode: false,
+                ...storeProperties
+            });
+            const track = trackFunction(queryData, MINIMAL_TRACK_INDEX);
+            // then it returns a track with the genes' OQL and labels
+            assert.equal(track.label, 'BRCA1 / PTEN');
+            assert.equal(track.oql, '[BRCA1; PTEN;]');
+        });
+
+        it('if queried for a merged track with a label, uses that to label the track', () => {
+            // given store properties for three patients and query data
+            // for a two-gene merged track with a label
+            const storeProperties = makeMinimal3Patient3GeneStoreProperties();
+            const queryData = {
+                cases: makeMinimal3Patient3GeneCaseData(),
+                oql: {
+                    list: [
+                        {gene: 'BRCA1', oql_line: 'BRCA1;', parsed_oql_line: {gene: 'BRCA1', alterations: []}, data: []},
+                        {gene: 'PTEN', oql_line: 'PTEN;', parsed_oql_line: {gene: 'PTEN', alterations: []}, data: []}
+                    ],
+                    label: 'HELLO'
+                }
+            };
+            // when the track formatting function is called with this query
+            const trackFunction = makeGeneticTrackWith({
+                sampleMode: false,
+                ...storeProperties
+            });
+            const track = trackFunction(queryData, MINIMAL_TRACK_INDEX);
+            // then it returns a track with that label and the genes' OQL
+            assert.equal(track.label, 'HELLO');
+            assert.equal(track.oql, '[BRCA1; PTEN;]');
+        });
     });
 
     describe('percentAltered', () => {

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -295,9 +295,13 @@ export function makeGeneticTrackWith({
         },
         index: number
     ): GeneticTrackSpec => {
-        const data = isMergedTrackFilter(oql) ? [] : (sampleMode
-            ? makeGeneticTrackData(dataByCase.samples, oql.gene, samples as Sample[], coverageInformation, selectedMolecularProfiles)
-            : makeGeneticTrackData(dataByCase.patients, oql.gene, patients as Patient[], coverageInformation, selectedMolecularProfiles)
+        const geneSymbolArray = (isMergedTrackFilter(oql)
+            ? oql.list.map(({gene}) => gene)
+            : [oql.gene]
+        );
+        const data = (sampleMode
+            ? makeGeneticTrackData(dataByCase.samples, geneSymbolArray, samples as Sample[], coverageInformation, selectedMolecularProfiles)
+            : makeGeneticTrackData(dataByCase.patients, geneSymbolArray, patients as Patient[], coverageInformation, selectedMolecularProfiles)
         );
         const info = isMergedTrackFilter(oql) ? '' : alterationInfoForCaseAggregatedDataByOQLLine(
             sampleMode,

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -248,15 +248,19 @@ export function alterationInfoForCaseAggregatedDataByOQLLine(
     sampleMode: boolean,
     data: {
         cases: CaseAggregatedData<AnnotatedExtendedAlteration>,
-        oql: {gene: string}
+        oql: {gene: string} | string[]
     },
     sequencedSampleKeysByGene: {[hugoGeneSymbol:string]:string[]},
     sequencedPatientKeysByGene: {[hugoGeneSymbol:string]:string[]})
 {
-    const sequenced =
-        sampleMode ?
-            sequencedSampleKeysByGene[data.oql.gene].length :
-            sequencedPatientKeysByGene[data.oql.gene].length;
+    const geneSymbolArray = (data.oql instanceof Array
+        ? data.oql
+        : [data.oql.gene]
+    );
+    const sequenced = (sampleMode
+        ? _.uniq(_.flatMap(geneSymbolArray, symbol => sequencedSampleKeysByGene[symbol])).length
+        : _.uniq(_.flatMap(geneSymbolArray, symbol => sequencedPatientKeysByGene[symbol])).length
+    );
 
     const altered =
         sampleMode ?
@@ -303,9 +307,9 @@ export function makeGeneticTrackWith({
             ? makeGeneticTrackData(dataByCase.samples, geneSymbolArray, samples as Sample[], coverageInformation, selectedMolecularProfiles)
             : makeGeneticTrackData(dataByCase.patients, geneSymbolArray, patients as Patient[], coverageInformation, selectedMolecularProfiles)
         );
-        const info = isMergedTrackFilter(oql) ? '' : alterationInfoForCaseAggregatedDataByOQLLine(
+        const info = alterationInfoForCaseAggregatedDataByOQLLine(
             sampleMode,
-            {cases: dataByCase, oql},
+            {cases: dataByCase, oql: geneSymbolArray},
             sequencedSampleKeysByGene,
             sequencedPatientKeysByGene
         ).percent;

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -69,7 +69,7 @@ export default function tabularDownload(
     //Add genetic data
     for (const geneticTrack of geneticTracks) {
         const currentTrackData = geneticTrack.data;
-        const currentGeneName = currentTrackData[0].gene; //The gene is the same for all entries of the track
+        const currentGeneName = currentTrackData[0].trackLabel;   // the label is the same for all entries of the track
         //Add the currentGeneName to the oncoprintData if it does not exist
         if (oncoprintData.CNA[currentGeneName] === undefined) {
             oncoprintData.CNA[currentGeneName] = {};

--- a/src/shared/lib/oql/oqlfilter.d.ts
+++ b/src/shared/lib/oql/oqlfilter.d.ts
@@ -6,7 +6,7 @@
 
 //var filterData = function (oql_query, data, _accessors, opt_default_oql, opt_by_oql_line, opt_mark_oql_regulation_direction)
 
-import {SingleGeneQuery} from "./oql-parser";
+import {SingleGeneQuery, MergedGeneQuery} from "./oql-parser";
 import {AnnotatedMutation, ExtendedAlteration} from "../../../pages/resultsView/ResultsViewPageStore";
 import {NumericGeneMolecularData, Mutation} from "../../api/generated/CBioPortalAPI";
 
@@ -14,11 +14,20 @@ type OQLAlterationFilterString = string;
 
 export type OQLLineFilterOutput<T> = {
     gene: string;
-    parsed_oql_line: SingleGeneQuery[];
+    parsed_oql_line: SingleGeneQuery;
     oql_line: string;
     data: T[];
 };
 
+export type MergedTrackLineFilterOutput<T> = {
+    list: OQLLineFilterOutput<T>[],
+    label?: string
+};
+export type UnflattenedOQLLineFilterOutput<T> = (
+    OQLLineFilterOutput<T> | MergedTrackLineFilterOutput<T>
+);
+
+/* Interprets datatypes statements and flattens out merged track queries. */
 export declare function parseOQLQuery(
     oql_query: string,
     opt_default_oql?: OQLAlterationFilterString
@@ -28,3 +37,10 @@ export declare function filterCBioPortalWebServiceData(oql_query:string, data:(M
 
 export declare function filterCBioPortalWebServiceDataByOQLLine(oql_query:string, data:(AnnotatedMutation | NumericGeneMolecularData)[], accessors:any, default_oql:string): OQLLineFilterOutput<ExtendedAlteration&AnnotatedMutation>[];
 export declare function filterCBioPortalWebServiceDataByOQLLine(oql_query:string, data:(Mutation | NumericGeneMolecularData)[], accessors:any, default_oql:string): OQLLineFilterOutput<ExtendedAlteration>[];
+
+export declare function filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+    oql_query: string,
+    data: (AnnotatedMutation|NumericGeneMolecularData)[],
+    accessors:any,
+    default_oql:string
+): UnflattenedOQLLineFilterOutput<ExtendedAlteration&AnnotatedMutation>[];

--- a/src/shared/lib/oql/oqlfilter.d.ts
+++ b/src/shared/lib/oql/oqlfilter.d.ts
@@ -27,6 +27,10 @@ export type UnflattenedOQLLineFilterOutput<T> = (
     OQLLineFilterOutput<T> | MergedTrackLineFilterOutput<T>
 );
 
+export declare function isMergedTrackFilter<T>(
+    oqlFilter: UnflattenedOQLLineFilterOutput<T>
+): oqlFilter is MergedTrackLineFilterOutput<T>;
+
 /* Interprets datatypes statements and flattens out merged track queries. */
 export declare function parseOQLQuery(
     oql_query: string,

--- a/src/shared/lib/oql/oqlfilter.js
+++ b/src/shared/lib/oql/oqlfilter.js
@@ -10,6 +10,10 @@ function isMergedTrackLine(line) {
     return line.list !== undefined;
 }
 
+export function isMergedTrackFilter(oqlFilter) {
+    return oqlFilter.list !== undefined;
+}
+
 function parseMergedTrackOQLQuery(oql_query, opt_default_oql = '') {
     /* In: - oql_query, a string, an OQL query
      - opt_default_oql, a string, default OQL to add to any empty line

--- a/src/shared/lib/oql/oqlfilter.js
+++ b/src/shared/lib/oql/oqlfilter.js
@@ -3,19 +3,20 @@
 import * as _ from 'lodash';
 import oql_parser from './oql-parser';
 
-export function parseOQLQuery(oql_query, opt_default_oql = '') {
+function isDatatypeStatement(line) {
+    return line.gene !== undefined && line.gene.toUpperCase() === 'DATATYPES';
+}
+function isMergedTrackLine(line) {
+    return line.list !== undefined;
+}
+
+function parseMergedTrackOQLQuery(oql_query, opt_default_oql = '') {
     /* In: - oql_query, a string, an OQL query
      - opt_default_oql, a string, default OQL to add to any empty line
-     Out: An array, with each element being a parsed single-gene OQL line,
-     with all 'DATATYPES' lines applied to subsequent lines and removed.
+     Out: An array, with each element being a parsed single-gene or
+     merged-track OQL line, with all 'DATATYPES' lines applied to subsequent
+     lines and removed.
      */
-
-    function isDatatypeStatement(line) {
-        return line.gene !== undefined && line.gene.toUpperCase() === 'DATATYPES';
-    }
-    function isMergedTrackLine(line) {
-        return line.list !== undefined;
-    }
 
     /* In:
     *     - oql_lines:
@@ -82,6 +83,22 @@ export function parseOQLQuery(oql_query, opt_default_oql = '') {
         ).query;
     }
 
+    const parsed = oql_parser.parse(oql_query);
+    let parsed_with_datatypes = applyDatatypes(parsed, false);
+    if (opt_default_oql.length > 0) {
+        const default_alterations = oql_parser.parse(`DUMMYGENE:${opt_default_oql};`)[0].alterations;
+        parsed_with_datatypes = applyDatatypes(parsed_with_datatypes, default_alterations);
+    }
+    return parsed_with_datatypes;
+}
+
+export function parseOQLQuery(oql_query, opt_default_oql = '') {
+    /* In: - oql_query, a string, an OQL query
+     - opt_default_oql, a string, default OQL to add to any empty line
+     Out: An array, with each element being a parsed single-gene OQL line,
+     with all 'DATATYPES' lines applied to subsequent lines and removed.
+     */
+
     /* In: SingleGeneLine | MergedTrackLine
      * Out: SingleGeneLine[]
      */
@@ -92,17 +109,8 @@ export function parseOQLQuery(oql_query, opt_default_oql = '') {
         );
     }
 
-    const parsed = oql_parser.parse(oql_query);
-    const parsed_with_datatypes = applyDatatypes(parsed, false)
-    const parsed_by_gene = _.flatMap(parsed_with_datatypes, extractGeneLines);
-    if (opt_default_oql.length > 0) {
-        for (var i = 0; i < parsed_by_gene.length; i++) {
-            if (!parsed_by_gene[i].alterations) {
-                parsed_by_gene[i].alterations = oql_parser.parse("DUMMYGENE:" + opt_default_oql + ";")[0].alterations;
-            }
-        }
-    }
-    return parsed_by_gene;
+    const parsed_with_datatypes = parseMergedTrackOQLQuery(oql_query, opt_default_oql);
+    return _.flatMap(parsed_with_datatypes, extractGeneLines);
 }
 
 var parsedOQLAlterationToSourceOQL = function(alteration) {
@@ -401,19 +409,26 @@ var isDatumWantedByOQLEXPOrPROTCommand = function(alt_cmd, datum, accessors) {
     }
 };
 
-var filterData = function (oql_query, data, _accessors, opt_default_oql, opt_by_oql_line) {
+function filterData(oql_query, data, _accessors, opt_default_oql = '', opt_by_oql_line) {
     /* In:	- oql_query, a string
      *	- data, a list of data
      *	- accessors, accessors as defined above,
      *	- opt_default_oql, an optional argument, string, default oql to insert to empty oql lines
-     *	- opt_by_oql_line, optional argument, boolean, see Out for description
+     *	- opt_by_oql_line, optional argument, boolean or string, see Out for description
      *  Out: the given data, filtered by the given oql query.
-     *	* If opt_by_oql_line is true, then the result is a list of lists,
-     *	    where out[i] = the result of filtering the given data by oql_query
-     *	    line i (after removing 'DATATYPES' lines and flattening merged
-     *	    track lines into their individual genes).
-     *	* If opt_by_oql_line is false, then the result is just a flat list,
-     *	    the data that is wanted by at least one oql line.
+     *    * If opt_by_oql_line is 'mergedtrack', then the result is
+     *      a list of objects having either a .data or .list property,
+     *      corresponding to single-gene and merged-track lines in
+     *      the OQL query respectively. out[i].data is the result of filtering
+     *      the given data by oql_query line i (after removing 'DATATYPES' lines)
+     *      or out[i].list is an array of such objects for the lines within the
+     *      merged track expression. Both objects have additional metadata
+     *      as listed in oqlfilter.d.ts.
+     *    * If opt_by_oql_line is 'gene' or true, then the result is just
+     *      a list of objects where out[i].data corresponds to gene i after
+     *      flattening merged track queries.
+     *    * If opt_by_oql_line is false or absent, then the result is
+     *      a flat list of the data that is wanted by at least one oql line.
      */
     data = $.extend(true, [], data); // deep copy, because of any modifications it will make during filtration
     var null_fn = function () {
@@ -432,24 +447,41 @@ var filterData = function (oql_query, data, _accessors, opt_default_oql, opt_by_
         data[i].molecularProfileAlterationType = accessors.molecularAlterationType(data[i].molecularProfileId);
     }
 
-    opt_default_oql = opt_default_oql || "";
-    var parsed_query = parseOQLQuery(oql_query, opt_default_oql)
-        .map(function (q_line) {
-            q_line.gene = q_line.gene.toUpperCase();
-            return q_line;
-        });
+    function applyToGeneLines(geneLineFunction) {
+        return (line) => {
+            if (isMergedTrackLine(line)) {
+                return {
+                    ...line,
+                    list: line.list.map(applyToGeneLines(geneLineFunction))
+                };
+            } else {
+                return geneLineFunction(line);
+            }
+        };
+    }
+
+    const queryParsingFunction = (
+        opt_by_oql_line === 'mergedtrack'
+        ? parseMergedTrackOQLQuery
+        : parseOQLQuery
+    );
+    const parsed_query = queryParsingFunction(oql_query, opt_default_oql).map(
+        applyToGeneLines(
+            q_line => ({ ...q_line, gene: q_line.gene.toUpperCase() })
+        )
+    );
 
     if (opt_by_oql_line) {
-        return parsed_query.map(function (query_line) {
-            return {
-                'gene': query_line.gene,
-                'parsed_oql_line': query_line,
-                'oql_line': unparseOQLQueryLine(query_line),
-                'data': data.filter(function (datum) {
-                    return isDatumWantedByOQLLine(query_line, datum, accessors.gene(datum).toUpperCase(), accessors);
-                })
-            };
-        });
+        return parsed_query.map(applyToGeneLines(
+            query_line => ({
+                gene: query_line.gene,
+                parsed_oql_line: query_line,
+                oql_line: unparseOQLQueryLine(query_line),
+                data: data.filter(datum =>
+                    isDatumWantedByOQLLine(query_line, datum, accessors.gene(datum).toUpperCase(), accessors)
+                )
+            })
+        ));
     } else {
         return data.filter(function (datum) {
             return isDatumWantedByOQL(parsed_query, datum, accessors);
@@ -469,7 +501,7 @@ export function filterCBioPortalWebServiceData(oql_query, data, accessors, opt_d
      *	- PROTEIN_LEVEL
      */
 
-    return filterData(oql_query, data, accessors, opt_default_oql, false);
+    return filterData(oql_query, data, accessors, opt_default_oql);
 }
 
 export function filterCBioPortalWebServiceDataByOQLLine(oql_query, data, accessors, opt_default_oql) {
@@ -482,7 +514,20 @@ export function filterCBioPortalWebServiceDataByOQLLine(oql_query, data, accesso
      *	- PROTEIN_LEVEL
      */
 
-    return filterData(oql_query, data, accessors, opt_default_oql, true);
+    return filterData(oql_query, data, accessors, opt_default_oql, 'gene');
+}
+
+export function filterCBioPortalWebServiceDataByUnflattenedOQLLine(oql_query, data, accessors, opt_default_oql) {
+    /* Wrapper method for filterData that has the cBioPortal default accessor functions
+     * Note that for use, the input data must have the field 'genetic_alteration_type,' which
+     * takes one of the following values:
+     *	- MUTATION_EXTENDED
+     *	- COPY_NUMBER_ALTERATION
+     *	- MRNA_EXPRESSION
+     *	- PROTEIN_LEVEL
+     */
+
+    return filterData(oql_query, data, accessors, opt_default_oql, 'mergedtrack');
 }
 
 

--- a/src/shared/lib/oql/oqlfilter.spec.ts
+++ b/src/shared/lib/oql/oqlfilter.spec.ts
@@ -1,0 +1,132 @@
+import {
+    filterCBioPortalWebServiceDataByUnflattenedOQLLine,
+    OQLLineFilterOutput,
+    MergedTrackLineFilterOutput
+} from './oqlfilter';
+import {NumericGeneMolecularData, MolecularProfile} from '../../api/generated/CBioPortalAPI';
+import accessors from './accessors';
+import * as _ from 'lodash';
+import {assert} from 'chai';
+import sinon from 'sinon';
+
+// This file uses type assertions to force functions that use overly specific
+// Swagger-generated types as parameters to accept mocked literals believed to
+// be sufficient
+// tslint:disable no-object-literal-type-assertion
+
+// I believe DETAILED projection to have enough details for the filter function
+const THREE_GENE_TWO_SAMPLE_CNA_DATA = [
+    {"sampleId": "TCGA-02-0001-01", "entrezGeneId": 672, "value": 1, "molecularProfileId": "gbm_tcga_gistic", "uniqueSampleKey": "VENHQS0wMi0wMDAxLTAxOmdibV90Y2dh", "uniquePatientKey": "VENHQS0wMi0wMDAxOmdibV90Y2dh", "patientId": "TCGA-02-0001", "studyId": "gbm_tcga", "gene": {"entrezGeneId": 672, "hugoGeneSymbol": "BRCA1", "type": "protein-coding", "cytoband": "17q21.31", "length": 8922}},
+    {"sampleId": "TCGA-02-0001-01", "entrezGeneId": 5728, "value": 0, "molecularProfileId": "gbm_tcga_gistic", "uniqueSampleKey": "VENHQS0wMi0wMDAxLTAxOmdibV90Y2dh", "uniquePatientKey": "VENHQS0wMi0wMDAxOmdibV90Y2dh", "patientId": "TCGA-02-0001", "studyId": "gbm_tcga", "gene": {"entrezGeneId": 5728, "hugoGeneSymbol": "PTEN", "type": "protein-coding", "cytoband": "10q23.31", "length": 11581}},
+    {"sampleId": "TCGA-02-0001-01", "entrezGeneId": 7157, "value": -1, "molecularProfileId": "gbm_tcga_gistic", "uniqueSampleKey": "VENHQS0wMi0wMDAxLTAxOmdibV90Y2dh", "uniquePatientKey": "VENHQS0wMi0wMDAxOmdibV90Y2dh", "patientId": "TCGA-02-0001", "studyId": "gbm_tcga", "gene": {"entrezGeneId": 7157, "hugoGeneSymbol": "TP53", "type": "protein-coding", "cytoband": "17p13.1", "length": 4576}},
+    {"sampleId": "TCGA-02-0003-01", "entrezGeneId": 672, "value": 0, "molecularProfileId": "gbm_tcga_gistic", "uniqueSampleKey": "VENHQS0wMi0wMDAzLTAxOmdibV90Y2dh", "uniquePatientKey": "VENHQS0wMi0wMDAzOmdibV90Y2dh", "patientId": "TCGA-02-0003", "studyId": "gbm_tcga", "gene": {"entrezGeneId": 672, "hugoGeneSymbol": "BRCA1", "type": "protein-coding", "cytoband": "17q21.31", "length": 8922}},
+    {"sampleId": "TCGA-02-0003-01", "entrezGeneId": 5728, "value": -1, "molecularProfileId": "gbm_tcga_gistic", "uniqueSampleKey": "VENHQS0wMi0wMDAzLTAxOmdibV90Y2dh", "uniquePatientKey": "VENHQS0wMi0wMDAzOmdibV90Y2dh", "patientId": "TCGA-02-0003", "studyId": "gbm_tcga", "gene": {"entrezGeneId": 5728, "hugoGeneSymbol": "PTEN", "type": "protein-coding", "cytoband": "10q23.31", "length": 11581}},
+    {"sampleId": "TCGA-02-0003-01", "entrezGeneId": 7157, "value": 0, "molecularProfileId": "gbm_tcga_gistic", "uniqueSampleKey": "VENHQS0wMi0wMDAzLTAxOmdibV90Y2dh", "uniquePatientKey": "VENHQS0wMi0wMDAzOmdibV90Y2dh", "patientId": "TCGA-02-0003", "studyId": "gbm_tcga", "gene": {"entrezGeneId": 7157, "hugoGeneSymbol": "TP53", "type": "protein-coding", "cytoband": "17p13.1", "length": 4576}}
+] as NumericGeneMolecularData[];
+// I believe these metadata to be all `new accessors()` needs
+const DATA_PROFILE = {
+    "molecularAlterationType": "COPY_NUMBER_ALTERATION",
+    "datatype": "DISCRETE",
+    "molecularProfileId": "gbm_tcga_gistic",
+    "studyId": "gbm_tcga",
+} as MolecularProfile;
+
+describe('filterCBioPortalWebServiceDataByUnflattenedOQLLine', () => {
+    it('returns a single .data object for a single-gene query', () => {
+        // given CNA data for 3 genes in 2 samples and an accessors instance
+        // aware of their profile
+        const dataArray: NumericGeneMolecularData[] = THREE_GENE_TWO_SAMPLE_CNA_DATA;
+        const accessorsInstance: accessors = new accessors([DATA_PROFILE]);
+        // when calling the function with an OQL query asking data for 1 gene
+        const filteredData = filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+            'BRCA1',
+            dataArray,
+            accessorsInstance,
+            ''
+        );
+        // then it returns a single data object with data for the 3 samples
+        assert.lengthOf(filteredData, 1);
+        assert.property(filteredData[0], 'data');
+    });
+
+    it('returns a .list with single .data object for a single-gene merged query', () => {
+        // given CNA data for 3 genes in 2 samples and an accessors instance
+        // aware of their profile
+        const dataArray: NumericGeneMolecularData[] = THREE_GENE_TWO_SAMPLE_CNA_DATA;
+        const accessorsInstance: accessors = new accessors([DATA_PROFILE]);
+        // when calling the function with an OQL query asking data for a
+        // 1-gene list
+        const filteredData = filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+            '[BRCA1]',
+            dataArray,
+            accessorsInstance,
+            ''
+        );
+        // then it returns a single list object containing a single data object
+        assert.lengthOf(filteredData, 1);
+        assert.property(filteredData[0], 'list');
+        assert.lengthOf((filteredData[0] as MergedTrackLineFilterOutput<object>).list, 1);
+        assert.property((filteredData[0] as MergedTrackLineFilterOutput<object>).list[0], 'data');
+    });
+
+    it('returns a .list with two .data objects for a two-gene merged query', () => {
+        // given CNA data for 3 genes in 2 samples and an accessors instance
+        // aware of their profile
+        const dataArray: NumericGeneMolecularData[] = THREE_GENE_TWO_SAMPLE_CNA_DATA;
+        const accessorsInstance: accessors = new accessors([DATA_PROFILE]);
+        // when calling the function with an OQL query asking data for a
+        // 2-gene list
+        const filteredData = filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+            '[BRCA1 PTEN]',
+            dataArray,
+            accessorsInstance,
+            ''
+        );
+        // then it returns a single list object containing 2 data objects
+        assert.lengthOf(filteredData, 1);
+        assert.property(filteredData[0], 'list');
+        assert.lengthOf((filteredData[0] as MergedTrackLineFilterOutput<object>).list, 2);
+        (filteredData[0] as MergedTrackLineFilterOutput<object>).list.forEach(
+            subline => assert.property(subline, 'data')
+        );
+    });
+
+    it('returns both a two-element .list and a .data if a merged-gene line precedes a single-gene one', () => {
+        // given CNA data for 3 genes in 2 samples and an accessors instance
+        // aware of their profile
+        const dataArray: NumericGeneMolecularData[] = THREE_GENE_TWO_SAMPLE_CNA_DATA;
+        const accessorsInstance: accessors = new accessors([DATA_PROFILE]);
+        // when calling the function with an OQL query asking data for 1 gene
+        const filteredData = filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+            '[BRCA1 PTEN] TP53',
+            dataArray,
+            accessorsInstance,
+            ''
+        );
+        // then it returns both a two-element .list and a .data
+        assert.lengthOf(filteredData, 2);
+        assert.property(filteredData[0], 'list');
+        assert.lengthOf((filteredData[0] as MergedTrackLineFilterOutput<object>).list, 2);
+        assert.property(filteredData[1], 'data');
+    });
+
+    it('returns both a .data and a two-element .list if a single-gene line precedes a merged-gene one', () => {
+        // given CNA data for 3 genes in 2 samples and an accessors instance
+        // aware of their profile
+        const dataArray: NumericGeneMolecularData[] = THREE_GENE_TWO_SAMPLE_CNA_DATA;
+        const accessorsInstance: accessors = new accessors([DATA_PROFILE]);
+        // when calling the function with an OQL query asking data for 1 gene
+        const filteredData = filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+            'PTEN [BRCA1 TP53]',
+            dataArray,
+            accessorsInstance,
+            ''
+        );
+        // then it returns both a .data and two-element .list
+        assert.lengthOf(filteredData, 2);
+        assert.property(filteredData[0], 'data');
+        assert.property(filteredData[1], 'list');
+        assert.lengthOf((filteredData[1] as MergedTrackLineFilterOutput<object>).list, 2);
+    });
+
+});


### PR DESCRIPTION
Recognising the OQL syntax introduced #1099, render each merged track query as a single Oncoprint track that aggregates the alterations for the genes in the same way they're aggregated for patients with multiple samples. Cover several of the functions that gain additional behaviour with unit tests, correct the documentation for the function that filters data by query statement, and refactor the interface of the function that performs the cell-wise aggregation for clarity.

## Screenshot ##
![Partial screenshot of an Oncoprint showing a track labelled ‘CDK INHIBITORS’ that displays alterations for both CDKN2A and CDKN2B (explained by the OQL in its tooltip), as well as a track labelled ‘MDM2 / MDM4’](https://user-images.githubusercontent.com/4929431/39585685-a88e5aa4-4ef5-11e8-9411-15a9706b202e.png)