### PR TITLE
e2e add timeout parameter for waitForNetworkQuiet

### DIFF
--- a/end-to-end-tests/specs/specUtils.js
+++ b/end-to-end-tests/specs/specUtils.js
@@ -78,12 +78,12 @@ const useExternalFrontend = !process.env.FRONTEND_TEST_DO_NOT_LOAD_EXTERNAL_FRON
 
 const useLocalDist = process.env.FRONTEND_TEST_USE_LOCAL_DIST;
 
-function waitForNetworkQuiet(){
+function waitForNetworkQuiet(timeout){
     browser.waitUntil(()=>{
         return browser.execute(function(){
             return window.ajaxQuiet === true;
         }).value == true
-    });
+    }, timeout);
 }
 
 function toStudyViewSummaryTab() {

--- a/end-to-end-tests/specs/studyview.spec.js
+++ b/end-to-end-tests/specs/studyview.spec.js
@@ -196,7 +196,8 @@ describe('study laml_tcga tests', () => {
             it('check', () => {
                 // This is one of the studies have MDACC heatmap enabled
                 goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}/study?id=brca_tcga_pub`);
-                waitForNetworkQuiet();
+                waitForNetworkQuiet(20000);
+                browser.waitForVisible("#studyViewTabs a.tabAnchor_heatmaps", 10000);
                 browser.click("#studyViewTabs a.tabAnchor_heatmaps");
                 assert(!browser.isExisting(ADD_CHART_BUTTON));
             });
@@ -390,7 +391,7 @@ describe('study view msk_impact_2017 study tests', () => {
         goToUrlAndSetLocalStorage(url);
     });
     it('the study should show proper number of samples/patients', () => {
-        waitForNetworkQuiet();
+        waitForNetworkQuiet(20000);
         waitForStudyViewSelectedInfo();
         assert(getTextFromElement(SELECTED_PATIENTS) === '10,336');
         assert(getTextFromElement(SELECTED_SAMPLES) === '10,945');


### PR DESCRIPTION
Both of these tests seem to fail often according to this: https://circleci.com/build-insights/gh/cBioPortal/cbioportal-frontend/master. In the errorshots i see loading icons, so possibly it's sometimes just not done downloading the data yet. Another thing that could happen was that the button that needs to be clicked wasn't visible yet