### PR TITLE
change the text length of protein column in mutation tab

### DIFF
--- a/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ProteinChangeColumnFormatter.tsx
@@ -154,7 +154,7 @@ export default class ProteinChangeColumnFormatter
                 text={text}
                 tooltip={<span>{text}</span>}
                 className={styles.proteinChange}
-                maxLength={20}
+                maxLength={40}
             />
         );
 


### PR DESCRIPTION
Allow more space for the text in the protein column. Change the text length from 20 to 40.