### PR TITLE
Custom tabs: invoke callback on unmount event of tab

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -181,8 +181,8 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
     }
 
     @autobind
-    private customTabMountCallback(div:HTMLDivElement,tab:any){
-        showCustomTab(div, tab, this.props.routing.location, this.resultsViewPageStore);
+    private customTabCallback(div:HTMLDivElement,tab:any, isUnmount = false){
+        showCustomTab(div, tab, this.props.routing.location, this.resultsViewPageStore, isUnmount);
     }
 
     componentWillUnmount(){
@@ -408,7 +408,10 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
             const customResultsTabs = AppConfig.serverConfig.custom_tabs.filter((tab: any) => tab.location === "RESULTS_PAGE").map((tab: any, i: number) => {
                 return (<MSKTab key={100 + i} id={'customTab' + i} unmountOnHide={(tab.unmountOnHide === true)}
                                 onTabDidMount={(div) => {
-                                    this.customTabMountCallback(div, tab)
+                                    this.customTabCallback(div, tab);
+                                }}
+                                onTabUnmount={(div) => {
+                                    this.customTabCallback(div, tab, true);
                                 }}
                                 linkText={tab.title}
                     />

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -22,6 +22,7 @@ export interface IMSKTabProps {
     anchorStyle?:{[k:string]:string|number|boolean};
     unmountOnHide?:boolean;
     onTabDidMount?:(tab:HTMLDivElement)=>void;
+    onTabUnmount?:(tab:HTMLDivElement)=>void;
 }
 
 @observer
@@ -58,6 +59,12 @@ export class MSKTab extends React.Component<IMSKTabProps,{}> {
     componentDidMount(){
         if (this.props.onTabDidMount) {
             this.props.onTabDidMount(this.div);
+        }
+    }
+
+    componentWillUnmount(){
+        if (this.props.onTabUnmount) {
+            this.props.onTabUnmount(this.div);
         }
     }
 

--- a/src/shared/lib/customTabs.ts
+++ b/src/shared/lib/customTabs.ts
@@ -23,12 +23,12 @@ export function loadCustomTabDeps(tab:any){
     }
 }
 
-export function showCustomTab(div:HTMLDivElement, tab:ICustomTabConfiguration, url:string, store:any){
+export function showCustomTab(div:HTMLDivElement, tab:ICustomTabConfiguration, url:string, store:any, isUnmount = false){
     tab.dependencyPromise = tab.dependencyPromise || loadCustomTabDeps(tab);
 
     const runCallback = (tab:ICustomTabConfiguration)=>{
         if (getBrowserWindow()[tab.mountCallbackName]) {
-            getBrowserWindow()[tab.mountCallbackName](div, tab, url, store, autorun);
+            getBrowserWindow()[tab.mountCallbackName](div, tab, url, store, autorun, isUnmount);
         } else {
             alert(`Callback for tab ${tab.title} not found`);
         }
@@ -38,3 +38,19 @@ export function showCustomTab(div:HTMLDivElement, tab:ICustomTabConfiguration, u
         runCallback(tab);
     });
 }
+
+// SAMPLE USAGE
+
+// const myFeatureGlobal = {};
+
+// function sampleTabCallback(div, tab, url, store, autorun, isUnmount){
+//     if (isMount) {
+//         myGlobal.myDisposer = autorun(function(){
+//             if (store.someData.isComplete) {
+//                 $(div).append(`<div>${store.someData.result}</div>`);
+//             }
+//         });
+//     } else { // clean up!
+//         myGlobal.myDisposer();
+//     }
+// }


### PR DESCRIPTION
Custom tabs need to implement an unmount event in order to dispose (cleanup) reactions that they created on mounting.  This in turn will allow gc of observables to which the tabs were bound.  MSKTabs needs to call any configured mount and unmount handlers passed as properties. 