### PR TITLE
Fix mutation mapper tool BRCA1/2 no results

### DIFF
--- a/end-to-end-tests/specs/mutationMapperTool.spec.js
+++ b/end-to-end-tests/specs/mutationMapperTool.spec.js
@@ -32,17 +32,32 @@ describe('Mutation Mapper Tool', function() {
 
             // check total number of mutations (this gets Showing 1-25 of 122
             // Mutations)
-            const mutationCount = browser.getText('.//*[text()[contains(.,"122 Mutations")]]')
+            let mutationCount = browser.getText('.//*[text()[contains(.,"122 Mutations")]]')
             assert.ok(mutationCount.length > 0);
 
             const brca1 = browser.getText('.//*[text()[contains(.,"BRCA1")]]')
             assert.ok(brca1.length > 0);
+            browser.elements(".nav-pill").click("a*=BRCA1")
+            // check total number of mutations (this gets Showing 1-25 of 85
+            // Mutations)
+            mutationCount = browser.getText('.//*[text()[contains(.,"85 Mutations")]]')
+            assert.ok(mutationCount.length > 0);
 
             const brca2 = browser.getText('.//*[text()[contains(.,"BRCA2")]]')
             assert.ok(brca2.length > 0);
+            browser.elements(".nav-pill").click("a*=BRCA2")
+            // check total number of mutations (this gets Showing 1-25 of 113
+            // Mutations)
+            mutationCount = browser.getText('.//*[text()[contains(.,"113 Mutations")]]')
+            assert.ok(mutationCount.length > 0);
 
             const pten = browser.getText('.//*[text()[contains(.,"PTEN")]]')
             assert.ok(pten.length > 0);
+            browser.elements(".nav-pill").click("a*=PTEN")
+            // check total number of mutations (this gets Showing 1-25 of 136
+            // Mutations)
+            mutationCount = browser.getText('.//*[text()[contains(.,"136 Mutations")]]')
+            assert.ok(mutationCount.length > 0);
         });
 
         it('should correctly annotate the protein changes example and display the results', ()=>{

--- a/src/pages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -130,7 +130,7 @@ export default class MutationMapperToolStore
     }, []);
 
     readonly indexedVariantAnnotations = remoteData<{[genomicLocation: string]: VariantAnnotation} | undefined>({
-        invoke: async () => await fetchVariantAnnotationsIndexedByGenomicLocation(this.rawMutations),
+        invoke: async () => await fetchVariantAnnotationsIndexedByGenomicLocation(this.rawMutations, AppConfig.isoformOverrideSource),
         onError: (err: Error) => {
             this.criticalErrors.push(err);
         }

--- a/src/shared/lib/MutationAnnotator.spec.ts
+++ b/src/shared/lib/MutationAnnotator.spec.ts
@@ -407,6 +407,7 @@ describe("MutationAnnotator", () => {
 
             fetchVariantAnnotationsIndexedByGenomicLocation(
                 _.cloneDeep(mutationsWithGenomicLocation),
+                "uniprot",
                 genomeNexusClient
             ).then((indexedVariantAnnotations: {[genomicLocation: string]: VariantAnnotation}) => {
                 const data = annotateMutations(_.cloneDeep(mutationsWithGenomicLocation), indexedVariantAnnotations);

--- a/src/shared/lib/MutationAnnotator.ts
+++ b/src/shared/lib/MutationAnnotator.ts
@@ -52,6 +52,7 @@ export function resolveMissingMutationTypes(mutations: Partial<Mutation>[])
 }
 
 export async function fetchVariantAnnotationsIndexedByGenomicLocation(mutations: Mutation[],
+                                                                      isoformOverrideSource: string = "uniprot",
                                                                       client: GenomeNexusAPI = genomeNexusClient)
 {
     const genomicLocations = uniqueGenomicLocations(mutations);
@@ -59,7 +60,8 @@ export async function fetchVariantAnnotationsIndexedByGenomicLocation(mutations:
     const variantAnnotations = genomicLocations.length > 0 ? await client.fetchVariantAnnotationByGenomicLocationPOST(
         {
             genomicLocations,
-            fields: ['annotation_summary']
+            fields: ['annotation_summary'],
+            isoformOverrideSource
         }
     ): [];
 


### PR DESCRIPTION
Send isoformoverridesource when annotating. No results were showing up because the default ensembl canonicalTranscript differs from uniprot