### PR TITLE
fix back button bug in results view caused by redirect

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -176,8 +176,8 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
         getBrowserWindow().resultsViewPageStore = this.resultsViewPageStore;
     }
 
-    private handleTabChange(id: string) {
-        this.props.routing.updateRoute({},`results/${id}`);
+    private handleTabChange(id: string, replace?:boolean) {
+        this.props.routing.updateRoute({},`results/${id}`, false, replace);
     }
 
     @autobind
@@ -482,7 +482,7 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
 
         if (this.resultsViewPageStore.studies.isComplete && !this.resultsViewPageStore.tabId) {
             setTimeout(()=>{
-                this.handleTabChange(this.currentTab(this.resultsViewPageStore.tabId));
+                this.handleTabChange(this.currentTab(this.resultsViewPageStore.tabId), true);
             });
             return null;
         } else {

--- a/src/shared/lib/ExtendedRouterStore.ts
+++ b/src/shared/lib/ExtendedRouterStore.ts
@@ -139,7 +139,7 @@ export default class ExtendedRouterStore extends RouterStore {
         return _.some(tests,(test)=>test.test(path));
     }
 
-    @action updateRoute(newParams: QueryParams, path:string | undefined = undefined, clear = false) {
+    @action updateRoute(newParams: QueryParams, path:string | undefined = undefined, clear = false, replace = false) {
         // default to current path
         path = (path !== undefined) ? path : this.location.pathname;
 
@@ -166,7 +166,7 @@ export default class ExtendedRouterStore extends RouterStore {
         if (!ServerConfigHelpers.sessionServiceIsEnabled() || !this.sessionEnabledForPath(path) || JSON.stringify(newQuery).length < this.urlLengthThresholdForSession){
             // if there happens to be session, kill it because we're going URL, baby
             delete this._session;
-            this.push( URL.format({pathname: path, query: newQuery, hash:this.location.hash}) );
+            this[replace ? "replace" : "push"]( URL.format({pathname: path, query: newQuery, hash:this.location.hash}) );
         } else {
             // we are using session: do we need to make a new session?
 
@@ -180,7 +180,7 @@ export default class ExtendedRouterStore extends RouterStore {
                 // add session version
                 this._session = pendingSession;
 
-                this.push( URL.format({pathname: path, query: { session_id:'pending'}, hash:this.location.hash}) );
+                this[replace ? "replace" : "push"]( URL.format({pathname: path, query: { session_id:'pending'}, hash:this.location.hash}) );
                 this.saveRemoteSession(pendingSession.query).then((sessionResponse)=>{
                     this._session!.id = sessionResponse.id;
                     // we use replace because we don't want the pending state ("?session_id=pending") in the history
@@ -193,7 +193,7 @@ export default class ExtendedRouterStore extends RouterStore {
                     this.replace( URL.format({pathname: this.location.pathname, query: {session_id:sessionResponse.id}, hash:this.location.hash}) );
                 });
             } else { // we already have a session but we only need to update path or hash
-                this.push( URL.format({pathname: path, query: {session_id:this._session.id}, hash:this.location.hash}) );
+                this[replace ? "replace" : "push"]( URL.format({pathname: path, query: {session_id:this._session.id}, hash:this.location.hash}) );
             }
         }
 


### PR DESCRIPTION
The bug:
(1) Go to cbioportal.org
(2) Submit a query to go to results page
(3) Wait for page to finish loading
(4) Click browser back button

We can't go back, we're stuck on the results page.

The cause of the bug was that when we go to the "results" route, without a tab specified (i.e. as opposed to  "results/oncoprint"), we auto-redirect to oncoprint or cancer types summary, depending on the query. But in the redirection, we *add* the redirected URL to history, we do not replace the original "results" route. Thus, clicking on "back" will just go back to "results" where we get redirected back to "results/oncoprint".

This PR makes it so that the redirection replaces the "results" URL in history, with e.g. "results/oncoprint", rather than adding "results/oncoprint" to the history as a new entry.