### PR TITLE
Use string replace over regex

### DIFF
--- a/src/pages/studyView/StudyViewUtils.spec.ts
+++ b/src/pages/studyView/StudyViewUtils.spec.ts
@@ -1846,5 +1846,13 @@ describe('StudyViewUtils', () => {
             assert.equal(result.length, 1);
             assert.equal(result[0], 'test1,test2');
         });
+
+        it('Allow using back slash to escape the comma actually in the content, multiple instances', () => {
+            let result = getClinicalEqualityFilterValuesByString('test1\\,test2,test3, test4\\,test5\\,test6');
+            assert.equal(result.length, 3);
+            assert.equal(result[0], 'test1,test2');
+            assert.equal(result[1], 'test3');
+            assert.equal(result[2], 'test4,test5,test6');
+        });
     });
 });

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -1255,5 +1255,5 @@ export function submitToPage(url:string, params: { [id: string]: string }, targe
 }
 
 export function getClinicalEqualityFilterValuesByString(filterValues: string):string[] {
-    return filterValues.split(/(?<!\\),/).map(val=>val.trim().replace('\\,',','));
+    return filterValues.replace(/\\,/g,'$@$').split(",").map(val=>val.trim().replace(/\$@\$/g,','));
 }


### PR DESCRIPTION
The Lookbehinds is only supported in ECMA2018 which ony chrome supports it at this moment. https://stackoverflow.com/questions/50011366/javascript-regex-negative-lookbehind-not-working-in-firefox

# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/5697  https://github.com/cBioPortal/cbioportal/issues/5696
