### PR TITLE
Add EllipsisTextTooltip component and use in ClinicalTable

### DIFF
--- a/src/pages/studyView/table/ClinicalTable.tsx
+++ b/src/pages/studyView/table/ClinicalTable.tsx
@@ -13,6 +13,7 @@ import {
     getFrequencyStr
 } from "../StudyViewUtils";
 import {SortDirection} from "../../../shared/components/lazyMobXTable/LazyMobXTable";
+import EllipsisTextTooltip from "../../../shared/components/ellipsisTextTooltip/EllipsisTextTooltip";
 
 export interface IClinicalTableProps {
     data: ClinicalDataCountWithColor[];
@@ -112,7 +113,7 @@ export default class ClinicalTable extends React.Component<IClinicalTableProps, 
                             <rect x="0" y="0" width="12" height="12" fill={data.color}/>
                         </g>
                     </svg>
-                    <span className={styles.ellipsisText} title={data.value}>{data.value}</span>
+                    <EllipsisTextTooltip text={data.value}></EllipsisTextTooltip>
                 </div>
             )
         },

--- a/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.module.scss
+++ b/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.module.scss
@@ -1,0 +1,6 @@
+.text {
+    white-space: nowrap;
+    overflow: hidden;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+}

--- a/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.tsx
+++ b/src/shared/components/ellipsisTextTooltip/EllipsisTextTooltip.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {action, observable} from 'mobx';
+import {observer} from "mobx-react";
+import styles from "./EllipsisTextTooltip.module.scss";
+import DefaultTooltip from "../defaultTooltip/DefaultTooltip";
+import $ from "jquery";
+import autobind from "autobind-decorator";
+
+@observer
+export default class EllipsisTextTooltip extends React.Component<{ text:string },{}> {
+
+    @observable tooltipVisible = false;
+
+    el:HTMLSpanElement;
+
+    @autobind
+    @action
+    onVisibleChange(isVisible:boolean){
+        const isOverflowed = (this.el.scrollWidth - $(this.el).innerWidth()) > 1;
+        this.tooltipVisible = isVisible && isOverflowed;
+    }
+
+    @autobind
+    setRef(el:HTMLSpanElement){
+        this.el = el;
+    }
+
+    render(){
+        return <DefaultTooltip overlay={<span>{this.props.text}</span>}
+                               visible={this.tooltipVisible}
+                               onVisibleChange={(this.onVisibleChange as any)}
+        >
+            <span className={styles.text} ref={this.setRef}>{this.props.text}</span>
+        </DefaultTooltip>
+    }
+
+}


### PR DESCRIPTION
When text in table cells in study view overflow, we need a tooltip
This solves issue https://github.com/cBioPortal/cbioportal/issues/5427