### PR TITLE
e2etest: use navigator.webdriver flag to detect e2e context

### DIFF
--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -58,14 +58,14 @@ if (browser) {
     });
 }
 
-if (localStorage.e2etest) {
+// e2e test specific stuff
+if (getBrowserWindow().navigator.webdriver) {
+
     $(document).ready(()=>{
         $("body").addClass("e2etest");
         window.e2etest = true;
     });
-}
 
-if (getBrowserWindow().navigator.webdriver) {
     setNetworkListener();
 }
 


### PR DESCRIPTION
This is a more direct way to detect e2e context.  