### PR TITLE
E2E tests remove redundant viewport size

### DIFF
--- a/end-to-end-tests/specs/home.spec.js
+++ b/end-to-end-tests/specs/home.spec.js
@@ -111,7 +111,6 @@ describe('homepage', function() {
 
         beforeEach(function(){
             goToUrlAndSetLocalStorage(CBIOPORTAL_URL);
-            browser.setViewportSize({ height:1400, width:1000 });
             browser.waitForExist('[data-test="StudySelect"] input[type=checkbox]');
         });
 
@@ -237,7 +236,6 @@ describe('cross cancer query', function() {
 
     it('should show cross cancer bar chart with TP53 in title when selecting multiple studies and querying for TP53', function() {
         goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}`);
-        browser.setViewportSize({ height:1400, width:1000 });
 
         $('[data-test="StudySelect"]').waitForExist(20000);
         var checkBoxes = $$('[data-test="StudySelect"]');
@@ -270,7 +268,6 @@ describe('single study query', function() {
     describe('mutation mapper ', function() {
         it('should show somatic and germline mutation rate', function() {
            goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}`);
-            browser.setViewportSize({ height:1400, width:1000 });
 
             var input = $(".autosuggest input[type=text]");
 
@@ -311,7 +308,6 @@ describe('single study query', function() {
 
         it('should show lollipop for MUC2', function() {
             goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}/index.do?cancer_study_id=cellline_nci60&Z_SCORE_THRESHOLD=2&RPPA_SCORE_THRESHOLD=2&data_priority=0&case_set_id=cellline_nci60_cnaseq&gene_list=MUC2&geneset_list=+&tab_index=tab_visualize&Action=Submit&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=cellline_nci60_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=cellline_nci60_cna`);
-            browser.setViewportSize({ height:1400, width:1000 });
 
             //  wait for mutations tab
             $('a.tabAnchor_mutations').waitForExist(10000);

--- a/end-to-end-tests/specs/screenshot.spec.js
+++ b/end-to-end-tests/specs/screenshot.spec.js
@@ -246,7 +246,6 @@ describe('study view screenshot test', function(){
         mutatedGenesHeader.waitForExist(30000);
 
         // give charts time to render
-        browser.setViewportSize({ height: 1600, width: 1000 })
         browser.pause(5000);
 
         var res = browser.checkElement('#page_wrapper_table', {hide:['.qtip', '#footer-span-version'] });


### PR DESCRIPTION
We are setting this in goToUrlAnSetLocalStorage, so need to call multiple times