### PR TITLE
Study View: reduce delay of study view summary appearance

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -122,7 +122,7 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
             // this gives time for charts to render
             // product requirement that the summary data show after charts have rendered
             // to call attention to the summary results
-            return await sleep(3000);
+            return await sleep(10);
         }
     });
 


### PR DESCRIPTION
We should not wait 3 seconds before showing the study view results summary div.  It's too long.