### PR TITLE
Fix mutation mapper tool example protein change

### DIFF
--- a/end-to-end-tests/specs/mutationMapperTool.spec.js
+++ b/end-to-end-tests/specs/mutationMapperTool.spec.js
@@ -1,0 +1,94 @@
+
+var assertScreenShotMatch = require('../lib/testUtils').assertScreenShotMatch;
+
+var assert = require('assert');
+var expect = require('chai').expect;
+var goToUrlAndSetLocalStorage = require('./specUtils').goToUrlAndSetLocalStorage;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, "");
+
+describe('Mutation Mapper Tool', function() {
+    before(function(){
+        goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}`);
+    });
+
+    describe('example genomic changes input', ()=>{
+        beforeEach(()=>{
+            var url = `${CBIOPORTAL_URL}/mutation_mapper.jsp`;
+            goToUrlAndSetLocalStorage(url);
+            browser.waitForVisible('[data-test=GenomicChangesExampleButton]',10000)
+        });
+
+        it('should correctly annotate the genomic changes example and display the results', ()=>{
+            browser.click('[data-test=GenomicChangesExampleButton]');
+            browser.click('[data-test=MutationMapperToolVisualizeButton]');
+
+            // mutations table should be visiable after oncokb icon shows up,
+            // also need to wait for mutations to be sorted properly
+            browser.waitForVisible("[data-test=oncogenic-icon-image]",20000);
+
+            const mutationsT790M = browser.getText('.//*[text()[contains(.,"T790M")]]')
+            assert.equal(mutationsT790M.length, 2, "there should be two samples with a T790M mutation");
+
+            // check total number of mutations (this gets Showing 1-25 of 122
+            // Mutations)
+            const mutationCount = browser.getText('.//*[text()[contains(.,"122 Mutations")]]')
+            assert.ok(mutationCount.length > 0);
+
+            const brca1 = browser.getText('.//*[text()[contains(.,"BRCA1")]]')
+            assert.ok(brca1.length > 0);
+
+            const brca2 = browser.getText('.//*[text()[contains(.,"BRCA2")]]')
+            assert.ok(brca2.length > 0);
+
+            const pten = browser.getText('.//*[text()[contains(.,"PTEN")]]')
+            assert.ok(pten.length > 0);
+        });
+
+        it('should correctly annotate the protein changes example and display the results', ()=>{
+            browser.click('[data-test=ProteinChangesExampleButton]');
+            browser.click('[data-test=MutationMapperToolVisualizeButton]');
+
+            // mutations table should be visiable after oncokb icon shows up,
+            // also need to wait for mutations to be sorted properly
+            browser.waitForVisible("[data-test=oncogenic-icon-image]",20000);
+
+            const mutationsT790M = browser.getText('.//*[text()[contains(.,"T790M")]]')
+            assert.equal(mutationsT790M.length, 2, "there should be two samples with a T790M mutation");
+
+            // check total number of mutations (this gets Showing 1-25 of 124
+            // Mutations)
+            const mutationCount = browser.getText('.//*[text()[contains(.,"124 Mutations")]]')
+            assert.ok(mutationCount.length > 0);
+
+            const brca1 = browser.getText('.//*[text()[contains(.,"BRCA1")]]')
+            assert.ok(brca1.length > 0);
+
+            const brca2 = browser.getText('.//*[text()[contains(.,"BRCA2")]]')
+            assert.ok(brca2.length > 0);
+
+            const pten = browser.getText('.//*[text()[contains(.,"PTEN")]]')
+            assert.ok(pten.length > 0);
+        });
+
+        it('should not display mutations that do not affect the displayed transcript id (HIST1H2BN, ENST00000396980)', ()=>{
+            var input = $("#standaloneMutationTextInput");
+            input.setValue(
+                "Sample_ID Cancer_Type Chromosome Start_Position End_Position Reference_Allele Variant_Allele\nTCGA-49-4494-01 Lung_Adenocarcinoma 6 27819890 27819890 A G"
+            );
+
+            browser.click('[data-test=MutationMapperToolVisualizeButton]');
+
+            browser.waitForVisible("[class=borderedChart]",20000);
+
+            const transcriptId = browser.getText('.//*[text()[contains(.,"ENST00000396980")]]')
+            assert.ok(transcriptId.length > 0, "the canonical transcript id for HIST1H2BN should be ENST00000396980");
+
+
+            const mutationCount = browser.getText('.//*[text()[contains(.,"There are no results")]]');
+            assert.ok(mutationCount.length > 0, "there shouldn't be any mutations visible");
+
+        });
+    });
+
+});

--- a/src/pages/tools/mutationMapper/MutationMapperTool.tsx
+++ b/src/pages/tools/mutationMapper/MutationMapperTool.tsx
@@ -117,7 +117,7 @@ export default class MutationMapperTool extends React.Component<IMutationMapperT
                     <p>
                         Please input <b>tab-delimited</b> or <b>space-delimited</b> mutation data. (Load example data:
                         <span> <a onClick={this.handleLoadExampleGenomicCoordinates} data-test="GenomicChangesExampleButton">Genomic Changes</a></span>,
-                        <span> <a onClick={this.handleLoadExampleGeneAndProteinChange}>Protein Changes</a></span>,
+                        <span> <a onClick={this.handleLoadExampleGeneAndProteinChange} data-test="ProteinChangesExampleButton">Protein Changes</a></span>,
                         <span> <a onClick={this.handleLoadExamplePartiallyAnnotated}>Genomic and Protein Changes</a></span>)
                     </p>
 

--- a/src/pages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -171,7 +171,7 @@ export default class MutationMapperToolStore
                         this.canonicalTranscriptsByHugoSymbol.result[gene.hugoGeneSymbol].transcriptId : undefined;
                     
                     const getMutations = () => {
-                        if (canonicalTranscriptId && this.indexedVariantAnnotations.result) {
+                        if (canonicalTranscriptId && this.indexedVariantAnnotations.result && !_.isEmpty(this.indexedVariantAnnotations.result)) {
                             return filterMutationsByTranscriptId(this.mutations.result, canonicalTranscriptId, this.indexedVariantAnnotations.result);
                         } else {
                             return this.mutationsByGene[gene.hugoGeneSymbol];


### PR DESCRIPTION
This was broken in the PR that filtered mutation mapper tool by transcript id.
When gene/protein change is given, we don't know the transcript id. Therefore
check whether the annotations based on genomic positions are actually being
used.