### PR TITLE
Adding a display name to allow users to visualize on their choice of ID

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -260,7 +260,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                             target="_blank"
                                             onClick={(e: React.MouseEvent<HTMLAnchorElement>) => this.handleSampleClick(sample.id, e)}
                                         >
-                                            {sample.id}
+                                            {SampleManager.getClinicalAttributeInSample(sample, "DISPLAY_SAMPLE_NAME") ? `${SampleManager.getClinicalAttributeInSample(sample, "DISPLAY_SAMPLE_NAME")!.value} (${sample.id})` : sample.id}
                                         </a>
                                         {sampleManager &&
                                         sampleManager.clinicalDataLegacyCleanAndDerived[sample.id] &&

--- a/src/pages/patientView/sampleManager.tsx
+++ b/src/pages/patientView/sampleManager.tsx
@@ -149,6 +149,12 @@ class SampleManager {
         return uniqueValues.length === 1 && uniqueValues[0];
     }
 
+    static getClinicalAttributeInSample(sample: ClinicalDataBySampleId, clinicalAttributeId: string) : ClinicalData | undefined {
+        return _.find(sample.clinicalData, (data) => {
+            return data.clinicalAttributeId === clinicalAttributeId;
+        })
+    }
+
     getComponentForSample(sampleId: string,
                           fillOpacity: number = 1,
                           extraTooltipText: string = '',


### PR DESCRIPTION
Changing to "id (display name)" in the header and make it in the first row in various mouse over tables.
Fix https://github.com/cBioPortal/cbioportal/issues/5711.
