### PR TITLE
Update oncoprintjs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6018,9 +6018,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -6113,8 +6113,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -6175,7 +6175,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -6267,7 +6267,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -6275,7 +6275,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -12629,9 +12629,9 @@
       }
     },
     "oncoprintjs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.1.5.tgz",
-      "integrity": "sha512-nYGyr/WlUrZtsJWEyzt5hYcUzYAvx77ybLAf4ii2/lIfwgPxcmTcx0KRCavWpUGgAYTf0wLgnDN845Zpzpiygw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/oncoprintjs/-/oncoprintjs-1.1.6.tgz",
+      "integrity": "sha512-HDn5c85Gk38a2xzyHGQJp6f6OfYP0r3ZoZmSE8eWJI1HkIZbYZCT6qZ1d28g2r/4uOWRRBp4lTiLnHFF6UnkYw==",
       "requires": {
         "express": "4.15.4",
         "gl-matrix": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "mobxpromise": "^1.3.1",
     "node-sass": "^4.3.0",
     "numeral": "^2.0.6",
-    "oncoprintjs": "^1.1.5",
+    "oncoprintjs": "^1.1.6",
     "parameter-validator": "^1.0.2",
     "pdfobject": "^2.0.201604172",
     "plotly.js": "^1.31.2",


### PR DESCRIPTION
New oncoprintjs version uses webpack url-loader to load images instead of using relative paths.