### PR TITLE
Handle broken virtual study fetching for heroku

### DIFF
--- a/src/pages/resultsView/ResultsViewPageHelpers.ts
+++ b/src/pages/resultsView/ResultsViewPageHelpers.ts
@@ -73,7 +73,9 @@ export function getVirtualStudies(cancerStudyIds:string[]):Promise<VirtualStudy[
                 (virtualStudy: VirtualStudy) => (missingFromCancerStudies.includes(virtualStudy.id))
             );
             resolve(virtualStudies);
-        });
+        }).catch(()=>{
+            resolve([]);
+;       });
     });
     return prom;
 


### PR DESCRIPTION
On heroku we try to use proxy to load virtual studies. It breaks. We need to fail gracefully.