### PR TITLE
AWS apiRoot hack: fix session service proxy

### DIFF
--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -9,14 +9,14 @@ export class AppStore {
     @observable authMethod:string | undefined;
 
     @computed get isLoggedIn(){
-        return _.isString(this.userName) && this.userName !== "anonymousUser"
+        return _.isString(this.userName) && this.userName !== "anonymousUser";
     }
 
     @computed get logoutUrl(){
         if (this.authMethod === "saml") {
-            return "/saml/logout";
+            return "saml/logout";
         } else {
-            return "j_spring_security_logout"
+            return "j_spring_security_logout";
         }
     }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -90,7 +90,7 @@ export function setServerConfig(serverConfig:{[key:string]:any }){
     // ** Don't try this at home, kids **
     if (frontendOverride.apiRoot) {
         console.log(`Overriding apiRoot with: ${frontendOverride.apiRoot}`);
-        config.apiRoot = `//${frontendOverride.apiRoot}/`;
+        config.apiRoot = `${frontendOverride.apiRoot}`;
     }
 
     // allow any hardcoded serverConfig props to override those from service

--- a/src/pages/resultsView/network/Network.tsx
+++ b/src/pages/resultsView/network/Network.tsx
@@ -57,7 +57,7 @@ export default class Network extends React.Component<INetworkTabParams, {}> {
         }
 
         const strParams = encodeURIComponent(JSON.stringify(networkParams));
-        return `${trimTrailingSlash(path)}/reactapp/network/network.htm?${AppConfig.serverConfig.app_version}&apiHost=${encodeURIComponent(AppConfig.apiRoot!)}#${strParams}`;
+        return `${trimTrailingSlash(path)}/reactapp/network/network.htm?${AppConfig.serverConfig.app_version}&apiHost=${encodeURIComponent(AppConfig.apiRoot!.replace(/^http[s]?:\/\//,''))}#${strParams}`;
     }
 
     render(){

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -131,11 +131,25 @@ export function getGenomeNexusApiUrl() {
 }
 
 export function getVirtualStudyServiceUrl() {
-    return buildCBioPortalAPIUrl("api-legacy/proxy/session/virtual_study");
+    if (AppConfig.serverConfig && AppConfig.serverConfig.hasOwnProperty("apiRoot")) {
+        // TODO: remove this after switch to AWS. This is a hack to use proxy
+        // session-service from non apiRoot. We'll have to come up with a better
+        // solution for auth portals
+        return buildCBioPortalPageUrl("api-legacy/proxy/session/virtual_study");
+    } else {
+        return buildCBioPortalAPIUrl("api-legacy/proxy/session/virtual_study");
+    }
 }
 
 export function getSessionServiceUrl() {
-    return buildCBioPortalAPIUrl("api-legacy/proxy/session/main_session");
+    if (AppConfig.serverConfig && AppConfig.serverConfig.hasOwnProperty("apiRoot")) {
+        // TODO: remove this after switch to AWS. This is a hack to use proxy
+        // session-service from non apiRoot. We'll have to come up with a better
+        // solution for auth portals
+        return buildCBioPortalPageUrl("api-legacy/proxy/session/main_session");
+    } else {
+        return buildCBioPortalAPIUrl("api-legacy/proxy/session/main_session");
+    }
 }
 
 export function getConfigurationServiceApiUrl() {


### PR DESCRIPTION
Don't use the apiRoot proxy, instead always use baseUrl's one. This restores
session service functionality when using this AWS specific hack. At some point
we'll have to come up with a better solution for portals with authorization
enabled (one can only log in to a single server, not both).