### PR TITLE
Fix tests

### DIFF
--- a/end-to-end-tests/specs/home.spec.js
+++ b/end-to-end-tests/specs/home.spec.js
@@ -1186,7 +1186,7 @@ describe('case set selection in front page query form', function(){
         browser.waitForExist('[data-test="dataTypePrioritySelector"] input[type="checkbox"][data-test="M"]', 10000);
         browser.waitForExist('[data-test="dataTypePrioritySelector"] input[type="checkbox"][data-test="C"]', 10000);
         browser.waitForExist(selectedCaseSet_sel, 10000);
-        browser.waitUntil(()=>(browser.getText(selectedCaseSet_sel) === "All (21333)"), 5000);
+        browser.waitUntil(()=>(/All \(\d+\)/.test(browser.getText(selectedCaseSet_sel))), 5000); // since sample #s change across studies, dont depend this test on specific number
 
         // Deselect all tcga -provisional studies
         browser.click('div[data-test="cancerTypeListContainer"] input[data-test="selectAllStudies"]');


### PR DESCRIPTION
(1) A test that breaks with diff sample counts
(2) Make oncoprint clinical track selector not load until click - this fixes tests that are breaking depending on how long this takes.