### PR TITLE
DataAccessTokens download token details on auth. portals

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -7,6 +7,9 @@ import {openSocialAuthWindow} from "../../shared/lib/openSocialAuthWindow";
 import {AppStore} from "../../AppStore";
 import {observer} from "mobx-react";
 import {buildCBioPortalPageUrl} from "../../shared/api/urls";
+import {Dropdown, DropdownToggleProps, DropdownMenuProps} from 'react-bootstrap';
+import {DataAccessTokens} from "../../shared/components/dataAccessTokens/DataAccessTokens";
+import {observable} from "mobx";
 
 @observer
 export default class PortalHeader extends React.Component<{ appStore:AppStore }, {}> {
@@ -115,10 +118,15 @@ export default class PortalHeader extends React.Component<{ appStore:AppStore },
             <div id="rightHeaderContent">
                 <If condition={this.props.appStore.isLoggedIn}>
                     <Then>
-                        <div className="identity">Logged in as {this.props.appStore.userName}
-                            <span className="pipeSeperator">|</span>
-                             <a href={buildCBioPortalPageUrl(this.props.appStore.logoutUrl)}>Sign out</a>
-
+                        <div className="identity">
+                            <Dropdown id="mydropdown">
+                                <Dropdown.Toggle {...({rootCloseEvent: "click"} as DropdownToggleProps)} className="btn-sm">
+                                    Logged in as {this.props.appStore.userName}
+                                </Dropdown.Toggle>
+                                <Dropdown.Menu {...({bsRole: "menu"} as DropdownMenuProps)} style={{ paddingLeft:10, overflow:'auto', maxHeight:300, whiteSpace:'nowrap' }}>
+                                    <DataAccessTokens appStore={this.props.appStore}/>
+                                </Dropdown.Menu>
+                            </Dropdown>
                         </div>
                     </Then>
                     <Else>
@@ -127,7 +135,6 @@ export default class PortalHeader extends React.Component<{ appStore:AppStore },
                         </If>
                     </Else>
                 </If>
-
                 <If condition={!_.isEmpty(AppConfig.serverConfig.skin_right_logo)}>
                     <img id="institute-logo" src={`images/${AppConfig.serverConfig.skin_right_logo!}`} alt="Institute Logo" />
                 </If>

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -94,6 +94,6 @@ export interface IServerConfig {
     "base_url": string|null;
     "user_email_address": string;
     "sessionServiceEnabled": boolean;
-    "session_url_length_threshold":string;
-
+    "session_url_length_threshold": string;
+    "dat_revoke_other_tokens": boolean;
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -2,6 +2,7 @@ import {IServerConfig} from "./IAppConfig";
 
 const ServerConfigDefaults: Partial<IServerConfig> = {
     app_version:"1.0",
+    dat_revoke_other_tokens:true,
     civic_url:"https://civicdb.org/api/",
     disabled_tabs:"",
 

--- a/src/shared/api/generated/CBioPortalAPI.ts
+++ b/src/shared/api/generated/CBioPortalAPI.ts
@@ -1,4 +1,5 @@
 import * as request from "superagent";
+import { getLegacyDataAccessTokenUrl } from "../urls";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type CancerStudy = {
@@ -170,6 +171,12 @@ export type CopyNumberSeg = {
 
         'uniqueSampleKey': string
 
+};
+export type DataAccessToken = {
+    'token': string
+    'username': string
+    'expiration': string
+    'creation': string
 };
 export type DiscreteCopyNumberData = {
     'alteration': number
@@ -5232,7 +5239,7 @@ export default class CBioPortalAPI {
          * @param {string} projection - Level of detail of the response
          * @param {integer} pageSize - Page size of the result list
          * @param {integer} pageNumber - Page number of the result list
-        
+
          * @param {string} direction - Direction of the sort
     */
     getAllPatientsInStudyUsingGET(parameters: {
@@ -6503,4 +6510,262 @@ export default class CBioPortalAPI {
                 return response.body;
             });
         };
+
+    /**
+     * createDataAccessToken
+     * @method
+     * @name CBioPortalAPI#createDataAccessTokenUsingPOST
+     * @param {boolean} allowRevocationOfOtherTokens - allowRevocationOfOtherTokens
+     */
+    createDataAccessTokenUsingPOST(parameters: {
+        'allowRevocationOfOtherTokens' ? : boolean,
+        $queryParameters ? : any
+    }): Promise < DataAccessToken > {
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let url = getLegacyDataAccessTokenUrl();
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['allowRevocationOfOtherTokens'] !== undefined) {
+                queryParameters['allowRevocationOfOtherTokens'] = parameters['allowRevocationOfOtherTokens'];
+            } else {
+                queryParameters['allowRevocationOfOtherTokens'] = false;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', url, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    getDataAccessTokenUsingGETURL(parameters: {
+        'token': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let url = getLegacyDataAccessTokenUrl() + '/{token}';
+
+        url = url.replace('{token}', parameters['token'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return url + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * getDataAccessToken
+     * @method
+     * @name CBioPortalAPI#getDataAccessTokenUsingGET
+     * @param {string} token - token
+     */
+    getDataAccessTokenUsingGET(parameters: {
+        'token': string,
+        $queryParameters ? : any
+    }): Promise < DataAccessToken > {
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let url = getLegacyDataAccessTokenUrl() + '/{token}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = '*/*';
+
+            url = url.replace('{token}', parameters['token'] + '');
+
+            if (parameters['token'] === undefined) {
+                reject(new Error('Missing required  parameter: token'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', url, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    revokeDataAccessTokenUsingDELETEURL(parameters: {
+        'token': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let url = getLegacyDataAccessTokenUrl() + '/{token}';
+        url = url.replace('{token}', parameters['token'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return url + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * revokeDataAccessToken
+     * @method
+     * @name CBioPortalAPI#revokeDataAccessTokenUsingDELETE
+     * @param {string} token - token
+     */
+    revokeDataAccessTokenUsingDELETE(parameters: {
+        'token': string,
+        $queryParameters ? : any
+    }): Promise < any > {
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let url = getLegacyDataAccessTokenUrl() + '/{token}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = '*/*';
+
+            url = url.replace('{token}', parameters['token'] + '');
+
+            if (parameters['token'] === undefined) {
+                reject(new Error('Missing required  parameter: token'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('DELETE', url, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    getAllDataAccessTokensUsingGETURL(parameters: {
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let url = getLegacyDataAccessTokenUrl() + '/{token}';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return url + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * getAllDataAccessTokens
+     * @method
+     * @name CBioPortalAPI#getAllDataAccessTokensUsingGET
+     */
+    getAllDataAccessTokensUsingGET(parameters: {
+        $queryParameters ? : any
+    }): Promise < Array < DataAccessToken >
+        > {
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let url = getLegacyDataAccessTokenUrl() + 's';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = '*/*';
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', url, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    revokeAllDataAccessTokensUsingDELETEURL(parameters: {
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let url = getLegacyDataAccessTokenUrl() + 's';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return url + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * revokeAllDataAccessTokens
+     * @method
+     * @name CBioPortalAPI#revokeAllDataAccessTokensUsingDELETE
+     */
+    revokeAllDataAccessTokensUsingDELETE(parameters: {
+        $queryParameters ? : any
+    }): Promise < any > {
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let url = getLegacyDataAccessTokenUrl() + 's';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = '*/*';
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('DELETE', url, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        }).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
 }
+

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -207,3 +207,7 @@ export function getDocsUrl(sourceUrl:string,docsBaseUrl?:string): string {
         return docsBaseUrl + "/" + sourceUrl;
     }
 }
+
+export function getLegacyDataAccessTokenUrl(){
+    return buildCBioPortalAPIUrl("api-legacy/dataAccessToken");
+}

--- a/src/shared/components/dataAccessTokens/DataAccessTokens.tsx
+++ b/src/shared/components/dataAccessTokens/DataAccessTokens.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+import AppConfig from "appConfig";
+import {If, Then, Else} from 'react-if';
+import client from "shared/api/cbioportalClientInstance";
+import {AppStore} from "../../../AppStore";
+import LoadingIndicator from "../loadingIndicator/LoadingIndicator";
+import {observer} from "mobx-react";
+import {observable} from "mobx";
+import {buildCBioPortalPageUrl} from "../../api/urls";
+import {isNullOrUndefined} from "util";
+import fileDownload from 'react-file-download';
+
+export class UserDataAccessToken {
+    @observable token : string;
+    @observable creationDate: string;
+    @observable expirationDate: string;
+    @observable username: string;
+    constructor(token: string, creationDate: string, expirationDate: string, username: string) {
+        this.token = token;
+        this.creationDate = creationDate;
+        this.expirationDate = expirationDate;
+        this.username = username;
+    }
+}
+
+export interface IDataAccessTokensProps {
+    token?:string;
+    creationDate?:string;
+    expirationDate?:string;
+    loadingComponent?:JSX.Element;
+    appStore:AppStore;
+}
+
+function buildDataAccessTokenFileContents(dat:UserDataAccessToken | undefined) {
+    if (!isNullOrUndefined(dat)) {
+        const fileContents = "token: " + dat!.token + "\n" +
+            "creation_date: " + dat!.creationDate + "\n" +
+            "expiration_date: " + dat!.expirationDate;
+        return fileContents;
+    } else {
+        alert("Cannot create Data Access Token file for user with non-existent tokens.");
+        return null;
+    }
+}
+
+@observer
+export class DataAccessTokens extends React.Component<IDataAccessTokensProps, {}> {
+    public static defaultProps: Partial<IDataAccessTokensProps> = {
+        loadingComponent:<LoadingIndicator isLoading={true}/>
+    };
+
+    constructor(props: IDataAccessTokensProps) {
+        super(props);
+    }
+
+    getDatDropdownList() {
+        const listItems = [
+            {
+                id:"signout",
+                action:<a href={buildCBioPortalPageUrl(this.props.appStore.logoutUrl)}>Sign out</a>,
+                hide:false
+            },
+            {
+                id:"datDownload",
+                action:<a onClick={() => this.downloadDataAccessTokenFile()}>Download token</a>,
+                hide:AppConfig.serverConfig.authenticationMethod === "social_auth"
+            }
+        ];
+
+        const shownListItems = listItems.filter((l)=>{
+            return !l.hide;
+        });
+
+        return shownListItems.map((l)=>{
+            return <li>{l.action}</li>;
+        });
+    }
+
+    async downloadDataAccessTokenFile() {
+        const dat = await this.generateNewDataAccessToken();
+        if (!isNullOrUndefined(dat)) {
+            const fileContents = buildDataAccessTokenFileContents(dat);
+            fileDownload(fileContents, "cbioportal_data_access_token.txt");
+        }
+    }
+
+    async generateNewDataAccessToken() {
+        if (this.props.appStore.isLoggedIn) {
+            let _token = await Promise.resolve(
+                client.createDataAccessTokenUsingPOST(
+                    {'allowRevocationOfOtherTokens':AppConfig.serverConfig.dat_revoke_other_tokens}))
+            const dat = new UserDataAccessToken(_token.token, _token.creation, _token.expiration, _token.username);
+            this.setState({userDataAccessToken : dat})
+            return dat;
+        } else {
+            return undefined;
+        }
+    }
+
+    render(){
+        return(
+        <ul className="list-unstyled">
+            {
+                this.getDatDropdownList()
+            }
+        </ul>
+        );
+    }
+}


### PR DESCRIPTION
# What? Why?
Added "Download token" link which generates a new token for a user on an authenticated portal. If user is on portal with authentication method "social_auth" then this link is suppressed.

Changes proposed in this pull request:
* Users on authenticated portals can now download API access tokens from username dropdown on portal home page. 
* Added DAT endpoint calls to `CBioPortalAPI.ts`
* Added new react component for DataAccessTokens
* Moved sign out link to dropdown
* Add DAT file contents build and download link
* Suppress DAT download if auth method is social_auth

**Dropdown for user on authenticated portal:**
<img width="230" alt="screen shot 2018-11-12 at 12 18 58 pm" src="https://user-images.githubusercontent.com/15623749/48368049-a435ed00-e680-11e8-8437-4fe8131f9ed8.png">

**Dropdown for user on portal with authentication method = "social_auth"**
<img width="268" alt="dat-dropdown-social_auth" src="https://user-images.githubusercontent.com/15623749/48440974-568cb380-e758-11e8-8ec8-773a8f5ab67f.png">

[Sample DAT download file](https://github.com/cBioPortal/cbioportal-frontend/files/2577354/cbioportal_data_access_token.7.txt)


# Checks
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:

