### PR TITLE
Added download controls for study view charts

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -123,6 +123,8 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
             },
             analysisGroupsSettings: this.store.analysisGroupsSettings
         };
+
+        // TODO enable data download for bar chart, too
         switch (chartMeta.chartType) {
             case ChartType.PIE_CHART: {
                 props.promise = this.store.studyViewClinicalDataCountsCache.get({
@@ -132,6 +134,16 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
                 props.filters = this.store.getClinicalDataFiltersByUniqueKey(chartMeta.uniqueKey);
                 props.onUserSelection = this.handlers.onUserSelection;
                 props.onResetSelection = this.handlers.onUserSelection;
+                props.download = [
+                    {
+                        initDownload: () => this.store.getClinicalData(chartMeta),
+                        type: 'TSV'
+                    }, {
+                        type: 'SVG'
+                    }, {
+                        type: 'PDF'
+                    }
+                ];
                 break;
             }
             case ChartType.TABLE: {
@@ -142,6 +154,14 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
                 });
                 props.onUserSelection = this.handlers.onUserSelection;
                 props.onResetSelection = this.handlers.onUserSelection;
+                props.disableGraphicsDownload = true;
+                props.download = [
+                    {
+                        // TODO implement a proper data download function
+                        initDownload: () => Promise.resolve("NA"),
+                        type: 'TSV'
+                    }
+                ];
                 break;
             }
             case ChartType.MUTATED_GENES_TABLE: {
@@ -151,6 +171,14 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
                 props.onResetSelection = this.handlers.resetGeneFilter;
                 props.selectedGenes=this.store.selectedGenes;
                 props.onGeneSelect=this.store.onCheckGene;
+                props.disableGraphicsDownload = true;
+                props.download = [
+                    {
+                        // TODO implement a proper data download function
+                        initDownload: () => Promise.resolve("NA"),
+                        type: 'TSV'
+                    }
+                ];
                 break;
             }
             case ChartType.CNA_GENES_TABLE: {
@@ -160,10 +188,24 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
                 props.onResetSelection = this.handlers.resetCNAGeneFilter;
                 props.selectedGenes=this.store.selectedGenes;
                 props.onGeneSelect=this.store.onCheckGene;
+                props.disableGraphicsDownload = true;
+                props.download = [
+                    {
+                        // TODO implement a proper data download function
+                        initDownload: () => Promise.resolve("NA"),
+                        type: 'TSV'
+                    }
+                ];
                 break;
             }
             case ChartType.SURVIVAL: {
                 props.promise = this.store.getSurvivalData(chartMeta);
+                props.download = [
+                    {
+                        initDownload: () => this.store.getSurvivalDownloadData(chartMeta),
+                        type: 'TSV'
+                    }
+                ];
                 // only want to pass these in when necessary, otherwise charts will unnecessarily update when they change
                 props.patientKeysWithNAInSelectedClinicalData = this.store.patientKeysWithNAInSelectedClinicalData;
                 props.patientToAnalysisGroup = this.store.patientToAnalysisGroup;

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -67,9 +67,9 @@ export const COLORS = [
     '#651062', '#329267', '#5574a1', '#3b3ea5'
 ];
 
-export const NA_COLOR = '#CCCCCC'
-
-export const UNSELECTED_COLOR = '#808080'
+export const NA_COLOR = '#CCCCCC';
+export const UNSELECTED_COLOR = '#808080';
+export const NA_DATA = "NA";
 
 export function updateGeneQuery(geneQueries: SingleGeneQuery[], selectedGene: string): string {
 

--- a/src/pages/studyView/chartHeader/ChartHeader.tsx
+++ b/src/pages/studyView/chartHeader/ChartHeader.tsx
@@ -2,6 +2,12 @@ import * as React from "react";
 import "./styles.scss";
 import {If} from 'react-if';
 import {ChartMeta, ChartType} from "pages/studyView/StudyViewPageStore";
+import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
+import bind from "bind-decorator";
+import fileDownload from 'react-file-download';
+import {action, computed, observable} from "mobx";
+import {observer} from "mobx-react";
+import {IChartContainerDownloadProps} from "../charts/ChartContainer";
 
 export interface IChartHeaderProps {
     chartMeta: ChartMeta;
@@ -11,6 +17,7 @@ export interface IChartHeaderProps {
     hideLabel?       : boolean;
     chartControls?   : ChartControls;
     changeChartType  : (chartType: ChartType) => void;
+    download?        : IChartContainerDownloadProps[];
     setAnalysisGroups  : () => void;
 }
 
@@ -21,9 +28,75 @@ export interface ChartControls {
     showAnalysisGroupsIcon?   : boolean;
 }
 
+@observer
 export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
     constructor(props: IChartHeaderProps) {
         super(props);
+    }
+
+    @observable downloadMenuActive = false;
+    @observable downloadPending = {
+        TSV: false,
+        SVG: false,
+        PDF: false
+    };
+
+    @computed
+    get fileName() {
+        return this.props.chartMeta.displayName.replace(/[ \t]/g, '_');
+    }
+
+    private downloadControls() {
+        const overlay = (
+            <div className="studyViewChartHeaderDownloadControls">
+                {
+                    this.props.download && this.props.download.map( props =>
+                        <button
+                            key={props.type}
+                            className="btn btn-xs"
+                            onClick={() => {
+                                this.downloadPending[props.type] = true;
+                                props.initDownload!().then(data => {
+                                    if (data && data.length > 0) {
+                                        fileDownload(data, `${this.fileName}.${props.type.substring(0, 3).toLowerCase()}`);
+                                    }
+                                    this.downloadPending[props.type] = false;
+                                }).catch(() => {
+                                    // TODO this.triggerDownloadError();
+                                    this.downloadPending[props.type] = false;
+                                });
+                            }}
+                        >
+                            {this.downloadPending[props.type] ? <i className="fa fa-spinner fa-spin" aria-hidden="true" /> : props.type}
+                        </button>
+                    )
+                }
+            </div>
+        );
+
+        return (
+            <DefaultTooltip
+                placement="bottom"
+                overlay={overlay}
+                destroyTooltipOnHide={true}
+                onVisibleChange={this.onTooltipVisibleChange as any}
+                trigger={["click"]}
+            >
+                <button className="btn btn-xs">
+                    <i className="fa fa-download" aria-hidden="true" title="Download" />
+                </button>
+            </DefaultTooltip>
+        );
+    }
+
+    @bind
+    @action
+    onTooltipVisibleChange(visible: boolean) {
+        this.downloadMenuActive = visible;
+    }
+
+    @computed get active() {
+        return this.downloadMenuActive || this.props.active;
     }
 
     public render() {
@@ -33,7 +106,7 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
                 { !this.props.hideLabel && <span>{this.props.chartMeta.displayName}</span>}
                 </div>
                 <div className='controls'>
-                    <If condition={this.props.active}>
+                    <If condition={this.active}>
                         <div role="group" className="btn-group">
                             <If condition={this.props.chartControls && this.props.chartControls.showResetIcon}>
                                 <button className="btn btn-xs" onClick={() => this.props.resetChart()}>
@@ -61,6 +134,9 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
                                     <img src="images/survival_icon.svg" style={{verticalAlign:"initial"}} width="10" height="10" className="icon hover" alt="Survival Analysis"/>
                                 </button>
                             </If>
+                            <If condition={this.props.download && this.props.download.length > 0}>
+                                {this.downloadControls()}
+                            </If>
                             <button className="btn btn-xs"  onClick={() => this.props.deleteChart()}>
                                 <i className="fa fa-times" aria-hidden="true" title="Delete chart"></i>
                             </button>
@@ -68,7 +144,7 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
                     </If>
                 </div>
             </div>
-        )
+        );
     }
 
 }

--- a/src/pages/studyView/chartHeader/styles.scss
+++ b/src/pages/studyView/chartHeader/styles.scss
@@ -55,3 +55,13 @@
         border: 1px solid grey;
     }
 }
+
+.studyViewChartHeaderDownloadControls {
+    display: flex;
+    flex-direction: column;
+
+    button {
+        margin-top: 2px;
+        margin-bottom: 2px;
+    }
+}

--- a/src/shared/lib/svgToPdfDownload.ts
+++ b/src/shared/lib/svgToPdfDownload.ts
@@ -1,32 +1,53 @@
 import fileDownload from 'react-file-download';
-import request from "superagent";
+import {default as request, Request} from "superagent";
 
 function base64ToArrayBuffer(base64:string) {
-    var binaryString = window.atob(base64);
-    var binaryLen = binaryString.length;
-    var bytes = new Uint8Array(binaryLen);
-    for (var i = 0; i < binaryLen; i++) {
-        var ascii = binaryString.charCodeAt(i);
+    const binaryString = window.atob(base64);
+    const binaryLen = binaryString.length;
+    const bytes = new Uint8Array(binaryLen);
+    for (let i = 0; i < binaryLen; i++) {
+        const ascii = binaryString.charCodeAt(i);
         bytes[i] = ascii;
     }
     return bytes;
 }
 
 export default function (filename:string, svg:Element, servletUrl?: string) {
+    const req = svgToPdfRequest(svg, servletUrl);
+
+    if (!req) {
+       return false;
+    }
+
+    req.end((err, res)=>{
+        if (!err && res.ok) {
+            fileDownload(base64ToArrayBuffer(res.text), filename);
+        }
+    });
+
+    return true;
+}
+
+export function svgToPdfRequest(svg:Element, servletUrl?: string): Request|undefined {
     const svgelement = "<?xml version='1.0'?>"+(new XMLSerializer()).serializeToString(svg);
     const two_megabyte_limit = 2000000;
+
     if (svgelement.length > two_megabyte_limit) {
-        return false;
+        return undefined;
     }
+
     const servletURL = servletUrl || "svgtopdf.do";
     const filetype = "pdf_data";
-    request.post(servletURL)
+
+    return request.post(servletURL)
         .type('form')
-        .send({ filetype, svgelement})
-        .end((err, res)=>{
-            if (!err && res.ok) {
-                fileDownload(base64ToArrayBuffer(res.text), filename);
-            }
-        });
-    return true;
+        .send({filetype, svgelement});
+}
+
+export async function svgToPdfPromise(svg:Element, servletUrl?: string) {
+    const res = await svgToPdfRequest(svg, servletUrl);
+
+    if(res && res.ok) {
+        return base64ToArrayBuffer(res.text);
+    }
 }


### PR DESCRIPTION
# What? Why?
Partially addressed download functionality for the study view components.

Changes proposed in this pull request:
- Added download icon into `ChartHeader` (related to https://github.com/cBioPortal/cbioportal/issues/4155)
- Added full download functionality for `PieChart` (related to https://github.com/cBioPortal/cbioportal/issues/4156)
- Added data download functionality for `SurvivalChart` (related to https://github.com/cBioPortal/cbioportal/issues/4159)

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)