### PR TITLE
Fixed LazyMobxTable filter reset issue 

### DIFF
--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -1059,6 +1059,17 @@ describe('LazyMobXTable', ()=>{
             clock.tick(1000);
             assert.equal(table.find(SimpleTable).props().rows.length, data.length);
         });
+        it("keeps filtering intact even after re-rendering", ()=>{
+            const filterString = "asdfj";
+            const table = mount(<Table columns={columns} data={data}/>);
+            simulateTableSearchInput(table, filterString);
+            clock.tick(1000);
+            assert.equal(table.find(SimpleTable).props().rows.length, 1);
+
+            // force re-render
+            table.update();
+            assert.equal(table.find(SimpleTable).props().rows.length, 1);
+        });
     });
     describe('downloading data', ()=>{
         it("gives just the column names when theres no data in the table", async ()=>{

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -194,7 +194,7 @@ function getDownloadObject<T>(columns: Column<T>[], rowData: T) {
 }
 
 class LazyMobXTableStore<T> {
-    @observable public filterString:string;
+    public filterString:string|undefined;
     @observable private _page:number;
     @observable private _itemsPerPage:number;
     @observable private _itemsLabel:string|undefined;
@@ -254,14 +254,6 @@ class LazyMobXTableStore<T> {
 
     @computed get maxPage() {
         return maxPage(this.displayData.length, this.itemsPerPage);
-    }
-
-    @computed get filterStringUpper() {
-        return this.filterString.toUpperCase();
-    }
-
-    @computed get filterStringLower() {
-        return this.filterString.toLowerCase();
     }
 
     @computed public get columnVisibility() {
@@ -484,6 +476,9 @@ class LazyMobXTableStore<T> {
     }
 
     @action setFilterString(str:string) {
+        // we need to keep the filter string value in this store as well as in the data store,
+        // because data store gets reset each time the component receives props.
+        this.filterString = str;
         this.dataStore.filterString = str;
         this.page = 0;
         this.dataStore.setFilter((d:T, filterString:string, filterStringUpper:string, filterStringLower:string)=>{
@@ -539,6 +534,11 @@ class LazyMobXTableStore<T> {
         if (this.dataStore.sortMetric === undefined) {
             this.dataStore.sortMetric = this.sortMetric;
         }
+
+        // we would like to keep the previous filter if exists
+        if (this.filterString) {
+            this.setFilterString(this.filterString);
+        }
     }
 
     @action updateColumnVisibility(id:string, visible:boolean)
@@ -561,7 +561,6 @@ class LazyMobXTableStore<T> {
     }
 
     constructor(lazyMobXTableProps:LazyMobXTableProps<T>) {
-        this.filterString = "";
         this.sortColumn = lazyMobXTableProps.initialSortColumn || "";
         this.sortAscending = (lazyMobXTableProps.initialSortDirection !== "desc"); // default ascending
         this.setProps(lazyMobXTableProps);


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal-frontend/issues/1071.

Changes proposed in this pull request:
- Restoring the `store.dataStore.filterString` value for `LazyMobXTable` after each re-render

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)