### PR TITLE
Using npm ci instead of npm install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           - v1-dependencies-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
-      - run: npm install
+      - run: npm ci
       - run:
           name: "Ignore https to http switches on circleci in package lock (not sure why this happens)"
           command: "git diff --exit-code package-lock.json || sed -i 's/http:/https:/g' package-lock.json"
@@ -96,7 +96,7 @@ jobs:
           command: |
             ./node_modules/http-server/bin/http-server --cors dist/ -p 3000 & \
             cd end-to-end-tests && \
-            npm install && \
+            npm ci && \
             ./node_modules/webdriver-manager/bin/webdriver-manager update --versions.chrome '2.37' && \
             ./node_modules/webdriver-manager/bin/webdriver-manager start --versions.chrome '2.37' & \
             ./scripts/env_vars.sh && \


### PR DESCRIPTION
This will help early detection of missing / outdated dependencies.

# What? Why?
Fixes issues like the one below:
```
node install

node-pre-gyp ERR! Tried to download(404): https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v64-darwin-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for fsevents@1.1.3 and node@10.11.0 (node-v64 ABI, unknown) (falling back to source compile with node-gyp) 
```
Such issues will occur if the dependencies are not up to date and a developer starts on a fresh/clean development machine.