### PR TITLE
Should not show VAF plot when there is no VAF data

### DIFF
--- a/src/pages/patientView/genomicOverview/GenomicOverview.tsx
+++ b/src/pages/patientView/genomicOverview/GenomicOverview.tsx
@@ -77,7 +77,18 @@ export default class GenomicOverview extends React.Component<IGenomicOverviewPro
     }
 
     private shouldShowVAFPlot():boolean {
-        return this.props.mergedMutations.length > 0;
+        return this.props.mergedMutations.length > 0 && this.isFrequencyExist();
+    }
+
+    private isFrequencyExist():boolean {
+        for (const frequencyId of Object.keys(this.state.frequencies)){
+            if (this.state.frequencies.hasOwnProperty(frequencyId)){
+                for (const frequency of this.state.frequencies[frequencyId]){
+                    return !isNaN(frequency);
+                }
+            }
+        }
+        return false;
     }
 
     private getTracksWidth():number {


### PR DESCRIPTION
Add additional check for the VAF plot.
Fix cbioportal#5108
