### PR TITLE
Only attach the semicolon when query has alteration

### DIFF
--- a/src/pages/studyView/StudyViewUtils.spec.ts
+++ b/src/pages/studyView/StudyViewUtils.spec.ts
@@ -60,13 +60,13 @@ describe('StudyViewUtils', () => {
 
     describe('updateGeneQuery', () => {
         it('when gene selected in table', () => {
-            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }], 'TTN'), 'TP53;\nTTN;',);
-            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }, { gene: 'TTN', alterations: false }], 'ALK'), 'TP53;\nTTN;\nALK;',);
+            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }], 'TTN'), 'TP53 TTN',);
+            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }, { gene: 'TTN', alterations: false }], 'ALK'), 'TP53 TTN ALK',);
         });
         it('when gene unselected in table', () => {
             assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }], 'TP53'), '');
-            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }, { gene: 'TTN', alterations: false }], 'TP53'), 'TTN;',);
-            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }, { gene: 'TTN', alterations: false }], 'ALK'), 'TP53;\nTTN;\nALK;',);
+            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }, { gene: 'TTN', alterations: false }], 'TP53'), 'TTN',);
+            assert.equal(updateGeneQuery([{ gene: 'TP53', alterations: false }, { gene: 'TTN', alterations: false }], 'ALK'), 'TP53 TTN ALK',);
         });
     });
 

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -125,7 +125,7 @@ export function updateGeneQuery(geneQueries: SingleGeneQuery[], selectedGene: st
             alterations: false
         })
     }
-    return updatedQueries.map(query=>unparseOQLQueryLine(query)).join('\n');
+    return updatedQueries.map(query=>unparseOQLQueryLine(query)).join(' ');
 
 }
 

--- a/src/shared/lib/oql/oqlfilter.js
+++ b/src/shared/lib/oql/oqlfilter.js
@@ -206,8 +206,8 @@ export function unparseOQLQueryLine(parsed_oql_query_line) {
     ret += gene;
     if (alterations.length > 0) {
         ret += ": " + alterations.map(parsedOQLAlterationToSourceOQL).join(" ");
+        ret += ";";
     }
-    ret += ";";
     return ret;
 };
 

--- a/src/shared/lib/oql/oqlfilter.spec.ts
+++ b/src/shared/lib/oql/oqlfilter.spec.ts
@@ -125,7 +125,7 @@ describe("doesQueryContainMutationOQL", ()=>{
 describe("unparseOQLQueryLine", ()=>{
     it("unparses query with no alterations", ()=>{
         const parsedLine = parseOQLQuery("TP53;")[0];
-        assert.equal(unparseOQLQueryLine(parsedLine), "TP53;");
+        assert.equal(unparseOQLQueryLine(parsedLine), "TP53");
     });
     it("unparses query with MUT keyword", ()=>{
         const parsedLine = parseOQLQuery("TP53: MUT;")[0];


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/5590
