### PR TITLE
Update study view filters with Component PillTag and GroupLogic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3214,6 +3214,14 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
     },
+    "contrast": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/contrast/-/contrast-1.0.1.tgz",
+      "integrity": "sha1-g5xm2IUiadM/TrChuS2ZS90WOF4=",
+      "requires": {
+        "hex-to-rgb": "1.0.1"
+      }
+    },
     "convert-css-color-name-to-hex": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/convert-css-color-name-to-hex/-/convert-css-color-name-to-hex-0.1.1.tgz",
@@ -8585,6 +8593,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "hex-to-rgb": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hex-to-rgb/-/hex-to-rgb-1.0.1.tgz",
+      "integrity": "sha1-EAud8SazLydirfhIa+aMZe+O0qQ="
     },
     "history": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "chart.js": "^2.6.0",
     "classnames": "^2.2.5",
     "clinical-timeline": "0.0.18",
+    "contrast": "^1.0.1",
     "convert-css-color-name-to-hex": "^0.1.1",
     "copy-webpack-plugin": "^4.0.1",
     "cross-env": "^3.1.4",

--- a/src/globalStyles/variables.scss
+++ b/src/globalStyles/variables.scss
@@ -35,3 +35,5 @@ $headerColor: #3786C2;
 $cornerBorderRadius: 5px;
 
 $standardMargin:15px;
+
+$study-view-primary-color: #2986E2;

--- a/src/pages/studyView/SelectedInfo/styles.module.scss
+++ b/src/pages/studyView/SelectedInfo/styles.module.scss
@@ -4,7 +4,7 @@
 
 .content {
   padding: 0 5px;
-  color: #2986e2;
+  color: $study-view-primary-color;
 }
 
 .title, .content {

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -5,7 +5,16 @@ import {ChartContainer, IChartContainerProps} from 'pages/studyView/charts/Chart
 import { MSKTab, MSKTabs } from "../../shared/components/MSKTabs/MSKTabs";
 import { reaction, observable } from 'mobx';
 import { If } from 'react-if';
-import {ChartMeta, ChartType, ChartTypeEnum, DataBinMethodConstants, StudyViewPageStore, AnalysisGroup, UniqueKey, CUSTOM_CHART_KEYS} from 'pages/studyView/StudyViewPageStore';
+import {
+    ChartMeta,
+    ChartType,
+    ChartTypeEnum,
+    DataBinMethodConstants,
+    StudyViewPageStore,
+    AnalysisGroup,
+    CUSTOM_CHART_KEYS,
+    UniqueKey
+} from 'pages/studyView/StudyViewPageStore';
 import SummaryHeader from 'pages/studyView/SummaryHeader';
 import {Gene, SampleIdentifier, ClinicalAttribute} from 'shared/api/generated/CBioPortalAPI';
 import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
@@ -21,6 +30,7 @@ import ReactGridLayout from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import {stringListToSet} from "../../shared/lib/StringUtils";
+import {StudyViewComponentLoader} from "./charts/StudyViewComponentLoader";
 
 export interface IStudyViewPageProps {
     routing: any;
@@ -60,11 +70,17 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
             addGeneFilters: (entrezGeneIds: number[]) => {
                 this.store.addGeneFilters(entrezGeneIds);
             },
+            removeGeneFilter: (entrezGeneId:number) => {
+                this.store.removeGeneFilter(entrezGeneId);
+            },
             resetGeneFilter: (chartMeta: ChartMeta) => {
                 this.store.resetGeneFilter();
             },
             resetCNAGeneFilter: (chartMeta: ChartMeta) => {
                 this.store.resetCNAGeneFilter();
+            },
+            removeCNAGeneFilter: (filter:CopyNumberGeneFilterElement) => {
+                this.store.removeCNAGeneFilters(filter);
             },
             addCNAGeneFilters: (filters:CopyNumberGeneFilterElement[]) => {
                 this.store.addCNAGeneFilters(filters);
@@ -376,17 +392,20 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
                                 geneQuery={this.store.geneQueryStr}
                                 selectedSamples={this.store.selectedSamples.result!}
                                 updateCustomCasesFilter={(cases: SampleIdentifier[], keepCurrent?:boolean)=>{
-                                    this.handlers.updateChartSampleIdentifierFilter('customFilters',cases,keepCurrent);
+                                    this.handlers.updateChartSampleIdentifierFilter(UniqueKey.SELECT_CASES_BY_IDS,cases,keepCurrent);
                                 }}
                                 updateSelectedGenes={this.handlers.updateSelectedGenes}
                                 studyWithSamples={this.store.studyWithSamples.result}
                                 filter={this.store.userSelections}
+                                allGenes={this.store.allGenes.result}
                                 attributesMetaSet={this.store.chartMetaSet}
                                 user={AppConfig.userEmailAddress}
                                 getClinicalData={this.store.getDownloadDataPromise}
                                 onSubmitQuery={()=> this.store.onSubmitQuery()}
                                 updateClinicalDataEqualityFilter={this.handlers.onValueSelection}
                                 updateClinicalDataIntervalFilter={this.handlers.onUpdateIntervalFilters}
+                                removeGeneFilter={this.handlers.removeGeneFilter}
+                                removeCNAGeneFilter={this.handlers.removeCNAGeneFilter}
                                 clearCNAGeneFilter={this.handlers.clearCNAGeneFilter}
                                 clearGeneFilter={this.handlers.clearGeneFilter}
                                 clearChartSampleIdentifierFilter={this.handlers.clearChartSampleIdentifierFilter}

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -52,7 +52,11 @@ import {
     makePatientToClinicalAnalysisGroup,
     EXPONENTIAL_FRACTION_DIGITS,
     generateScatterPlotDownloadData,
-    NA_DATA, ONE_GRID_TABLE_ROWS, PIE_TO_TABLE_LIMIT, COLORS, NA_COLOR, getSamplesByExcludingFiltersOnChart, getFilteredSampleIdentifiers
+    NA_DATA, ONE_GRID_TABLE_ROWS, PIE_TO_TABLE_LIMIT,
+    COLORS, NA_COLOR,
+    getSamplesByExcludingFiltersOnChart,
+    getFilteredSampleIdentifiers,
+    UNSELECTED_GROUP_COLOR, SELECTED_GROUP_COLOR
 } from './StudyViewUtils';
 import MobxPromise from 'mobxpromise';
 import {SingleGeneQuery} from 'shared/lib/oql/oql-parser';
@@ -378,11 +382,11 @@ export class StudyViewPageStore {
             return {
                 groups: [{
                     value: UNSELECTED_ANALYSIS_GROUP_VALUE,
-                    color: "blue",
+                    color: UNSELECTED_GROUP_COLOR,
                     legendText: "Unselected patients"
                 },{
                     value: SELECTED_ANALYSIS_GROUP_VALUE,
-                    color: "red",
+                    color: SELECTED_GROUP_COLOR,
                     legendText: "Selected patients"
                 }] as AnalysisGroup[]
             }

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -83,6 +83,7 @@ export enum ChartTypeEnum {
 export type ChartType = 'PIE_CHART' | 'BAR_CHART' | 'SURVIVAL' | 'TABLE' | 'SCATTER' | 'MUTATED_GENES_TABLE' | 'CNA_GENES_TABLE' | 'NONE';
 
 export enum UniqueKey {
+    SELECT_CASES_BY_IDS = 'CUSTOM_FILTERS',
     MUTATED_GENES_TABLE = 'MUTATED_GENES_TABLE',
     CNA_GENES_TABLE = 'CNA_GENES_TABLE',
     MUTATION_COUNT_CNA_FRACTION = 'MUTATION_COUNT_CNA_FRACTION',
@@ -129,7 +130,7 @@ export type ChartMeta = {
 export const CUSTOM_CHART_KEYS = [UniqueKey.SAMPLES_PER_PATIENT, UniqueKey.WITH_CNA_DATA, UniqueKey.WITH_MUTATION_DATA];
 
 export const SpecialCharts: ChartMeta[] = [{
-    uniqueKey: 'customFilters',
+    uniqueKey: UniqueKey.SELECT_CASES_BY_IDS,
     displayName: 'Select by IDs',
     description: 'Select by IDs',
     dimension: {
@@ -560,6 +561,24 @@ export class StudyViewPageStore {
         this._mutatedGeneFilter = [...this._mutatedGeneFilter, {entrezGeneIds: entrezGeneIds}];
     }
 
+    @action
+    removeGeneFilter(toBeRemoved: number) {
+        this._mutatedGeneFilter = _.reduce(this._mutatedGeneFilter, (acc, next) => {
+            const newGroup = _.reduce(next.entrezGeneIds, (list, entrezGeneId) => {
+                if (entrezGeneId !== toBeRemoved) {
+                    list.push(entrezGeneId);
+                }
+                return list;
+            }, [] as number[]);
+            if (newGroup.length > 0) {
+                acc.push({
+                    entrezGeneIds: newGroup
+                });
+            }
+            return acc;
+        }, [] as MutationGeneFilter[]);
+    }
+
     @action resetGeneFilter() {
         this._mutatedGeneFilter = [];
     }
@@ -597,7 +616,25 @@ export class StudyViewPageStore {
 
     @action
     addCNAGeneFilters(filters: CopyNumberGeneFilterElement[]) {
-        this._cnaGeneFilter = [...this._cnaGeneFilter , {alterations: filters}];
+        this._cnaGeneFilter = [...this._cnaGeneFilter, {alterations: filters}];
+    }
+
+    @action
+    removeCNAGeneFilters(toBeRemoved: CopyNumberGeneFilterElement) {
+        this._cnaGeneFilter = _.reduce(this._cnaGeneFilter, (acc, next) => {
+            const newGroup = _.reduce(next.alterations, (list, filter) => {
+                if (filter.entrezGeneId !== toBeRemoved.entrezGeneId && filter.alteration !== toBeRemoved.alteration) {
+                    list.push(filter);
+                }
+                return list;
+            }, [] as CopyNumberGeneFilterElement[]);
+            if (newGroup.length > 0) {
+                acc.push({
+                    alterations: newGroup
+                });
+            }
+            return acc;
+        }, [] as CopyNumberGeneFilter[]);
     }
 
     @action
@@ -1447,6 +1484,14 @@ export class StudyViewPageStore {
             } else {
                 return [];
             }
+        },
+        default: []
+    });
+
+    readonly allGenes = remoteData<Gene[]>({
+        await:()=>[],
+        invoke: async () => {
+            return defaultClient.getAllGenesUsingGET({});
         },
         default: []
     });

--- a/src/pages/studyView/StudyViewUtils.spec.ts
+++ b/src/pages/studyView/StudyViewUtils.spec.ts
@@ -6,7 +6,8 @@ import {
     intervalFiltersDisplayValue, isEveryBinDistinct, toFixedDigit, getExponent,
     getCNAByAlteration,
     getDefaultChartTypeByClinicalAttribute,
-    getVirtualStudyDescription, calculateLayout, getLayoutMatrix, LayoutMatrixItem, getQValue, pickClinicalDataColors, getSamplesByExcludingFiltersOnChart, getFilteredSampleIdentifiers
+    getVirtualStudyDescription, calculateLayout, getLayoutMatrix, LayoutMatrixItem, getQValue, pickClinicalDataColors, getSamplesByExcludingFiltersOnChart, getFilteredSampleIdentifiers,
+    getHugoSymbolByEntrezGeneId
 } from 'pages/studyView/StudyViewUtils';
 import {DataBin, StudyViewFilter, ClinicalDataIntervalFilterValue, Sample} from 'shared/api/generated/CBioPortalAPIInternal';
 import {ClinicalAttribute, Gene} from 'shared/api/generated/CBioPortalAPI';
@@ -1392,4 +1393,27 @@ describe('StudyViewUtils', () => {
             assert.deepEqual(getFilteredSampleIdentifiers(samples,  (sample) => sample.copyNumberSegmentPresent),[{ sampleId: 'sample2', studyId: 'study1' }]);
         });
     });
+
+    describe('getHugoSymbolByEntrezGeneId', () => {
+        const braf = {
+            "entrezGeneId": 673,
+            "hugoGeneSymbol": "BRAF",
+            "type": "protein-coding",
+            "cytoband": "7q34",
+            "length": 205602,
+            "chromosome": "7"
+        };
+
+        it('Return undefined for gene not exist', () => {
+            assert.isTrue(getHugoSymbolByEntrezGeneId([], 1) === undefined);
+        });
+
+        it('Return undefined for gene not exist', () => {
+            assert.isTrue(getHugoSymbolByEntrezGeneId([braf], 1) === undefined);
+        });
+
+        it('Return appropriate entrez gene', () => {
+            assert.isTrue(getHugoSymbolByEntrezGeneId([braf], 673) === 'BRAF');
+        });
+    })
 });

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -20,9 +20,16 @@ import {ChartDimension, ChartMeta, ChartType, ChartTypeEnum, ClinicalDataType} f
 import {Layout} from 'react-grid-layout';
 import internalClient from "shared/api/cbioportalInternalClientInstance";
 
+
+// Study View Default colors: tetradic color scheme
+export const PRIMARY_COLOR = '#2986E2';
+export const SECONDARY_COLOR = '#dc3912';
+export const TERTIARY_COLOR = '#f88508';
+export const QUATERNARY_COLOR = '#109618';
+
 //TODO:cleanup
 export const COLORS = [
-    '#2986e2', '#dc3912', '#f88508', '#109618',
+    PRIMARY_COLOR, SECONDARY_COLOR, TERTIARY_COLOR, QUATERNARY_COLOR,
     '#990099', '#0099c6', '#dd4477', '#66aa00',
     '#b82e2e', '#316395', '#994499', '#22aa99',
     '#aaaa11', '#6633cc', '#e67300', '#8b0707',
@@ -88,7 +95,8 @@ export const FIXED_COLORS: {[clinicalAttribute: string]: string} = {
     M: "#316395"
 };
 
-export const PRIMARY_COLOR = '#2986E2'; // Study View Blue
+export const SELECTED_GROUP_COLOR = SECONDARY_COLOR;
+export const UNSELECTED_GROUP_COLOR = PRIMARY_COLOR;
 
 export const NA_COLOR = '#CCCCCC';
 export const UNSELECTED_COLOR = '#808080';

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -88,11 +88,19 @@ export const FIXED_COLORS: {[clinicalAttribute: string]: string} = {
     M: "#316395"
 };
 
+export const PRIMARY_COLOR = '#2986E2'; // Study View Blue
+
 export const NA_COLOR = '#CCCCCC';
 export const UNSELECTED_COLOR = '#808080';
 export const NA_DATA = "NA";
 export const EXPONENTIAL_FRACTION_DIGITS = 3;
 export const ONE_GRID_TABLE_ROWS = 8;
+export const MUTATED_GENE_COLOR='#008000'; // green
+export const DEL_COLOR = '#0000FF'; // blue
+export const AMP_COLOR = '#FF0000'; // red
+export const FILTER_TITLE_COLOR = '#A9A9A9'; // darkgray
+export const FILTER_CONTENT_COLOR = PRIMARY_COLOR;
+
 
 // ---- These are the settings from configs.json in the previous study view ----
 // TODO: figure out a way to custom the following settings
@@ -303,7 +311,7 @@ export function getVirtualStudyDescription(
 
                 return cnaGene.alterations.map(alteration => {
                     let geneSymbol = entrezIdSet[alteration.entrezGeneId] || alteration.entrezGeneId
-                    return geneSymbol + "-" + (alteration.alteration === -2 ? 'DEL' : 'AMP')
+                    return geneSymbol + "-" + getCNAByAlteration(alteration.alteration)
                 }).join(', ').trim();
             }).map(line => '  - ' + line));
         }
@@ -774,6 +782,12 @@ export function getCNAByAlteration(alteration: number) {
     return '';
 }
 
+export function getCNAColorByAlteration(alteration: number):string|undefined {
+    if ([-2, 2].includes(alteration))
+        return alteration === -2 ? DEL_COLOR : AMP_COLOR;
+    return undefined;
+}
+
 export function getDefaultChartTypeByClinicalAttribute(clinicalAttribute: ClinicalAttribute): ChartType | undefined {
     if (DEFAULT_ATTRS_SHOW_AS_TABLE.includes(getClinicalAttributeUniqueKey(clinicalAttribute))) {
         return ChartTypeEnum.TABLE;
@@ -1050,4 +1064,9 @@ export function getSamplesByExcludingFiltersOnChart(
     return internalClient.fetchFilteredSamplesUsingPOST({
         studyViewFilter: updatedFilter
     });
+}
+
+export function getHugoSymbolByEntrezGeneId(allGenes:Gene[], entrezGeneId: number) {
+    let result = _.find(allGenes, gene => gene.entrezGeneId === entrezGeneId);
+    return result === undefined ? undefined : result.hugoGeneSymbol;
 }

--- a/src/pages/studyView/SummaryHeader.tsx
+++ b/src/pages/studyView/SummaryHeader.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Sample, ClinicalDataIntervalFilterValue, SampleIdentifier } from 'shared/api/generated/CBioPortalAPIInternal';
+import {
+    Sample,
+    ClinicalDataIntervalFilterValue,
+    SampleIdentifier,
+    CopyNumberGeneFilterElement
+} from 'shared/api/generated/CBioPortalAPIInternal';
 import { observer } from "mobx-react";
 import { computed, observable, action } from 'mobx';
 import styles from "./styles.module.scss";
@@ -21,6 +26,8 @@ import SelectedInfo from "./SelectedInfo/SelectedInfo";
 import classnames from "classnames";
 import { getPercentage } from 'shared/lib/FormatUtils';
 import MobxPromise from 'mobxpromise';
+import {GroupLogic} from "./filters/groupLogic/GroupLogic";
+import {isFiltered} from "./StudyViewUtils";
 const CheckedSelect = require("react-select-checked").CheckedSelect;
 
 export interface ISummaryHeaderProps {
@@ -32,10 +39,13 @@ export interface ISummaryHeaderProps {
     filter: StudyViewFilterWithSampleIdentifierFilters;
     attributesMetaSet: {[id:string]:ChartMeta};
     user?: string;
+    allGenes: Gene[];
     getClinicalData: () => Promise<string>;
     onSubmitQuery:() => void
     updateClinicalDataEqualityFilter: (chartMeta: ChartMeta, value: string[]) => void;
     updateClinicalDataIntervalFilter: (chartMeta: ChartMeta, values: ClinicalDataIntervalFilterValue[]) => void;
+    removeGeneFilter: (entrezGeneId: number) => void;
+    removeCNAGeneFilter: (filter: CopyNumberGeneFilterElement) => void;
     clearGeneFilter: () => void;
     clearCNAGeneFilter: () => void;
     clearChartSampleIdentifierFilter: (chartMeta: ChartMeta) => void;
@@ -270,8 +280,11 @@ export default class SummaryHeader extends React.Component<ISummaryHeaderProps, 
                 <UserSelections
                     filter={this.props.filter}
                     attributesMetaSet={this.props.attributesMetaSet}
+                    allGenes={this.props.allGenes}
                     updateClinicalDataEqualityFilter={this.props.updateClinicalDataEqualityFilter}
                     updateClinicalDataIntervalFilter={this.props.updateClinicalDataIntervalFilter}
+                    removeGeneFilter={this.props.removeGeneFilter}
+                    removeCNAGeneFilter={this.props.removeCNAGeneFilter}
                     clearCNAGeneFilter={this.props.clearCNAGeneFilter}
                     clearGeneFilter={this.props.clearGeneFilter}
                     clearChartSampleIdentifierFilter={this.props.clearChartSampleIdentifierFilter}

--- a/src/pages/studyView/UserSelections.tsx
+++ b/src/pages/studyView/UserSelections.tsx
@@ -1,20 +1,36 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { observer } from "mobx-react";
-import { computed } from 'mobx';
+import {observer} from "mobx-react";
+import {computed} from 'mobx';
 import styles from "./styles.module.scss";
-import {ClinicalDataIntervalFilterValue, StudyViewFilter} from 'shared/api/generated/CBioPortalAPIInternal';
-import { ChartMeta, UniqueKey, StudyViewFilterWithSampleIdentifierFilters} from 'pages/studyView/StudyViewPageStore';
-import {intervalFiltersDisplayValue, isFiltered} from 'pages/studyView/StudyViewUtils';
-import autobind from 'autobind-decorator';
+import {
+    ClinicalDataIntervalFilterValue,
+    CopyNumberGeneFilterElement
+} from 'shared/api/generated/CBioPortalAPIInternal';
+import {ChartMeta, UniqueKey, StudyViewFilterWithSampleIdentifierFilters} from 'pages/studyView/StudyViewPageStore';
+import {
+    FILTER_CONTENT_COLOR,
+    FILTER_TITLE_COLOR,
+    getCNAColorByAlteration,
+    getHugoSymbolByEntrezGeneId,
+    intervalFiltersDisplayValue,
+    isFiltered, MUTATED_GENE_COLOR, NA_COLOR
+} from 'pages/studyView/StudyViewUtils';
+import {PillTag} from "../../shared/components/PillTag/PillTag";
+import {GroupLogic} from "./filters/groupLogic/GroupLogic";
+import {Gene} from "../../shared/api/generated/CBioPortalAPI";
+import classnames from 'classnames';
 
 export interface IUserSelectionsProps {
     filter: StudyViewFilterWithSampleIdentifierFilters;
     attributesMetaSet: { [id: string]: ChartMeta };
+    allGenes: Gene[];
     updateClinicalDataEqualityFilter: (chartMeta: ChartMeta, value: string[]) => void;
     updateClinicalDataIntervalFilter: (chartMeta: ChartMeta, values: ClinicalDataIntervalFilterValue[]) => void;
     clearGeneFilter: () => void;
     clearCNAGeneFilter: () => void;
+    removeGeneFilter: (entrezGeneId: number) => void;
+    removeCNAGeneFilter: (filter: CopyNumberGeneFilterElement) => void;
     clearChartSampleIdentifierFilter: (chartMeta: ChartMeta) => void;
     clearAllFilters: () => void
 }
@@ -31,217 +47,134 @@ export default class UserSelections extends React.Component<IUserSelectionsProps
         return isFiltered(this.props.filter)
     }
 
-    @computed private get clinicalDataEqualityFilters() {
-        return _.reduce((this.props.filter.clinicalDataEqualityFilters || []), (acc,clinicalDataEqualityFilter) => {
-            let chartMeta = this.props.attributesMetaSet[clinicalDataEqualityFilter.clinicalDataType + '_' + clinicalDataEqualityFilter.attributeId];
+    @computed
+    get allComponents() {
+        let components = [] as JSX.Element[];
+
+        // Pie chart filters
+        _.reduce((this.props.filter.clinicalDataEqualityFilters || []), (acc, clinicalDataEqualityFilter) => {
+            const chartMeta = this.props.attributesMetaSet[clinicalDataEqualityFilter.clinicalDataType + '_' + clinicalDataEqualityFilter.attributeId];
             if (chartMeta) {
-                let labelValueSet = _.keyBy(clinicalDataEqualityFilter.values);
-                acc.push(<ChartFilter
-                    chartMeta={chartMeta}
-                    labelValueSet={labelValueSet}
-                    updateFilter={this.props.updateClinicalDataEqualityFilter}
+                acc.push(
+                    <GroupLogic
+                        components={[
+                            <PillTag
+                                content={chartMeta.displayName}
+                                backgroundColor={FILTER_TITLE_COLOR}
+                            />,
+                            <GroupLogic components={clinicalDataEqualityFilter.values.map(label => {
+                                return <PillTag
+                                    content={label}
+                                    backgroundColor={FILTER_CONTENT_COLOR}
+                                    onDelete={() => this.props.updateClinicalDataEqualityFilter(chartMeta, _.remove(clinicalDataEqualityFilter.values, value => value !== label))}
+                                />
+                            })} operation={'OR'} group={clinicalDataEqualityFilter.values.length > 1 ? true : false}/>
+                        ]}
+                        operation={clinicalDataEqualityFilter.values.length > 1 ? 'IN' : 'IS'}
+                        group={true}/>
+                );
+            }
+            return acc;
+        }, components);
+
+        // Bar chart filters
+        _.reduce((this.props.filter.clinicalDataIntervalFilters || []), (acc, clinicalDataIntervalFilter) => {
+            const chartMeta = this.props.attributesMetaSet[clinicalDataIntervalFilter.clinicalDataType + '_' + clinicalDataIntervalFilter.attributeId];
+            if (chartMeta) {
+                acc.push(
+                    <GroupLogic
+                        components={[
+                            <PillTag
+                                content={chartMeta.displayName}
+                                backgroundColor={FILTER_TITLE_COLOR}
+                            />,
+                            <PillTag
+                                content={intervalFiltersDisplayValue(clinicalDataIntervalFilter.values)}
+                                backgroundColor={FILTER_CONTENT_COLOR}
+                                onDelete={() => this.props.updateClinicalDataEqualityFilter(chartMeta, [])}
+                            />
+                        ]}
+                        operation={'IS'}
+                        group={true}/>
+                );
+            }
+            return acc;
+        }, components);
+
+        // Mutated Genes table
+        let chartMeta = this.props.attributesMetaSet[UniqueKey.MUTATED_GENES_TABLE];
+        if (chartMeta && !_.isEmpty(this.props.filter.mutatedGenes)) {
+            components.push(<GroupLogic components={this.props.filter.mutatedGenes.map(filter => {
+                return <GroupLogic
+                    components={filter.entrezGeneIds.map((entrezGene, index) => {
+                        const hugoSymbol = getHugoSymbolByEntrezGeneId(this.props.allGenes, entrezGene);
+                        return <PillTag
+                            content={hugoSymbol === undefined ? `Entrez Gene ID: ${entrezGene}` : hugoSymbol}
+                            backgroundColor={MUTATED_GENE_COLOR}
+                            onDelete={() => this.props.removeGeneFilter(entrezGene)}
+                        />
+                    })}
+                    operation="OR"
+                    group={filter.entrezGeneIds.length > 1}
+                />
+            })} operation={"AND"} group={false}/>);
+        }
+
+        // CNA table files
+        chartMeta = this.props.attributesMetaSet[UniqueKey.CNA_GENES_TABLE];
+        if (chartMeta && !_.isEmpty(this.props.filter.cnaGenes)) {
+            components.push(<GroupLogic components={this.props.filter.cnaGenes.map(filter => {
+                return <GroupLogic
+                    components={filter.alterations.map((filter, index) => {
+                        const hugoSymbol = getHugoSymbolByEntrezGeneId(this.props.allGenes, filter.entrezGeneId);
+                        let tagColor = getCNAColorByAlteration(filter.alteration);
+                        tagColor = tagColor === undefined ? NA_COLOR : tagColor;
+                        return <PillTag
+                            content={hugoSymbol === undefined ? `Entrez Gene ID: ${filter.entrezGeneId}` : hugoSymbol}
+                            backgroundColor={tagColor}
+                            onDelete={() => this.props.removeCNAGeneFilter(filter)}
+                        />
+                    })}
+                    operation="OR"
+                    group={filter.alterations.length > 1}
+                />
+            })} operation={"AND"} group={false}/>);
+        }
+
+        // Select IDs by Case Selector, Scatter Plot
+        _.reduce((this.props.filter.sampleIdentifiersSet || []), (acc, sampleIdentifiers, chartUniqKey) => {
+            const chartMeta = this.props.attributesMetaSet[chartUniqKey];
+            if (chartMeta) {
+                let customChartName = chartMeta.uniqueKey === UniqueKey.SELECT_CASES_BY_IDS ? 'IDs' : chartMeta.displayName;
+                acc.push(<PillTag
+                    content={`Selected ${sampleIdentifiers.length} samples by ${customChartName}`}
+                    backgroundColor={FILTER_TITLE_COLOR}
+                    onDelete={() => this.props.clearChartSampleIdentifierFilter(chartMeta)}
                 />);
             }
             return acc;
-        },[] as JSX.Element[])
-    }
-
-    @computed private get clinicalDataIntervalFilters() {
-        return _.map((this.props.filter.clinicalDataIntervalFilters || []), clinicalDataIntervalFilter => {
-            const chartMeta = this.props.attributesMetaSet[clinicalDataIntervalFilter.clinicalDataType + '_' + clinicalDataIntervalFilter.attributeId];
-            if (chartMeta) {
-                return (
-                    <ClinicalDataIntervalFilter
-                        chartMeta={chartMeta}
-                        values={clinicalDataIntervalFilter.values}
-                        updateClinicalDataIntervalFilter={this.props.updateClinicalDataIntervalFilter}
-                    />
-                );
-            } else {
-                return null;
-            }
-        });
-    }
-
-    @computed private get mutatedGeneFilter() {
-        let chartMeta = this.props.attributesMetaSet[UniqueKey.MUTATED_GENES_TABLE];
-        if (chartMeta && !_.isEmpty(this.props.filter.mutatedGenes)) {
-            return (
-                <ChartFilter
-                    chartMeta={chartMeta}
-                    clearFilter={this.props.clearGeneFilter}
-                />)
-        }
-        return null;
-    }
-
-    @computed private get cnaGeneFilter() {
-        let chartMeta = this.props.attributesMetaSet[UniqueKey.CNA_GENES_TABLE];
-        if (chartMeta && !_.isEmpty(this.props.filter.cnaGenes)) {
-            return (
-                <ChartFilter
-                    chartMeta={chartMeta}
-                    clearFilter={this.props.clearCNAGeneFilter}
-                />)
-        }
-        return null;
-    }
-
-    @computed private get sampleIdentifiersFilters() {
-        return _.reduce(this.props.filter.sampleIdentifiersSet, (acc, sampleIdentifiers, chartUniqKey) => {
-            let chartMeta = this.props.attributesMetaSet[chartUniqKey];
-            if (chartMeta) {
-                acc.push(<ChartFilter
-                    chartMeta={chartMeta}
-                    clearFilter={this.props.clearChartSampleIdentifierFilter}
-                />)
-            }
-            return acc;
-        },[] as JSX.Element[])
+        }, components);
+        return components;
     }
 
     render() {
         if (this.showFilters) {
             return (
                 <div className={styles.userSelections}>
-                    <span>Your selection:</span>
-                    <div>
-                        {this.clinicalDataEqualityFilters}
-                        {this.clinicalDataIntervalFilters}
-                        {this.cnaGeneFilter}
-                        {this.mutatedGeneFilter}
-                        {this.sampleIdentifiersFilters}
-                        <span><button className="btn btn-default btn-xs" onClick={this.props.clearAllFilters}>Clear All</button></span>
+                    <div style={{display: 'flex', flexWrap: 'wrap'}}>
+                        <GroupLogic
+                            components={this.allComponents}
+                            operation="AND"
+                            group={false}
+                        />
+                        <button className={classnames('btn btn-default btn-sm', styles.summaryHeaderBtn, styles.summaryClearAllBtn)}
+                                onClick={this.props.clearAllFilters}>Clear All Filters
+                        </button>
                     </div>
                 </div>
             );
         } else {
             return null;
         }
-    }
-}
-
-
-export interface IChartFilterProps {
-    chartMeta: ChartMeta;
-    labelValueSet?: { [id: string]: any };
-    updateFilter?: (chartMeta: ChartMeta, value: any[]) => void;
-    clearFilter?: (chartMeta: ChartMeta) => void; // could be used if we want to remove all filters for that particular chart
-}
-
-@observer
-class ChartFilter extends React.Component<IChartFilterProps, {}> {
-
-    @autobind
-    private updateFilter(displayLabel: string) {
-        if (this.props.updateFilter) {
-            let filteredValues = _.filter(this.props.labelValueSet || {}, (_value, _displayLabel) => _displayLabel !== displayLabel);
-            this.props.updateFilter(this.props.chartMeta, filteredValues);
-        }
-    }
-
-    @autobind
-    private clearFilter() {
-        if (this.props.clearFilter) {
-            this.props.clearFilter(this.props.chartMeta)
-        }
-    }
-
-    render() {
-        return (
-            <span className={styles.filter}>
-                <span className={styles.name}>{this.props.chartMeta.displayName}</span>
-                {this.props.labelValueSet && _.map(this.props.labelValueSet, (value, displayLabel) => {
-                    return (
-                        <UnitFilter
-                            value={value}
-                            displayLabel={displayLabel}
-                            removeFilter={this.updateFilter} />
-                    )
-                })}
-                {!this.props.labelValueSet &&
-                    <i
-                        className="fa fa-times"
-                        style={{ cursor: "pointer" }}
-                        onClick={this.clearFilter}
-                    />
-                }
-            </span>
-        )
-    }
-}
-
-export interface IClinicalDataIntervalFilterProps {
-    chartMeta: ChartMeta;
-    values: ClinicalDataIntervalFilterValue[];
-    updateClinicalDataIntervalFilter: (chartMeta: ChartMeta, values: ClinicalDataIntervalFilterValue[]) => void;
-}
-
-class ClinicalDataIntervalFilter extends React.Component<IClinicalDataIntervalFilterProps, {}> {
-
-    @autobind
-    private updateClinicalDataIntervalFilter() {
-        this.props.updateClinicalDataIntervalFilter(this.props.chartMeta, []);
-    }
-
-    render() {
-        return (
-            <span className={styles.filter}>
-                <span className={styles.name}>{this.props.chartMeta.displayName}</span>
-                <IntervalFilter
-                    values={this.props.values}
-                    removeClinicalDataIntervalFilter={this.updateClinicalDataIntervalFilter}
-                />
-            </span>
-        );
-    }
-}
-
-export interface IUnitFilterProps {
-    value: string;
-    displayLabel: string
-    removeFilter: (value: string) => void
-}
-
-@observer
-class UnitFilter extends React.Component<IUnitFilterProps, {}> {
-
-    @autobind
-    private removeFilter() {
-        this.props.removeFilter(this.props.displayLabel)
-    }
-
-    render() {
-        return (
-            <span className={styles.value}>
-                <span className={styles.label}>{this.props.displayLabel}</span>
-                <i
-                    className="fa fa-times"
-                    style={{ cursor: "pointer" }}
-                    onClick={this.removeFilter}
-                />
-            </span>
-        )
-    }
-}
-
-class IntervalFilter extends React.Component<{ values: ClinicalDataIntervalFilterValue[]; removeClinicalDataIntervalFilter: (values: ClinicalDataIntervalFilterValue[]) => void; }, {}> {
-
-    @autobind
-    private removeClinicalDataIntervalFilter() {
-        this.props.removeClinicalDataIntervalFilter([]);
-    }
-
-    render() {
-        return (
-            <span className={styles.value}>
-                <span className={styles.label}>{intervalFiltersDisplayValue(this.props.values)}</span>
-                <i
-                    className="fa fa-times"
-                    style={{ cursor: "pointer" }}
-                    onClick={this.removeClinicalDataIntervalFilter}
-                />
-            </span>
-        );
     }
 }

--- a/src/pages/studyView/UserSelections.tsx
+++ b/src/pages/studyView/UserSelections.tsx
@@ -56,22 +56,20 @@ export default class UserSelections extends React.Component<IUserSelectionsProps
             const chartMeta = this.props.attributesMetaSet[clinicalDataEqualityFilter.clinicalDataType + '_' + clinicalDataEqualityFilter.attributeId];
             if (chartMeta) {
                 acc.push(
-                    <GroupLogic
-                        components={[
-                            <PillTag
-                                content={chartMeta.displayName}
-                                backgroundColor={FILTER_TITLE_COLOR}
-                            />,
-                            <GroupLogic components={clinicalDataEqualityFilter.values.map(label => {
-                                return <PillTag
-                                    content={label}
-                                    backgroundColor={FILTER_CONTENT_COLOR}
-                                    onDelete={() => this.props.updateClinicalDataEqualityFilter(chartMeta, _.remove(clinicalDataEqualityFilter.values, value => value !== label))}
-                                />
-                            })} operation={'OR'} group={clinicalDataEqualityFilter.values.length > 1 ? true : false}/>
-                        ]}
-                        operation={clinicalDataEqualityFilter.values.length > 1 ? 'IN' : 'IS'}
-                        group={true}/>
+                    <div className={styles.parentGroupLogic}>
+                        <GroupLogic
+                            components={[
+                                <span className={styles.filterClinicalAttrName}>{chartMeta.displayName}</span>,
+                                <GroupLogic components={clinicalDataEqualityFilter.values.map(label => {
+                                    return <PillTag
+                                        content={label}
+                                        backgroundColor={FILTER_CONTENT_COLOR}
+                                        onDelete={() => this.props.updateClinicalDataEqualityFilter(chartMeta, _.remove(clinicalDataEqualityFilter.values, value => value !== label))}
+                                    />
+                                })} operation={'or'} group={false}/>
+                            ]}
+                            operation={':'}
+                            group={false}/></div>
                 );
             }
             return acc;
@@ -82,20 +80,17 @@ export default class UserSelections extends React.Component<IUserSelectionsProps
             const chartMeta = this.props.attributesMetaSet[clinicalDataIntervalFilter.clinicalDataType + '_' + clinicalDataIntervalFilter.attributeId];
             if (chartMeta) {
                 acc.push(
-                    <GroupLogic
+                    <div className={styles.parentGroupLogic}><GroupLogic
                         components={[
-                            <PillTag
-                                content={chartMeta.displayName}
-                                backgroundColor={FILTER_TITLE_COLOR}
-                            />,
+                            <span className={styles.filterClinicalAttrName}>{chartMeta.displayName}</span>,
                             <PillTag
                                 content={intervalFiltersDisplayValue(clinicalDataIntervalFilter.values)}
                                 backgroundColor={FILTER_CONTENT_COLOR}
                                 onDelete={() => this.props.updateClinicalDataEqualityFilter(chartMeta, [])}
                             />
                         ]}
-                        operation={'IS'}
-                        group={true}/>
+                        operation={':'}
+                        group={false}/></div>
                 );
             }
             return acc;
@@ -104,41 +99,43 @@ export default class UserSelections extends React.Component<IUserSelectionsProps
         // Mutated Genes table
         let chartMeta = this.props.attributesMetaSet[UniqueKey.MUTATED_GENES_TABLE];
         if (chartMeta && !_.isEmpty(this.props.filter.mutatedGenes)) {
-            components.push(<GroupLogic components={this.props.filter.mutatedGenes.map(filter => {
-                return <GroupLogic
-                    components={filter.entrezGeneIds.map((entrezGene, index) => {
-                        const hugoSymbol = getHugoSymbolByEntrezGeneId(this.props.allGenes, entrezGene);
-                        return <PillTag
-                            content={hugoSymbol === undefined ? `Entrez Gene ID: ${entrezGene}` : hugoSymbol}
-                            backgroundColor={MUTATED_GENE_COLOR}
-                            onDelete={() => this.props.removeGeneFilter(entrezGene)}
-                        />
-                    })}
-                    operation="OR"
-                    group={filter.entrezGeneIds.length > 1}
-                />
-            })} operation={"AND"} group={false}/>);
+            components.push(<div className={styles.parentGroupLogic}><GroupLogic
+                components={this.props.filter.mutatedGenes.map(filter => {
+                    return <GroupLogic
+                        components={filter.entrezGeneIds.map((entrezGene, index) => {
+                            const hugoSymbol = getHugoSymbolByEntrezGeneId(this.props.allGenes, entrezGene);
+                            return <PillTag
+                                content={hugoSymbol === undefined ? `Entrez Gene ID: ${entrezGene}` : hugoSymbol}
+                                backgroundColor={MUTATED_GENE_COLOR}
+                                onDelete={() => this.props.removeGeneFilter(entrezGene)}
+                            />
+                        })}
+                        operation="or"
+                        group={filter.entrezGeneIds.length > 1}
+                    />
+                })} operation={"and"} group={false}/></div>);
         }
 
         // CNA table files
         chartMeta = this.props.attributesMetaSet[UniqueKey.CNA_GENES_TABLE];
         if (chartMeta && !_.isEmpty(this.props.filter.cnaGenes)) {
-            components.push(<GroupLogic components={this.props.filter.cnaGenes.map(filter => {
-                return <GroupLogic
-                    components={filter.alterations.map((filter, index) => {
-                        const hugoSymbol = getHugoSymbolByEntrezGeneId(this.props.allGenes, filter.entrezGeneId);
-                        let tagColor = getCNAColorByAlteration(filter.alteration);
-                        tagColor = tagColor === undefined ? NA_COLOR : tagColor;
-                        return <PillTag
-                            content={hugoSymbol === undefined ? `Entrez Gene ID: ${filter.entrezGeneId}` : hugoSymbol}
-                            backgroundColor={tagColor}
-                            onDelete={() => this.props.removeCNAGeneFilter(filter)}
-                        />
-                    })}
-                    operation="OR"
-                    group={filter.alterations.length > 1}
-                />
-            })} operation={"AND"} group={false}/>);
+            components.push(<div className={styles.parentGroupLogic}><GroupLogic
+                components={this.props.filter.cnaGenes.map(filter => {
+                    return <GroupLogic
+                        components={filter.alterations.map((filter, index) => {
+                            const hugoSymbol = getHugoSymbolByEntrezGeneId(this.props.allGenes, filter.entrezGeneId);
+                            let tagColor = getCNAColorByAlteration(filter.alteration);
+                            tagColor = tagColor === undefined ? NA_COLOR : tagColor;
+                            return <PillTag
+                                content={hugoSymbol === undefined ? `Entrez Gene ID: ${filter.entrezGeneId}` : hugoSymbol}
+                                backgroundColor={tagColor}
+                                onDelete={() => this.props.removeCNAGeneFilter(filter)}
+                            />
+                        })}
+                        operation="or"
+                        group={filter.alterations.length > 1}
+                    />
+                })} operation={"and"} group={false}/></div>);
         }
 
         // Select IDs by Case Selector, Scatter Plot
@@ -146,11 +143,11 @@ export default class UserSelections extends React.Component<IUserSelectionsProps
             const chartMeta = this.props.attributesMetaSet[chartUniqKey];
             if (chartMeta) {
                 let customChartName = chartMeta.uniqueKey === UniqueKey.SELECT_CASES_BY_IDS ? 'IDs' : chartMeta.displayName;
-                acc.push(<PillTag
+                acc.push(<div className={styles.parentGroupLogic}><PillTag
                     content={`Selected ${sampleIdentifiers.length} samples by ${customChartName}`}
                     backgroundColor={FILTER_TITLE_COLOR}
                     onDelete={() => this.props.clearChartSampleIdentifierFilter(chartMeta)}
-                />);
+                /></div>);
             }
             return acc;
         }, components);
@@ -161,16 +158,11 @@ export default class UserSelections extends React.Component<IUserSelectionsProps
         if (this.showFilters) {
             return (
                 <div className={styles.userSelections}>
-                    <div style={{display: 'flex', flexWrap: 'wrap'}}>
-                        <GroupLogic
-                            components={this.allComponents}
-                            operation="AND"
-                            group={false}
-                        />
-                        <button className={classnames('btn btn-default btn-sm', styles.summaryHeaderBtn, styles.summaryClearAllBtn)}
-                                onClick={this.props.clearAllFilters}>Clear All Filters
-                        </button>
-                    </div>
+                    {this.allComponents}
+                    <button
+                        className={classnames('btn btn-default btn-sm', styles.summaryHeaderBtn, styles.summaryClearAllBtn)}
+                        onClick={this.props.clearAllFilters}>Clear All Filters
+                    </button>
                 </div>
             );
         } else {

--- a/src/pages/studyView/charts/barChart/BarChart.tsx
+++ b/src/pages/studyView/charts/barChart/BarChart.tsx
@@ -9,7 +9,12 @@ import { AbstractChart } from "pages/studyView/charts/ChartContainer";
 import { bind } from "bind-decorator";
 import BarChartAxisLabel from "./BarChartAxisLabel";
 import {
-    filterCategoryBins, filterNumericalBins, formatNumericalTickValues, generateCategoricalData, generateNumericalData
+    filterCategoryBins,
+    filterNumericalBins,
+    formatNumericalTickValues,
+    generateCategoricalData,
+    generateNumericalData,
+    SELECTED_GROUP_COLOR, UNSELECTED_GROUP_COLOR
 } from "../../StudyViewUtils";
 
 export interface IBarChartProps {
@@ -148,7 +153,7 @@ export default class BarChart extends React.Component<IBarChartProps, {}> implem
                         style={{
                             data: {
                                 fill: (d: BarDatum) =>
-                                    this.isDataBinSelected(d.dataBin, this.props.filters) ? "#dc3912" : "#2986e2"
+                                    this.isDataBinSelected(d.dataBin, this.props.filters) ? SELECTED_GROUP_COLOR : UNSELECTED_GROUP_COLOR
                             }
                         }}
                         data={this.barData}

--- a/src/pages/studyView/filters/groupLogic/GroupLogic.tsx
+++ b/src/pages/studyView/filters/groupLogic/GroupLogic.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {observer} from "mobx-react";
+import {computed} from 'mobx';
+import styles from "./styles.module.scss";
+import classnames from 'classnames';
+
+export interface IGroupLogicProps {
+    components: JSX.Element[],
+    operation: string,
+    group: boolean,
+}
+
+@observer
+export class GroupLogic extends React.Component<IGroupLogicProps, {}> {
+    @computed
+    get child() {
+        let elements = [];
+        if (this.props.group) {
+            elements.push(<span className={classnames(styles.text, styles.mostLeft)}>(</span>);
+        }
+        _.reduce(this.props.components, (acc, next, index): any => {
+                if (index > 0) {
+                    acc.push(<span className={styles.text}>{this.props.operation}</span>);
+                }
+                acc.push(next);
+                return acc;
+            }, elements
+        );
+        if (this.props.group) {
+            elements.push(<span className={classnames(styles.text, styles.mostRight)}>)</span>);
+        }
+        return elements;
+    }
+
+    render() {
+        return <div className={styles.main}>{
+            this.child
+        }</div>;
+    };
+}

--- a/src/pages/studyView/filters/groupLogic/styles.module.scss
+++ b/src/pages/studyView/filters/groupLogic/styles.module.scss
@@ -2,7 +2,6 @@
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    margin: 2px 0;
 }
 
 .text {

--- a/src/pages/studyView/filters/groupLogic/styles.module.scss
+++ b/src/pages/studyView/filters/groupLogic/styles.module.scss
@@ -1,0 +1,19 @@
+.main {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    margin: 2px 0;
+}
+
+.text {
+    font-weight: bold;
+    margin: 0 5px;
+}
+
+.mostLeft {
+    margin-left: 0;
+}
+
+.mostRight {
+    margin-right: 0;
+}

--- a/src/pages/studyView/styles.module.scss
+++ b/src/pages/studyView/styles.module.scss
@@ -32,33 +32,25 @@
     flex-direction: column;
 }
 .userSelections {
-    font-size: 12px;
+    font-size: 13px;
     margin: 5px;
+    border: 1px solid lightgrey;
+    border-radius: 5px;
+    padding: 5px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+}
 
-    .filter {
-        padding-right: 10px;
-        display: inline;
-        > .name {
-            display: inline;
-            padding-right: 5px;
-        }
-        > .value {
-            padding-right: 5px;
-            font-weight: bold;
-            display: inline;
-
-            > .label {
-                padding-right: 5px;
-            }
-        }
-        &:last-child {
-            padding-right: 0px;
-        }
-    }
+.parentGroupLogic {
+    background-color: #eeeeee;
+    border-radius: 5px;
+    margin: 2px 5px 2px 0;
+    padding: 5px;
 }
 
 .summaryHeader{
-    margin: 5px;
+    margin: 5px 5px 20px 5px;
     font-size: 16px;
     display: flex;
     align-items: center;
@@ -74,6 +66,12 @@
 }
 
 .summaryClearAllBtn {
-  margin: 2px 0 2px 5px !important;
+    height: 30px;
+    margin-left: 5px !important;
+
 }
 
+.filterClinicalAttrName {
+    font-size: 13px;
+    font-weight: bold;
+}

--- a/src/pages/studyView/styles.module.scss
+++ b/src/pages/studyView/styles.module.scss
@@ -33,6 +33,7 @@
 }
 .userSelections {
     font-size: 12px;
+    margin: 5px;
 
     .filter {
         padding-right: 10px;
@@ -71,3 +72,8 @@
 .summaryHeaderItem {
     margin: 0 2px !important;
 }
+
+.summaryClearAllBtn {
+  margin: 2px 0 !important;
+}
+

--- a/src/pages/studyView/styles.module.scss
+++ b/src/pages/studyView/styles.module.scss
@@ -74,6 +74,6 @@
 }
 
 .summaryClearAllBtn {
-  margin: 2px 0 !important;
+  margin: 2px 0 2px 5px !important;
 }
 

--- a/src/pages/studyView/table/CNAGenesTable.tsx
+++ b/src/pages/studyView/table/CNAGenesTable.tsx
@@ -12,7 +12,7 @@ import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
 import LabeledCheckbox from "shared/components/labeledCheckbox/LabeledCheckbox";
 import FixedHeaderTable from "./FixedHeaderTable";
 import {bind} from "bind-decorator";
-import {getCNAByAlteration, getQValue} from "../StudyViewUtils";
+import {getCNAByAlteration, getCNAColorByAlteration, getQValue} from "../StudyViewUtils";
 
 
 export type  CNAGenesTableUserSelectionWithIndex = CopyNumberGeneFilterElement & {
@@ -94,7 +94,7 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
         {
             name: 'CNA',
             render: (data: CopyNumberCountByGene) =>
-                <span className={classnames(data.alteration === -2 ? styles.del : styles.amp)}>
+                <span style={{color: getCNAColorByAlteration(data.alteration)}}>
                     {getCNAByAlteration(data.alteration)}
                 </span>,
             sortBy: (data: CopyNumberCountByGene) => data.alteration,

--- a/src/pages/studyView/table/FixedHeaderTable.tsx
+++ b/src/pages/studyView/table/FixedHeaderTable.tsx
@@ -154,7 +154,7 @@ export default class FixedHeaderTable<T> extends React.Component<IFixedHeaderTab
                     <input placeholder={"Search..."} type="text" onInput={this.onFilterTextChange()}
                            className={classnames('form-control', styles.tableSearchInput)}/>
                     <If condition={this.props.showSelectSamples}>
-                        <button className="btn btn-primary btn-sm" onClick={this.afterSelectingRows}>Select Samples</button>
+                        <button className={classnames("btn btn-primary btn-sm", styles.selectSamplesBtn)} onClick={this.afterSelectingRows}>Select Samples</button>
                     </If>
                 </div>
             </div>

--- a/src/pages/studyView/table/tables.module.scss
+++ b/src/pages/studyView/table/tables.module.scss
@@ -103,4 +103,5 @@
 
 .selectSamplesBtn {
   background-color: $study-view-primary-color !important;
+  border-color: $study-view-primary-color !important;
 }

--- a/src/pages/studyView/table/tables.module.scss
+++ b/src/pages/studyView/table/tables.module.scss
@@ -1,3 +1,4 @@
+
 .studyViewTablesTable {
   padding: 0 1px;
   display: flex;
@@ -35,7 +36,7 @@
 }
 
 .geneSymbol:hover {
-  border: 2px solid #1974b8;
+  border: 2px solid $study-view-primary-color;
   cursor: pointer;
 }
 
@@ -98,4 +99,8 @@
 
 .noFlexShrink {
   flex-shrink: 0;
+}
+
+.selectSamplesBtn {
+  background-color: $study-view-primary-color !important;
 }

--- a/src/shared/components/PillTag/PillTag.tsx
+++ b/src/shared/components/PillTag/PillTag.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import styles from './styles.module.scss';
+import {If} from 'react-if';
+import contrast from 'contrast';
+import {computed} from 'mobx';
+
+export interface IPillTagProps {
+    content: string;
+    backgroundColor: string;
+    onDelete?: () => void;
+}
+
+export class PillTag extends React.Component<IPillTagProps, {}> {
+
+    @computed
+    get contentColor() {
+        let _contrast = contrast(this.props.backgroundColor);
+        if (_contrast === 'light') {
+            return '#000';
+        } else {
+            return '#fff'
+        }
+    }
+
+    render() {
+        return (<div className={styles.main} style={{background: this.props.backgroundColor, color: this.contentColor}}>
+            <span className={styles.content}>{this.props.content}</span>
+            <If condition={_.isFunction(this.props.onDelete)}>
+                <span className={styles.delete} onClick={this.props.onDelete}><i className="fa fa-times-circle"></i></span>
+            </If>
+        </div>)
+    }
+}

--- a/src/shared/components/PillTag/styles.module.scss
+++ b/src/shared/components/PillTag/styles.module.scss
@@ -1,0 +1,22 @@
+$wide: 10px;
+$regular: 5px;
+
+.main {
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
+  font-size: 13px;
+  display: flex;
+  align-content: center;
+}
+
+.content {
+  margin: $regular $wide $regular $wide;
+}
+
+.delete {
+  padding-left: $regular;
+  margin: $regular $regular $regular 0;
+  border-left: 1px dashed white;
+  cursor: pointer;
+}

--- a/typings/missing.d.ts
+++ b/typings/missing.d.ts
@@ -32,3 +32,4 @@ declare module 'victory';
 declare module 'universal-ga';
 declare module 'mixpanel-browser';
 declare module 'measure-text';
+declare module 'contrast';


### PR DESCRIPTION
- Use different colors to indicate filter types
- Use AND, OR, IN, IS indicating the relationships among filters

Example: MSK IMPACT 2017
![screen shot 2018-09-19 at 3 39 07 pm](https://user-images.githubusercontent.com/5400599/45776845-30e4a180-bc22-11e8-9174-3e5a4dbcb787.png)

Clinical attribute display name: dark grey
Clinical value: study view blue

Select by IDs: dark grey
Mutated Genes: green
Deletion: blue
Amplification: red


TODO: now we almost allow user come to study with filters, should we support that in the URL?

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

