### PR TITLE
Add DAT method check to hide 'Download Token' option if DAT method is 'none'

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -96,4 +96,5 @@ export interface IServerConfig {
     "sessionServiceEnabled": boolean;
     "session_url_length_threshold": string;
     "dat_revoke_other_tokens": boolean;
+    "dat_method": string;
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -3,6 +3,7 @@ import {IServerConfig} from "./IAppConfig";
 const ServerConfigDefaults: Partial<IServerConfig> = {
     app_version:"1.0",
     dat_revoke_other_tokens:true,
+    dat_method:"none",
     civic_url:"https://civicdb.org/api/",
     disabled_tabs:"",
 

--- a/src/shared/components/dataAccessTokens/DataAccessTokens.tsx
+++ b/src/shared/components/dataAccessTokens/DataAccessTokens.tsx
@@ -63,10 +63,9 @@ export class DataAccessTokens extends React.Component<IDataAccessTokensProps, {}
             {
                 id:"datDownload",
                 action:<a onClick={() => this.downloadDataAccessTokenFile()}>Download token</a>,
-                hide:AppConfig.serverConfig.authenticationMethod === "social_auth"
+                hide:(AppConfig.serverConfig.authenticationMethod === "social_auth" || (AppConfig.serverConfig.dat_method !== "uuid" && AppConfig.serverConfig.dat_method !== "jwt"))
             }
         ];
-
         const shownListItems = listItems.filter((l)=>{
             return !l.hide;
         });
@@ -90,7 +89,6 @@ export class DataAccessTokens extends React.Component<IDataAccessTokensProps, {}
                 internalClient.createDataAccessTokenUsingPOST(
                     {'allowRevocationOfOtherTokens':AppConfig.serverConfig.dat_revoke_other_tokens}))
             const dat = new UserDataAccessToken(_token.token, _token.creation, _token.expiration, _token.username);
-            this.setState({userDataAccessToken : dat})
             return dat;
         } else {
             return undefined;


### PR DESCRIPTION
# What? Why?
Add DAT method check to hide 'Download Token' option if DAT method is 'none'

Changes proposed in this pull request:
* Added check to determine whether DAT method is "none"
* If DAT method is "none" then hide 'Token Download' from authorized user dropdown menu.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>
