### PR TITLE
Preventing MSKTabs unmountOnHide to override MSKTab unmountOnHide

### DIFF
--- a/src/shared/components/MSKTabs/MSKTabs.spec.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.spec.tsx
@@ -131,4 +131,44 @@ describe('MSKTabs', () => {
         assert.equal(tabs.find('.msk-tab').length, 1);
     });
 
+    it('if individual tab is unmountOnHide false then it will not be unmounted even if parent unmountOnHide is true', async ()=>{
+        tabs = mount(
+            <MSKTabs unmountOnHide={true}>
+                <MSKTab unmountOnHide={false} id="one" linkText="One"><span className="content">One</span></MSKTab>
+                <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
+            </MSKTabs>
+        );
+
+        await sleep(0);
+        assert.equal(tabs.find('.msk-tab').length, 1);
+
+        tabs.setProps({ activeTabId:"two" });
+        await sleep(0);
+        assert.equal(tabs.find('.msk-tab').length, 2);
+
+        tabs.setProps({ activeTabId:"one" });
+        await sleep(0);
+        assert.equal(tabs.find('.msk-tab').length, 1);
+    });
+
+    it('if individual tab is unmountOnHide true then it will be unmounted even if parent unmountOnHide is false', async ()=>{
+        tabs = mount(
+            <MSKTabs unmountOnHide={false}>
+                <MSKTab unmountOnHide={true} id="one" linkText="One"><span className="content">One</span></MSKTab>
+                <MSKTab linkText="Two" id="two"><span className="content">Two</span></MSKTab>
+            </MSKTabs>
+        );
+
+        await sleep(0);
+        assert.equal(tabs.find('.msk-tab').length, 1);
+
+        tabs.setProps({ activeTabId:"two" });
+        await sleep(0);
+        assert.equal(tabs.find('.msk-tab').length, 1);
+
+        tabs.setProps({ activeTabId:"one" });
+        await sleep(0);
+        assert.equal(tabs.find('.msk-tab').length, 2);
+    });
+
 });

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -201,7 +201,7 @@ export class MSKTabs extends React.Component<IMSKTabsProps, IMSKTabsState> {
                         this.shownTabs.push(child.props.id);
                         memo.push(this.cloneTab(child, false));
                     } else if (
-                        (child.props.unmountOnHide === false || (this.props.unmountOnHide === false))
+                        (child.props.unmountOnHide === false || (child.props.unmountOnHide === undefined && this.props.unmountOnHide === false))
                         && _.includes(this.shownTabs, child.props.id)) {
                         // if we're NOT unmounting it and the tab has been shown and it's not loading, include it
                         memo.push(this.cloneTab(child, true));


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/5348.

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)