### PR TITLE
Fix e2e test mrna enrichment

### DIFF
--- a/end-to-end-tests/specs/screenshot.spec.js
+++ b/end-to-end-tests/specs/screenshot.spec.js
@@ -299,6 +299,9 @@ describe("enrichments tab screenshot tests", function() {
     });
     it('enrichments tab coadread_tcga_pub mRNA profile', function(){
         browser.waitForVisible('div[data-test="MutationEnrichmentsTab"]',10000);
+        // wait for mutations to appear, TODO: there is a bug when clicking
+        // immediately on mRNA tab
+        browser.waitForText('.//*[text()[contains(.,"PIK3CA")]]');
         browser.waitForVisible('a=mRNA', 10000);
         browser.click('a=mRNA');
         browser.waitForVisible('div[data-test="MRNAEnrichmentsTab"]',20000);


### PR DESCRIPTION
Wait for mutations to appear, TODO: there is a bug when clicking immediately on mRNA tab

```
breadcrumbs.ts:166 TypeError: Cannot read property 'coadread_tcga_pub_rna_seq_mrna' of undefined
    at MolecularProfileSelector.tsx:49
    at Array.map (<anonymous>)
    at e.invoke (MolecularProfileSelector.tsx:48)
    at e.get (MobxPromise.ts:166)
    at lt (mobx.module.js:2812)
    at e.computeValue (mobx.module.js:1407)
    at e.trackAndCompute (mobx.module.js:1397)
    at e.get (mobx.module.js:1360)
    at e.<anonymous> (mobx.module.js:3120)
    at e.get (mobx.module.js:1006)
    at e.get (MobxPromise.ts:116)
    at lt (mobx.module.js:2812)
    at e.computeValue (mobx.module.js:1407)
    at e.trackAndCompute (mobx.module.js:1397)
    at e.get (mobx.module.js:1360)
    at it (mobx.module.js:2763)
    at e.get (mobx.module.js:1359)
    at it (mobx.module.js:2763)
    at e.runReaction (mobx.module.js:2953)
    at bt (mobx.module.js:3083)
    at qn (mobx.module.js:3061)
    at mobx.module.js:3090
    at gr (scheduler.production.min.js:13)
    at qn (mobx.module.js:3090)
    at gt (mobx.module.js:3066)
    at et (mobx.module.js:2621)
    at k (mobx.module.js:899)
    at O (mobx.module.js:866)
    at e.n (mobx.module.js:854)
    at internalStatus (MobxPromise.ts:175)
```