### PR TITLE
Mutationmapper handle p. hgvspShort prefix

### DIFF
--- a/src/shared/lib/MutationAnnotator.ts
+++ b/src/shared/lib/MutationAnnotator.ts
@@ -88,6 +88,10 @@ export function annotateMutation(mutation: Mutation,
 
         if (canonicalTranscript) {
             annotatedMutation.proteinChange = annotatedMutation.proteinChange || canonicalTranscript.hgvspShort;
+            // remove p. prefix if exists
+            if (annotatedMutation.proteinChange) {
+                annotatedMutation.proteinChange = annotatedMutation.proteinChange.replace(/^p./,"");
+            }
             annotatedMutation.mutationType = annotatedMutation.mutationType || canonicalTranscript.variantClassification;
 
             if (canonicalTranscript.proteinPosition) {


### PR DESCRIPTION
In case HGVSp_Short has p. in column, remove it. This way we can handle both `hgvspShort` formats.