### PR TITLE
Disabled MSKTabs page recalculation on window resize

### DIFF
--- a/src/pages/resultsView/expression/ExpressionWrapper.tsx
+++ b/src/pages/resultsView/expression/ExpressionWrapper.tsx
@@ -534,6 +534,7 @@ export default class ExpressionWrapper extends React.Component<ExpressionWrapper
                 <div style={{marginBottom:15}}>
 
                     <MSKTabs onTabClick={this.handleTabClick}
+                             arrowStyle={{'line-height': .8}}
                              enablePagination={true}
                              unmountOnHide={true}
                              tabButtonStyle="pills"

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -170,10 +170,8 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
             }
 
             timeout = window.setTimeout(() => {
-                this.setState({
-                    currentPage: 1,
-                    pageBreaks: [] as string[]
-                } as IMSKTabsState);
+                // re-init paging for the resized container size
+                this.initPaging();
             }, 600);
         };
     }
@@ -275,9 +273,11 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
                 {prev}
                 {pages[this.state.currentPage - 1]}
                 {next}
-                {this.props.enablePagination && (
-                    <ReactResizeDetector handleWidth={true} onResize={this.initOnResize.bind(this)()} />
-                )}
+                {// TODO this doesn't always calculate the page size properly after resize, disabling for now
+                // this.props.enablePagination && (
+                //     <ReactResizeDetector handleWidth={true} onResize={this.initOnResize.bind(this)()} />
+                // )
+                }
             </ul>
         );
     }
@@ -320,24 +320,29 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
 
     componentDidMount() {
 
-        setTimeout(()=>{
+        setTimeout(() => {
             // if there are page breaks, it means that page calculations already performed
-            if (this.props.enablePagination &&
-                this.state.pageBreaks.length  === 0)
-            {
-                // find page breaks: depends on width of the container
-                const pageBreaks: string[] = this.findPageBreaks();
-
-                // find current page: depends on active tab id
-                const currentPage: number = this.findCurrentPage(pageBreaks);
-
-                this.setState({
-                    currentPage,
-                    pageBreaks
-                } as IMSKTabsState);
+            if (this.state.pageBreaks.length  === 0) {
+                this.initPaging();
             }
         },1);
 
+    }
+
+    initPaging() {
+        if (this.props.enablePagination)
+        {
+            // find page breaks: depends on width of the container
+            const pageBreaks: string[] = this.findPageBreaks();
+
+            // find current page: depends on active tab id
+            const currentPage: number = this.findCurrentPage(pageBreaks);
+
+            this.setState({
+                currentPage,
+                pageBreaks
+            } as IMSKTabsState);
+        }
     }
 
     findCurrentPage(pageBreaks: string[]) {


### PR DESCRIPTION
# What? Why?
- Fix https://github.com/cBioPortal/cbioportal/issues/4875
- But this also disables page recalculation on resize events

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)