### PR TITLE
add tooltip for pie chart icon

### DIFF
--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -330,10 +330,12 @@ export default class StudyList extends QueryStoreComponent<IStudyListProps, {}>
                             placement="top"
                             overlay={
                                 <div className={styles.tooltip}
-                                >View study summary</div>
+                                >View clinical and genomic data of this study</div>
                             }
                         >
-							<StudyLink studyId={study.studyId} className={classNames(styles.summaryIcon, 'ci ci-pie-chart')}/>
+							<span>
+								<StudyLink studyId={study.studyId} className={classNames(styles.summaryIcon, 'ci ci-pie-chart')}/>
+							</span>
 						</DefaultTooltip>
                     )}
                 </span>


### PR DESCRIPTION
add tooltip back for pie chart icon in query page.
Fix https://github.com/cBioPortal/cbioportal/issues/5637.