### PR TITLE
Add genome build info to mutation mapper tool

### DIFF
--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
@@ -169,6 +169,8 @@ export default class MutationMapperTool extends React.Component<IMutationMapperT
                         <span> <a onClick={this.handleLoadExampleGenomicCoordinates} data-test="GenomicChangesExampleButton">Genomic Changes</a></span>,
                         <span> <a onClick={this.handleLoadExampleGeneAndProteinChange} data-test="ProteinChangesExampleButton">Protein Changes</a></span>,
                         <span> <a onClick={this.handleLoadExamplePartiallyAnnotated} data-test="GenomicAndProteinChangesExampleButton">Genomic and Protein Changes</a></span>)
+                        <br /><br />
+                        The annotations are based on genome build GRCh37 (hg19).
                     </p>
 
                     {this.dataFormatToggler()}
@@ -253,8 +255,10 @@ export default class MutationMapperTool extends React.Component<IMutationMapperT
                     select a file with mutation data for upload.<br />
                 </p>
                 <p>
-                    Mutation files should be tab delimited, and should at least have
-                    the genomic location headers in the first line for a successful annotation:
+                    Mutation files should be tab delimited, and should at
+                    least have the genomic location headers in the first line
+                    for a successful annotation. Note that all variants have
+                    to be reported for genome build GRCh37 (hg19).
                 </p>
                 <ul>
                     <li>Chromosome</li>


### PR DESCRIPTION
We currently don't indicate which version we are using. Text becomes:

<img width="1351" alt="screen shot 2019-01-26 at 1 57 52 pm" src="https://user-images.githubusercontent.com/1334004/51791522-6ff7a600-2172-11e9-8055-50d70bd6d8e5.png">
