### PR TITLE
Displaying tooltip feedback for async copy actions as well

### DIFF
--- a/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
@@ -19,46 +19,71 @@ export class CopyDownloadButtons extends React.Component<ICopyDownloadButtonsPro
         showCopyMessage: false
     };
 
+    get baseTooltipProps()
+    {
+        return {
+            placement: "top",
+            mouseLeaveDelay: 0,
+            mouseEnterDelay: 0.5
+        };
+    }
+
+    copyButton()
+    {
+        const button = (
+            <button
+                ref={this.props.copyButtonRef}
+                className="btn btn-sm btn-default"
+                data-clipboard-text="NA"
+                id="copyButton"
+                onClick={this.props.handleCopy}
+            >
+                {this.props.copyLabel} <i className='fa fa-clipboard'/>
+            </button>
+        );
+
+        // We need two separate tooltips to properly show/hide "Copied" text, and switch between "Copy" and "Copied".
+        // (Also, we need to manually set the visibility due to async rendering issues after clicking the button)
+        return (
+            <DefaultTooltip
+                overlay={<span className="alert-success">Copied!</span>}
+                visible={this.props.showCopyMessage}
+                {...this.baseTooltipProps}
+            >
+                <DefaultTooltip
+                    overlay={<span>Copy</span>}
+                    visible={this.props.showCopyMessage ? false : undefined}
+                    {...this.baseTooltipProps}
+                >
+                    {button}
+                </DefaultTooltip>
+            </DefaultTooltip>
+        );
+    }
+
+    downloadButton()
+    {
+        return (
+            <DefaultTooltip
+                overlay={<span>Download TSV</span>}
+                {...this.baseTooltipProps}
+            >
+                <Button className="btn-sm" onClick={this.props.handleDownload}>
+                    {this.props.downloadLabel} <i className='fa fa-cloud-download'/>
+                </Button>
+            </DefaultTooltip>
+        );
+    }
+
     public render() {
         return (
             <span className={this.props.className}>
                 <ButtonGroup style={{ marginLeft:10 }} className={this.props.className}>
                     <If condition={this.props.showCopy}>
-                        <DefaultTooltip
-                            overlay={() => {
-                                if (this.props.showCopyMessage) {
-                                    return <span className="alert-success">Copied!</span>;
-                                }
-                                else {
-                                    return <span>Copy</span>;
-                                }
-                            }}
-                            placement="top"
-                            mouseLeaveDelay={0}
-                            mouseEnterDelay={0.5}
-                        >
-                            <button
-                                ref={this.props.copyButtonRef}
-                                className="btn btn-sm btn-default"
-                                data-clipboard-text="NA"
-                                id="copyButton"
-                                onClick={this.props.handleCopy}
-                            >
-                                {this.props.copyLabel} <i className='fa fa-clipboard'/>
-                            </button>
-                        </DefaultTooltip>
+                        {this.copyButton()}
                     </If>
                     <If condition={this.props.showDownload}>
-                        <DefaultTooltip
-                            overlay={<span>Download TSV</span>}
-                            mouseLeaveDelay={0}
-                            mouseEnterDelay={0.5}
-                            placement="top"
-                        >
-                            <Button className="btn-sm" onClick={this.props.handleDownload}>
-                                {this.props.downloadLabel} <i className='fa fa-cloud-download'/>
-                            </Button>
-                        </DefaultTooltip>
+                        {this.downloadButton()}
                     </If>
                 </ButtonGroup>
             </span>

--- a/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
@@ -30,6 +30,7 @@ export class CopyDownloadControls extends React.Component<IAsyncCopyDownloadCont
     @observable downloadingData = false;
     @observable copyingData = false;
     @observable showErrorMessage = false;
+    @observable showTooltipCopyMessage = false;
 
     private _copyButton: HTMLButtonElement|null = null;
     private _modalCopyButton: HTMLButtonElement|null = null;
@@ -39,6 +40,7 @@ export class CopyDownloadControls extends React.Component<IAsyncCopyDownloadCont
 
     public static defaultProps:IAsyncCopyDownloadControlsProps = {
         className: "",
+        copyMessageDuration: 3000,
         showCopy: true,
         showDownload: true,
         downloadFilename: "data.tsv"
@@ -74,13 +76,12 @@ export class CopyDownloadControls extends React.Component<IAsyncCopyDownloadCont
 
     public render()
     {
-        const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
-
         return (
             <span>
                 <CopyDownloadButtons
                     className={this.props.className}
                     showCopy={this.props.showCopy}
+                    showCopyMessage={this.showTooltipCopyMessage}
                     showDownload={this.props.showDownload}
                     copyLabel={this.props.copyLabel}
                     downloadLabel={this.props.downloadLabel}
@@ -197,6 +198,9 @@ export class CopyDownloadControls extends React.Component<IAsyncCopyDownloadCont
                 this._copyText = text;
                 this.copyingData = true;
             }
+            else {
+                this.showSimpleCopyMessage();
+            }
         });
     }
 
@@ -253,5 +257,16 @@ export class CopyDownloadControls extends React.Component<IAsyncCopyDownloadCont
         // promise is rejected: we need to hide the download indicator and show an error message
         this.downloadingData = false;
         this.showErrorMessage = true;
+    }
+
+    @action
+    private showSimpleCopyMessage()
+    {
+        this.showTooltipCopyMessage = true;
+
+        // we only want to show the notification for a limited time
+        setTimeout(() => {
+            this.showTooltipCopyMessage = false;
+        }, this.props.copyMessageDuration);
     }
 }


### PR DESCRIPTION
# What? Why?
Fix cBioPortal/cbioportal/issues/3709.

Changes proposed in this pull request:
- Showing a notification after clicking on the copy button for the mutations tab (in general, for async copy operations)

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)