### PR TITLE
FACETS development - adding sample-id componenets & expanding CNA column

### DIFF
--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -9,7 +9,8 @@ import {Mutation, ClinicalData} from "shared/api/generated/CBioPortalAPI";
 import AlleleCountColumnFormatter from "shared/components/mutationTable/column/AlleleCountColumnFormatter";
 import MutantCopiesColumnFormatter from "shared/components/mutationTable/column/MutantCopiesColumnFormatter";
 import CancerCellFractionColumnFormatter from "shared/components/mutationTable/column/CancerCellFractionColumnFormatter";
-import ClonalColumnFormatter from "shared/components/mutationTable/column/ClonalColumnFormatter";
+//import ClonalColumnFormatter from "shared/components/mutationTable/column/ClonalColumnFormatter";
+import FACETSClonalColumnFormatter from "./column/FACETSClonalColumnFormatter";
 import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import FACETSColumnFormatter from "./column/FACETSColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
@@ -107,14 +108,14 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         this._columns[MutationTableColumnType.CLONAL] = {
             name: "Clonal",
             tooltip: (<span>FACETS Clonal</span>),
-            render:(d:Mutation[])=>ClonalColumnFormatter.renderFunction(d, this.getSamples()),
+            render:(d:Mutation[])=>FACETSClonalColumnFormatter.renderFunction(d, this.getSamples(), this.props.sampleManager),
             sortBy:(d:Mutation[])=>d.map(m=>m.ccfMCopiesUpper),
-            download:(d:Mutation[])=>ClonalColumnFormatter.getClonalDownload(d)
+            download:(d:Mutation[])=>FACETSClonalColumnFormatter.getClonalDownload(d)
         };
 
         this._columns[MutationTableColumnType.MUTANT_COPIES] = {
             name: "Mutant Copies",
-             tooltip: (<span>FACETS Best Guess for Mutant Copies / Total Copies</span>),
+            tooltip: (<span>FACETS Best Guess for Mutant Copies / Total Copies</span>),
             render:(d:Mutation[])=>MutantCopiesColumnFormatter.renderFunction(d, this.props.sampleIdToClinicalDataMap, this.getSamples()),
             sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValueAsString(d, this.props.sampleIdToClinicalDataMap, this.getSamples())        
         };

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -112,6 +112,13 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             download:(d:Mutation[])=>ClonalColumnFormatter.getClonalDownload(d)
         };
 
+        this._columns[MutationTableColumnType.MUTANT_COPIES] = {
+            name: "Mutant Copies",
+             tooltip: (<span>FACETS Best Guess for Mutant Copies / Total Copies</span>),
+            render:(d:Mutation[])=>MutantCopiesColumnFormatter.renderFunction(d, this.props.sampleIdToClinicalDataMap, this.getSamples()),
+            sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValueAsString(d, this.props.sampleIdToClinicalDataMap, this.getSamples())        
+        };
+
         // customization for allele count columns
 
         this._columns[MutationTableColumnType.REF_READS_N].render =
@@ -178,7 +185,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         // hide if multiple samples (same as Copy Number column)
         // included because Mutant copies should only be shown in conjunction with Copy Num
         this._columns[MutationTableColumnType.MUTANT_COPIES].shouldExclude = ()=>{
-            return (!this.hasMutantCopies || this.getSamples().length > 1 || !this.props.discreteCNAMolecularProfileId);
+            return (!this.hasMutantCopies || !this.props.discreteCNAMolecularProfileId);
         };
 
         // only hide tumor column if there is one sample and no uncalled
@@ -188,7 +195,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             return this.getSamples().length < 2 && !this.hasUncalledMutations;
         };
         this._columns[MutationTableColumnType.COPY_NUM].shouldExclude = ()=>{
-            return (!this.props.discreteCNAMolecularProfileId) || (this.getSamples().length > 1);
+            return (!this.props.discreteCNAMolecularProfileId);
         };
     }
 

--- a/src/pages/patientView/mutation/column/FACETSClonalColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/FACETSClonalColumnFormatter.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react';
-//import * as _ from 'lodash';
-//import {If, Else, Then } from 'react-if';
 import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
-//import 'rc-tooltip/assets/bootstrap_white.css';
 import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import SampleManager from "../../sampleManager";
-//import {isUncalled} from 'shared/lib/MutationUtils';
 import {floatValueIsNA} from "shared/lib/NumberUtils";
 
 export default class FACETSClonalColumnFormatter {
 
-    public static getDisplayValue(mutations:Mutation[], sampleIds:string[], sampleManager:SampleManager|null) {
+    public static getDisplayValue(mutations:Mutation[], sampleIds:string[], sampleManager:SampleManager) {
         let values:string[] = [];
         const sampleToValue:{[key: string]: any} = {};
         const sampleToCCF:{[key: string]: number} = {};
@@ -29,13 +25,13 @@ export default class FACETSClonalColumnFormatter {
         if (!samplesWithValue) {
             return (<span></span>);
         } else if (samplesWithValue.length === 1) {
-             tdValue = <li><DefaultTooltip overlay={FACETSClonalColumnFormatter.getTooltip(`${samplesWithValue[0]}`, `${sampleToValue[samplesWithValue[0]]}`, `${sampleToCCF[samplesWithValue[0]]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{FACETSClonalColumnFormatter.getClonalCircle(sampleToValue[samplesWithValue[0]])}</DefaultTooltip></li>;
+             tdValue = <li><DefaultTooltip overlay={FACETSClonalColumnFormatter.getTooltip(`${samplesWithValue[0]}`, `${sampleToValue[samplesWithValue[0]]}`, `${sampleToCCF[samplesWithValue[0]]}`, sampleManager)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{FACETSClonalColumnFormatter.getClonalCircle(sampleToValue[samplesWithValue[0]])}</DefaultTooltip></li>;
         }
         // multiple value: add sample id and value pairs
         else {
              tdValue = samplesWithValue.map((sampleId:string) => {
                 return (
-                    <li><DefaultTooltip overlay={FACETSClonalColumnFormatter.getTooltip(`${sampleId}`, `${sampleToValue[sampleId]}`, `${sampleToCCF[sampleId]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{FACETSClonalColumnFormatter.getClonalCircle(`${sampleToValue[sampleId]}`)}</DefaultTooltip></li>
+                    <li><DefaultTooltip overlay={FACETSClonalColumnFormatter.getTooltip(`${sampleId}`, `${sampleToValue[sampleId]}`, `${sampleToCCF[sampleId]}`, sampleManager)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{FACETSClonalColumnFormatter.getClonalCircle(`${sampleToValue[sampleId]}`)}</DefaultTooltip></li>
                 );
             });
         }
@@ -46,7 +42,7 @@ export default class FACETSClonalColumnFormatter {
                );
     }
 
-    public static getTooltip(sampleId:string, clonalValue:string, ccfMCopies:string) {
+    public static getTooltip(sampleId:string, clonalValue:string, ccfMCopies:string, sampleManager:SampleManager) {
         let clonalColor = "";
         if (clonalValue === "yes") {
             clonalColor = "limegreen";
@@ -57,13 +53,13 @@ export default class FACETSClonalColumnFormatter {
         }
         return (
                 <div>
-                        <table>
-                                <tr><td>Sample</td><td><strong>{sampleId}</strong></td></tr>
-                                <tr><td>Clonal</td><td><span style={{color: `${clonalColor}`, fontWeight: "bold"}}>{clonalValue}</span></td></tr>
-                                <tr><td style={{paddingRight:5}}>CCF</td><td><strong>{ccfMCopies}</strong></td></tr>
-                        </table>
+                    <table>
+                        <tr><td style={{paddingRight:10}}>{sampleManager.getComponentForSample(sampleId, 1, "")}</td><td><strong></strong></td></tr>
+                        <tr><td style={{paddingRight:5}}>Clonal</td><td><span style={{color: `${clonalColor}`, fontWeight: "bold"}}>{clonalValue}</span></td></tr>
+                        <tr><td style={{paddingRight:5}}>CCF</td><td><strong>{ccfMCopies}</strong></td></tr>
+                    </table>
                 </div>
-        );
+            );
     }
 
     public static getClonalCircle(clonalValue:string) {
@@ -109,15 +105,6 @@ export default class FACETSClonalColumnFormatter {
         if (!sampleManager) {
             return (<span></span>);
         }
-        const sampleOrder = sampleManager.getSampleIdsInOrder();
-        const sampleElements = mutations.map((m:Mutation) => {
-            const args = FACETSClonalColumnFormatter.getComponentForSampleArgs(m);
-            return FACETSClonalColumnFormatter.convertMutationToSampleElement(
-                m,
-                sampleManager.getColorForSample(m.sampleId),
-                sampleManager.getComponentForSample(m.sampleId, args.opacity, args.extraTooltipText)
-            );
-        });
         return FACETSClonalColumnFormatter.getDisplayValue(mutations, sampleIds, sampleManager);
     }
 
@@ -128,103 +115,6 @@ export default class FACETSClonalColumnFormatter {
                 result.push(FACETSClonalColumnFormatter.getClonalValue([mutation]));
             }
         }
-        if (result.length == 1) {
-            return result[0];
-        }
         return result;
     }
-
-
-
-
-
-
-
-
-
-    public static getComponentForSampleArgs<T extends {ccfMCopies:number}>(mutation:T) {
-        const ccfMCopiesValue = mutation.ccfMCopies;
-        let opacity: number = 1;
-        let extraTooltipText: string = '';
-        if (ccfMCopiesValue !== 1) {
-            opacity = .5;
-        }
-        return {
-           opacity,
-           extraTooltipText
-        };
-    }
-
-
-    public static convertMutationToSampleElement<T extends {sampleId:string, ccfMCopies:number}>(mutation:T, color:string, sampleComponent:any) {
-            const ccfMCopies = mutation.ccfMCopies;
-            const text = (<span>
-                    <strong>{ccfMCopies.toFixed(2)}</strong>
-                </span>);
-            return {
-                sampleId:mutation.sampleId, component:sampleComponent, text, ccfMCopies
-            };
-    }
-
-/*
-    public static renderFunction(mutations:Mutation[], sampleManager:SampleManager|null) {
-        const barX = sampleOrder.reduce((map, sampleId:string, i:number) => {map[sampleId] = FACETSColumnFormatter.indexToBarLeft(i); return map;}, {} as {[s:string]:number});
-        const sampleElements = mutations.map((m:Mutation) => {
-            const args = FACETSColumnFormatter.getComponentForSampleArgs(m);
-            return FACETSColumnFormatter.convertMutationToSampleElement(
-                m,
-                sampleManager.getColorForSample(m.sampleId),
-                barX[m.sampleId],
-                sampleManager.getComponentForSample(m.sampleId, args.opacity, args.extraTooltipText)
-            );
-        });
-        const sampleToElements = sampleElements.reduce((map, elements:any) => {if (elements) { map[elements.sampleId] = elements } return map; }, {} as {[s:string]:any});
-        const elementsInSampleOrder = sampleOrder.map((sampleId:string) => sampleToElements[sampleId]).filter((x:any) => !!x);
-        const tooltipLines = elementsInSampleOrder.map((elements:any)=>(<span key={elements.sampleId}>{elements.component}  {elements.text}<br/></span>));
-        const ccfMCopiesValues = sampleOrder.map((sampleId:string) => (sampleToElements[sampleId] && sampleToElements[sampleId].ccfMCopies) || undefined);
-        const bars = elementsInSampleOrder.map((elements:any)=>elements.bar);
-
-        let content:JSX.Element = <span />;
-
-        // single sample: just show the number
-        if (sampleManager.samples.length === 1) {
-            content = <span>{ (!isNaN(ccfMCopiesValues[0]) ? ccfMCopiesValues[0].toFixed(2) : '') }</span>;
-        }
-        // multiple samples: show a graphical component
-        // (if no tooltip info available do not update content)
-        else if (tooltipLines.length > 0) {
-            content = (
-                <svg
-                    width={FACETSColumnFormatter.getSVGWidth(sampleOrder.length)}
-                    height={FACETSColumnFormatter.maxBarHeight}
-                >
-                    {bars}
-                </svg>
-            );
-        }
-        // as long as we have tooltip lines, show tooltip in either cases (single or multiple)
-        if (tooltipLines.length > 0)
-        {
-            const overlay = () => <span>{tooltipLines}</span>;
-
-            content = (
-                <DefaultTooltip
-                    placement="left"
-                    overlay={overlay}
-                    arrowContent={<div className="rc-tooltip-arrow-inner"/>}
-                    destroyTooltipOnHide={true}
-                >
-                    {content}
-                </DefaultTooltip>
-            );
-        }
-
-        return content;
-    }
-
-    public static getSVGWidth(numSamples:number) {
-        return numSamples*FACETSColumnFormatter.barWidth + (numSamples-1)*FACETSColumnFormatter.barSpacing
-    }
-*/
-
 }

--- a/src/pages/patientView/mutation/column/FACETSClonalColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/FACETSClonalColumnFormatter.tsx
@@ -1,0 +1,230 @@
+import * as React from 'react';
+//import * as _ from 'lodash';
+//import {If, Else, Then } from 'react-if';
+import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
+//import 'rc-tooltip/assets/bootstrap_white.css';
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
+import SampleManager from "../../sampleManager";
+//import {isUncalled} from 'shared/lib/MutationUtils';
+import {floatValueIsNA} from "shared/lib/NumberUtils";
+
+export default class FACETSClonalColumnFormatter {
+
+    public static getDisplayValue(mutations:Mutation[], sampleIds:string[], sampleManager:SampleManager|null) {
+        let values:string[] = [];
+        const sampleToValue:{[key: string]: any} = {};
+        const sampleToCCF:{[key: string]: number} = {};
+        for (const mutation of mutations) {
+            sampleToValue[mutation.sampleId] = FACETSClonalColumnFormatter.getClonalValue([mutation]);
+        }
+        for (const mutation of mutations) {
+            sampleToCCF[mutation.sampleId] = mutation.ccfMCopies;
+        }
+        // exclude samples with invalid count value (undefined || emtpy || lte 0)
+        const samplesWithValue = sampleIds.filter(sampleId =>
+            sampleToValue[sampleId] && sampleToValue[sampleId].toString().length > 0);
+
+        // single value: just add the actual value only
+        let tdValue = null;
+        if (!samplesWithValue) {
+            return (<span></span>);
+        } else if (samplesWithValue.length === 1) {
+             tdValue = <li><DefaultTooltip overlay={FACETSClonalColumnFormatter.getTooltip(`${samplesWithValue[0]}`, `${sampleToValue[samplesWithValue[0]]}`, `${sampleToCCF[samplesWithValue[0]]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{FACETSClonalColumnFormatter.getClonalCircle(sampleToValue[samplesWithValue[0]])}</DefaultTooltip></li>;
+        }
+        // multiple value: add sample id and value pairs
+        else {
+             tdValue = samplesWithValue.map((sampleId:string) => {
+                return (
+                    <li><DefaultTooltip overlay={FACETSClonalColumnFormatter.getTooltip(`${sampleId}`, `${sampleToValue[sampleId]}`, `${sampleToCCF[sampleId]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{FACETSClonalColumnFormatter.getClonalCircle(`${sampleToValue[sampleId]}`)}</DefaultTooltip></li>
+                );
+            });
+        }
+        return (
+                <span style={{display:'inline-block', minWidth:100}}>
+                    <ul style={{marginBottom:0}} className="list-inline list-unstyled">{ tdValue }</ul>
+                </span>
+               );
+    }
+
+    public static getTooltip(sampleId:string, clonalValue:string, ccfMCopies:string) {
+        let clonalColor = "";
+        if (clonalValue === "yes") {
+            clonalColor = "limegreen";
+        } else if  (clonalValue === "no") {
+            clonalColor = "dimgrey";
+        } else {
+            clonalColor = "lightgrey";
+        }
+        return (
+                <div>
+                        <table>
+                                <tr><td>Sample</td><td><strong>{sampleId}</strong></td></tr>
+                                <tr><td>Clonal</td><td><span style={{color: `${clonalColor}`, fontWeight: "bold"}}>{clonalValue}</span></td></tr>
+                                <tr><td style={{paddingRight:5}}>CCF</td><td><strong>{ccfMCopies}</strong></td></tr>
+                        </table>
+                </div>
+        );
+    }
+
+    public static getClonalCircle(clonalValue:string) {
+        let color:string = "";
+        if (clonalValue === "yes") {
+            color = "limegreen";
+        } else if (clonalValue === "no") {
+            color = "dimgrey";
+        } else {
+            color = "lightgrey";
+        }
+        return (
+                <svg height="10" width="10">
+                    <circle cx={5} cy={5} r={5} fill={`${color}`}/>
+                </svg>
+        );
+    }
+
+    public static getCcfMCopiesUpperValue(mutations:Mutation[]):number {
+        const ccfMCopiesUpperValue = mutations[0].ccfMCopiesUpper;
+        return ccfMCopiesUpperValue;
+    }
+
+    public static getCcfMCopiesValue(mutations:Mutation[]):number {
+        const ccfMCopiesValue = mutations[0].ccfMCopies;
+        return ccfMCopiesValue;
+    }
+
+    public static getClonalValue(mutations:Mutation[]):string {
+        let textValue:string = "";
+        const ccfMCopiesUpperValue = FACETSClonalColumnFormatter.getCcfMCopiesUpperValue(mutations);
+        if (floatValueIsNA(ccfMCopiesUpperValue)) {
+            textValue = "";
+        } else if (ccfMCopiesUpperValue === 1) {
+            textValue = "yes";
+        } else {
+            textValue = "no";
+        }
+        return textValue;
+    }
+
+    public static renderFunction(mutations:Mutation[], sampleIds:string[], sampleManager:SampleManager|null) {
+        if (!sampleManager) {
+            return (<span></span>);
+        }
+        const sampleOrder = sampleManager.getSampleIdsInOrder();
+        const sampleElements = mutations.map((m:Mutation) => {
+            const args = FACETSClonalColumnFormatter.getComponentForSampleArgs(m);
+            return FACETSClonalColumnFormatter.convertMutationToSampleElement(
+                m,
+                sampleManager.getColorForSample(m.sampleId),
+                sampleManager.getComponentForSample(m.sampleId, args.opacity, args.extraTooltipText)
+            );
+        });
+        return FACETSClonalColumnFormatter.getDisplayValue(mutations, sampleIds, sampleManager);
+    }
+
+    public static getClonalDownload(mutations:Mutation[]): string|string[] {
+        let result = [];
+        if (mutations) {
+            for (let mutation of mutations) {
+                result.push(FACETSClonalColumnFormatter.getClonalValue([mutation]));
+            }
+        }
+        if (result.length == 1) {
+            return result[0];
+        }
+        return result;
+    }
+
+
+
+
+
+
+
+
+
+    public static getComponentForSampleArgs<T extends {ccfMCopies:number}>(mutation:T) {
+        const ccfMCopiesValue = mutation.ccfMCopies;
+        let opacity: number = 1;
+        let extraTooltipText: string = '';
+        if (ccfMCopiesValue !== 1) {
+            opacity = .5;
+        }
+        return {
+           opacity,
+           extraTooltipText
+        };
+    }
+
+
+    public static convertMutationToSampleElement<T extends {sampleId:string, ccfMCopies:number}>(mutation:T, color:string, sampleComponent:any) {
+            const ccfMCopies = mutation.ccfMCopies;
+            const text = (<span>
+                    <strong>{ccfMCopies.toFixed(2)}</strong>
+                </span>);
+            return {
+                sampleId:mutation.sampleId, component:sampleComponent, text, ccfMCopies
+            };
+    }
+
+/*
+    public static renderFunction(mutations:Mutation[], sampleManager:SampleManager|null) {
+        const barX = sampleOrder.reduce((map, sampleId:string, i:number) => {map[sampleId] = FACETSColumnFormatter.indexToBarLeft(i); return map;}, {} as {[s:string]:number});
+        const sampleElements = mutations.map((m:Mutation) => {
+            const args = FACETSColumnFormatter.getComponentForSampleArgs(m);
+            return FACETSColumnFormatter.convertMutationToSampleElement(
+                m,
+                sampleManager.getColorForSample(m.sampleId),
+                barX[m.sampleId],
+                sampleManager.getComponentForSample(m.sampleId, args.opacity, args.extraTooltipText)
+            );
+        });
+        const sampleToElements = sampleElements.reduce((map, elements:any) => {if (elements) { map[elements.sampleId] = elements } return map; }, {} as {[s:string]:any});
+        const elementsInSampleOrder = sampleOrder.map((sampleId:string) => sampleToElements[sampleId]).filter((x:any) => !!x);
+        const tooltipLines = elementsInSampleOrder.map((elements:any)=>(<span key={elements.sampleId}>{elements.component}  {elements.text}<br/></span>));
+        const ccfMCopiesValues = sampleOrder.map((sampleId:string) => (sampleToElements[sampleId] && sampleToElements[sampleId].ccfMCopies) || undefined);
+        const bars = elementsInSampleOrder.map((elements:any)=>elements.bar);
+
+        let content:JSX.Element = <span />;
+
+        // single sample: just show the number
+        if (sampleManager.samples.length === 1) {
+            content = <span>{ (!isNaN(ccfMCopiesValues[0]) ? ccfMCopiesValues[0].toFixed(2) : '') }</span>;
+        }
+        // multiple samples: show a graphical component
+        // (if no tooltip info available do not update content)
+        else if (tooltipLines.length > 0) {
+            content = (
+                <svg
+                    width={FACETSColumnFormatter.getSVGWidth(sampleOrder.length)}
+                    height={FACETSColumnFormatter.maxBarHeight}
+                >
+                    {bars}
+                </svg>
+            );
+        }
+        // as long as we have tooltip lines, show tooltip in either cases (single or multiple)
+        if (tooltipLines.length > 0)
+        {
+            const overlay = () => <span>{tooltipLines}</span>;
+
+            content = (
+                <DefaultTooltip
+                    placement="left"
+                    overlay={overlay}
+                    arrowContent={<div className="rc-tooltip-arrow-inner"/>}
+                    destroyTooltipOnHide={true}
+                >
+                    {content}
+                </DefaultTooltip>
+            );
+        }
+
+        return content;
+    }
+
+    public static getSVGWidth(numSamples:number) {
+        return numSamples*FACETSColumnFormatter.barWidth + (numSamples-1)*FACETSColumnFormatter.barSpacing
+    }
+*/
+
+}

--- a/src/pages/patientView/mutation/column/FACETSMutantCopiesColumnFormatter.tsx
+++ b/src/pages/patientView/mutation/column/FACETSMutantCopiesColumnFormatter.tsx
@@ -3,6 +3,7 @@ import DefaultTooltip from 'shared/components/defaultTooltip/DefaultTooltip';
 import {Mutation, ClinicalData} from "shared/api/generated/CBioPortalAPI";
 import styles from "./mutationType.module.scss";
 import getCanonicalMutationType from "shared/lib/getCanonicalMutationType";
+import SampleManager from "../../sampleManager";
 
 interface IMutationTypeFormat {
     label?: string;
@@ -15,7 +16,7 @@ interface IMutationTypeFormat {
 /**
  * @author Avery Wang
  */
-export default class MutantCopiesColumnFormatter {
+export default class FACETSMutantCopiesColumnFormatter {
     /* Determines the display value by using the impact field.
      *
      * @param data  column formatter data
@@ -24,7 +25,7 @@ export default class MutantCopiesColumnFormatter {
     public static getDisplayValue(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]):{[key: string]: string} {
         const sampleToValue:{[key: string]: string} = {};
         for (const mutation of data) {
-            const value:string = MutantCopiesColumnFormatter.getMutantCopiesOverTotalCopies(mutation, sampleIdToClinicalDataMap);
+            const value:string = FACETSMutantCopiesColumnFormatter.getMutantCopiesOverTotalCopies(mutation, sampleIdToClinicalDataMap);
             if (value.toString().length > 0) {
                 sampleToValue[mutation.sampleId] = value;
             }
@@ -33,7 +34,7 @@ export default class MutantCopiesColumnFormatter {
     }
 
     public static getDisplayValueAsString(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]):string {
-        const displayValuesBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
+        const displayValuesBySample:{[key: string]: string} = FACETSMutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
         const sampleIdsWithValues = sampleIds.filter(sampleId => displayValuesBySample[sampleId]);
         const displayValuesAsString = sampleIdsWithValues.map((sampleId:string) => {
             return displayValuesBySample[sampleId];
@@ -42,7 +43,7 @@ export default class MutantCopiesColumnFormatter {
     }
 
     public static invalidTotalCopyNumber(value:number):boolean {
-        return (value === -1 || value === null);
+        return (value === -1 || value === null); 
     }
 
     public static getVariantAlleleFraction(mutation:Mutation):number {
@@ -55,7 +56,7 @@ export default class MutantCopiesColumnFormatter {
 
     public static getMutantCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):number {
         const sampleId:string = mutation.sampleId;
-        const variantAlleleFraction:number = MutantCopiesColumnFormatter.getVariantAlleleFraction(mutation);
+        const variantAlleleFraction:number = FACETSMutantCopiesColumnFormatter.getVariantAlleleFraction(mutation);
         const totalCopyNumber = mutation.totalCopyNumber;
         let purity = null;
         if (sampleIdToClinicalDataMap) {
@@ -74,8 +75,8 @@ export default class MutantCopiesColumnFormatter {
     public static getMutantCopiesOverTotalCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string {
         let textValue:string = "";
         const totalCopyNumber:number = mutation.totalCopyNumber;
-        const mutantCopies:number = MutantCopiesColumnFormatter.getMutantCopies(mutation, sampleIdToClinicalDataMap)
-        if (mutantCopies === -1 || MutantCopiesColumnFormatter.invalidTotalCopyNumber(totalCopyNumber)) {
+        const mutantCopies:number = FACETSMutantCopiesColumnFormatter.getMutantCopies(mutation, sampleIdToClinicalDataMap)
+        if (mutantCopies === -1 || FACETSMutantCopiesColumnFormatter.invalidTotalCopyNumber(totalCopyNumber)) {
             textValue = "";
         } else {
             textValue = mutantCopies.toString() + "/" + totalCopyNumber.toString();
@@ -92,7 +93,7 @@ export default class MutantCopiesColumnFormatter {
     public static getMutantCopiesToolTip(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIdsWithValues:string[]):{[key: string]: string} {
         const sampleToToolTip:{[key: string]: string} = {};
         for (const mutation of data) {
-            sampleToToolTip[mutation.sampleId] = MutantCopiesColumnFormatter.constructToolTipString(mutation, sampleIdToClinicalDataMap);
+            sampleToToolTip[mutation.sampleId] = FACETSMutantCopiesColumnFormatter.constructToolTipString(mutation, sampleIdToClinicalDataMap);
         }
         return sampleToToolTip;
     }
@@ -105,8 +106,8 @@ export default class MutantCopiesColumnFormatter {
     public static constructToolTipString(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string {
         let textValue:string = "";
         const totalCopyNumber:number = mutation.totalCopyNumber;
-        const mutantCopies:number = MutantCopiesColumnFormatter.getMutantCopies(mutation, sampleIdToClinicalDataMap);
-        if (mutantCopies === -1 || MutantCopiesColumnFormatter.invalidTotalCopyNumber(totalCopyNumber)) {
+        const mutantCopies:number = FACETSMutantCopiesColumnFormatter.getMutantCopies(mutation, sampleIdToClinicalDataMap);
+        if (mutantCopies === -1 || FACETSMutantCopiesColumnFormatter.invalidTotalCopyNumber(totalCopyNumber)) {
             textValue = "Missing data values, mutant copies can not be computed";
         } else {
             textValue = mutantCopies.toString(10) + " out of " + totalCopyNumber.toString(10) + " copies of this gene are mutated";
@@ -114,21 +115,25 @@ export default class MutantCopiesColumnFormatter {
         return textValue;
     }
 
-    public static renderFunction(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]) {
+    public static renderFunction(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[], sampleManager:SampleManager|null) {
+        if (!sampleManager) {
+            return (<span></span>);
+        }
         // get display text values map (sampleid -> value), list of sample ids with values in 'displayValuesBySample', and calculate tooltip by sample
-        const displayValuesBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
+        const displayValuesBySample:{[key: string]: string} = FACETSMutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
         const sampleIdsWithValues = sampleIds.filter(sampleId => displayValuesBySample[sampleId]);
-        const toolTipBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getMutantCopiesToolTip(data, sampleIdToClinicalDataMap, sampleIdsWithValues);
+        const toolTipBySample:{[key: string]: string} = FACETSMutantCopiesColumnFormatter.getMutantCopiesToolTip(data, sampleIdToClinicalDataMap, sampleIdsWithValues);
         if (!sampleIdsWithValues) {
             return (<span></span>);
         } else {
             let content = sampleIdsWithValues.map((sampleId:string) => {
                 let textValue = displayValuesBySample[sampleId];
-                // if current item is not last samle in list then append '; ' to end of text value
+                // if current item is not last sample in list then append '; ' to end of text value
                 if (sampleIdsWithValues.indexOf(sampleId) !== (sampleIdsWithValues.length - 1)) {
                     textValue = textValue + "; ";
                 }
-                return <li><DefaultTooltip overlay={<span>{toolTipBySample[sampleId]}</span>} placement='left' arrowContent={<div className="rc-tooltip-arrow-inner"/>}><span>{textValue}</span></DefaultTooltip></li>
+                let componentBySample = sampleManager.getComponentForSample(sampleId, 1, "");
+                return <li><DefaultTooltip overlay={<span key={sampleId}>{componentBySample} {toolTipBySample[sampleId]}</span>} placement='left' arrowContent={<div className="rc-tooltip-arrow-inner"/>}><span>{textValue}</span></DefaultTooltip></li>
             })
             return (
              <span style={{display:'inline-block', minWidth:100}}>
@@ -137,20 +142,4 @@ export default class MutantCopiesColumnFormatter {
             );
        }
     }
-
-    public static getMutantCopiesDownload(mutations:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined) {
-    {
-        let result = [];
-        if (mutations) {
-            for (let mutation of mutations) {
-                result.push(MutantCopiesColumnFormatter.getMutantCopiesOverTotalCopies(mutation, sampleIdToClinicalDataMap));
-            }
-        }
-        if (result.length == 1) {
-            return result[0];
-        }
-        return result;
-    }
-}
-
 }

--- a/src/pages/patientView/sampleManager.tsx
+++ b/src/pages/patientView/sampleManager.tsx
@@ -181,6 +181,16 @@ class SampleManager {
     getComponentsForSamples() {
         this.samples.map((sample)=>this.getComponentForSample(sample.id));
     }
+
+    mapComponentForSample(sampleId: string, sampleIdToComponentMap: {[s:string]:JSX.Element | undefined}) {
+        sampleIdToComponentMap[sampleId] = this.getComponentForSample(sampleId);
+    }
+
+    getSampleIdToIconComponentMap() {
+        let sampleIdToComponentMap: {[s:string]:JSX.Element | undefined} = {};
+        this.samples.map((sample)=>this.mapComponentForSample(sample.id, sampleIdToComponentMap));
+        return sampleIdToComponentMap;
+    }
 }
 
 export default SampleManager;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -441,9 +441,9 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
         this._columns[MutationTableColumnType.MUTANT_COPIES] = {
             name: "Mutant Copies",
             tooltip: (<span>FACETS Best Guess for Mutant Copies / Total Copies</span>),
-            render:(d:Mutation[])=>MutantCopiesColumnFormatter.renderFunction(d, this.props.sampleIdToClinicalDataMap),
-            download:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValue(d, this.props.sampleIdToClinicalDataMap),
-            sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValue(d, this.props.sampleIdToClinicalDataMap)
+            render:(d:Mutation[])=>MutantCopiesColumnFormatter.renderFunction(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId]),
+            download:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValueAsString(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId]),
+            sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValueAsString(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId])
         };
 
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT] = {

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -255,7 +255,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
                 if (this.props.discreteCNACache && this.props.molecularProfileIdToMolecularProfile) {
                     return DiscreteCNAColumnFormatter.renderFunction(d,
                         this.props.molecularProfileIdToMolecularProfile as {[molecularProfileId:string]:MolecularProfile},
-                        this.props.discreteCNACache as DiscreteCNACache, this.props.sampleIdToClinicalDataMap);
+                        this.props.discreteCNACache as DiscreteCNACache, this.props.sampleIdToClinicalDataMap, [d[0].sampleId]);
                 } else {
                     return (<span></span>);
                 }
@@ -265,7 +265,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
                     return DiscreteCNAColumnFormatter.getSortValue(d,
                         this.props.molecularProfileIdToMolecularProfile as {[molecularProfileId:string]:MolecularProfile},
                         this.props.discreteCNACache as DiscreteCNACache,
-                        this.props.sampleIdToClinicalDataMap);
+                        this.props.sampleIdToClinicalDataMap, [d[0].sampleId]);
                 } else {
                     return "";
                 }
@@ -276,6 +276,7 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
                         this.props.molecularProfileIdToMolecularProfile as {[molecularProfileId:string]:MolecularProfile},
                         this.props.discreteCNACache as DiscreteCNACache,
                         this.props.sampleIdToClinicalDataMap,
+                        [d[0].sampleId],
                         filterString);
                 } else {
                     return false;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -88,6 +88,7 @@ export interface IMutationTableProps {
     columnVisibility?: {[columnId: string]: boolean};
     columnVisibilityProps?: IColumnVisibilityControlsProps;
     sampleIdToClinicalDataMap?: {[key:string]: ClinicalData[]};
+    sampleIdToIconComponentMap?: {[key:string]: JSX.Element | undefined};
 }
 
 export enum MutationTableColumnType {

--- a/src/shared/components/mutationTable/column/ClonalColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ClonalColumnFormatter.tsx
@@ -70,11 +70,10 @@ export default class ClonalColumnFormatter {
         }
         return (
                 <div>
-                        <table>
-                                <tr><td>Sample</td><td><strong>{sampleId}</strong></td></tr>
-                                <tr><td>Clonal</td><td><span style={{color: `${clonalColor}`, fontWeight: "bold"}}>{clonalValue}</span></td></tr>
-                                <tr><td style={{paddingRight:5}}>CCF</td><td><strong>{ccfMCopies}</strong></td></tr>
-                        </table>
+                    <table>
+                        <tr><td style={{paddingRight:5}}>Clonal</td><td><span style={{color: `${clonalColor}`, fontWeight: "bold"}}>{clonalValue}</span></td></tr>
+                        <tr><td style={{paddingRight:5}}>CCF</td><td><strong>{ccfMCopies}</strong></td></tr>
+                    </table>
                 </div>
         );
     }
@@ -119,19 +118,7 @@ export default class ClonalColumnFormatter {
     }
 
     public static renderFunction(data:Mutation[], sampleIds:string[]) {
-        // use text for all purposes (display, sort, filter)
         return ClonalColumnFormatter.getDisplayValue(data,sampleIds);
-        /*
-        const text:string = ClonalColumnFormatter.getDisplayValue(data, sampleIds);
-        if (text === "yes") {
-            return (<svg>
-                        <circle cx={10} cy={10} r={5} fill="green" />
-                    </svg>);
-        } else {
-            let content = <span>{text}</span>;
-            return content;
-        }
-        */
     }
 
     public static getClonalDownload(mutations:Mutation[]): string|string[]

--- a/src/shared/components/mutationTable/column/ClonalColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ClonalColumnFormatter.tsx
@@ -26,12 +26,12 @@ export default class ClonalColumnFormatter {
     public static getDisplayValue(data:Mutation[], sampleIds:string[]) {
         let values:string[] = [];
         const sampleToValue:{[key: string]: any} = {};
-        const sampleToCCFMCopiesUpper:{[key: string]: number} = {};
+        const sampleToCCF:{[key: string]: number} = {};
         for (const mutation of data) {
             sampleToValue[mutation.sampleId] = ClonalColumnFormatter.getClonalValue([mutation]);
         }
         for (const mutation of data) {
-            sampleToCCFMCopiesUpper[mutation.sampleId] = mutation.ccfMCopiesUpper;
+            sampleToCCF[mutation.sampleId] = mutation.ccfMCopies;
         }
         // exclude samples with invalid count value (undefined || emtpy || lte 0)
         const samplesWithValue = sampleIds.filter(sampleId =>
@@ -42,13 +42,13 @@ export default class ClonalColumnFormatter {
         if (!samplesWithValue) {
             return (<span></span>);
         } else if (samplesWithValue.length === 1) {
-             tdValue = <li><DefaultTooltip overlay={ClonalColumnFormatter.getTooltip(`${samplesWithValue[0]}`, `${sampleToValue[samplesWithValue[0]]}`, `${sampleToCCFMCopiesUpper[samplesWithValue[0]]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{ClonalColumnFormatter.getClonalCircle(sampleToValue[samplesWithValue[0]])}</DefaultTooltip></li>;
+             tdValue = <li><DefaultTooltip overlay={ClonalColumnFormatter.getTooltip(`${samplesWithValue[0]}`, `${sampleToValue[samplesWithValue[0]]}`, `${sampleToCCF[samplesWithValue[0]]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{ClonalColumnFormatter.getClonalCircle(sampleToValue[samplesWithValue[0]])}</DefaultTooltip></li>;
         }
         // multiple value: add sample id and value pairs
         else {
              tdValue = samplesWithValue.map((sampleId:string) => {
                 return (
-                    <li><DefaultTooltip overlay={ClonalColumnFormatter.getTooltip(`${sampleId}`, `${sampleToValue[sampleId]}`, `${sampleToCCFMCopiesUpper[sampleId]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{ClonalColumnFormatter.getClonalCircle(`${sampleToValue[sampleId]}`)}</DefaultTooltip></li>
+                    <li><DefaultTooltip overlay={ClonalColumnFormatter.getTooltip(`${sampleId}`, `${sampleToValue[sampleId]}`, `${sampleToCCF[sampleId]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{ClonalColumnFormatter.getClonalCircle(`${sampleToValue[sampleId]}`)}</DefaultTooltip></li>
                 );
             });
         }
@@ -59,7 +59,7 @@ export default class ClonalColumnFormatter {
                );
     }
 
-    public static getTooltip(sampleId:string, clonalValue:string, ccfMCopiesUpperValue:string) {
+    public static getTooltip(sampleId:string, clonalValue:string, ccfMCopies:string) {
         let clonalColor = "";
         if (clonalValue === "yes") {
             clonalColor = "limegreen";
@@ -73,7 +73,7 @@ export default class ClonalColumnFormatter {
                         <table>
                                 <tr><td>Sample</td><td><strong>{sampleId}</strong></td></tr>
                                 <tr><td>Clonal</td><td><span style={{color: `${clonalColor}`, fontWeight: "bold"}}>{clonalValue}</span></td></tr>
-                                <tr><td style={{paddingRight:5}}>CCF Upper</td><td><strong>{ccfMCopiesUpperValue}</strong></td></tr>
+                                <tr><td style={{paddingRight:5}}>CCF</td><td><strong>{ccfMCopies}</strong></td></tr>
                         </table>
                 </div>
         );

--- a/src/shared/components/mutationTable/column/ClonalColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ClonalColumnFormatter.tsx
@@ -17,7 +17,7 @@ interface IMutationTypeFormat {
  * @author Avery Wang
  */
 export default class ClonalColumnFormatter {
-    
+
     /* Determines the display value by using the impact field.
      *
      * @param data  column formatter data
@@ -26,24 +26,75 @@ export default class ClonalColumnFormatter {
     public static getDisplayValue(data:Mutation[], sampleIds:string[]) {
         let values:string[] = [];
         const sampleToValue:{[key: string]: any} = {};
+        const sampleToCCFMCopiesUpper:{[key: string]: number} = {};
         for (const mutation of data) {
             sampleToValue[mutation.sampleId] = ClonalColumnFormatter.getClonalValue([mutation]);
+        }
+        for (const mutation of data) {
+            sampleToCCFMCopiesUpper[mutation.sampleId] = mutation.ccfMCopiesUpper;
         }
         // exclude samples with invalid count value (undefined || emtpy || lte 0)
         const samplesWithValue = sampleIds.filter(sampleId =>
             sampleToValue[sampleId] && sampleToValue[sampleId].toString().length > 0);
 
         // single value: just add the actual value only
-        if (samplesWithValue.length === 1) {
-            values = [sampleToValue[samplesWithValue[0]].toString()];
+        let tdValue = null;
+        if (!samplesWithValue) {
+            return (<span></span>);
+        } else if (samplesWithValue.length === 1) {
+             tdValue = <li><DefaultTooltip overlay={ClonalColumnFormatter.getTooltip(`${samplesWithValue[0]}`, `${sampleToValue[samplesWithValue[0]]}`, `${sampleToCCFMCopiesUpper[samplesWithValue[0]]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{ClonalColumnFormatter.getClonalCircle(sampleToValue[samplesWithValue[0]])}</DefaultTooltip></li>;
         }
         // multiple value: add sample id and value pairs
         else {
-            values = samplesWithValue.map((sampleId:string) => (`${sampleId}: ${sampleToValue[sampleId]}`));
+             tdValue = samplesWithValue.map((sampleId:string) => {
+                return (
+                    <li><DefaultTooltip overlay={ClonalColumnFormatter.getTooltip(`${sampleId}`, `${sampleToValue[sampleId]}`, `${sampleToCCFMCopiesUpper[sampleId]}`)} placement="left" arrowContent={<div className="rc-tooltip-arrow-inner"/>}>{ClonalColumnFormatter.getClonalCircle(`${sampleToValue[sampleId]}`)}</DefaultTooltip></li>
+                );
+            });
         }
-        return values.join("\n");
+        return (
+                <span style={{display:'inline-block', minWidth:100}}>
+                    <ul style={{marginBottom:0}} className="list-inline list-unstyled">{ tdValue }</ul>
+                </span>
+               );
     }
-       
+
+    public static getTooltip(sampleId:string, clonalValue:string, ccfMCopiesUpperValue:string) {
+        let clonalColor = "";
+        if (clonalValue === "yes") {
+            clonalColor = "limegreen";
+        } else if  (clonalValue === "no") {
+            clonalColor = "dimgrey";
+        } else {
+            clonalColor = "lightgrey";
+        }
+        return (
+                <div>
+                        <table>
+                                <tr><td>Sample</td><td><strong>{sampleId}</strong></td></tr>
+                                <tr><td>Clonal</td><td><span style={{color: `${clonalColor}`, fontWeight: "bold"}}>{clonalValue}</span></td></tr>
+                                <tr><td style={{paddingRight:5}}>CCF Upper</td><td><strong>{ccfMCopiesUpperValue}</strong></td></tr>
+                        </table>
+                </div>
+        );
+    }
+
+    public static getClonalCircle(clonalValue:string) {
+        let color:string = "";
+        if (clonalValue === "yes") {
+            color = "limegreen";
+        } else if (clonalValue === "no") {
+            color = "dimgrey";
+        } else {
+            color = "lightgrey";
+        }
+        return (
+                <svg height="10" width="10">
+                    <circle cx={5} cy={5} r={5} fill={`${color}`}/>
+                </svg>
+        );
+    }
+
     public static getCcfMCopiesUpperValue(data:Mutation[]):number {
         const ccfMCopiesUpperValue = data[0].ccfMCopiesUpper;
         return ccfMCopiesUpperValue;
@@ -69,29 +120,20 @@ export default class ClonalColumnFormatter {
 
     public static renderFunction(data:Mutation[], sampleIds:string[]) {
         // use text for all purposes (display, sort, filter)
+        return ClonalColumnFormatter.getDisplayValue(data,sampleIds);
+        /*
         const text:string = ClonalColumnFormatter.getDisplayValue(data, sampleIds);
-        let content = <span>{text}</span>;
-        return content;
-    }
-    
-    // can be removed if mouseover is dropped
-    public static getTextValue(data:number):string {
-        let textValue:string = "";
-        if (data) {
-            textValue = data.toString();
+        if (text === "yes") {
+            return (<svg>
+                        <circle cx={10} cy={10} r={5} fill="green" />
+                    </svg>);
+        } else {
+            let content = <span>{text}</span>;
+            return content;
         }
-        return textValue;
+        */
     }
 
-    // can be removed if mouseover is dropped
-    public static getTooltipValue(data:Mutation[]):string {
-        const ccfMCopiesValue = ClonalColumnFormatter.getCcfMCopiesValue(data);
-        if (floatValueIsNA(ccfMCopiesValue)) {
-            return "FACETS data not available";
-        } 
-        return "CCF: " + ClonalColumnFormatter.getTextValue(ccfMCopiesValue);
-    } 
-            
     public static getClonalDownload(mutations:Mutation[]): string|string[]
     {
         let result = [];
@@ -106,4 +148,3 @@ export default class ClonalColumnFormatter {
         return result;
     }
 }
-

--- a/src/shared/components/mutationTable/column/MutantCopiesColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutantCopiesColumnFormatter.tsx
@@ -15,15 +15,13 @@ interface IMutationTypeFormat {
 /**
  * @author Avery Wang
  */
-export default class MutantCopiesColumnFormatter
-{
+export default class MutantCopiesColumnFormatter {
     /* Determines the display value by using the impact field.
      *
      * @param data  column formatter data
      * @returns {string}    mutation assessor text value
      */
-    public static getDisplayValue(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]):{[key: string]: string}
-    {
+    public static getDisplayValue(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]):{[key: string]: string} {
         const sampleToValue:{[key: string]: string} = {};
         for (const mutation of data) {
             const value:string = MutantCopiesColumnFormatter.getMutantCopiesOverTotalCopies(mutation, sampleIdToClinicalDataMap);
@@ -43,16 +41,14 @@ export default class MutantCopiesColumnFormatter
         return displayValuesAsString.join("; ");
     }
 
-    public static invalidTotalCopyNumber(value:number):boolean
-    { 
+    public static invalidTotalCopyNumber(value:number):boolean {
         if (value === -1 || value === null) {
             return true;
         }
         return false;
     }
 
-    public static getVariantAlleleFraction(mutation:Mutation):number
-    {
+    public static getVariantAlleleFraction(mutation:Mutation):number {
         let variantAlleleFraction = 0;
         if (mutation.tumorRefCount !== null && mutation.tumorAltCount !== null) {
             variantAlleleFraction = mutation.tumorAltCount/(mutation.tumorRefCount + mutation.tumorAltCount);
@@ -60,8 +56,7 @@ export default class MutantCopiesColumnFormatter
         return variantAlleleFraction;
     }
 
-    public static getMutantCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):number
-    {
+    public static getMutantCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):number {
         const sampleId:string = mutation.sampleId;
         const variantAlleleFraction:number = MutantCopiesColumnFormatter.getVariantAlleleFraction(mutation);
         const totalCopyNumber = mutation.totalCopyNumber;
@@ -78,9 +73,8 @@ export default class MutantCopiesColumnFormatter
         const mutantCopies:number = Math.min(totalCopyNumber, Math.round((variantAlleleFraction/purity)*totalCopyNumber))
         return mutantCopies;
     }
- 
-    public static getMutantCopiesOverTotalCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string
-    {
+
+    public static getMutantCopiesOverTotalCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string {
         let textValue:string = "";
         const totalCopyNumber:number = mutation.totalCopyNumber;
         const mutantCopies:number = MutantCopiesColumnFormatter.getMutantCopies(mutation, sampleIdToClinicalDataMap)
@@ -94,23 +88,22 @@ export default class MutantCopiesColumnFormatter
 
     /**
      * Returns map of sample id to tooltip text value.
-     * @param data 
-     * @param sampleIdToClinicalDataMap 
-     * @param sampleIdsWithValues 
+     * @param data
+     * @param sampleIdToClinicalDataMap
+     * @param sampleIdsWithValues
      */
-    public static getMutantCopiesToolTip(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIdsWithValues:string[]):{[key: string]: string}
-    {
+    public static getMutantCopiesToolTip(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIdsWithValues:string[]):{[key: string]: string} {
         const sampleToToolTip:{[key: string]: string} = {};
         for (const mutation of data) {
             sampleToToolTip[mutation.sampleId] = MutantCopiesColumnFormatter.constructToolTipString(mutation, sampleIdToClinicalDataMap);
         }
         return sampleToToolTip;
     }
-    
+
     /**
      * Constructs tooltip string value.
-     * @param mutation 
-     * @param sampleIdToClinicalDataMap 
+     * @param mutation
+     * @param sampleIdToClinicalDataMap
      */
     public static constructToolTipString(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string {
         let textValue:string = "";
@@ -124,13 +117,11 @@ export default class MutantCopiesColumnFormatter
         return textValue;
     }
 
-    public static renderFunction(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[])
-    {
+    public static renderFunction(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]) {
         // get display text values map (sampleid -> value), list of sample ids with values in 'displayValuesBySample', and calculate tooltip by sample
         const displayValuesBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
         const sampleIdsWithValues = sampleIds.filter(sampleId => displayValuesBySample[sampleId]);
         const toolTipBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getMutantCopiesToolTip(data, sampleIdToClinicalDataMap, sampleIdsWithValues);
-        
         if (!sampleIdsWithValues) {
             return (<span></span>);
         } else {
@@ -145,9 +136,8 @@ export default class MutantCopiesColumnFormatter
             return (
              <span style={{display:'inline-block', minWidth:100}}>
                  <ul style={{marginBottom:0}} className="list-inline list-unstyled">{ content }</ul>
-             </span> 
+             </span>
             );
        }
-
     }
 }


### PR DESCRIPTION
# What? Why?
Additional revisions after receiving feedback from Nikki

**Patient View**
- Sample Id replaced with Sample Id Icon component
- FACETS columns + CNA column will display multiple values if more than one sample shares a mutation 
- tooltips added for each value

Additional bugfix for download/sort/filter of FACETS columns

Changes proposed in this pull request:
- adding a patient-view column formatter for FACETS columns/CNA column (for adding sample manager and generating icons)

![screen shot 2019-01-09 at 12 53 56 pm](https://user-images.githubusercontent.com/18199796/50918372-11aa9380-140e-11e9-8ca4-3defea3e9548.png)

Additional feedback/changes is expected. Future work includes cleaning up the code after general display is decided.

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
