### PR TITLE
StudyView: The study summary info should wait until charts are render…

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -85,7 +85,6 @@ import {ChartDimension, ChartTypeEnum, STUDY_VIEW_CONFIG, StudyViewLayout} from 
 import {getMDAndersonHeatmapStudyMetaUrl} from "../../shared/api/urls";
 import onMobxPromise from "../../shared/lib/onMobxPromise";
 
-
 export enum ClinicalDataTypeEnum {
     SAMPLE = 'SAMPLE',
     PATIENT = 'PATIENT',
@@ -445,9 +444,9 @@ export class StudyViewPageStore {
         };
     }
 
-    private clinicalDataBinPromises: { [id: string]: MobxPromise<DataBin[]> } = {};
-    private clinicalDataCountPromises: { [id: string]: MobxPromise<ClinicalDataCountWithColor[]> } = {};
-    private customChartsPromises: { [id: string]: MobxPromise<ClinicalDataCountWithColor[]> } = {};
+    public clinicalDataBinPromises: { [id: string]: MobxPromise<DataBin[]> } = {};
+    public clinicalDataCountPromises: { [id: string]: MobxPromise<ClinicalDataCountWithColor[]> } = {};
+    public customChartsPromises: { [id: string]: MobxPromise<ClinicalDataCountWithColor[]> } = {};
 
     @observable.ref private _analysisGroupsClinicalAttribute:ClinicalAttribute|undefined;
     @observable.ref private _analysisGroups:ReadonlyArray<AnalysisGroup>|undefined;

--- a/src/pages/studyView/styles.module.scss
+++ b/src/pages/studyView/styles.module.scss
@@ -5,6 +5,15 @@
     z-index: 2;
 }
 
+.selectedInfoLoadingIndicator {
+    padding: 5;
+    position: absolute;
+    right: 20px;
+    width: 200px;
+    top: 5px;
+    z-index: 0;
+}
+
 .selectedInfoCheckbox {
     margin: 2px 3px 0 0 !important;
 }

--- a/src/pages/studyView/styles.scss
+++ b/src/pages/studyView/styles.scss
@@ -73,7 +73,7 @@ $selectHeightInner: $selectHeight - 2px;
 }
 
 .studyFilterResult {
-    transition: all 200ms;
+    transition: all 500ms;
     background:#eee;
     border:1px solid $borderColor;
     transform: scale(0); /* Standard syntax */


### PR DESCRIPTION
…ed before fading in

Product team wants the summary info to show after charts are rendered, to make sure user's eye is drawn to totals