### PR TITLE
Temporarily disable filters in url test

### DIFF
--- a/end-to-end-tests/specs/studyview.spec.js
+++ b/end-to-end-tests/specs/studyview.spec.js
@@ -397,7 +397,7 @@ describe('study view msk_impact_2017 study tests', () => {
     });
 });
 
-describe('check the filters are working properly', ()=>{
+describe.skip('check the filters are working properly', ()=>{
     before(() => {
         const url = `${CBIOPORTAL_URL}/study?id=laml_tcga&filters={%22clinicalDataEqualityFilters%22:[{%22attributeId%22:%22SEX%22,%22clinicalDataType%22:%22PATIENT%22,%22values%22:[%22Female%22]}],%22clinicalDataIntervalFilters%22:[{%22attributeId%22:%22AGE%22,%22clinicalDataType%22:%22PATIENT%22,%22values%22:[{%22start%22:25,%22end%22:30},{%22start%22:30,%22end%22:35},{%22start%22:35,%22end%22:40},{%22start%22:40,%22end%22:45},{%22start%22:45,%22end%22:50},{%22start%22:50,%22end%22:55},{%22start%22:55,%22end%22:60},{%22start%22:60,%22end%22:65},{%22start%22:65,%22end%22:70},{%22start%22:70,%22end%22:75},{%22start%22:75,%22end%22:80}]}],%22mutatedGenes%22:[{%22entrezGeneIds%22:[2322,4869]}],%22cnaGenes%22:[{%22alterations%22:[{%22alteration%22:-2,%22entrezGeneId%22:60412},{%22alteration%22:2,%22entrezGeneId%22:84435}]}]}`;
         goToUrlAndSetLocalStorage(url);


### PR DESCRIPTION
Temporarily disable the test designed to test whether study view supports `filters` in URL.

This seems related to the proxy setting with the recent AWS move.
This feature is not fully supported anyway, so temporarily disable the test should not impact anything.