### PR TITLE
Fix msk

### DIFF
--- a/my-index.ejs
+++ b/my-index.ejs
@@ -25,6 +25,7 @@
             skinIsMarkdownDocumentation:true,
             skinDocumentationBaseUrl:"https://raw.githubusercontent.com/cbioportal/cbioportal/release-1.15.0/docs",
             googleAnalyticsProfile:'UA-85438068-3',
+            urlLengthThresholdForSession:10,
             // customTabs:[
             //     {
             //         "title": "Custom Tab",

--- a/src/shared/components/MSKTabs/MSKTabs.spec.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.spec.tsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import {ThreeBounce} from 'better-react-spinkit';
 import {sleep} from "../../lib/TimeUtils";
 
-describe.skip('MSKTabs', () => {
+describe('MSKTabs', () => {
 
     let tabs: any;
 
@@ -29,9 +29,17 @@ describe.skip('MSKTabs', () => {
     });
 
     it('initial render only mounts first tab', async ()=>{
-        await sleep(1);
+        await sleep(0);
         assert.equal(tabs.find('.msk-tab').length, 1);
     });
+
+    it('render of tab is deferred to frame following', async ()=>{
+        assert.equal(tabs.find('.msk-tab').length, 0);
+        await sleep(0);
+        assert.equal(tabs.find('.msk-tab').length, 1);
+    });
+
+
 
     it('creates two tab buttons and toggles them properly', ()=>{
         assert.equal(tabs.find('li').length, 2);
@@ -50,25 +58,25 @@ describe.skip('MSKTabs', () => {
             </MSKTabs>
         );
 
-        await sleep(1);
+        await sleep(0);
 
         assert.equal(tabs.find('.msk-tab').length, 1);
         tabs.setProps({ activeTabId:"two" });
 
-        await sleep(1);
+        await sleep(0);
 
         assert.equal(tabs.find('.msk-tab').length, 2, "didn't unmount");
         assert.isTrue(tabs.find(MSKTab).at(0).hasClass('hiddenByPosition'));
 
         tabs.setProps({ activeTabId:"one" });
 
-        await sleep(1);
+        await sleep(0);
 
         assert.isTrue(tabs.find(MSKTab).at(1).hasClass('hiddenByPosition'));
         assert.isFalse(tabs.find(MSKTab).at(0).hasClass('hiddenByPosition'));
     });
 
-    it('if unmount on hide is true, we retain tabs when we click away', async()=>{
+    it('if unmount on hide is true, we DO NOT retain tabs when we click away', async()=>{
         tabs = mount(
             <MSKTabs unmountOnHide={true}>
                 <MSKTab id="one" linkText="One"><span className="content">One</span></MSKTab>
@@ -76,94 +84,51 @@ describe.skip('MSKTabs', () => {
             </MSKTabs>
         );
 
-        await sleep(1);
+        await sleep(0);
         assert.equal(tabs.find('.msk-tab').length, 1);
 
         tabs.setProps({ activeTabId:"two" });
-        await sleep(10);
+        await sleep(0);
         assert.equal(tabs.find('.msk-tab').length, 1, "did unmount");
-        // assert.isTrue(tabs.find(MSKTab).at(0).hasClass('hiddenByPosition'));
-        //
-        // tabs.setProps({ activeTabId:"one" });
-        //
-        // await sleep(1);
-        //
-        // assert.isTrue(tabs.find(MSKTab).at(1).hasClass('hiddenByPosition'));
-        // assert.isFalse(tabs.find(MSKTab).at(0).hasClass('hiddenByPosition'));
+        assert.isFalse(tabs.find(MSKTab).at(0).hasClass('hiddenByPosition'));
+
+        tabs.setProps({ activeTabId:"one" });
+        await sleep(0);
+        assert.isFalse(tabs.find(MSKTab).at(0).hasClass('hiddenByPosition'));
     });
 
-    it('if unMountOnHide = true, switch tab causes mounting, switching again causes hide/show', ()=>{
+    it('if unMountOnHide = false, switch tab causes mounting, switching again causes hide/show',async ()=>{
         tabs = mount(
             <MSKTabs unmountOnHide={false}>
                 <MSKTab id="one" linkText="One"><span className="content">One</span></MSKTab>
                 <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
             </MSKTabs>
         );
+        await sleep(0);
         assert.equal(tabs.find('.msk-tab').length, 1);
         tabs.setProps({ activeTabId:"two" });
         assert.equal(tabs.find('.msk-tab').length, 2);
         tabs.setProps({ activeTabId:"one" });
     });
 
-    it('if individual tab is unmountOnHide false then it will not be unmounted', ()=>{
+    it('if individual tab is unmountOnHide false then it will not be unmounted', async ()=>{
         tabs = mount(
             <MSKTabs>
                 <MSKTab unmountOnHide={false} id="one" linkText="One"><span className="content">One</span></MSKTab>
                 <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
             </MSKTabs>
         );
+
+        await sleep(0);
         assert.equal(tabs.find('.msk-tab').length, 1);
+
         tabs.setProps({ activeTabId:"two" });
+        await sleep(0);
         assert.equal(tabs.find('.msk-tab').length, 2);
+
         tabs.setProps({ activeTabId:"one" });
+        await sleep(0);
         assert.equal(tabs.find('.msk-tab').length, 1);
-    });
-
-    it('if individual tab is unmountOnHide false then it will not be unmounted', ()=>{
-        tabs = mount(
-            <MSKTabs unmountOnHide={true}>
-                <MSKTab unmountOnHide={false} id="one" linkText="One"><span className="content">One</span></MSKTab>
-                <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
-            </MSKTabs>
-        );
-        assert.equal(tabs.find('.msk-tab').length, 1);
-        tabs.setProps({ activeTabId:"two" });
-        assert.equal(tabs.find('.msk-tab').length, 2);
-        tabs.setProps({ activeTabId:"one" });
-        assert.equal(tabs.find('.msk-tab').length, 1);
-    });
-
-    it('does not display tabs that have hide={true}', ()=>{
-        let tabs2 = mount(<MSKTabs>
-            <MSKTab id="one" linkText="One"><span className="content">One</span></MSKTab>
-            <MSKTab linkText="Two" id="two" hide={true}><span className="content">Two</span></MSKTab>
-        </MSKTabs>);
-        assert.deepEqual(tabText(tabs2), ["One"]);
-    });
-
-    it('does not display the content of tabs that have loading={true}, instead showing a spinner; and ' +
-        'does not show a tab with loading={true} unless it is the active tab', ()=>{
-
-        tabs.setProps({ activeTabId: "one" });
-        const tab = tabs.find(MSKTab).at(0);
-        let span:ReactWrapper<any,any> = tab.find("span").at(0);
-        assert(span.exists(), "the span exists");
-        assert.equal(span.text(), "One");
-
-        let tabs2 = mount(<MSKTabs activeTabId="one">
-            <MSKTab id="one" linkText="One"><span className="content">One</span></MSKTab>
-            <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
-        </MSKTabs>);
-
-        const tab2 = tabs2.find(MSKTab).at(0);
-        span = tab2.find("span").at(0);
-        assert.notEqual(span.text(), "One", "the span with the content 'One' does not exist for a loading tab");
-        assert(tab2.find(".default-spinner").at(0).exists(), "a loading tab contains a spinner element");
-        assert.deepEqual(tabText(tabs2), ["One", "Two"], "both tabs visible");
-
-        tabs2.setProps({ activeTabId: "two" });
-        assert.deepEqual(tabText(tabs2), ["Two"], "only one tab visible, since the other is loading");
-
     });
 
 });


### PR DESCRIPTION
@adamabeshouse I think this simplifies/clarifies the deferred render functionality in MSKTabs (the behavior which i could not adequately explain before.    

I decided not to make DeferredRender a library component just yet


Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
