### PR TITLE
Filter mutationMapperTool by transcriptid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6018,9 +6018,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
           }
         },
         "fs.realpath": {
@@ -6113,8 +6113,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "optional": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "has-unicode": {
@@ -6175,7 +6175,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
@@ -6267,7 +6267,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "requires": {
-            "mime-db": "~1.27.0"
+            "mime-db": "1.27.0"
           }
         },
         "minimatch": {
@@ -6275,7 +6275,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.7"
           }
         },
         "minimist": {

--- a/src/pages/tools/mutationMapper/MutationMapperTool.tsx
+++ b/src/pages/tools/mutationMapper/MutationMapperTool.tsx
@@ -115,8 +115,8 @@ export default class MutationMapperTool extends React.Component<IMutationMapperT
             return (
                 <div className="standalone-mutation-input">
                     <p>
-                        Please input <b>tab-delimited</b> mutation data. (Load example data:
-                        <span> <a onClick={this.handleLoadExampleGenomicCoordinates}>Genomic Changes</a></span>,
+                        Please input <b>tab-delimited</b> or <b>space-delimited</b> mutation data. (Load example data:
+                        <span> <a onClick={this.handleLoadExampleGenomicCoordinates} data-test="GenomicChangesExampleButton">Genomic Changes</a></span>,
                         <span> <a onClick={this.handleLoadExampleGeneAndProteinChange}>Protein Changes</a></span>,
                         <span> <a onClick={this.handleLoadExamplePartiallyAnnotated}>Genomic and Protein Changes</a></span>)
                     </p>
@@ -147,6 +147,7 @@ export default class MutationMapperTool extends React.Component<IMutationMapperT
                         className="btn btn-lg btn-primary"
                         onClick={this.handleVisualize}
                         disabled={this.inputContent.length === 0}
+                        data-test="MutationMapperToolVisualizeButton"
                     >
                         Visualize
                     </button>

--- a/src/pages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -8,9 +8,11 @@ import {remoteData} from "shared/api/remoteData";
 import {ClinicalData, Gene, Mutation} from "shared/api/generated/CBioPortalAPI";
 import {
     fetchGenes, fetchMyCancerGenomeData, fetchOncoKbAnnotatedGenes, fetchOncoKbData,
-    ONCOKB_DEFAULT
+    ONCOKB_DEFAULT,
+    fetchCanonicalEnsemblGeneIds,
+    getCanonicalTranscriptsByHugoSymbol
 } from "shared/lib/StoreUtils";
-import {annotateMutations, resolveDefaultsForMissingValues} from "shared/lib/MutationAnnotator";
+import {annotateMutations, resolveDefaultsForMissingValues, fetchVariantAnnotationsIndexedByGenomicLocation, filterMutationsByTranscriptId} from "shared/lib/MutationAnnotator";
 import {getClinicalData, getGeneList, mutationInputToMutation, MutationInput} from "shared/lib/MutationInputParser";
 import {updateMissingGeneInfo} from "shared/lib/MutationUtils";
 import {IOncoKbData} from "shared/model/OncoKB";
@@ -21,6 +23,7 @@ import PubMedCache from "shared/cache/PubMedCache";
 import GenomeNexusEnrichmentCache from "shared/cache/GenomeNexusEnrichment";
 import PdbHeaderCache from "shared/cache/PdbHeaderCache";
 import MutationMapperStore from "shared/components/mutationMapper/MutationMapperStore";
+import { VariantAnnotation, EnsemblTranscript } from "shared/api/generated/GenomeNexusAPI";
 
 export default class MutationMapperToolStore
 {
@@ -34,11 +37,31 @@ export default class MutationMapperToolStore
         invoke: () => fetchGenes(this.hugoGeneSymbols.result)
     }, []);
 
+    readonly canonicalTranscriptsByHugoSymbol = remoteData<{[hugoGeneSymbol:string]:EnsemblTranscript} | undefined>({
+        await: () => [
+            this.hugoGeneSymbols
+        ],
+        invoke: async()=>{
+            if (this.hugoGeneSymbols.result) {
+                return getCanonicalTranscriptsByHugoSymbol(this.hugoGeneSymbols.result, this.isoformOverrideSource);
+            } else {
+                return undefined;
+            }
+        },
+        onError: (err: Error) => {
+            throw new Error("Failed to get canonical transcript");
+        }
+    }, undefined);
+
+    @computed get isoformOverrideSource(): string {
+        return AppConfig.isoformOverrideSource || "uniprot";
+    }
+
     readonly hugoGeneSymbols = remoteData({
         await: () => [
-            this.annotatedMutations
+            this.indexedVariantAnnotations
         ],
-        invoke: () => Promise.resolve(getGeneList(this.annotatedMutations.result))
+        invoke: () => Promise.resolve(getGeneList(this.annotatedMutations))
     }, []);
 
     readonly oncoKbAnnotatedGenes = remoteData({
@@ -90,14 +113,14 @@ export default class MutationMapperToolStore
 
     readonly mutations = remoteData<Mutation[]>({
         await: () => [
-            this.annotatedMutations,
+            this.indexedVariantAnnotations,
             this.genes
         ],
         invoke: () => {
             let mutations: Mutation[] = [];
 
-            if (this.annotatedMutations.result) {
-                mutations =  this.annotatedMutations.result;
+            if (this.annotatedMutations) {
+                mutations =  this.annotatedMutations;
                 resolveDefaultsForMissingValues(mutations);
                 updateMissingGeneInfo(mutations, this.genesByHugoSymbol);
             }
@@ -106,12 +129,12 @@ export default class MutationMapperToolStore
         }
     }, []);
 
-    readonly annotatedMutations = remoteData<Mutation[]>({
-        invoke: async () => await annotateMutations(this.rawMutations),
+    readonly indexedVariantAnnotations = remoteData<{[genomicLocation: string]: VariantAnnotation} | undefined>({
+        invoke: async () => await fetchVariantAnnotationsIndexedByGenomicLocation(this.rawMutations),
         onError: (err: Error) => {
             this.criticalErrors.push(err);
         }
-    }, []);
+    }, undefined);
 
     readonly hotspotData = remoteData({
         await:()=>[
@@ -133,7 +156,9 @@ export default class MutationMapperToolStore
         await: () => [
             this.genes,
             this.mutations,
-            this.uniqueSampleKeyToTumorType
+            this.uniqueSampleKeyToTumorType,
+            this.indexedVariantAnnotations,
+            this.canonicalTranscriptsByHugoSymbol
         ],
         invoke: () => {
             if (this.genes.result) {
@@ -141,9 +166,21 @@ export default class MutationMapperToolStore
                 //  an Immutable as the result of reduce, and MutationMapperStore when it is made immutable all the
                 //  mobx machinery going on in the readonly remoteDatas and observables somehow gets messed up.
                 return Promise.resolve(_.reduce(this.genes.result, (map: { [hugoGeneSymbol: string]: MutationMapperStore }, gene: Gene) => {
+                    // only pass mutations to the component that apply to the given transcript id
+                    const canonicalTranscriptId = this.canonicalTranscriptsByHugoSymbol.result && this.canonicalTranscriptsByHugoSymbol.result[gene.hugoGeneSymbol]? 
+                        this.canonicalTranscriptsByHugoSymbol.result[gene.hugoGeneSymbol].transcriptId : undefined;
+                    
+                    const getMutations = () => {
+                        if (canonicalTranscriptId && this.indexedVariantAnnotations.result) {
+                            return filterMutationsByTranscriptId(this.mutations.result, canonicalTranscriptId, this.indexedVariantAnnotations.result);
+                        } else {
+                            return this.mutationsByGene[gene.hugoGeneSymbol];
+                        }
+                    };
+
                     map[gene.hugoGeneSymbol] = new MutationMapperStore(AppConfig,
                         gene,
-                        ()=>this.mutationsByGene[gene.hugoGeneSymbol],
+                        getMutations,
                         this.indexedHotspotData,
                         this.oncoKbAnnotatedGenes.result || {},
                         this.oncoKbData,
@@ -165,6 +202,11 @@ export default class MutationMapperToolStore
     @computed get rawMutations(): Mutation[]
     {
         return mutationInputToMutation(this.mutationData) as Mutation[] || [];
+    }
+
+    @computed get annotatedMutations(): Mutation[]
+    {
+        return this.indexedVariantAnnotations.result? annotateMutations(this.rawMutations, this.indexedVariantAnnotations.result) : [];
     }
 
     @computed get mutationsByGene(): {[hugoGeneSymbol:string]: Mutation[]} {

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -830,7 +830,7 @@ export default class LazyMobXTable<T> extends React.Component<LazyMobXTableProps
 
     render() {
         return (
-            <div>
+            <div data-test="LazyMobXTable">
                 <Observer>
                     {this.getTopToolbar}
                 </Observer>

--- a/src/shared/lib/MutationAnnotator.spec.ts
+++ b/src/shared/lib/MutationAnnotator.spec.ts
@@ -2,9 +2,10 @@ import {assert} from "chai";
 import sinon from 'sinon';
 import * as _ from 'lodash';
 
-import {annotateMutations, resolveMissingProteinPositions} from "./MutationAnnotator";
+import {annotateMutations, resolveMissingProteinPositions, fetchVariantAnnotationsIndexedByGenomicLocation} from "./MutationAnnotator";
 import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import {initMutation} from "test/MutationMockUtils";
+import { VariantAnnotation } from "shared/api/generated/GenomeNexusAPI";
 
 describe("MutationAnnotator", () => {
     const fetchStubResponse = [
@@ -362,7 +363,11 @@ describe("MutationAnnotator", () => {
                 fetchVariantAnnotationByGenomicLocationPOST: fetchStub
             };
 
-            annotateMutations([], genomeNexusClient).then((data: Mutation[]) => {
+            fetchVariantAnnotationsIndexedByGenomicLocation(
+                [],
+                genomeNexusClient
+            ).then((indexedVariantAnnotations: {[genomicLocation: string]: VariantAnnotation}) => {
+                const data = annotateMutations([], indexedVariantAnnotations);
                 assert.equal(data.length, 0, "annotated mutation data should be empty");
                 assert.isFalse(fetchStub.called, "variant annotation fetcher should NOT be called");
                 done();
@@ -377,7 +382,12 @@ describe("MutationAnnotator", () => {
                 fetchVariantAnnotationByGenomicLocationPOST: fetchStub
             };
 
-            annotateMutations(_.cloneDeep(mutationsWithNoGenomicLocation), genomeNexusClient).then((data: Mutation[]) => {
+            fetchVariantAnnotationsIndexedByGenomicLocation(
+                _.cloneDeep(mutationsWithNoGenomicLocation),
+                genomeNexusClient
+            ).then((indexedVariantAnnotations: {[genomicLocation: string]: VariantAnnotation}) => {
+                const data = annotateMutations(_.cloneDeep(mutationsWithNoGenomicLocation), indexedVariantAnnotations);
+
                 assert.deepEqual(data, mutationsWithNoGenomicLocation,
                     "annotated mutation data should be identical to the initial input");
                 assert.isFalse(fetchStub.called,
@@ -395,7 +405,12 @@ describe("MutationAnnotator", () => {
                 fetchVariantAnnotationByGenomicLocationPOST: fetchStub
             };
 
-            annotateMutations(_.cloneDeep(mutationsWithGenomicLocation), genomeNexusClient).then((data: Mutation[]) => {
+            fetchVariantAnnotationsIndexedByGenomicLocation(
+                _.cloneDeep(mutationsWithGenomicLocation),
+                genomeNexusClient
+            ).then((indexedVariantAnnotations: {[genomicLocation: string]: VariantAnnotation}) => {
+                const data = annotateMutations(_.cloneDeep(mutationsWithGenomicLocation), indexedVariantAnnotations);
+
                 assert.notDeepEqual(data, mutationsWithGenomicLocation,
                     "annotated mutation data should be different than the initial input");
                 assert.isTrue(fetchStub.called,

--- a/src/shared/lib/MutationInputParser.spec.ts
+++ b/src/shared/lib/MutationInputParser.spec.ts
@@ -143,7 +143,8 @@ describe("MutationInputParser", () => {
     });
 
     it("extracts mutation input headers", () => {
-        const richInputIndexMap = buildIndexMap(partiallyAnnotatedMutationInput.split("\n")[0]);
+        const separator = "\t";
+        const richInputIndexMap = buildIndexMap(partiallyAnnotatedMutationInput.split("\n")[0], separator);
         assert.equal(richInputIndexMap["hugo_symbol"], 0);
         assert.equal(richInputIndexMap["sample_id"], 1);
         assert.equal(richInputIndexMap["protein_change"], 2);
@@ -154,7 +155,7 @@ describe("MutationInputParser", () => {
         assert.equal(richInputIndexMap["reference_allele"], 7);
         assert.equal(richInputIndexMap["variant_allele"], 8);
 
-        const basicInputIndexMap = buildIndexMap(basicMutationInput.split("\n")[0]);
+        const basicInputIndexMap = buildIndexMap(basicMutationInput.split("\n")[0], separator);
         assert.equal(basicInputIndexMap["sample_id"], 0);
         assert.equal(basicInputIndexMap["chromosome"], 1);
         assert.equal(basicInputIndexMap["start_position"], 2);
@@ -162,11 +163,11 @@ describe("MutationInputParser", () => {
         assert.equal(basicInputIndexMap["reference_allele"], 4);
         assert.equal(basicInputIndexMap["variant_allele"], 5);
 
-        const minimalInputIndexMap = buildIndexMap(minimalMutationInput.split("\n")[0])
+        const minimalInputIndexMap = buildIndexMap(minimalMutationInput.split("\n")[0], separator);
         assert.equal(minimalInputIndexMap["hugo_symbol"], 0);
         assert.equal(minimalInputIndexMap["protein_change"], 1);
 
-        const clinicalInputIndexMap = buildIndexMap(mutationInputWithClinicalData.split("\n")[0]);
+        const clinicalInputIndexMap = buildIndexMap(mutationInputWithClinicalData.split("\n")[0], separator);
         assert.equal(clinicalInputIndexMap["sample_id"], 0);
         assert.equal(clinicalInputIndexMap["cancer_type"], 1);
     });

--- a/src/shared/lib/MutationInputParser.ts
+++ b/src/shared/lib/MutationInputParser.ts
@@ -65,9 +65,9 @@ export type MutationInput = Mutation & ClinicalInput;
  * @param header    header line (first line) of the input
  * @returns {object} map of <header name, index> pairs
  */
-export function buildIndexMap(header: string): {[columnName:string]: number}
+export function buildIndexMap(header: string, separator: string): {[columnName:string]: number}
 {
-    const columns = header.split("\t");
+    const columns = header.split(separator);
     const map:{[columnName:string]: number}  = {};
 
     columns.forEach((columnName: string, index: number) => {
@@ -88,12 +88,12 @@ export function buildIndexMap(header: string): {[columnName:string]: number}
  */
 export function parseLine(line: string,
                           indexMap: {[columnName:string]: number},
+                          separator: string,
                           headerMap: {[attrName:string]: string} = MODEL_TO_HEADER): Partial<MutationInput>
 {
     const mutation: Partial<MutationInput> = {};
 
-    // assuming values are separated by tabs
-    const values = line.split("\t");
+    const values = line.split(separator);
 
     // find the corresponding column for each field, and set the value
     Object.keys(headerMap).forEach((key: keyof MutationInput | keyof Gene) => {
@@ -150,19 +150,22 @@ export function parseInput(input: string): Partial<MutationInput>[]
 {
     const mutationData: Partial<MutationInput>[] = [];
 
+    // use tab as column separator unless there are no tabs, then use space
+    const separator = (input.indexOf("\t") > 0)? "\t" : " ";
+
     const lines = input.split("\n");
 
     if (lines.length > 0)
     {
         // assuming first line is a header
         // TODO allow comments?
-        const indexMap = buildIndexMap(lines[0]);
+        const indexMap = buildIndexMap(lines[0], separator);
 
         // rest should be data
         lines.slice(1).forEach(line => {
             // skip empty lines
             if (line.length > 0) {
-                mutationData.push(parseLine(line, indexMap));
+                mutationData.push(parseLine(line, indexMap, separator));
             }
         });
     }

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -141,6 +141,32 @@ export async function fetchCanonicalTranscript(hugoSymbol: string,
     });
 }
 
+export async function fetchCanonicalTranscripts(hugoSymbols: string[],
+                                                isoformOverrideSource: string,
+                                                client:GenomeNexusAPI = genomeNexusClient)
+{
+    return await client.fetchCanonicalEnsemblTranscriptsByHugoSymbolsPOST({
+        hugoSymbols, isoformOverrideSource
+    });
+}
+
+export async function getCanonicalTranscriptsByHugoSymbol(hugoSymbols: string[],
+                                                          isoformOverrideSource: string,
+                                                          client:GenomeNexusAPI = genomeNexusClient)
+{
+    const transcripts = await fetchCanonicalTranscripts(hugoSymbols, isoformOverrideSource, client);
+    return transcripts? _.zipObject(hugoSymbols, transcripts) : undefined;
+}
+
+export async function fetchCanonicalEnsemblGeneIds(hugoSymbols: string[],
+                                                   isoformOverrideSource: string,
+                                                   client:GenomeNexusAPI = genomeNexusClient)
+{
+    // TODO: this endpoint should accept isoformOverrideSource
+    return await client.fetchCanonicalEnsemblGeneIdByHugoSymbolsPOST({
+        hugoSymbols});
+}
+
 export async function fetchEnsemblTranscriptsByEnsemblFilter(ensemblFilter: Partial<EnsemblFilter>,
                                                              client:GenomeNexusAPI = genomeNexusClient)
 {


### PR DESCRIPTION
Only show mutations for the canonical transcriptId being displayed. Related to:

https://github.com/genome-nexus/genome-nexus/issues/205

Try with:

```
Sample_ID	Cancer_Type	Chromosome	Start_Position	End_Position	Reference_Allele	Variant_Allele
TCGA-49-4494-01	Lung Adenocarcinoma	6	27819890	27819890	A	G
```

Now doesn't show any mutations.

Discuss: might be better to not show any genes at all in this case, but might be ok for now.

Also this should at some point be applied to mutations tab, but we should figure out what the best way to do it is.