### PR TITLE
Show results if incorrect/old study id in session

### DIFF
--- a/src/pages/resultsView/ResultsViewPageHelpers.ts
+++ b/src/pages/resultsView/ResultsViewPageHelpers.ts
@@ -126,19 +126,16 @@ export function updateStoreFromQuery(resultsViewPageStore:ResultsViewPageStore, 
 export function getVirtualStudies(cancerStudyIds:string[]):Promise<VirtualStudy[]>{
 
     const prom = new Promise<VirtualStudy[]>((resolve, reject)=>{
-        client.getAllStudiesUsingGET({projection:"SUMMARY"}).then((allStudies)=>{
-            //console.log(cancerStudyIds);
-            //console.log(allStudies);
-            const virtualStudyIds = _.differenceWith(cancerStudyIds, allStudies,(id:string, study:CancerStudy)=>id==study.studyId);
-
-            if (virtualStudyIds.length > 0) {
-                Promise.all(virtualStudyIds.map(id =>  sessionServiceClient.getVirtualStudy(id)))
-                    .then((virtualStudies)=>{
-                         resolve(virtualStudies);
-                    })
-            } else {
-                resolve([]);
-            }
+        Promise.all([
+            sessionServiceClient.getUserVirtualStudies(),
+            client.getAllStudiesUsingGET({projection:"SUMMARY"})
+        ]).then(([userVirtualStudies, allCancerStudies])=>{
+            // return virtual studies from given cancer study ids
+            const missingFromCancerStudies = _.differenceWith(cancerStudyIds, allCancerStudies,(id:string, study:CancerStudy)=>id==study.studyId);
+            const virtualStudies = userVirtualStudies.filter(
+                (virtualStudy: VirtualStudy) => (missingFromCancerStudies.includes(virtualStudy.id))
+            );
+            resolve(virtualStudies);
         });
     });
     return prom;

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1465,8 +1465,13 @@ export class ResultsViewPageStore {
         }
     }, {});
 
-    readonly virtualStudies = remoteData(async ()=>{
-        return ServerConfigHelpers.sessionServiceIsEnabled() ? getVirtualStudies(this.cohortIdsList) : [];
+    readonly virtualStudies = remoteData({
+        invoke: async ()=> {
+            return ServerConfigHelpers.sessionServiceIsEnabled() ? getVirtualStudies(this.cohortIdsList) : [];
+        },
+        onError: () => {
+            // fail silently when an error occurs with the virtual studies
+        }
     });
 
     readonly studyIds = remoteData({

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -1136,21 +1136,15 @@ describe("ResultsViewPageStoreUtils", ()=>{
             } as CancerStudy
         };
 
-        let virtualStudies: { [id: string]: VirtualStudy } = {
-            'virtual_study_1': $.extend({},virtualStudy,{"id": "virtual_study_1"}) as VirtualStudy,
-            'virtual_study_2': $.extend({},virtualStudy,{"id": "virtual_study_2"}) as VirtualStudy
-        };
+        let virtualStudies: VirtualStudy[] = [
+            $.extend({},virtualStudy,{"id": "virtual_study_1"}) as VirtualStudy,
+            $.extend({},virtualStudy,{"id": "virtual_study_2"}) as VirtualStudy
+        ];
 
         before(()=>{
-            sinon.stub(sessionServiceClient, "getVirtualStudy").callsFake(function fakeFn(id:string) {
+            sinon.stub(sessionServiceClient, "getUserVirtualStudies").callsFake(function fakeFn(id:string) {
                 return new Promise((resolve, reject) => {
-                    let obj = virtualStudies[id]
-                    if(_.isUndefined(obj)){
-                        reject()
-                    }
-                    else{
-                        resolve(obj);
-                    }
+                    resolve(virtualStudies);
                 });
             });
             //
@@ -1202,10 +1196,10 @@ describe("ResultsViewPageStoreUtils", ()=>{
 
         //this case is not possible because id in these scenarios are first identified in QueryBuilder.java and
         //returned to query selector page
-        it("when virtual study query having private study or unknow virtual study id", (done)=>{
-            fetchQueriedStudies({},['shared_study1']).catch((error)=>{
-                done();
-            });
+        it("when virtual study query having private study or unknow virtual study id", async ()=>{
+            let test = await fetchQueriedStudies({},['shared_study1']);
+            // assume no studies returned
+            assert.equal(test.length, 0);
         });
 
 

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.ts
@@ -20,9 +20,11 @@ import {
 } from "./ResultsViewPageStore";
 import {IndicatorQueryResp} from "../../shared/api/generated/OncoKbAPI";
 import _ from "lodash";
-import sessionServiceClient from "shared/api//sessionServiceInstance";
-import { VirtualStudy } from "shared/model/VirtualStudy";
 import client from "shared/api/cbioportalClientInstance";
+import { VirtualStudy } from "shared/model/VirtualStudy";
+import {
+    getVirtualStudies,
+} from "./ResultsViewPageHelpers";
 
 type CustomDriverAnnotationReport = {
     hasBinary: boolean,
@@ -230,7 +232,7 @@ export async function fetchQueriedStudies(filteredPhysicalStudies:{[id:string]:C
     let unknownIds:{[id:string]:boolean} = {};
     for(const id of queriedIds){
         if(filteredPhysicalStudies[id]){
-            queriedStudies.push(filteredPhysicalStudies[id])
+            queriedStudies.push(filteredPhysicalStudies[id]);
         } else {
             unknownIds[id]=true;
         }
@@ -246,23 +248,22 @@ export async function fetchQueriedStudies(filteredPhysicalStudies:{[id:string]:C
                 delete unknownIds[study.studyId];
             })
     
-        }).catch(() => {}) //this is for private instances. it throws error when the study is not found
+        }).catch(() => {}); //this is for private instances. it throws error when the study is not found
+
+        await getVirtualStudies(Object.keys(unknownIds)).then((virtualStudies: VirtualStudy[]) => {
+            virtualStudies.forEach(virtualStudy=>{
+                // tslint:disable-next-line:no-object-literal-type-assertion
+                const cancerStudy = {
+                    allSampleCount: _.sumBy(virtualStudy.data.studies, study=>study.samples.length),
+                    studyId: virtualStudy.id,
+                    name: virtualStudy.data.name,
+                    description: virtualStudy.data.description,
+                    cancerTypeId: "My Virtual Studies"
+                } as CancerStudy;
+                queriedStudies.push(cancerStudy);
+            });
+        });
     }
-
-    let virtualStudypromises = Object.keys(unknownIds).map(id =>sessionServiceClient.getVirtualStudy(id))
-
-    await Promise.all(virtualStudypromises).then((allData: VirtualStudy[]) => {
-        allData.forEach(virtualStudy=>{
-            let study = {
-                allSampleCount:_.sumBy(virtualStudy.data.studies, study=>study.samples.length),
-                studyId: virtualStudy.id,
-                name: virtualStudy.data.name,
-                description: virtualStudy.data.description,
-                cancerTypeId: "My Virtual Studies"
-            } as CancerStudy;
-            queriedStudies.push(study)
-        })
-    });
 
     return queriedStudies;
 }


### PR DESCRIPTION
This still shows results on results view if any of the studies in the session
has an incorrect study id.

Related:

https://github.com/cBioPortal/cbioportal/issues/5325

This session id currently lists nothing:

http://www.cbioportal.org/results/cancerTypesSummary?session_id=5bd240d0498eb8b3d5688318

It's a bit funky how we are doing http calls in helper functions. We should prolly just move this to the store level

I've created an issue to give some more visual feedback to the user:

https://github.com/cBioPortal/cbioportal/issues/5328

** NOTE **

I found this issue by spotting 4x errors in grafana:

https://snapshot.raintank.io/dashboard/snapshot/cCTUZdDT70Q5182s520A8SXHbko4j8is?refresh=5s&orgId=2

I think in general it makes it easier to monitor services when we don't rely on 404 errors in the logic. [LBYL instead of EAFP](https://www.reddit.com/r/javascript/comments/440wib/lbyl_or_eafp/). That's why in this PR we pull all user's virtual studies to determine whether a missing study id is a virtual study instead of sending each missing study id and getting a 404.