### PR TITLE
CircleCI: don't use base env for release branches

### DIFF
--- a/scripts/env_vars.sh
+++ b/scripts/env_vars.sh
@@ -7,9 +7,9 @@ NC='\033[0m'
 if [[ "$CIRCLECI" ]]; then
     # on circle ci determine env variables based on branch or in case of PR
     # what branch the PR is pointing to
-    if [[ "$CIRCLE_PR_NUMBER" ]]; then
+    if [[ "$CIRCLE_PR_NUMBER" ]] && ! [[ $CIRCLE_BRANCH == "release-"* ]]; then
         BRANCH=$(curl "https://github.com/cBioPortal/cbioportal-frontend/pull/${CIRCLE_PR_NUMBER}" | grep -oE 'title="cBioPortal/cbioportal-frontend:[^"]*' | cut -d: -f2 | head -1)
-    elif [[ "$CIRCLE_PULL_REQUEST" ]]; then
+    elif [[ "$CIRCLE_PULL_REQUEST" ]] && ! [[ $CIRCLE_BRANCH == "release-"* ]]; then
         BRANCH=$(curl "${CIRCLE_PULL_REQUEST}" | grep -oE 'title="cBioPortal/cbioportal-frontend:[^"]*' | cut -d: -f2 | head -1)
     else
         BRANCH=$CIRCLE_BRANCH


### PR DESCRIPTION
Even for PRs use the environment for the release branch. This avoids testing
against e.g. master when opening a PR from release-x branch to master.