### PR TITLE
Query store should not read from current route query on homepage.  An…

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -28,12 +28,12 @@ export interface IResultsViewPageProps {
     routing: any;
 }
 
-export function createQueryStore() {
+export function createQueryStore(currentQuery?:any) {
 
     const win:any = window;
 
     // lets make query Store since it's used in a lot of places
-    const queryStore = new QueryStore(win, getBrowserWindow().routingStore.query);
+    const queryStore = new QueryStore(win, currentQuery);
 
     queryStore.singlePageAppSubmitRoutine = function(path:string, query:CancerStudyQueryUrlParams) {
 

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -43,10 +43,6 @@ function initStore() {
 
     resultsViewPageStore.tabId = getTabId(getBrowserWindow().globalStores.routing.location.pathname);
 
-    if (!getBrowserWindow().currentQueryStore) {
-        getBrowserWindow().currentQueryStore = createQueryStore();
-    }
-
     let lastQuery:any;
     let lastPathname:string;
 

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -18,6 +18,7 @@ import {ServerConfigHelpers} from "../../../config/config";
 import AppConfig from "appConfig";
 import {StudyLink} from "../../../shared/components/StudyLink/StudyLink";
 import {createQueryStore} from "../../home/HomePage";
+import getBrowserWindow from "../../../shared/lib/getBrowserWindow";
 
 @observer
 export default class QuerySummary extends React.Component<{ routingStore:ExtendedRouterStore, store: ResultsViewPageStore }, {}> {
@@ -31,7 +32,7 @@ export default class QuerySummary extends React.Component<{ routingStore:Extende
     @autobind
     private handleModifyQueryClick() {
         // this will have no functional impact after initial invocation of this method
-        this.queryStore = (this.queryStore) ? undefined : createQueryStore();
+        this.queryStore = (this.queryStore) ? undefined : createQueryStore(getBrowserWindow().routingStore.query);
     }
 
     @computed get queryFormVisible(){

--- a/src/shared/lib/ExtendedRouterStore.ts
+++ b/src/shared/lib/ExtendedRouterStore.ts
@@ -203,7 +203,8 @@ export default class ExtendedRouterStore extends RouterStore {
 
     @computed
     public get query(){
-        if (this._session) {
+        // this allows url based query to override a session (if sessionId has been cleared in url)
+        if (this._session && this.location.query.session_id) {
             return this._session.query;
         } else {
             return this.location.query;


### PR DESCRIPTION
…d don't allow session to be read from memory when there is no sessionid in url

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
