### PR TITLE
exon number column and HGVSc column in mutation table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,15 +92,7 @@ jobs:
       - run:
           name: "Spin up frontend over ssl if necessary and run end to end tests"
           command: |
-            eval "$(./scripts/env_vars.sh)" && ( \
-                (echo $CBIOPORTAL_URL | grep -q https) \
-                && ( \
-                    openssl \
-                        req -newkey rsa:2048 -new -nodes -x509 -days 1 -keyout key.pem -out cert.pem \
-                        -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" && \
-                    ./node_modules/http-server/bin/http-server -S -C cert.pem --cors dist/ -p 3000 \
-                ) || ./node_modules/http-server/bin/http-server --cors dist/ -p 3000 \
-            ) & \
+            yarn serveDist & \
             cd end-to-end-tests && \
             yarn install --frozen-lockfile && \
             ./node_modules/webdriver-manager/bin/webdriver-manager update --versions.chrome '2.42' && \

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ env/custom.sh
 image-compare/errors.js
 errorshots/
 TESTS.xml
+key.pem
+cert.pem

--- a/end-to-end-tests/specs/mutationTable.spec.js
+++ b/end-to-end-tests/specs/mutationTable.spec.js
@@ -12,13 +12,13 @@ function waitForGenomeNexusAnnotation() {
     browser.pause(5000);// wait for annotation
 }
 
-describe('Mutation Mapper Tool', function() {
+describe('Mutation Table', function() {
     before(function(){
         goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}`);
     });
 
-    describe('example genomic changes input', ()=>{
-        beforeEach(()=>{
+    describe('try getting exon and hgvsc info from genome nexus', ()=>{
+        before(()=>{
             var url = `${CBIOPORTAL_URL}/results/mutations?Action=Submit&Z_SCORE_THRESHOLD=1.0&cancer_study_id=gbm_tcga_pub&cancer_study_list=gbm_tcga_pub&case_ids=&case_set_id=gbm_tcga_pub_sequenced&clinicallist=PROFILED_IN_gbm_tcga_pub_cna_rae&gene_list=TP53%20MDM2%20MDM4&gene_set_choice=user-defined_list&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=gbm_tcga_pub_cna_rae&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=gbm_tcga_pub_mutations&show_samples=false`;
 
             goToUrlAndSetLocalStorage(url);
@@ -35,64 +35,49 @@ describe('Mutation Mapper Tool', function() {
             // click on column button
             browser.click("button*=Columns");
             // scroll down to activated "exon" selection
-            browser.scroll(0, 1000);
+            browser.scroll(1000, 1000);
             // click "exon"
             browser.click('//*[text()="Exon"]');
-            waitForNetworkQuiet();
-            // check if 3 exact matches for 6 appear
+            // check if three exact matches for 6 appear
+            browser.waitUntil(() => {
+                textValuesWith6 = browser.getText('//*[text()="6"]');
+                return textValuesWith6.length > 1;
+            }, 60000, "Exon data not in Exon column");
             textValuesWith6 = browser.getText('//*[text()="6"]');
-            assert.ok(textValuesWith6.length === 4);
+            assert.equal(textValuesWith6.length, 3);
         });
 
         it('should show more exon number after clicking "Show more"', ()=>{
-            // check if 6 appears once in COSMIC column
-            browser.waitForText('//*[text()="6"]',30000);
-            var textValuesWith6 = browser.getText('//*[text()="6"]');
-            assert.ok(textValuesWith6.length === 1);
-            // click on column button
-            browser.click("button*=Columns");
-            // scroll down to activated "exon" selection
-            browser.scroll(0, 1000);
-            // click "exon"
-            browser.click('//*[text()="Exon"]');
-            waitForNetworkQuiet();
             // click "show more" to add more data
             browser.click("button*=Show more");
-            waitForNetworkQuiet();
             // check if 6 exact matches for 6 appear
-            textValuesWith6 = browser.getText('//*[text()="6"]');
-            assert.ok(textValuesWith6.length === 6);
+            browser.waitUntil(() => {
+                textValuesWith6 = browser.getText('//*[text()="6"]');
+                return textValuesWith6.length === 6;
+            }, 20000, "Exon data not in Exon column after clikcing show more button");
         });
 
-        it('should show the HGVSc data after adding the HGVSc column', ()=>{           
-            // click on column button
+        it('should show the HGVSc data after adding the HGVSc column', ()=>{
+            // reopen columns
             browser.click("button*=Columns");
-            // scroll down to activated "HGVSc" selection
-            browser.scroll(0, 1000);
             // click "HGVSc"
-            browser.waitForText('//*[text()="HGVSc"]',30000);
             browser.click('//*[text()="HGVSc"]');
-            waitForNetworkQuiet();
+
             // check if "ENST00000269305.4:c.817C>T" appears
-            var hgvscValues = browser.getText('//*[text()[contains(.,"ENST00000269305.4:c.817C>T")]]');
-            assert.ok(hgvscValues.length > 0);
+            browser.waitUntil(() => {
+                var hgvscValues = browser.getText('//*[text()[contains(.,"ENST00000269305.4:c.817C>T")]]');
+                return hgvscValues.length > 0;
+            }, 20000, "HGVSc values not in hgvs column");
         });
 
-        it('should show more HGVSc data after clicking "Show more"', ()=>{           
-            // click on column button
-            browser.click("button*=Columns");
-            // scroll down to activated "HGVSc" selection
-            browser.scroll(0, 1000);
-            // click "HGVSc"
-            browser.waitForText('//*[text()="HGVSc"]',30000);
-            browser.click('//*[text()="HGVSc"]');
-            waitForNetworkQuiet();
+        it('should show more HGVSc data after clicking "Show more"', ()=>{
             // click "show more" to add more data
             browser.click("button*=Show more");
-            waitForNetworkQuiet();
             // check if "C>T" exact matches for 12 appear
-            var hgvscValues = browser.getText('//*[text()[contains(.,"C>T")]]');
-            assert.ok(hgvscValues.length === 12);
+            browser.waitUntil(() => {
+                var hgvscValues = browser.getText('//*[text()[contains(.,"C>T")]]');
+                return hgvscValues.length > 0;
+            }, 20000, "HGVSc values not in hgvs column after clicking show more button");
         });
     });
 

--- a/end-to-end-tests/specs/mutationTable.spec.js
+++ b/end-to-end-tests/specs/mutationTable.spec.js
@@ -1,0 +1,99 @@
+
+var assertScreenShotMatch = require('../lib/testUtils').assertScreenShotMatch;
+
+var assert = require('assert');
+var expect = require('chai').expect;
+var goToUrlAndSetLocalStorage = require('./specUtils').goToUrlAndSetLocalStorage;
+var waitForNetworkQuiet = require('./specUtils').waitForNetworkQuiet;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, "");
+
+function waitForGenomeNexusAnnotation() {
+    browser.pause(5000);// wait for annotation
+}
+
+describe('Mutation Mapper Tool', function() {
+    before(function(){
+        goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}`);
+    });
+
+    describe('example genomic changes input', ()=>{
+        beforeEach(()=>{
+            var url = `${CBIOPORTAL_URL}/results/mutations?Action=Submit&Z_SCORE_THRESHOLD=1.0&cancer_study_id=gbm_tcga_pub&cancer_study_list=gbm_tcga_pub&case_ids=&case_set_id=gbm_tcga_pub_sequenced&clinicallist=PROFILED_IN_gbm_tcga_pub_cna_rae&gene_list=TP53%20MDM2%20MDM4&gene_set_choice=user-defined_list&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=gbm_tcga_pub_cna_rae&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=gbm_tcga_pub_mutations&show_samples=false`;
+
+            goToUrlAndSetLocalStorage(url);
+            // mutations table should be visiable after oncokb icon shows up,
+            // also need to wait for mutations to be sorted properly
+            browser.waitForVisible("tr:nth-child(1) [data-test=oncogenic-icon-image]",30000);
+        });
+
+        it('should show the exon number after adding the exon column', ()=>{
+            // check if 6 appears once in COSMIC column
+            browser.waitForText('//*[text()="6"]',30000);
+            var textValuesWith6 = browser.getText('//*[text()="6"]');
+            assert.ok(textValuesWith6.length === 1);
+            // click on column button
+            browser.click("button*=Columns");
+            // scroll down to activated "exon" selection
+            browser.scroll(0, 1000);
+            // click "exon"
+            browser.click('//*[text()="Exon"]');
+            waitForNetworkQuiet();
+            // check if 3 exact matches for 6 appear
+            textValuesWith6 = browser.getText('//*[text()="6"]');
+            assert.ok(textValuesWith6.length === 4);
+        });
+
+        it('should show more exon number after clicking "Show more"', ()=>{
+            // check if 6 appears once in COSMIC column
+            browser.waitForText('//*[text()="6"]',30000);
+            var textValuesWith6 = browser.getText('//*[text()="6"]');
+            assert.ok(textValuesWith6.length === 1);
+            // click on column button
+            browser.click("button*=Columns");
+            // scroll down to activated "exon" selection
+            browser.scroll(0, 1000);
+            // click "exon"
+            browser.click('//*[text()="Exon"]');
+            waitForNetworkQuiet();
+            // click "show more" to add more data
+            browser.click("button*=Show more");
+            waitForNetworkQuiet();
+            // check if 6 exact matches for 6 appear
+            textValuesWith6 = browser.getText('//*[text()="6"]');
+            assert.ok(textValuesWith6.length === 6);
+        });
+
+        it('should show the HGVSc data after adding the HGVSc column', ()=>{           
+            // click on column button
+            browser.click("button*=Columns");
+            // scroll down to activated "HGVSc" selection
+            browser.scroll(0, 1000);
+            // click "HGVSc"
+            browser.waitForText('//*[text()="HGVSc"]',30000);
+            browser.click('//*[text()="HGVSc"]');
+            waitForNetworkQuiet();
+            // check if "ENST00000269305.4:c.817C>T" appears
+            var hgvscValues = browser.getText('//*[text()[contains(.,"ENST00000269305.4:c.817C>T")]]');
+            assert.ok(hgvscValues.length > 0);
+        });
+
+        it('should show more HGVSc data after clicking "Show more"', ()=>{           
+            // click on column button
+            browser.click("button*=Columns");
+            // scroll down to activated "HGVSc" selection
+            browser.scroll(0, 1000);
+            // click "HGVSc"
+            browser.waitForText('//*[text()="HGVSc"]',30000);
+            browser.click('//*[text()="HGVSc"]');
+            waitForNetworkQuiet();
+            // click "show more" to add more data
+            browser.click("button*=Show more");
+            waitForNetworkQuiet();
+            // check if "C>T" exact matches for 12 appear
+            var hgvscValues = browser.getText('//*[text()[contains(.,"C>T")]]');
+            assert.ok(hgvscValues.length === 12);
+        });
+    });
+
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "buildGenomeNexusAPI": "node scripts/generate-api.js src/shared/api/generated GenomeNexusAPI GenomeNexusAPIInternal",
     "updateHotspotGenes": "./scripts/get_hotspot_genes.sh > src/shared/static-data/hotspotGenes.json",
     "compileOqlParser": "cd src/shared/lib/oql && pegjs oql-parser.pegjs",
+    "serveDist": "./scripts/serve_dist.sh",
     "testTime": "start_time=`date +%s` && karma start karma.conf.js && echo run time is $(expr `date +%s` - $start_time) s",
     "test": "karma start karma.conf.js",
     "test:watch": "yarn run test -- --watch",

--- a/scripts/serve_dist.sh
+++ b/scripts/serve_dist.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# serve frontend as https if CBIOPORTAL_URL contains https, use http otherwise
+bash ${SCRIPT_DIR}/env_vars.sh || exit 1
+eval "$(bash $SCRIPT_DIR/env_vars.sh)"
+(echo $CBIOPORTAL_URL | grep -q https) \
+&& ( \
+    openssl \
+        req -newkey rsa:2048 -new -nodes -x509 -days 1 -keyout key.pem -out cert.pem \
+        -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" && \
+    ./node_modules/http-server/bin/http-server -S -C cert.pem --cors dist/ -p 3000 \
+) || ./node_modules/http-server/bin/http-server --cors dist/ -p 3000

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -52,7 +52,9 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             MutationTableColumnType.FUNCTIONAL_IMPACT,
             MutationTableColumnType.COSMIC,
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
-            MutationTableColumnType.TUMORS
+            MutationTableColumnType.TUMORS,
+            MutationTableColumnType.EXON,
+            MutationTableColumnType.HGVSC
         ]
     };
 
@@ -107,7 +109,8 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         this._columns[MutationTableColumnType.VAR_READS].download =
             (d:Mutation[])=>AlleleCountColumnFormatter.getReads(d, "tumorAltCount");
 
-
+        this._columns[MutationTableColumnType.EXON].sortBy = undefined;
+        
         // order columns
         this._columns[MutationTableColumnType.TUMORS].order = 5;
         this._columns[MutationTableColumnType.GENE].order = 20;
@@ -132,6 +135,8 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         this._columns[MutationTableColumnType.MRNA_EXPR].order = 182;
         this._columns[MutationTableColumnType.COHORT].order = 183;
         this._columns[MutationTableColumnType.COSMIC].order = 184;
+        this._columns[MutationTableColumnType.EXON].order = 185;
+        this._columns[MutationTableColumnType.HGVSC].order = 186;
 
         // exclusions
         this._columns[MutationTableColumnType.MRNA_EXPR].shouldExclude = ()=>{

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -44,7 +44,9 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
             MutationTableColumnType.NORMAL_ALLELE_FREQ,
             MutationTableColumnType.CANCER_TYPE,
-            MutationTableColumnType.NUM_MUTATIONS
+            MutationTableColumnType.NUM_MUTATIONS,
+            MutationTableColumnType.EXON,
+            MutationTableColumnType.HGVSC
         ]
     };
 
@@ -87,6 +89,8 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
         this._columns[MutationTableColumnType.VAR_READS_N].order = 200;
         this._columns[MutationTableColumnType.REF_READS_N].order = 210;
         this._columns[MutationTableColumnType.NUM_MUTATIONS].order = 220;
+        this._columns[MutationTableColumnType.EXON].order = 230;
+        this._columns[MutationTableColumnType.HGVSC].order = 240;
 
         // exclude
         this._columns[MutationTableColumnType.CANCER_TYPE].shouldExclude = ()=>{

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -24,6 +24,7 @@ import ValidationStatusColumnFormatter from "./column/ValidationStatusColumnForm
 import StudyColumnFormatter from "./column/StudyColumnFormatter";
 import {ICosmicData} from "shared/model/Cosmic";
 import AnnotationColumnFormatter from "./column/AnnotationColumnFormatter";
+import ExonColumnFormatter from "./column/ExonColumnFormatter";
 import {IMyCancerGenomeData} from "shared/model/MyCancerGenome";
 import {IHotspotDataWrapper} from "shared/model/CancerHotspots";
 import {IOncoKbDataWrapper} from "shared/model/OncoKB";
@@ -44,6 +45,7 @@ import {IPaginationControlsProps} from "../paginationControls/PaginationControls
 import {IColumnVisibilityControlsProps} from "../columnVisibilityControls/ColumnVisibilityControls";
 import MobxPromise from "mobxpromise";
 import { VariantAnnotation } from "shared/api/generated/GenomeNexusAPI";
+import HgvscColumnFormatter from "./column/HgvscColumnFormatter";
 
 export interface IMutationTableProps {
     studyIdToStudy?: {[studyId:string]:CancerStudy};
@@ -116,7 +118,9 @@ export enum MutationTableColumnType {
     REF_READS,
     VAR_READS,
     CANCER_TYPE,
-    NUM_MUTATIONS
+    NUM_MUTATIONS,
+    EXON,
+    HGVSC
 }
 
 type MutationTableColumn = Column<Mutation[]>&{order?:number, shouldExclude?:()=>boolean};
@@ -503,6 +507,28 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
             sortBy: (d:Mutation[]) => MutationCountColumnFormatter.sortBy(d, this.props.mutationCountCache),
             download: (d:Mutation[]) => MutationCountColumnFormatter.download(d, this.props.mutationCountCache),
             tooltip:(<span>Total number of nonsynonymous mutations in the sample</span>),
+            align: "right"
+        };
+
+        this._columns[MutationTableColumnType.EXON] = {
+            name: "Exon",
+            render: (d:Mutation[]) => (this.props.genomeNexusCache
+                ? ExonColumnFormatter.renderFunction(d, this.props.genomeNexusCache)
+                : <span></span>),
+            download: (d:Mutation[]) => ExonColumnFormatter.download(d, this.props.genomeNexusCache as GenomeNexusCache),
+            sortBy: (d:Mutation[]) => ExonColumnFormatter.getSortValue(d, this.props.genomeNexusCache as GenomeNexusCache),
+            visible: false,
+            align: "right"
+        };
+
+        this._columns[MutationTableColumnType.HGVSC] = {
+            name: "HGVSc",
+            render: (d:Mutation[]) => (this.props.genomeNexusCache
+                ? HgvscColumnFormatter.renderFunction(d, this.props.genomeNexusCache)
+                : <span></span>),
+            download: (d:Mutation[]) => HgvscColumnFormatter.download(d, this.props.genomeNexusCache as GenomeNexusCache),
+            sortBy: (d:Mutation[]) => HgvscColumnFormatter.getSortValue(d, this.props.genomeNexusCache as GenomeNexusCache),
+            visible: false,
             align: "right"
         };
     }

--- a/src/shared/components/mutationTable/column/ExonColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ExonColumnFormatter.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import {Circle} from "better-react-spinkit";
+import 'rc-tooltip/assets/bootstrap_white.css';
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
+import {default as TableCellStatusIndicator, TableCellStatus} from "shared/components/TableCellStatus";
+import { VariantAnnotation } from 'shared/api/generated/GenomeNexusAPI';
+import GenomeNexusCache, { GenomeNexusCacheDataType } from "shared/cache/GenomeNexusCache";
+import styles from "./exon.module.scss";
+
+export default class ExonColumnFormatter {
+    
+    public static renderFunction(data:Mutation[],
+                                 genomeNexusCache:GenomeNexusCache|undefined) {
+        const genomeNexusCacheData = ExonColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
+        return (
+            <div className={styles["exon-table"]}>
+                <span>{ExonColumnFormatter.getExonDataViz(genomeNexusCacheData)}</span>
+            </div>
+        );
+    }
+
+    private static getGenomeNexusDataFromCache(data:Mutation[], cache:GenomeNexusCache|undefined):GenomeNexusCacheDataType | null {
+        if (data.length === 0 || !cache) {
+            return null;
+        }
+        return cache.get(data[0]);
+    }
+
+    private static getExonDataViz(genomeNexusCacheData:GenomeNexusCacheDataType|null) {
+        let status:TableCellStatus | null = null;
+
+        if (genomeNexusCacheData === null) {
+            status = TableCellStatus.LOADING;
+        } else if (genomeNexusCacheData.status === "error") {
+            status = TableCellStatus.ERROR;
+        } else if (genomeNexusCacheData.data === null) {
+            status = TableCellStatus.NA;
+        } else {
+            let exonData = ExonColumnFormatter.getData(genomeNexusCacheData.data);
+            if (exonData == null) {
+                return exonData;
+            }
+            else {
+                return <span style = {{display:"inline-block", float:"right"}}>            
+                    <span style = {{float:"left",width:"24px", textAlign:"right"}}> {exonData.split("/")[0]} </span>  
+                    <span style = {{float:"left", marginLeft:"4px", marginRight:"4px"}}>/</span>
+                    <span style = {{float:"left",width:"24px", textAlign:"left"}}> {exonData.split("/")[1]} </span>
+                </span>
+            }        
+        }
+
+        if (status !== null) {
+            // show loading circle
+            if (status === TableCellStatus.LOADING) {
+                return <Circle size={18} scaleEnd={0.5} scaleStart={0.2} color="#aaa" className="pull-right"/>;
+            } 
+            else {
+                return <TableCellStatusIndicator status={status}/>;
+            }
+        }
+    }
+
+    public static getData(genomeNexusData: VariantAnnotation | null): string | null
+    {
+        if (!genomeNexusData)
+        {
+            return null;
+        }
+        return genomeNexusData.annotation_summary.transcriptConsequenceSummary.exon; 
+    }
+
+    public static download(data:Mutation[], genomeNexusCache:GenomeNexusCache): string
+    {
+        const genomeNexusData = ExonColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
+        const exonData = genomeNexusData && ExonColumnFormatter.getData(genomeNexusData.data);
+
+        if (!exonData) {
+            return "";
+        }
+        else {
+            return exonData;
+        }
+    }
+
+    public static getSortValue(data:Mutation[], genomeNexusCache:GenomeNexusCache): number|null {
+        const genomeNexusCacheData = ExonColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
+        if (genomeNexusCacheData) {
+            let exonData = ExonColumnFormatter.getData(genomeNexusCacheData.data);            
+            if (exonData == null) {
+                return null;
+            }
+            else {
+                return parseInt(exonData.split("/")[0]);
+            }
+        }    
+        else {
+            return null;
+        }
+    }
+}

--- a/src/shared/components/mutationTable/column/ExonColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ExonColumnFormatter.tsx
@@ -66,7 +66,21 @@ export default class ExonColumnFormatter {
         {
             return null;
         }
-        return genomeNexusData.annotation_summary.transcriptConsequenceSummary.exon; 
+        const exon = genomeNexusData.annotation_summary.transcriptConsequenceSummary.exon;
+        if (exon) {
+            return exon;
+        }
+        else {
+            // find any other mutation affecting the exon on the same transcript
+            const transcriptConsequence = genomeNexusData.transcript_consequences.filter(
+                x => ((x.transcript_id === genomeNexusData.annotation_summary.transcriptConsequenceSummary.transcriptId) && x.exon)
+            )[0];
+            if (transcriptConsequence) {
+                return transcriptConsequence.exon;
+            } else {
+                return null;
+            }
+        }
     }
 
     public static download(data:Mutation[], genomeNexusCache:GenomeNexusCache): string
@@ -85,14 +99,14 @@ export default class ExonColumnFormatter {
     public static getSortValue(data:Mutation[], genomeNexusCache:GenomeNexusCache): number|null {
         const genomeNexusCacheData = ExonColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
         if (genomeNexusCacheData) {
-            let exonData = ExonColumnFormatter.getData(genomeNexusCacheData.data);            
+            let exonData = ExonColumnFormatter.getData(genomeNexusCacheData.data);
             if (exonData == null) {
                 return null;
             }
             else {
                 return parseInt(exonData.split("/")[0]);
             }
-        }    
+        }
         else {
             return null;
         }

--- a/src/shared/components/mutationTable/column/HgvscColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/HgvscColumnFormatter.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import {Circle} from "better-react-spinkit";
+import 'rc-tooltip/assets/bootstrap_white.css';
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
+import {default as TableCellStatusIndicator, TableCellStatus} from "shared/components/TableCellStatus";
+import { VariantAnnotation } from 'shared/api/generated/GenomeNexusAPI';
+import GenomeNexusCache, { GenomeNexusCacheDataType } from "shared/cache/GenomeNexusCache";
+
+export default class HgvscColumnFormatter {
+    
+    public static renderFunction(data:Mutation[],
+                                 genomeNexusCache:GenomeNexusCache|undefined) {
+        const genomeNexusCacheData = HgvscColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
+        return (
+            <div>
+                <span>{HgvscColumnFormatter.getHgvscDataViz(genomeNexusCacheData)}</span>
+            </div>
+        );
+    }
+
+    private static getGenomeNexusDataFromCache(data:Mutation[], cache:GenomeNexusCache|undefined):GenomeNexusCacheDataType | null {
+        if (data.length === 0 || !cache) {
+            return null;
+        }
+        return cache.get(data[0]);
+    }
+
+    private static getHgvscDataViz(genomeNexusCacheData:GenomeNexusCacheDataType|null) {
+        let status:TableCellStatus | null = null;
+
+        if (genomeNexusCacheData === null) {
+            status = TableCellStatus.LOADING;
+        } else if (genomeNexusCacheData.status === "error") {
+            status = TableCellStatus.ERROR;
+        } else if (genomeNexusCacheData.data === null) {
+            status = TableCellStatus.NA;
+        } else {
+            let hgvscData = HgvscColumnFormatter.getData(genomeNexusCacheData.data);
+            if (hgvscData == null) {
+                return hgvscData;
+            }
+            else {
+                return <span style={{display: "inline-block", float:"right"}}>            
+                    {hgvscData}     
+                </span>
+            }        
+        }
+
+        if (status !== null) {
+            // show loading circle
+            if (status === TableCellStatus.LOADING) {
+                return <Circle size={18} scaleEnd={0.5} scaleStart={0.2} color="#aaa" className="pull-right"/>;
+            } 
+            else {
+                return <TableCellStatusIndicator status={status}/>;
+            }
+        }
+    }
+
+    public static getData(genomeNexusData: VariantAnnotation | null): string | null
+    {
+        if (!genomeNexusData)
+        {
+            return null;
+        }
+        return genomeNexusData.annotation_summary.transcriptConsequenceSummary.hgvsc; 
+    }
+
+    public static download(data:Mutation[], genomeNexusCache:GenomeNexusCache): string
+    {
+        const genomeNexusData = HgvscColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
+        const hgvscData = genomeNexusData && HgvscColumnFormatter.getData(genomeNexusData.data);
+
+        if (!hgvscData) {
+            return "";
+        }
+        else {
+            return hgvscData;
+        }
+    }
+
+    public static getSortValue(data:Mutation[], genomeNexusCache:GenomeNexusCache): number|null {
+        const genomeNexusCacheData = HgvscColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
+        if (genomeNexusCacheData) {
+            let hgvscData =  HgvscColumnFormatter.getData(genomeNexusCacheData.data);
+            if (hgvscData == null) {
+                return null
+            }
+            else {
+                return parseInt(hgvscData.split("c.")[1]);
+            }           
+        }    
+        else {
+            return null;
+        }
+    }
+}

--- a/src/shared/components/mutationTable/column/exon.module.scss
+++ b/src/shared/components/mutationTable/column/exon.module.scss
@@ -1,0 +1,3 @@
+.exon-table {
+    min-width: 62px;
+  }


### PR DESCRIPTION
Add a column to show the exon number in mutation table in result view and patient view. The exon number can be 1~3 digits.
![image](https://user-images.githubusercontent.com/16869603/52447088-c6af9900-2afd-11e9-9055-545d43b9a14b.png)

![image](https://user-images.githubusercontent.com/16869603/52584067-27411d80-2dff-11e9-96cc-3d2412220d7c.png)



Add another column to show the HGVSc in mutation table in result view and patient view.
![image](https://user-images.githubusercontent.com/16869603/52433223-96a2ce80-2ada-11e9-883c-b781de7bafad.png)


Fixes: 
#5609 https://github.com/cBioPortal/cbioportal/issues/5609
#2996 https://github.com/cBioPortal/cbioportal/issues/2996
