### PR TITLE
Replace 'Enter Gene Set' by 'Enter Genes' to avoid confusion in the query page

### DIFF
--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -80,7 +80,7 @@ export default class GeneSetSelector extends QueryStoreComponent<GeneSetSelector
 							   secondaryComponent={<a target="_blank" href={getOncoQueryDocUrl()}>Advanced: Onco Query Language (OQL)</a>}
 							   promises={[this.store.mutSigForSingleStudy, this.store.gisticForSingleStudy, this.store.genes]}
 				>
-					Enter Gene Set:
+					Enter Genes:
 				</SectionHeader>
 
 				<FlexCol overflow>


### PR DESCRIPTION
This is a very minor fix which replaces the word 'Enter Gene Set' in the query page by 'Enter Genes', since the extra GSVA box for querying gene sets contains 'Enter Gene Sets', and can lead to confusion.