### PR TITLE
Make wider heatmap menu

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.spec.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.spec.tsx
@@ -4,7 +4,6 @@ describe("PlotsTab", ()=>{
     describe("controls", ()=>{
         describe("gene lock", ()=>{
             it("genes can be freely selected when gene lock is off", ()=>{
-                assert.equal(1,1);
             });
             it("when gene lock is selected, both axes gene selection should be the one from the axis where lock was clicked", ()=>{
             });

--- a/src/pages/resultsView/plots/PlotsTab.spec.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.spec.tsx
@@ -4,6 +4,7 @@ describe("PlotsTab", ()=>{
     describe("controls", ()=>{
         describe("gene lock", ()=>{
             it("genes can be freely selected when gene lock is off", ()=>{
+                assert.equal(1,1);
             });
             it("when gene lock is selected, both axes gene selection should be the one from the axis where lock was clicked", ()=>{
             });

--- a/src/shared/components/oncoprint/controls/CustomDropdown.tsx
+++ b/src/shared/components/oncoprint/controls/CustomDropdown.tsx
@@ -6,7 +6,7 @@ import {observable} from "mobx";
 
 export interface ICustomDropdownProps extends ButtonProps {
     title: string;
-    buttonProps?: ButtonProps;
+    classType?: string;
 }
 
 class CustomButton extends React.Component<any,{}> { // cant type this more specifically because of some typing issues w ES6 classes not having component.replaceState
@@ -22,10 +22,10 @@ class CustomButton extends React.Component<any,{}> { // cant type this more spec
 class CustomMenu extends React.Component<any,{}> {
 
     render() {
-        const { children } = this.props;
+        const { classType, children } = this.props;
 
         return (
-            <div className="dropdown-menu" style={{ padding: '6px' }}>
+            <div className={`dropdown-menu ${classType}`} style={{ padding: '6px' }}>
                 {children}
             </div>
         );
@@ -46,12 +46,12 @@ export default class CustomDropdown extends React.Component<ButtonProps, {}> {
     }
 
     render() {
-        const {children, id, ...props} = this.props;
+        const {children, id, classType, ...props} = this.props;
         return (
             <RootCloseWrapper onRootClose={this.hide}>
                 <Dropdown id={id+""} open={this.open}>
                     <CustomButton bsStyle="default" bsRole="toggle" title="Custom Toggle" onClick={this.toggle} {...props}/>
-                    <CustomMenu bsRole="menu">
+                    <CustomMenu bsRole="menu" classType={classType}>
                         {children}
                     </CustomMenu>
                 </Dropdown>

--- a/src/shared/components/oncoprint/controls/CustomDropdown.tsx
+++ b/src/shared/components/oncoprint/controls/CustomDropdown.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import {Button, Dropdown, ButtonProps} from "react-bootstrap";
 import {RootCloseWrapper} from "react-overlays";
+import classNames from "classnames";
 import {observer} from "mobx-react";
 import {observable} from "mobx";
 
 export interface ICustomDropdownProps extends ButtonProps {
     title: string;
-    classType?: string;
+    className?: string;
 }
 
 class CustomButton extends React.Component<any,{}> { // cant type this more specifically because of some typing issues w ES6 classes not having component.replaceState
@@ -22,10 +23,10 @@ class CustomButton extends React.Component<any,{}> { // cant type this more spec
 class CustomMenu extends React.Component<any,{}> {
 
     render() {
-        const { classType, children } = this.props;
+        const { className, children } = this.props;
 
         return (
-            <div className={`dropdown-menu ${classType}`} style={{ padding: '6px' }}>
+            <div className={classNames("dropdown-menu", className)} style={{ padding: '6px' }}>
                 {children}
             </div>
         );
@@ -46,12 +47,12 @@ export default class CustomDropdown extends React.Component<ButtonProps, {}> {
     }
 
     render() {
-        const {children, id, classType, ...props} = this.props;
+        const {children, id, className, ...props} = this.props;
         return (
             <RootCloseWrapper onRootClose={this.hide}>
                 <Dropdown id={id+""} open={this.open}>
                     <CustomButton bsStyle="default" bsRole="toggle" title="Custom Toggle" onClick={this.toggle} {...props}/>
-                    <CustomMenu bsRole="menu" classType={classType}>
+                    <CustomMenu bsRole="menu" className={classNames(className)}>
                         {children}
                     </CustomMenu>
                 </Dropdown>

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -471,7 +471,7 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
             menu = (<span>Error loading heatmap profiles.</span>);
         }
         return (
-            <CustomDropdown bsStyle="default" title="Heatmap" id="heatmapDropdown" classType="heatmap">
+            <CustomDropdown bsStyle="default" title="Heatmap" id="heatmapDropdown" className="heatmap">
                 {menu}
             </CustomDropdown>
         );

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -471,7 +471,7 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
             menu = (<span>Error loading heatmap profiles.</span>);
         }
         return (
-            <CustomDropdown bsStyle="default" title="Heatmap" id="heatmapDropdown">
+            <CustomDropdown bsStyle="default" title="Heatmap" id="heatmapDropdown" classType="heatmap">
                 {menu}
             </CustomDropdown>
         );

--- a/src/shared/components/oncoprint/controls/styles.scss
+++ b/src/shared/components/oncoprint/controls/styles.scss
@@ -24,7 +24,6 @@
     }
   }
 
-
   .dropdown-menu {
     width:270px;
     padding:12px !important;
@@ -36,6 +35,10 @@
       margin-bottom:0 !important;
     }
   }
+
+  .dropdown-menu.heatmap {
+    width:450px;
+  }  
 
   .oncoprint__controls__heatmap_menu {
     textarea {
@@ -84,7 +87,7 @@
     }
 
     .Select-menu-outer {
-      width: 300px;
+      width: 100%;
     }
   }
 

--- a/src/shared/components/oncoprint/controls/styles.scss
+++ b/src/shared/components/oncoprint/controls/styles.scss
@@ -34,17 +34,17 @@
     > :last-child {
       margin-bottom:0 !important;
     }
+    &.heatmap {
+      width:450px;
+    }  
   }
-
-  .dropdown-menu.heatmap {
-    width:450px;
-  }  
 
   .oncoprint__controls__heatmap_menu {
     textarea {
       width:100%;
       min-height:50px;
       border:1px solid $borderColor;
+      resize: vertical;
     }
     > *, button {
       margin-bottom:10px !important;
@@ -86,9 +86,6 @@
       height:32px;
     }
 
-    .Select-menu-outer {
-      width: 100%;
-    }
   }
 
   .clinical-track-selector .Select {


### PR DESCRIPTION
# What? Why?
This PR implements a wider heatmap menu  in order to accommodate menu items with longer names.

Changes proposed in this pull request:
- The heatmap menu is assigned an additional `heatmap` className.
- Css for oncoprint controls set this menu to 400px. 
- The selection menu is set to fill available real estate (100%).
- The text area for genes can only be resized in vertical direction. 

# Before
![screenshot from 2019-02-08 15-11-09](https://user-images.githubusercontent.com/745885/52483623-abec2b80-2bb4-11e9-92b0-66e00558af9b.png)
![screenshot from 2019-02-08 15-11-31](https://user-images.githubusercontent.com/745885/52483632-b1e20c80-2bb4-11e9-8653-66b5ad99129d.png)
## Genes text box
![screenshot from 2019-02-09 08-48-36](https://user-images.githubusercontent.com/745885/52518239-d76c2600-2c47-11e9-895e-adb0c04513bc.png)

# After
![screenshot from 2019-02-08 15-11-45](https://user-images.githubusercontent.com/745885/52483663-c8886380-2bb4-11e9-9ff3-fc6714358415.png)
![screenshot from 2019-02-08 15-11-48](https://user-images.githubusercontent.com/745885/52483665-ca522700-2bb4-11e9-9b46-e5a793a75f96.png)
## Genes text box:
![screenshot from 2019-02-09 08-47-39](https://user-images.githubusercontent.com/745885/52518251-1f8b4880-2c48-11e9-94c2-f2dac98b360d.png)


# Note
The other menu's of the oncoprint controls keep their original width.