### PR TITLE
Add correct study name to clinical attribute spans

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -218,7 +218,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         </a>
                                         {sampleManager &&
                                          sampleManager.clinicalDataLegacyCleanAndDerived[sample.id] &&
-                                         getSpanElementsFromCleanData(sampleManager.clinicalDataLegacyCleanAndDerived[sample.id], 'lgg_ucsf_2014')}
+                                         getSpanElementsFromCleanData(sampleManager.clinicalDataLegacyCleanAndDerived[sample.id], patientViewPageStore.studyId)}
                                     </span>
                                 )
                             }
@@ -285,6 +285,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                 <td><PatientHeader
                                     handlePatientClick={(id: string)=>this.handlePatientClick(id)}
                                     patient={patientViewPageStore.patientViewData.result.patient}
+                                    studyId={patientViewPageStore.studyId}
                                     darwinUrl={patientViewPageStore.darwinUrl.result}
                                     sampleManager={sampleManager}/></td>
                             </tr>

--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
@@ -168,7 +168,7 @@ function cleanAndDerive(clinicalData) {
  * @param {string} cancerStudyId    - short name of cancer study
  */
 function getSpanElements(clinicalData, cancerStudyId) {
-    return getSpanElementsFromCleanData(cleanAndDerive(clinicalData));
+    return getSpanElementsFromCleanData(cleanAndDerive(clinicalData), cancerStudyId);
 }
 
 function getSpanElementsFromCleanData(clinicalAttributesCleanDerived, cancerStudyId) {

--- a/src/pages/patientView/patientHeader/PatientHeader.tsx
+++ b/src/pages/patientView/patientHeader/PatientHeader.tsx
@@ -12,6 +12,7 @@ import DefaultTooltip from "../../../shared/components/defaultTooltip/DefaultToo
 
 export type IPatientHeaderProps = {
     patient:any;
+    studyId: string;
     sampleManager?:SampleManager | null;
     handlePatientClick:any;
     darwinUrl?: string;
@@ -21,7 +22,7 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
 
         return (
             <div className={styles.patientHeader}>
-                {this.props.patient && this.getOverlayTriggerPatient(this.props.patient, this.props.sampleManager)}
+                {this.props.patient && this.getOverlayTriggerPatient(this.props.patient, this.props.studyId, this.props.sampleManager)}
                 {this.getDarwinUrl(this.props.darwinUrl)}
             </div>
         );
@@ -49,7 +50,7 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
         );
     }
 
-    private getOverlayTriggerPatient(patient: any, sampleManager?: SampleManager|null) {
+    private getOverlayTriggerPatient(patient: any, studyId:string, sampleManager?: SampleManager|null) {
         const clinicalDataLegacy = fromPairs(patient.clinicalData.map(
             (x: any) => [x.clinicalAttributeId, x.value])
         );
@@ -72,7 +73,7 @@ export default class PatientHeader extends React.Component<IPatientHeaderProps, 
             >
                 <span className='clinical-spans' id='patient-attributes'>
                     <a href="javascript:void(0)" onClick={()=>this.props.handlePatientClick(patient.id)}>{patient.id}</a>
-                    {getSpanElements(clinicalDataLegacy, 'lgg_ucsf_2014')}
+                    {getSpanElements(clinicalDataLegacy, studyId)}
                 </span>
             </DefaultTooltip>
         );


### PR DESCRIPTION
Fix cbioportal/cbioportal#4170

This re-enables styling of clinical attributes on the patient view on a per study basis