### PR TITLE
use html5 history routes instead of hashfragments on patient page

### DIFF
--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'mobx-react';
-import { hashHistory, createMemoryHistory, Router } from 'react-router';
+import { hashHistory, browserHistory, createMemoryHistory, Router } from 'react-router';
 import { RouterStore, syncHistoryWithStore  } from 'mobx-react-router';
 import ExtendedRoutingStore from './shared/lib/ExtendedRouterStore';
 import {QueryStore} from "./shared/components/query/QueryStore";
@@ -16,6 +16,9 @@ import { validateParametersPatientView } from './shared/lib/validateParameters';
 import AppConfig from "appConfig";
 import browser from 'bowser';
 import './shared/lib/tracking';
+import 'script-loader!raven-js/dist/raven.js';
+import {correctPatientUrl} from "shared/lib/urlCorrection";
+
 
 if (localStorage.localdev === 'true' || localStorage.localdist === 'true') {
     __webpack_public_path__ = "//localhost:3000/"
@@ -51,17 +54,15 @@ if (localStorage.e2etest) {
     });
 }
 
+// this is to support old hash fragment style urls (from first round of 2017 refactoring)
+// we want to convert hash fragment route to HTML5 style route
+if (/#[^\?]*\?/.test(window.location.hash)) {
+    window.history.replaceState(null,null,correctPatientUrl(window.location.href));
+}
+
 // expose version on window
 window.FRONTEND_VERSION = VERSION;
 window.FRONTEND_COMMIT = COMMIT;
-
-import 'script-loader!raven-js/dist/raven.js';
-
-// explose jquery globally if it doesn't exist
-// if (!window.hasOwnProperty("jQuery")) {
-//     window.$ = $;
-//     window.jQuery = $;
-// }
 
 if (/cbioportal\.mskcc\.org|www.cbioportal\.org/.test(window.location.hostname) || window.localStorage.getItem('sentry') === 'true') {
     Raven.config('https://c93645c81c964dd284436dffd1c89551@sentry.io/164574', {
@@ -79,9 +80,20 @@ _.noConflict();
 
 const routingStore = new ExtendedRoutingStore();
 
-//sometimes we need to use memory history where there would be a conflict with
-//existing use of url hashfragment
-const history = (AppConfig.historyType === 'memory') ? createMemoryHistory() : hashHistory;
+//determine history type
+let history;
+switch (window.defaultRoute) {
+    case "/patient":
+        // these pages are going to use state of-the-art browser history
+        // when refactoring is done, all pages will use this
+        history = browserHistory;
+        break;
+    default:
+        // legacy pages will use memory history so as not to interfere
+        // with old url params
+        history = createMemoryHistory();
+        break;
+}
 
 const syncedHistory = syncHistoryWithStore(history, routingStore);
 

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -1,5 +1,6 @@
 export interface IAppConfig {
     apiRoot?: string;
+    baseUrl?:string;
     frontendUrl?: string;
     genomespaceEnabled: boolean;
     skinExampleStudyQueries: string[]; // in query the example searches

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -35,6 +35,7 @@ import { getMouseIcon } from './SVGIcons';
 
 import './patient.scss';
 import IFrameLoader from "../../shared/components/iframeLoader/IFrameLoader";
+import {getSampleViewUrl} from "../../shared/api/urls";
 
 const patientViewPageStore = new PatientViewPageStore();
 
@@ -66,8 +67,8 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
 
         //TODO: this should be done by a module so that it can be reused on other pages
         const reaction1 = reaction(
-            () => props.routing.location.query,
-            query => {
+            () => [props.routing.location.query, props.routing.location.hash],
+            ([query,hash]) => {
 
                 const validationResult = validateParametersPatientView(query);
 
@@ -85,11 +86,15 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                         patientViewPageStore.setSampleId(query.sampleId as string);
                     }
 
-                    let patientIdsInCohort = ('navCaseIds' in query ? (query.navCaseIds as string).split(",") : []);
+                    // if there is a navCaseId list in url
+                    const navCaseIdMatch = hash.match(/navCaseIds=([^&]*)/);
+                    if (navCaseIdMatch && navCaseIdMatch.length > 1) {
+                        const navCaseIds = navCaseIdMatch[1].split(',');
+                        patientViewPageStore.patientIdsInCohort = navCaseIds.map((entityId:string)=>{
+                            return entityId.includes(':') ? entityId : patientViewPageStore.studyId + ':' + entityId;
+                        });
+                    }
 
-                    patientViewPageStore.patientIdsInCohort = patientIdsInCohort.map(entityId=>{
-                        return entityId.includes(':') ? entityId : patientViewPageStore.studyId + ':' + entityId;
-                    });
                 } else {
                     patientViewPageStore.urlValidationError = validationResult.message;
                 }
@@ -229,7 +234,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                         {isPDX && getMouseIcon()}
                                         {isPDX && '\u00A0'}
                                         <a
-                                            href={`case.do?#/patient?sampleId=${sample.id}&studyId=${patientViewPageStore.studyMetaData.result!.studyId}`}
+                                            href={getSampleViewUrl(patientViewPageStore.studyMetaData.result!.studyId, sample.id)}
                                             target="_blank"
                                             onClick={(e: React.MouseEvent<HTMLAnchorElement>) => this.handleSampleClick(sample.id, e)}
                                         >

--- a/src/pages/resultsView/enrichments/MiniBoxPlot.tsx
+++ b/src/pages/resultsView/enrichments/MiniBoxPlot.tsx
@@ -15,6 +15,7 @@ import { getDownloadContent, getAlterationsTooltipContent, shortenGenesLabel,
     getBoxPlotModels, getBoxPlotScatterData } from 'pages/resultsView/enrichments/EnrichmentsUtil';
 import autobind from 'autobind-decorator';
 import CBIOPORTAL_VICTORY_THEME from "../../../shared/theme/cBioPoralTheme";
+import {getSampleViewUrl} from "../../../shared/api/urls";
 
 export interface IMiniBoxPlotProps {
     selectedGeneHugo: string;
@@ -166,8 +167,8 @@ export default class MiniBoxPlot extends React.Component<IMiniBoxPlotProps, {}> 
                                 <Popover positionLeft={this.tooltipModel.x + 22} 
                                     positionTop={this.tooltipModel.y - 22} className="cbioTooltip"
                                     onMouseEnter={this.tooltipMouseEnter} onMouseLeave={this.tooltipMouseLeave}>
-                                    <a href={'/case.do#/patient?sampleId=' + this.tooltipModel.datum.sampleId + '&studyId=' +
-                                    this.tooltipModel.datum.studyId} target="_blank"><b>{this.tooltipModel.datum.sampleId}</b></a><br />
+                                    <a href={getSampleViewUrl(this.tooltipModel.datum.studyId, this.tooltipModel.datum.sampleId)} target="_blank"><b>{this.tooltipModel.datum.sampleId}</b></a>
+                                    <br />
                                     mRNA expression: {this.tooltipModel.datum.y.toFixed(3)}<br />
                                     Alteration(s): {this.tooltipModel.datum.alterations}
                                 </Popover>

--- a/src/pages/resultsView/survival/SurvivalChart.tsx
+++ b/src/pages/resultsView/survival/SurvivalChart.tsx
@@ -18,6 +18,7 @@ import {
 } from "./SurvivalUtil";
 import CBIOPORTAL_VICTORY_THEME from "../../../shared/theme/cBioPoralTheme";
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
+import {getPatientViewUrl} from "../../../shared/api/urls";
 
 export interface ISurvivalChartProps {
     alteredPatientSurvivals: PatientSurvival[];
@@ -236,8 +237,7 @@ export default class SurvivalChart extends React.Component<ISurvivalChartProps, 
                         positionTop={this.tooltipModel.y - 60}
                         onMouseEnter={this.tooltipMouseEnter} onMouseLeave={this.tooltipMouseLeave}>
                         <div>
-                            Patient ID: <a href={'/case.do#/patient?caseId=' + this.tooltipModel.datum.patientId + '&studyId=' +
-                                this.tooltipModel.datum.studyId} target="_blank">{this.tooltipModel.datum.patientId}</a><br />
+                            Patient ID: <a href={getPatientViewUrl(this.tooltipModel.datum.studyId, this.tooltipModel.datum.patientId)} target="_blank">{this.tooltipModel.datum.patientId}</a><br />
                             {this.props.yLabelTooltip}: {(this.tooltipModel.datum.y).toFixed(2)}%<br />
                             {this.tooltipModel.datum.status ? this.props.xLabelWithEventTooltip :
                                 this.props.xLabelWithoutEventTooltip}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -3,6 +3,7 @@ import { Route, Redirect, IndexRedirect } from 'react-router';
 import { inject } from 'mobx-react';
 import Container from 'appShell/App/Container';
 import { restoreRouteAfterRedirect } from './shared/lib/redirectHelpers';
+import AppConfig from "appConfig";
 
 /* HOW TO ADD A NEW ROUTE
 * 1. Import the "page" component using the bundle-loader directives as seen in imports below
@@ -21,6 +22,7 @@ import TestimonialsPage from 'pages/staticPages/testimonialsPage/TestimonialsPag
 import DatasetPage from 'bundle-loader?lazy!babel-loader!./pages/datasetView/DatasetPage';
 import StudyViewPage from 'bundle-loader?lazy!babel-loader!./pages/studyView/StudyViewPage';
 import './globalComponents';
+import {getBasePath} from "shared/api/urls";
 
 // accepts bundle-loader's deferred loader function and defers execution of route's render
 // until chunk is loaded
@@ -48,16 +50,21 @@ let getBlankPage = function(){
     return <div />
 }
 
+console.log(getBasePath());
+
 export const makeRoutes = (routing) => {
     return (<Route path="/" component={Container}>
-        <Route path="/home" getComponent={lazyLoadComponent(HomePage)}/>
-        <Route path="/patient" getComponent={lazyLoadComponent(PatientViewPage)}/>
-        <Route path="/datasets" getComponent={lazyLoadComponent(DatasetPage)} />
-        <Route path="/restore" component={restoreRoute}/>
-        <Route path="/testimonials" component={TestimonialsPage}/>
-        <Route path="/blank" component={getBlankPage}/>
-        <Route path="/results" getComponent={lazyLoadComponent(ResultsViewPage)} />
-        <Route path="/study" getComponent={lazyLoadComponent(StudyViewPage)} />
+                <Route path="/home" getComponent={lazyLoadComponent(HomePage)}/>
+                <Route path="/datasets" getComponent={lazyLoadComponent(DatasetPage)} />
+                <Route path="/restore" component={restoreRoute}/>
+                <Route path="/testimonials" component={TestimonialsPage}/>
+                <Route path="/blank" component={getBlankPage}/>
+                <Route path="/results" getComponent={lazyLoadComponent(ResultsViewPage)} />
+                <Route path={getBasePath()}>
+                    <Route path="patient" getComponent={lazyLoadComponent(PatientViewPage)}/>
+                </Route>
+                <IndexRedirect to={defaultRoute}/>
+                <Route path="/study" getComponent={lazyLoadComponent(StudyViewPage)} />
         <IndexRedirect to={defaultRoute}/>
     </Route>)
 };

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -44,10 +44,10 @@ export function openStudySummaryFormSubmit(studyIds: string | ReadonlyArray<stri
     formSubmit(params.pathname, params.query, "_blank", method);
 }
 export function getSampleViewUrl(studyId:string, sampleId:string) {
-    return cbioUrl('case.do', {}, `/patient?studyId=${studyId}&sampleId=${sampleId}`);
+    return cbioUrl('patient', { sampleId, studyId });
 }
-export function getPatientViewUrl(studyId:string, patientId:string) {
-    return cbioUrl('case.do', {}, `/patient?studyId=${studyId}&caseId=${patientId}`);
+export function getPatientViewUrl(studyId:string, caseId:string) {
+    return cbioUrl('patient', { studyId, caseId });
 }
 export function getPubMedUrl(pmid:string) {
     return `https://www.ncbi.nlm.nih.gov/pubmed/${pmid}`;
@@ -112,4 +112,8 @@ export function getDarwinUrl(sampleIds:string[], caseId:string) {
 
 export function getStudyDownloadListUrl(){
     return cbioUrl('proxy/download.cbioportal.org/study_list.json');
+}
+
+export function getBasePath(){
+    return AppConfig.baseUrl!.replace(/[^\/]*/,"");
 }

--- a/src/shared/components/mutationTable/column/SampleColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/SampleColumnFormatter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {MolecularProfile, Mutation} from "shared/api/generated/CBioPortalAPI";
 import TruncatedText from "shared/components/TruncatedText";
+import {getPatientViewUrl, getSampleViewUrl} from "../../../api/urls";
 
 /**
  * @author Selcuk Onur Sumer
@@ -37,21 +38,8 @@ export default class SampleColumnFormatter
             const profile = molecularProfileIdToMolecularProfile[data[0].molecularProfileId];
             const studyId = profile && profile.studyId;
             if (studyId) {
-                let linkToPatientView:string = `#/patient?sampleId=${sampleId}&studyId=${studyId}`;
-                /**
-                 * HACK to deal with having mutation mapper on index.do
-                 * Change it to case.do
-                 * https://github.com/cBioPortal/cbioportal/issues/2783
-                 */
-                const indexLocation:number = window.location.href.search('index.do');
-                if (indexLocation > -1) {
-                    linkToPatientView = window.location.href.substring(0, indexLocation) + 'case.do' + linkToPatientView;
-                }
-                // END HACK
-
-
                 content = (
-                    <a href={linkToPatientView} target='_blank'>
+                    <a href={getSampleViewUrl(studyId, sampleId)} target='_blank'>
                         {content}
                     </a>
                 );

--- a/src/shared/components/rightbar/RightBar.tsx
+++ b/src/shared/components/rightbar/RightBar.tsx
@@ -125,7 +125,7 @@ export default class RightBar extends React.Component<IRightBarProps, IRightBarS
                         <a href="ln?q=BRAF:MUT=V600E">BRAF V600E mutations across cancer types</a>
                     </li>
                     <li>
-                        <a href="case.do#/patient?studyId=ucec_tcga_pub&caseId=TCGA-BK-A0CC">Patient view of an endometrial cancer case</a>
+                        <a href="patient?studyId=ucec_tcga_pub&caseId=TCGA-BK-A0CC">Patient view of an endometrial cancer case</a>
                     </li>
                 </ul>
             </div>

--- a/src/shared/lib/ExtendedRouterStore.ts
+++ b/src/shared/lib/ExtendedRouterStore.ts
@@ -20,7 +20,7 @@ export default class ExtendedRouterStore extends RouterStore {
         // put a leading slash if there isn't one
         path = URL.resolve('/', path);
 
-        this.push( URL.format({pathname: path, query: newQuery}) );
+        this.push( URL.format({pathname: path, query: newQuery, hash:this.location.hash}) );
 
     }
 

--- a/src/shared/lib/urlCorrection.spec.ts
+++ b/src/shared/lib/urlCorrection.spec.ts
@@ -1,0 +1,26 @@
+import {assert} from 'chai';
+import { correctPatientUrl } from "./urlCorrection";
+
+describe('correctPatientUrl', () => {
+
+    it('corrects hash route scheme to standard route (html5) but leaves navCaseIds as hash param', () => {
+
+        let before = 'http://www.cbioportal.org/case.do#/patient?studyId=chol_nus_2012&caseId=B085&navCaseIds=B085,B099,R104,T026,U044,W012,W039,W040';
+        let after = 'http://www.cbioportal.org/patient?studyId=chol_nus_2012&caseId=B085#&navCaseIds=B085,B099,R104,T026,U044,W012,W039,W040';
+
+        assert.equal(correctPatientUrl(before), after);
+
+        before = 'http://www.cbioportal.org/case.do#/patient?studyId=chol_nus_2012&navCaseIds=B085,B099,R104,T026,U044,W012,W039,W040&caseId=B085';
+        after = 'http://www.cbioportal.org/patient?studyId=chol_nus_2012&caseId=B085#&navCaseIds=B085,B099,R104,T026,U044,W012,W039,W040';
+
+        assert.equal(correctPatientUrl(before), after, 'handles params after navCaseIds');
+
+    });
+
+    it('leaves a correct url untouched', () => {
+        const correct = 'http://www.cbioportal.org/patient?studyId=chol_nus_2012&caseId=B085#navCaseIds=B085,B099,R104,T026,U044,W012,W039,W040';
+        assert.equal(correctPatientUrl(correct), correct);
+    });
+
+
+});

--- a/src/shared/lib/urlCorrection.ts
+++ b/src/shared/lib/urlCorrection.ts
@@ -1,0 +1,20 @@
+/*
+ * takes legacy style (hashRouter e.g. #/patient?patientId=x&navCaseIds=1,2,3,4) and
+ * rewrites it has a html5 history url (regular path and qstring params)
+ * BUT navCaseIds still need to be in # fragment to avoid url length limit
+ */
+export function correctPatientUrl(url:string){
+
+    let correctedUrl = url.replace(/#/,"");
+
+    correctedUrl = correctedUrl.replace(/\/case\.do/,"");
+
+    // once corrected, check to make sure that navCaseIds is appended as a hash fragment
+    const navCaseIds = correctedUrl.match(/&*navCaseIds=[^&]*/);
+    if (navCaseIds) {
+        correctedUrl = correctedUrl.replace(navCaseIds[0],"") + "#" + navCaseIds;
+    }
+
+    return correctedUrl
+
+}


### PR DESCRIPTION
Google will not index ajax pages routed  #hash fragments.  This PR changes patient page to use html5 history style routes.  

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
