### PR TITLE
Moved filter panel back into MutationMapper component

### DIFF
--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -52,12 +52,7 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
                         isUnaffected={!this.props.store.queryContainsMutationOql}
                         onToggle={this.onToggleOql}
                     />
-                    {this.props.store.mutationMapperStores.isComplete && ! this.props.store.mutationMapperStores.result[this.mutationsGeneTab].dataStore.showingAllData &&
-                        this.bannerAlert()
-                    }
                 </div>
-                
-
 
                 {(this.props.store.mutationMapperStores.isComplete) && (
                     <MSKTabs
@@ -111,26 +106,6 @@ export default class Mutations extends React.Component<IMutationsPageProps, {}>
         });
 
         return tabs;
-    }
-
-    protected bannerAlert(): JSX.Element|null
-    {
-        let dataStore = this.props.store.mutationMapperStores.result[this.mutationsGeneTab].dataStore;
-
-        return (
-            <div className={classnames("alert" , "alert-success")}>
-                <span style={{verticalAlign:"middle"}}>
-                    {`${dataStore.sortedFilteredData.length}/${dataStore.allData.length} `}
-                    {"mutations are shown based on your filtering."}
-                    <button className="btn btn-default btn-xs" 
-                            style={{cursor:"pointer", marginLeft:6}} 
-                            onClick={()=>{dataStore.resetFilterAndSelection();}}
-                    >
-                        Show all mutations
-                    </button>
-                </span>
-            </div>
-        );
     }
     
     protected handleTabChange(id: string) {

--- a/src/shared/components/mutationMapper/MutationMapper.tsx
+++ b/src/shared/components/mutationMapper/MutationMapper.tsx
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import autobind from "autobind-decorator";
 import {observer, Observer} from "mobx-react";
 import {computed, action, observable} from "mobx";
+import classnames from "classnames";
 // tslint:disable-next-line:no-import-side-effect
 import 'react-select/dist/react-select.css';
 import './styles.scss';
@@ -21,7 +22,6 @@ import ProteinImpactTypePanel from "shared/components/mutationTypePanel/ProteinI
 import ProteinChainPanel from "shared/components/proteinChainPanel/ProteinChainPanel";
 
 import MutationMapperStore from "./MutationMapperStore";
-import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { EnsemblTranscript } from 'shared/api/generated/GenomeNexusAPI';
 import Mutations from 'pages/resultsView/mutation/Mutations';
 import {IServerConfig} from "../../../config/IAppConfig";
@@ -347,12 +347,19 @@ export default class MutationMapper<P extends IMutationMapperProps> extends Reac
 
     protected filterResetPanel(): JSX.Element|null
     {
+        const dataStore = this.props.store.dataStore;
+
         return (
-            <div style={{marginTop:"5px", marginBottom:"5px"}}>
-                <span style={{color:"red", fontSize:"14px", fontFamily:"verdana,arial,sans-serif"}}>
-                    <span>Current view shows filtered results. Click </span>
-                    <a style={{cursor:"pointer"}} onClick={this.handlers.resetDataStore}>here</a>
-                    <span> to reset all filters.</span>
+            <div className={classnames("alert" , "alert-success")}>
+                <span style={{verticalAlign:"middle"}}>
+                    {`${dataStore.sortedFilteredData.length}/${dataStore.allData.length} mutations are shown based on your filtering.`}
+                    <button
+                        className="btn btn-default btn-xs"
+                        style={{cursor:"pointer", marginLeft:6}}
+                        onClick={() => dataStore.resetFilterAndSelection()}
+                    >
+                        Show all mutations
+                    </button>
                 </span>
             </div>
         );
@@ -396,6 +403,9 @@ export default class MutationMapper<P extends IMutationMapperProps> extends Reac
                 {
                     (!this.isLoading) && (
                     <div>
+                        {!this.props.store.dataStore.showingAllData &&
+                            this.filterResetPanel()
+                        }
                         <div style={{ display:'flex' }}>
                             <div className="borderedChart" style={{ marginRight:10 }}>
                                 {this.mutationPlot()}

--- a/src/shared/components/mutationMapper/MutationMapper.tsx
+++ b/src/shared/components/mutationMapper/MutationMapper.tsx
@@ -352,7 +352,7 @@ export default class MutationMapper<P extends IMutationMapperProps> extends Reac
         return (
             <div className={classnames("alert" , "alert-success")}>
                 <span style={{verticalAlign:"middle"}}>
-                    {`${dataStore.sortedFilteredData.length}/${dataStore.allData.length} mutations are shown based on your filtering.`}
+                    {`${dataStore.tableData.length}/${dataStore.allData.length} mutations are shown based on your filtering.`}
                     <button
                         className="btn btn-default btn-xs"
                         style={{cursor:"pointer", marginLeft:6}}


### PR DESCRIPTION
# What? Why?
Fix
- https://github.com/cBioPortal/cbioportal/issues/5255
- https://github.com/cBioPortal/cbioportal/issues/5256

![standalon_mutation_mapper_filter_panel](https://user-images.githubusercontent.com/3604198/48584370-8e7e2d00-e8f7-11e8-88e5-88c203339ef2.png)

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)