### PR TITLE
Make header gray for results + patient view

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -317,8 +317,7 @@ th.reactable-header-sort-asc:after {
 }
 
 #mainColumn {
-  padding: $gutterWidth 0;
-  background-color: white;
+  padding-top: $gutterWidth;
 }
 
 .fixedWidth {
@@ -558,6 +557,7 @@ h3.hr {
 }
 
 .staticPage {
+  padding-bottom: $gutterWidth;
 
   .markdown-body {
     h1 {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -11,8 +11,8 @@ import QueryAndDownloadTabs from "../../shared/components/query/QueryAndDownload
 import {PageLayout} from "../../shared/components/PageLayout/PageLayout";
 import RightBar from "../../shared/components/rightbar/RightBar";
 import getBrowserWindow from "../../shared/lib/getBrowserWindow";
-import {SampleList} from "../../shared/api/generated/CBioPortalAPI";
-import setWindowVariable from "../../shared/lib/setWindowVariable";
+// tslint:disable-next-line:no-import-side-effect
+import "./homePage.scss";
 
 (Chart as any).plugins.register({
     beforeDraw: function (chartInstance: any) {
@@ -72,7 +72,7 @@ export default class HomePage extends React.Component<IResultsViewPageProps, {}>
     public render() {
 
         return (
-            <PageLayout noMargin={true} rightBar={<RightBar queryStore={this.queryStore} />}>
+            <PageLayout className="HomePageLayout" noMargin={true} rightBar={<RightBar queryStore={this.queryStore} />}>
                 <div style={{padding:"0 15px"}}>
                     <div dangerouslySetInnerHTML={{__html:AppConfig.serverConfig.skin_blurb!}}></div>
                     <QueryAndDownloadTabs store={this.queryStore}/>

--- a/src/pages/home/homePage.scss
+++ b/src/pages/home/homePage.scss
@@ -1,0 +1,5 @@
+.HomePageLayout {
+    #mainColumn {
+        background: white;
+    }
+}


### PR DESCRIPTION
Keep header white for homepage. Only static page requires extra padding at the
bottom so add that.