### PR TITLE
Enable selecting custom backend on heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: http-server --cors dist/ -p ${PORT}
+web: ls dist.backup || cp -a dist/ dist.backup; cp -a dist.backup dist; for f in $(find dist/); do sed -i "s|replace_me_env_cbioportal_url|${CBIOPORTAL_URL:-http\://www.cbioportal.org}|g" $f; sed -i "s|replace_me_env_genome_nexus_url|${GENOME_NEXUS_URL:-https\://www.genomenexus.org}|g" $f; done && http-server --cors dist/ -p ${PORT}

--- a/app.json
+++ b/app.json
@@ -8,5 +8,15 @@
         {
           "url": "https://github.com/heroku/heroku-buildpack-nodejs#v91"
         }
-    ]
+    ],
+    "env": {
+        "CBIOPORTAL_URL": {
+            "description":"Don't change this on first build. Then use this to set backend url to e.g. http://www.cbioportal.org/beta",
+			"required": false
+        },
+        "GENOME_NEXUS_URL": {
+            "description":"Don't change on first build. Then use this to change genome nexus url to e.g. https://beta.genomenexus.org",
+			"required": false
+        }
+    }
 }

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -3,7 +3,11 @@ import AppConfig from "appConfig";
 import formSubmit from "shared/lib/formSubmit";
 
 export function getHost(){
-    return AppConfig.apiRoot;
+    if (typeof AppConfig.apiRoot === 'string') {
+        return AppConfig.apiRoot.replace(/^http[s]?:\/\//,'').replace(/\/$/,""); // get rid of protocol and trailing slashes
+    } else {
+        return AppConfig.apiRoot;
+    }
 }
 
 export type BuildUrlParams = {pathname:string, query?:QueryParams, hash?:string};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,8 +120,8 @@ var config = {
         new webpack.DefinePlugin({
             'VERSION': version, 
             'COMMIT': commit,
-            'ENV_CBIOPORTAL_URL': process.env.CBIOPORTAL_URL? JSON.stringify(cleanUrl(process.env.CBIOPORTAL_URL)) : '"unknown"',
-            'ENV_GENOME_NEXUS_URL': process.env.GENOME_NEXUS_URL? JSON.stringify(cleanUrl(process.env.GENOME_NEXUS_URL)) : '"unkown"',
+            'ENV_CBIOPORTAL_URL': process.env.CBIOPORTAL_URL? JSON.stringify(cleanUrl(process.env.CBIOPORTAL_URL)) : '"replace_me_env_cbioportal_url"',
+            'ENV_GENOME_NEXUS_URL': process.env.GENOME_NEXUS_URL? JSON.stringify(cleanUrl(process.env.GENOME_NEXUS_URL)) : '"replace_me_env_genome_nexus_url"',
         }),
         new HtmlWebpackPlugin({cache: false, template: 'my-index.ejs'}),
         WebpackFailPlugin,


### PR DESCRIPTION
Enable selection of a custom backend on heroku by changing env variables. Also, heroku was broken in general (backend api url was always unknown). This makes the standalone work again