### PR TITLE
Add EllipsisTextTooltip component and use in ClinicalTable

### DIFF
--- a/src/pages/studyView/table/ClinicalTable.tsx
+++ b/src/pages/studyView/table/ClinicalTable.tsx
@@ -13,6 +13,7 @@ import {
     getFrequencyStr
 } from "../StudyViewUtils";
 import {SortDirection} from "../../../shared/components/lazyMobXTable/LazyMobXTable";
+import EllipsisTextTooltip from "../../../shared/components/ellipsisTextTooltip/EllipsisTextTooltip";
 
 export interface IClinicalTableProps {
     data: ClinicalDataCountWithColor[];
@@ -112,7 +113,7 @@ export default class ClinicalTable extends React.Component<IClinicalTableProps, 
                             <rect x="0" y="0" width="12" height="12" fill={data.color}/>
                         </g>
                     </svg>
-                    <span className={styles.ellipsisText} title={data.value}>{data.value}</span>
+                    <EllipsisTextTooltip content={data.value}/>
                 </div>
             )
         },

--- a/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.module.scss
+++ b/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.module.scss
@@ -1,0 +1,6 @@
+.text {
+    white-space: nowrap;
+    overflow: hidden;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+}

--- a/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.tsx
+++ b/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import {observable} from 'mobx';
+import {observer} from "mobx-react";
+import styles from "./EllipsisTextTooltip.module.scss";
+import DefaultTooltip from "../defaultTooltip/DefaultTooltip";
+
+@observer
+export default class EllipsisTextTooltip extends React.Component<{ content: string }, {}> {
+    @observable disabled = false;
+    private contentRef: any;
+
+    constructor(props: { content: string }) {
+        super(props);
+    }
+
+    componentDidMount(): void {
+        if (this.contentRef.offsetWidth === this.contentRef.scrollWidth) {
+            this.disabled = true;
+        }
+    }
+
+    render() {
+        return <DefaultTooltip
+            overlay={() => <span>{this.props.content}</span>}
+            trigger={['hover']}
+            disabled={this.disabled}
+        >
+            <span className={styles.text} ref={(node) => {
+                this.contentRef = node;
+            }}>{this.props.content}</span>
+        </DefaultTooltip>
+    }
+}


### PR DESCRIPTION
Inspired by
https://stackoverflow.com/questions/21064101/understanding-offsetwidth-clientwidth-scrollwidth-and-height-respectively/21064102#21064102
https://stackoverflow.com/questions/7738117/html-text-overflow-ellipsis-detection

This solves issue https://github.com/cBioPortal/cbioportal/issues/5427