### PR TITLE
Disallow geneless queries

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1301,13 +1301,17 @@ export class QueryStore
             {
 	            if (this.isGenesetProfileSelected)
                 { //Only geneset profile selected
-                    if (!this.genesetQuery.length) 
+                    if (!this.genesetQuery.length && !this.oql.query.length) 
+                    {
+                        return "Please enter one or more gene symbols and gene sets.";
+                    }
+                    else if (!this.genesetQuery.length)
                     {
                         return "Please enter one or more gene sets or deselect gene set profiles.";
                     }
-                    if (this.oql.query.length)
+                    else if (!this.oql.query.length)
                     {
-                        return "Please select genetic profiles or remove the genes from the query.";
+                        return "Please enter one or more gene symbols.";
                     }
                 }
                 else
@@ -1327,12 +1331,9 @@ export class QueryStore
 	                {
 	                    return "Please enter one or more gene symbols and gene sets.";
 	                }
-	                else if (!this.oql.query.length && this.genesetQuery.length)
+	                else if (!this.oql.query.length)
 	                {
-	                    return "Please enter one or more gene symbols or deselect genetic profiles.";
-	                }
-	                else if (!this.genesetQuery.length && this.oql.query.length) {
-	                    return "Please enter one or more gene sets or deselect gene set profiles.";
+	                    return "Please enter one or more gene symbols.";
 	                }
 	            }
 	            else if (!this.oql.query.length)


### PR DESCRIPTION
The commit "Disallow geneless queries" from #1003 was not properly merged, although it was approved by @adamabeshouse and @alisman. This causes an error in the current cBioPortal as it is allowing queries with only gene sets. I just cherry-picked the commit and added it to master, can we merge it?  
