### PR TITLE
Redirect legacy oql docs url to new

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -103,6 +103,9 @@ export const makeRoutes = (routing) => {
                 <Redirect from={"/mutation_mapper.jsp"} to={"/mutation_mapper"}/>
                 <Redirect from={"/data_sets.jsp"} to={"/datasets"}/>
                 <Redirect from={"/oncoprinter.jsp"} to={"/oncoprinter"}/>
+                <Redirect from={"/onco_query_lang_desc.jsp"} to={"/oql"}/>
+
+
 
                 <Route path="*" onEnter={()=>{$(document).scrollTop(0)}} component={()=><PageNotFound/>}/>
 


### PR DESCRIPTION
Old link should direct to new one