### PR TITLE
Fixed ProgressIndicator related TS errors for the CN Segments tab

### DIFF
--- a/src/pages/resultsView/cnSegments/CNSegments.tsx
+++ b/src/pages/resultsView/cnSegments/CNSegments.tsx
@@ -121,7 +121,7 @@ export default class CNSegments extends React.Component<{ store: ResultsViewPage
         return (
             <div className="pillTabs">
                 <LoadingIndicator isLoading={this.isHidden} size={"big"} center={true}>
-                    <ProgressIndicator items={this.progressItems} show={this.isHidden} sequential={true}/>
+                    <ProgressIndicator getItems={() => this.progressItems} show={this.isHidden} sequential={true}/>
                 </LoadingIndicator>
                 <CNSegmentsDownloader
                     promise={this.props.store.cnSegments}


### PR DESCRIPTION
# What? Why?
Seems like latest changes in the `ProgressIndicator` component caused some TS errors for CN segments tab.

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)