### PR TITLE
oncoprint progress indicator improvements

### DIFF
--- a/src/shared/cache/OncoprintClinicalDataCache.ts
+++ b/src/shared/cache/OncoprintClinicalDataCache.ts
@@ -20,8 +20,14 @@ export enum SpecialAttribute {
     NumSamplesPerPatient = "NUM_SAMPLES_PER_PATIENT"
 }
 
+const locallyComputedSpecialAttributes = [SpecialAttribute.StudyOfOrigin, SpecialAttribute.NumSamplesPerPatient];
+
 export function clinicalAttributeIsPROFILEDIN(attribute:{clinicalAttributeId:string|SpecialAttribute}) {
     return attribute.clinicalAttributeId.startsWith(SpecialAttribute.ProfiledInPrefix);
+}
+
+export function clinicalAttributeIsLocallyComputed(attribute:{clinicalAttributeId:string|SpecialAttribute}) {
+    return clinicalAttributeIsPROFILEDIN(attribute) || (locallyComputedSpecialAttributes.indexOf(attribute.clinicalAttributeId as any) > -1);
 }
 
 type OncoprintClinicalData = ClinicalData[]|MutationSpectrum[];

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -959,7 +959,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
 
     public render() {
         return (
-            <div className="posRelative">
+            <div>
 
                 <LoadingIndicator isLoading={this.isHidden} size={"big"} center={true} className="oncoprintLoadingIndicator">
                     <div style={{marginTop:20}}>

--- a/src/shared/components/progressIndicator/styles.module.scss
+++ b/src/shared/components/progressIndicator/styles.module.scss
@@ -37,10 +37,11 @@
   flex-direction:row;
   align-items:center;
   justify-content: center;
-}
-
-.item-row-not-first {
   margin-top:4px;
+
+  &:nth-child(1) {
+    margin-top: 0px !important;
+  }
 }
 
 .pulse-spinner {


### PR DESCRIPTION
(1) Add "clinical" to the loading message, when clinical data loading is required (when there are selected clinical attributes which are not locally computed)
(2) Querying x samples and y genes
(3) Loading message indicating expected length of query

@schultzn @tmazor @jjgao @alisman 
the thresholds and loading messages are determined in: https://github.com/cBioPortal/cbioportal-frontend/pull/1749/files#diff-dcf685585bcddc86c05877659a76496eR401

![image](https://user-images.githubusercontent.com/636232/48871948-e6fc7100-edb4-11e8-879c-7244c96e17d4.png)

![image](https://user-images.githubusercontent.com/636232/48872103-afda8f80-edb5-11e8-94bf-a0fe52b58a34.png)
