### PR TITLE
Remove unsupported browser modal because it's interfering with googlebot

### DIFF
--- a/src/appShell/App/Container.tsx
+++ b/src/appShell/App/Container.tsx
@@ -67,7 +67,6 @@ export default class Container extends React.Component<IContainerProps, {}> {
                        </Then>
                         <Else>
                             <div className="contentWrapper">
-                                <UnsupportedBrowserModal/>
                                 {(this.isSessionLoaded) && this.props.children}
                             </div>
                         </Else>


### PR DESCRIPTION
Googlebot currently receives unsupported browser module, which may be interfering with its ability to index.

Part of fix for https://github.com/cBioPortal/cbioportal/issues/4024