### PR TITLE
Use opacity to hide hit zones in mutation lollipop plot (fixes PDF do…

### DIFF
--- a/src/shared/components/downloadControls/DownloadControls.tsx
+++ b/src/shared/components/downloadControls/DownloadControls.tsx
@@ -53,7 +53,7 @@ function makeMenuItem(spec:ButtonSpec) {
 
 @observer
 export default class DownloadControls extends React.Component<IDownloadControlsProps, {}> {
-    private svgsaver = new SvgSaver({},{});
+    private svgsaver = new SvgSaver();
     @observable private collapsed = true;
 
     @autobind
@@ -124,7 +124,7 @@ export default class DownloadControls extends React.Component<IDownloadControlsP
     }
 
     @computed get buttonSpecs() {
-        const middleButtons = (this.props.buttons || ["SVG", "PNG"]).map(x=>this.downloadControlsButtons[x]);
+        const middleButtons = (this.props.buttons || ["SVG", "PNG", "PDF"]).map(x=>this.downloadControlsButtons[x]);
         return (this.props.additionalLeftButtons || []).concat(middleButtons).concat(this.props.additionalRightButtons || []);
     }
 

--- a/src/shared/components/lollipopMutationPlot/Domain.tsx
+++ b/src/shared/components/lollipopMutationPlot/Domain.tsx
@@ -101,6 +101,7 @@ export default class Domain extends React.Component<DomainProps, {}> {
         if (reference) {
             props.ref=this.handlers.textRef;
             props.visibility="hidden";
+            props.style={opacity:0};
             props.className=this.props.hitzoneClassName;
         }
         return (<text {...props}>{text}</text>);
@@ -124,7 +125,7 @@ export default class Domain extends React.Component<DomainProps, {}> {
                     y={this.props.y}
                     width={this.props.width}
                     height={this.props.height}
-                    fill="rgba(0,0,0,0)"
+                    style={{opacity:0}}
                 />
             </g>
         );

--- a/src/shared/components/lollipopMutationPlot/Lollipop.tsx
+++ b/src/shared/components/lollipopMutationPlot/Lollipop.tsx
@@ -80,11 +80,11 @@ export default class Lollipop extends React.Component<LollipopProps, {}> {
                 />
                 <circle
                     className={this.props.hitzoneClassName}
-                    fill="rgba(0,0,0,0)"
                     r={this.props.hoverHeadRadius}
                     cx={this.circleX}
                     cy={this.circleY}
                     cursor="pointer"
+                    style={{opacity:0}}
                 />
                 {label}
             </g>

--- a/src/shared/components/lollipopMutationPlot/Sequence.tsx
+++ b/src/shared/components/lollipopMutationPlot/Sequence.tsx
@@ -50,7 +50,7 @@ export default class Sequence extends React.Component<ISequenceProps, {}> {
                     y={this.props.y}
                     width={this.props.width}
                     height={this.props.height}
-                    fill="rgba(0,0,0,0)"
+                    style={{opacity:0}}
                 />
             </g>
         );


### PR DESCRIPTION
…wnload issue)

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
