### PR TITLE
Fix patient page when navCaseIds is very long (google analytics regex…

### DIFF
--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -35,10 +35,17 @@ import superagentCache from 'superagent-cache';
 import getBrowserWindow from "shared/lib/getBrowserWindow";
 import {getConfigurationServiceApiUrl} from "shared/api/urls";
 import {AppStore} from "./AppStore";
+import {handleLongUrls} from "shared/lib/handleLongUrls";
 
 superagentCache(superagent);
 
+// this must occur before we initialize tracking
+// it fixes the hash portion of url when cohort patient list is too long
+handleLongUrls();
+
+
 // YOU MUST RUN THESE initialize and then set the public path after
+
 initializeConfiguration();
 // THIS TELLS WEBPACK BUNDLE LOADER WHERE TO LOAD SPLIT BUNDLES
 __webpack_public_path__ = AppConfig.frontendUrl;

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -12,7 +12,7 @@ import SignificantMutationalSignatures from "./patientHeader/SignificantMutation
 import {PaginationControls} from "../../shared/components/paginationControls/PaginationControls";
 import {IColumnVisibilityDef} from "shared/components/columnVisibilityControls/ColumnVisibilityControls";
 import {toggleColumnVisibility} from "shared/components/lazyMobXTable/ColumnVisibilityResolver";
-import {PatientViewPageStore} from "./clinicalInformation/PatientViewPageStore";
+import {parseCohortIds, PatientViewPageStore} from "./clinicalInformation/PatientViewPageStore";
 import ClinicalInformationPatientTable from "./clinicalInformation/ClinicalInformationPatientTable";
 import ClinicalInformationSamples from "./clinicalInformation/ClinicalInformationSamplesTable";
 import {inject, observer} from "mobx-react";
@@ -84,6 +84,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
 
         super();
 
+
         //TODO: this should be done by a module so that it can be reused on other pages
         const reaction1 = reaction(
             () => [props.routing.location.query, props.routing.location.hash, props.routing.location.pathname],
@@ -113,10 +114,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                     // if there is a navCaseId list in url
                     const navCaseIdMatch = hash.match(/navCaseIds=([^&]*)/);
                     if (navCaseIdMatch && navCaseIdMatch.length > 1) {
-                        const navCaseIds = navCaseIdMatch[1].split(',');
-                        patientViewPageStore.patientIdsInCohort = navCaseIds.map((entityId:string)=>{
-                            return entityId.includes(':') ? entityId : patientViewPageStore.studyId + ':' + entityId;
-                        });
+                        patientViewPageStore.patientIdsInCohort = parseCohortIds(navCaseIdMatch[1]);
                     }
 
                 } else {

--- a/src/shared/lib/handleLongUrls.ts
+++ b/src/shared/lib/handleLongUrls.ts
@@ -1,0 +1,25 @@
+import getBrowserWindow from "./getBrowserWindow";
+import {parseCohortIds} from "../../pages/patientView/clinicalInformation/PatientViewPageStore";
+
+export const NAVCASEIDS_PARAM = "navCaseIds";
+
+export const NAVCASEIDS_REGEXP = new RegExp(`${NAVCASEIDS_PARAM}=([^&]*)`);
+
+const PROP_NAME = "navCaseIdsCache";
+
+export function handleLongUrls(){
+    const navCaseIdMatch = getBrowserWindow().location.hash.match(new RegExp(NAVCASEIDS_REGEXP));
+    // google analytics starts to crash when location.href gets too long
+    // this is a fairly arbitrary length at which point we need to store these caseIds in localStorage instead of in hash
+    if (navCaseIdMatch && navCaseIdMatch[1].length > 60000) {
+        // now delete from url so that we don't hurt google analytics
+        getBrowserWindow().location.hash = getBrowserWindow().location.hash.replace(NAVCASEIDS_REGEXP,"");
+        getBrowserWindow()[PROP_NAME] = navCaseIdMatch[1];
+    }
+}
+
+export function getNavCaseIdsCache(){
+    const data = getBrowserWindow()[PROP_NAME];
+    delete getBrowserWindow()[PROP_NAME];
+    return (data) ? parseCohortIds(data) : undefined;
+}


### PR DESCRIPTION
We use url hash to transmit very large list of patients in cohort to patient page.  Google Analytics runs a regexp on entire url that crashes.  This fixes that by stashing list in local storage when list is too long.