### PR TITLE
Integration of treatment response data in PlotsTab (incl. new Waterfall plot)

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStoreUtils.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.ts
@@ -389,7 +389,8 @@ export function getMolecularProfiles(query:any){
         query.genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION,
         query.genetic_profile_ids_PROFILE_MRNA_EXPRESSION,
         query.genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION,
-        query.genetic_profile_ids_PROFILE_GENESET_SCORE
+        query.genetic_profile_ids_PROFILE_GENESET_SCORE,
+        query.genetic_profile_ids_TREATMENT_RESPONSE
     ].filter((profile:string|undefined)=>!!profile);
 
     // append 'genetic_profile_ids' which is sometimes in use

--- a/src/pages/resultsView/ResultsViewQuery.ts
+++ b/src/pages/resultsView/ResultsViewQuery.ts
@@ -15,6 +15,7 @@ export class ResultsViewQuery {
     @observable public _rppaScoreThreshold:number|undefined;
     @observable public _zScoreThreshold:number|undefined;
     @observable public genesetIds:string[] = [];
+    @observable public treatmentIds:string[] = [];
     @observable public cohortIdsList:string[] = [];//queried id(any combination of physical and virtual studies)
     @observable public oqlQuery:string = "";
 
@@ -100,6 +101,14 @@ export function updateResultsViewQuery(
         const parsedGeneSetList = urlQuery.geneset_list.trim().length ? (urlQuery.geneset_list.trim().split(/\s+/)) : [];
         if (!_.isEqual(parsedGeneSetList, rvQuery.genesetIds)) {
             rvQuery.genesetIds = parsedGeneSetList;
+        }
+    }
+
+    if (urlQuery.treatment_list) {
+        // we have to trim because for some reason we get a single space from submission
+        const parsedTreatmentList = urlQuery.treatment_list.trim().length ? (urlQuery.treatment_list.trim().split(/;/)) : [];
+        if (!_.isEqual(parsedTreatmentList, rvQuery.treatmentIds)) {
+            rvQuery.treatmentIds = parsedTreatmentList;
         }
     }
 

--- a/src/pages/resultsView/expression/ExpressionWrapper.tsx
+++ b/src/pages/resultsView/expression/ExpressionWrapper.tsx
@@ -30,7 +30,7 @@ import {CoverageInformation, isPanCanStudy, isTCGAProvStudy} from "../ResultsVie
 import {sleep} from "../../../shared/lib/TimeUtils";
 import {
     CNA_STROKE_WIDTH,
-    getCnaQueries, IBoxScatterPlotPoint, INumberAxisData, IScatterPlotData, IScatterPlotSampleData, IStringAxisData,
+    getCnaQueries, IBoxScatterPlotPoint, INumberAxisData, IScatterPlotData, IPlotSampleData, IStringAxisData,
     makeBoxScatterPlotData, makeScatterPlotPointAppearance,
     mutationRenderPriority, MutationSummary, mutationSummaryToAppearance, scatterPlotLegendData,
     scatterPlotTooltip, boxPlotTooltip, scatterPlotZIndexSortBy
@@ -45,7 +45,7 @@ import {MobxPromise} from "mobxpromise";
 import {stringListToSet} from "../../../shared/lib/StringUtils";
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
 import BoxScatterPlot from "../../../shared/components/plots/BoxScatterPlot";
-import {ViewType} from "../plots/PlotsTab";
+import {ViewType, PlotType} from "../plots/PlotsTab";
 import DownloadControls from "../../../shared/components/downloadControls/DownloadControls";
 import {maxPage} from "../../../shared/components/lazyMobXTable/utils";
 import {scatterPlotSize} from "../../../shared/components/plots/PlotUtils";
@@ -402,7 +402,7 @@ export default class ExpressionWrapper extends React.Component<ExpressionWrapper
 
     @computed get fill() {
         if (this.showCna || this.showMutations) {
-            return (d:IScatterPlotSampleData)=>this.scatterPlotAppearance(d).fill!;
+            return (d:IPlotSampleData)=>this.scatterPlotAppearance(d).fill!;
         } else {
             return mutationSummaryToAppearance[MutationSummary.Neither].fill;
         }
@@ -426,12 +426,12 @@ export default class ExpressionWrapper extends React.Component<ExpressionWrapper
     }
 
     @autobind
-    private strokeOpacity(d:IScatterPlotSampleData) {
+    private strokeOpacity(d:IPlotSampleData) {
         return this.scatterPlotAppearance(d).strokeOpacity;
     }
 
     @autobind
-    private stroke(d:IScatterPlotSampleData) {
+    private stroke(d:IPlotSampleData) {
         return this.scatterPlotAppearance(d).stroke;
     }
 
@@ -468,7 +468,7 @@ export default class ExpressionWrapper extends React.Component<ExpressionWrapper
     }
 
     @computed get zIndexSortBy() {
-        return scatterPlotZIndexSortBy<IScatterPlotSampleData>(
+        return scatterPlotZIndexSortBy<IPlotSampleData>(
             this.viewType
         );
     }
@@ -502,7 +502,7 @@ export default class ExpressionWrapper extends React.Component<ExpressionWrapper
                         strokeWidth={this.strokeWidth}
                         useLogSpaceTicks={true}
                         legendData={scatterPlotLegendData(
-                            _.flatten(this.boxPlotData.result.map(d=>d.data)), this.viewType, this.mutationDataExists, this.cnaDataExists, this.props.store.driverAnnotationSettings.driversAnnotated
+                            _.flatten(this.boxPlotData.result.map(d=>d.data)), this.viewType, PlotType.BoxPlot, this.mutationDataExists, this.cnaDataExists, this.props.store.driverAnnotationSettings.driversAnnotated
                         )}
                         legendLocationWidthThreshold={900}
                         boxCalculationFilter={this.boxCalculationFilter}

--- a/src/pages/resultsView/plots/styles.scss
+++ b/src/pages/resultsView/plots/styles.scss
@@ -36,8 +36,27 @@
       border-radius:4px;
     }
 
+    .btn.sort-order {
+      margin-right: 10px;
+      padding: 4px 9px;
+    }
+    
+    i.horizontal-axis {
+      transform: rotate(-90deg) scaleY(-1);
+    }
+
+    i.horz-descending {
+      transform: rotate(-90deg) scaleY(-1) scaleX(-1);
+    }
+
+    i.horz-ascending {
+      transform: rotate(-90deg) scaleY(-1);
+    }
+
+    i.vert-descending {
+      transform: scaleX(-1);
+    }
+
   }
-
-
 
 }

--- a/src/shared/api/generated/CBioPortalAPI-docs.json
+++ b/src/shared/api/generated/CBioPortalAPI-docs.json
@@ -4550,7 +4550,8 @@
             "PROTEIN_LEVEL",
             "PROTEIN_ARRAY_PROTEIN_LEVEL",
             "PROTEIN_ARRAY_PHOSPHORYLATION",
-            "GENESET_SCORE"
+            "GENESET_SCORE",
+            "TREATMENT_RESPONSE"
           ]
         },
         "molecularProfileId": {

--- a/src/shared/api/generated/CBioPortalAPI.ts
+++ b/src/shared/api/generated/CBioPortalAPI.ts
@@ -1,4 +1,6 @@
 import * as request from "superagent";
+import { SortOrder, Treatment } from "./CBioPortalAPIInternal";
+import _ from "lodash";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type CancerStudy = {
@@ -286,7 +288,7 @@ export type MolecularProfile = {
 
         'description': string
 
-        'molecularAlterationType': "MUTATION_EXTENDED" | "MUTATION_UNCALLED" | "FUSION" | "STRUCTURAL_VARIANT" | "COPY_NUMBER_ALTERATION" | "MICRO_RNA_EXPRESSION" | "MRNA_EXPRESSION" | "MRNA_EXPRESSION_NORMALS" | "RNA_EXPRESSION" | "METHYLATION" | "METHYLATION_BINARY" | "PHOSPHORYLATION" | "PROTEIN_LEVEL" | "PROTEIN_ARRAY_PROTEIN_LEVEL" | "PROTEIN_ARRAY_PHOSPHORYLATION" | "GENESET_SCORE"
+        'molecularAlterationType': "MUTATION_EXTENDED" | "MUTATION_UNCALLED" | "FUSION" | "STRUCTURAL_VARIANT" | "COPY_NUMBER_ALTERATION" | "MICRO_RNA_EXPRESSION" | "MRNA_EXPRESSION" | "MRNA_EXPRESSION_NORMALS" | "RNA_EXPRESSION" | "METHYLATION" | "METHYLATION_BINARY" | "PHOSPHORYLATION" | "PROTEIN_LEVEL" | "PROTEIN_ARRAY_PROTEIN_LEVEL" | "PROTEIN_ARRAY_PHOSPHORYLATION" | "GENESET_SCORE" | "TREATMENT_RESPONSE"
 
         'molecularProfileId': string
 
@@ -297,6 +299,10 @@ export type MolecularProfile = {
         'study': CancerStudy
 
         'studyId': string
+
+        'pivotThreshold': number
+
+        'sortOrder': SortOrder
 
 };
 export type MolecularProfileFilter = {
@@ -2357,6 +2363,11 @@ export default class CBioPortalAPI {
         }): Promise < Array < MolecularProfile >
         > {
             return this.fetchMolecularProfilesUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                response.body = _(response.body).each((d:MolecularProfile) => {
+                    if (d.sortOrder !== undefined) {
+                        d.sortOrder = d.sortOrder as any === "ASC"? SortOrder.ASC : SortOrder.DESC;
+                    }
+                });
                 return response.body;
             });
         };

--- a/src/shared/api/generated/CBioPortalAPIInternal.ts
+++ b/src/shared/api/generated/CBioPortalAPIInternal.ts
@@ -1,5 +1,9 @@
 import * as request from "superagent";
 
+export enum SortOrder {
+    UNDEFINED, ASC, DESC
+}
+
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type AlterationEnrichment = {
     'alteredCount': number
@@ -270,6 +274,44 @@ export type GenesetMolecularData = {
 
         'value': string
 
+};
+export type Treatment = {
+    'treatmentId': string
+
+    'name': string
+
+    'description': string
+
+    'refLink': string
+
+};
+export type TreatmentDataFilterCriteria = {
+    'treatmentIds': Array < string >
+
+    'sampleIds': Array < string >
+
+    'sampleListId': string
+
+};
+export type TreatmentMolecularData = {
+    'treatmentId': string
+
+    'geneticProfileId': string
+
+    'patientId': string
+
+    'sampleId': string
+
+    'studyId': string
+
+    'uniquePatientKey': string
+
+    'uniqueSampleKey': string
+
+    'value': any
+
+    'truncation': string | undefined
+    
 };
 export type Gistic = {
     'amp': boolean
@@ -1591,6 +1633,253 @@ export default class CBioPortalAPIInternal {
         let keys = Object.keys(queryParameters);
         return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
     };
+
+
+    /**
+     * Get all treatments
+     * @method
+     * @name CBioPortalAPIInternal#getAllTreatmentsUsingGET
+     * @param {string} projection - Level of detail of the response
+     * @param {integer} pageSize - Page size of the result list
+     * @param {integer} pageNumber - Page number of the result list
+     */
+    getAllTreatmentsUsingGETWithHttpInfo(parameters: {
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        'pageSize' ? : number,
+        'pageNumber' ? : number,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/treatments';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+
+            if (parameters['projection'] !== undefined) {
+                queryParameters['projection'] = parameters['projection'];
+            }
+
+            if (parameters['pageSize'] !== undefined) {
+                queryParameters['pageSize'] = parameters['pageSize'];
+            }
+
+            if (parameters['pageNumber'] !== undefined) {
+                queryParameters['pageNumber'] = parameters['pageNumber'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Get all treatments
+     * @method
+     * @name CBioPortalAPIInternal#getAllTreatmentsUsingGET
+     * @param {string} projection - Level of detail of the response
+     * @param {integer} pageSize - Page size of the result list
+     * @param {integer} pageNumber - Page number of the result list
+     */
+    getAllTreatmentsUsingGET(parameters: {
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        'pageSize' ? : number,
+        'pageNumber' ? : number,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < Array < Treatment >
+    > {
+        return this.getAllTreatmentsUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    /**
+     * Fetch treatments by ID
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentsUsingPOST
+     * @param {} treatmentIds - List of Treatment IDs
+     */
+    fetchTreatmentsUsingPOSTWithHttpInfo(parameters: {
+        'treatmentIds': Array < string > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/treatments/fetch';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['treatmentIds'] !== undefined) {
+                body = parameters['treatmentIds'];
+            }
+
+            if (parameters['treatmentIds'] === undefined) {
+                reject(new Error('Missing required  parameter: treatmentIds'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Fetch treatments by ID
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentsUsingPOST
+     * @param {} treatmentIds - List of Treatment IDs
+     */
+    fetchTreatmentsUsingPOST(parameters: {
+            'treatmentIds': Array < string > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < Treatment >
+        > {
+            return this.fetchTreatmentsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+
+    /**
+     * Get a treatment
+     * @method
+     * @name CBioPortalAPIInternal#getTreatmentUsingGETWithHttpInfo
+     * @param {string} treatmentId - Treatment ID e.g. GNF2_ZAP70
+     */
+    getTreatmentUsingGETWithHttpInfo(parameters: {
+        'treatmentId': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/treatments/{treatmentId}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+
+            path = path.replace('{treatmentId}', parameters['treatmentId'] + '');
+
+            if (parameters['treatmentId'] === undefined) {
+                reject(new Error('Missing required  parameter: treatmentId'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+
+    /**
+     * Fetch treatment "genetic data" items (treatment scores) by profile Id, treatment ids and sample ids
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentDataItemsUsingPOST
+     * @param {string} geneticProfileId - Genetic profile ID, e.g. gbm_tcga_treatment_ic50
+     * @param {} treatmentDataFilterCriteria - Search criteria to return the values for a given set of samples and treatment items. treatmentIds: The list of identifiers for the treatments of interest, e.g. `17-AAG`. Use one of these if you want to specify a subset of samples:(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01
+     */
+    fetchTreatmentDataItemsUsingPOSTWithHttpInfo(parameters: {
+        'geneticProfileId': string,
+        'treatmentDataFilterCriteria': TreatmentDataFilterCriteria,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/genetic-profiles/{geneticProfileId}/treatment-genetic-data/fetch';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            path = path.replace('{geneticProfileId}', parameters['geneticProfileId'] + '');
+
+            if (parameters['geneticProfileId'] === undefined) {
+                reject(new Error('Missing required  parameter: geneticProfileId'));
+                return;
+            }
+
+            if (parameters['treatmentDataFilterCriteria'] !== undefined) {
+                body = parameters['treatmentDataFilterCriteria'];
+            }
+
+            if (parameters['treatmentDataFilterCriteria'] === undefined) {
+                reject(new Error('Missing required  parameter: treatmentDataFilterCriteria'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Fetch treatment "genetic data" items (treatment scores) by profile Id, treatment ids and sample ids
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentDataItemsUsingPOST
+     * @param {string} geneticProfileId - Genetic profile ID, e.g. gbm_tcga_treatment_ic50
+     * @param {} treatmentDataFilterCriteria - Search criteria to return the values for a given set of samples and treatment items. treatmentIds: The list of identifiers for the treatments of interest, e.g. `17-AAG`. Use one of these if you want to specify a subset of samples:(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01
+     */
+    fetchTreatmentDataItemsUsingPOST(parameters: {
+            'geneticProfileId': string,
+            'treatmentDataFilterCriteria': TreatmentDataFilterCriteria,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < TreatmentMolecularData >
+        > {
+            return this.fetchTreatmentDataItemsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
 
     /**
      * Get the genes in a gene set that have expression correlated to the gene set scores (calculated using Spearman's correlation)

--- a/src/shared/cache/TreatmentCache.ts
+++ b/src/shared/cache/TreatmentCache.ts
@@ -1,0 +1,22 @@
+import LazyMobXCache from "../lib/LazyMobXCache";
+import {Treatment} from "../api/generated/CBioPortalAPIInternal";
+import internalClient from "../api/cbioportalInternalClientInstance";
+
+type Query = {
+    treatmentId:string;
+};
+
+function key(o:{treatmentId:string}) {
+    return o.treatmentId.toUpperCase();
+}
+
+async function fetch(queries:Query[]) {
+    return internalClient.fetchTreatmentsUsingPOST({treatmentIds: queries.map(q=>q.treatmentId.toUpperCase())});
+}
+
+export default class TreatmentCache extends LazyMobXCache<Treatment, Query> {
+
+    constructor() {
+        super(key, key, fetch);
+    }
+}

--- a/src/shared/cache/TreatmentMolecularDataCache.ts
+++ b/src/shared/cache/TreatmentMolecularDataCache.ts
@@ -1,0 +1,95 @@
+import LazyMobXCache, {AugmentedData} from "../lib/LazyMobXCache";
+import {TreatmentMolecularData, TreatmentDataFilterCriteria} from "../api/generated/CBioPortalAPIInternal";
+import client from "shared/api/cbioportalInternalClientInstance";
+import _ from "lodash";
+import {IDataQueryFilter} from "../lib/StoreUtils";
+
+interface IQuery {
+    treatmentId: string;
+    molecularProfileId: string;
+}
+
+type SampleFilterByProfile = {
+    [molecularProfileId: string]: IDataQueryFilter
+};
+
+function queryToKey(q: IQuery) {
+    return `${q.molecularProfileId}~${q.treatmentId}`;
+}
+
+function dataToKey(d:TreatmentMolecularData[], q:IQuery) {
+    return `${q.molecularProfileId}~${q.treatmentId}`;
+}
+
+/**
+/* Pairs each IQuery with an (array-wrapped) array of any matching data.
+*/
+function augmentQueryResults(queries: IQuery[], results: TreatmentMolecularData[][]) {
+    const keyedAugments: {[key: string]: AugmentedData<TreatmentMolecularData[], IQuery>} = {};
+    for (const query of queries) {
+        keyedAugments[queryToKey(query)] = {
+            data: [[]],
+            meta: query
+        };
+    }
+    for (const queryResult of results) {
+        for (let datum of queryResult) {
+            datum = handleValueTruncation(datum);
+            keyedAugments[
+                queryToKey({
+                    molecularProfileId: datum.geneticProfileId,
+                    treatmentId: datum.treatmentId
+                })
+            ].data[0].push(datum);
+        }
+    }
+    return _.values(keyedAugments);
+}
+
+// values are passed as strings from the REST facility
+// check for value truncators ('>' or '<') to appear in front of values
+// and convert to a numeric value and a separate truncation indicator
+function handleValueTruncation(datum:TreatmentMolecularData) {
+    let value = datum.value;
+    var matches = /([><]*)(.+)/.exec(value as string);
+    if (matches) {
+        datum.value = Number(matches[2]);
+        datum.truncation = (matches[1].length > 0) ? matches[1] : undefined;
+    } else {
+        datum.value = Number(value);
+        datum.truncation = undefined;
+    }
+    return datum;
+}
+
+async function fetch(
+    queries:IQuery[],
+    sampleFilterByProfile: SampleFilterByProfile
+): Promise<AugmentedData<TreatmentMolecularData[], IQuery>[]> {
+    const treatmentIdsByProfile = _.mapValues(
+        _.groupBy(queries, q => q.molecularProfileId),
+        profileQueries => profileQueries.map(q => q.treatmentId)
+    );
+    const params = Object.keys(treatmentIdsByProfile)
+        .map(profileId => ({
+            geneticProfileId: profileId,
+            // the Swagger-generated type expected by the client method below
+            // incorrectly requires both samples and a sample list;
+            // use 'as' to tell TypeScript that this object really does fit.
+            // tslint:disable-next-line: no-object-literal-type-assertion
+            treatmentDataFilterCriteria: {
+                treatmentIds: treatmentIdsByProfile[profileId],
+                ...sampleFilterByProfile[profileId]
+            } as TreatmentDataFilterCriteria
+        })
+    );
+    const dataPromises = params.map(param => client.fetchTreatmentDataItemsUsingPOST(param));
+    const results: TreatmentMolecularData[][] = await Promise.all(dataPromises);
+    return augmentQueryResults(queries, results);
+}
+
+export default class TreatmentMolecularDataCache extends LazyMobXCache<TreatmentMolecularData[], IQuery, IQuery>{
+    constructor(molecularProfileIdToSampleFilter: SampleFilterByProfile) {
+        super(queryToKey, dataToKey, fetch, molecularProfileIdToSampleFilter);
+    }
+}

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -8,7 +8,8 @@ import client from "shared/api/cbioportalClientInstance";
 import {ClinicalTrackSpec, GeneticTrackDatum} from "./Oncoprint";
 import {
     AnnotatedExtendedAlteration, AnnotatedMutation, AnnotatedNumericGeneMolecularData,
-    ExtendedAlteration
+    ExtendedAlteration,
+    AlterationTypeConstants
 } from "../../../pages/resultsView/ResultsViewPageStore";
 import _ from "lodash";
 import {alterationTypeToProfiledForText} from "./ResultsViewOncoprintUtils";
@@ -97,18 +98,21 @@ export function makeHeatmapTrackTooltip(genetic_alteration_type:MolecularProfile
         let data_header = '';
         let profile_data = 'N/A';
         switch(genetic_alteration_type) {
-            case "MRNA_EXPRESSION":
+            case AlterationTypeConstants.MRNA_EXPRESSION:
                 data_header = 'MRNA: ';
                 break;
-            case "PROTEIN_LEVEL":
+            case AlterationTypeConstants.PROTEIN_LEVEL:
                 data_header = 'PROT: ';
                 break;
-            case "METHYLATION":
+            case AlterationTypeConstants.METHYLATION:
                 data_header = 'METHYLATION: ';
+                break;
+            case AlterationTypeConstants.TREATMENT_RESPONSE:
+                data_header = 'TREATMENT: ';
                 break;
         }
         if ((d.profile_data !== null) && (typeof d.profile_data !== "undefined")) {
-            profile_data = d.profile_data.toFixed(2);
+            profile_data = d.category || d.profile_data.toFixed(2);
         }
         let ret = data_header + '<b>' + profile_data + '</b><br>';
         ret += (d.sample ? (link_id ? sampleViewAnchorTag(d.study, d.sample) : d.sample) : (link_id ? patientViewAnchorTag(d.study, d.patient) : d.patient));

--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -451,6 +451,7 @@ export default class BoxScatterPlot<D extends IBaseBoxScatterPlotPoint> extends 
             ifndef(this.props.strokeWidth, 0),
             ifndef(this.props.strokeOpacity, 1),
             ifndef(this.props.fillOpacity, 1),
+            ifndef(this.props.symbol, "circle"),
             this.props.zIndexSortBy
         );
     }
@@ -607,7 +608,7 @@ export default class BoxScatterPlot<D extends IBaseBoxScatterPlotPoint> extends 
                             />
                             {this.scatterPlotData.map(dataWithAppearance=>(
                                 <VictoryScatter
-                                    key={`${dataWithAppearance.fill},${dataWithAppearance.stroke},${dataWithAppearance.strokeWidth},${dataWithAppearance.strokeOpacity},${dataWithAppearance.fillOpacity}`}
+                                    key={`${dataWithAppearance.fill},${dataWithAppearance.stroke},${dataWithAppearance.strokeWidth},${dataWithAppearance.strokeOpacity},${dataWithAppearance.fillOpacity},${dataWithAppearance.symbol}`}
                                     style={{
                                         data: {
                                             fill: dataWithAppearance.fill,
@@ -618,7 +619,7 @@ export default class BoxScatterPlot<D extends IBaseBoxScatterPlotPoint> extends 
                                         }
                                     }}
                                     size={this.scatterPlotSize}
-                                    symbol={this.props.symbol || "circle"}
+                                    symbol={dataWithAppearance.symbol}
                                     data={dataWithAppearance.data}
                                     events={this.mouseEvents}
                                     x={this.scatterPlotX}

--- a/src/shared/components/plots/WaterfallPlot.tsx
+++ b/src/shared/components/plots/WaterfallPlot.tsx
@@ -1,0 +1,552 @@
+import _ from "lodash";
+import * as React from "react";
+import {observer, Observer} from "mobx-react";
+import bind from "bind-decorator";
+import {computed, observable} from "mobx";
+import CBIOPORTAL_VICTORY_THEME from "../../theme/cBioPoralTheme";
+import Timer = NodeJS.Timer;
+import {VictoryChart, VictoryAxis, VictoryBar, VictoryScatter, VictoryLegend, VictoryLabel} from "victory";
+import { makeScatterPlotSizeFunction as makePlotSizeFunction, dataPointIsTruncated } from "./PlotUtils";
+import { SortOrder } from "../../api/generated/CBioPortalAPIInternal";
+import WaterfallPlotTooltip from "./WaterfallPlotTooltip";
+import { tickFormatNumeral } from "./TickUtils";
+import { IWaterfallPlotData } from "pages/resultsView/plots/PlotsTabUtils";
+
+// TODO make distinction between public and internal interface for waterfall plot data
+export interface IBaseWaterfallPlotData {
+    value:number; // public
+    truncation?:string; // public
+    order?:number|undefined;
+    pivot_adjusted_value?:number;
+    fill?:string;
+    fillOpacity?:number;
+    stroke?:string;
+    strokeOpacity?:number;
+    strokeWidth?:number;
+    symbol?:string;
+    labelx?:number;
+    labely?:number;
+    labelVisibility?:boolean;
+    searchindicatorx?:number;
+    searchindicatory?:number;
+}
+
+export interface IWaterfallPlotProps<D extends IBaseWaterfallPlotData> {
+    svgId?:string;
+    title?:string;
+    data: D[];
+    chartWidth:number;
+    chartHeight:number;
+    highlight?:(d:D)=>boolean;
+    size?:number | ((d:D, active:boolean, isHighlighted?:boolean)=>number);
+    fill?:string|((d:D)=>string);
+    stroke?:string|((d:D)=>string);
+    fillOpacity?:number|((d:D)=>number);
+    strokeOpacity?:number|((d:D)=>number);
+    strokeWidth?:number|((d:D)=>number);
+    symbol?:string|((d:D)=>string);
+    labelVisibility?:boolean|((d:D)=>boolean);
+    zIndexSortBy?:((d:D)=>any)[]; // second argument to _.sortBy
+    tooltip?:(d:D)=>JSX.Element;
+    horizontal:boolean;
+    legendData?:{name:string|string[], symbol:any}[]; // see http://formidable.com/open-source/victory/docs/victory-legend/#data
+    log?:boolean;
+    useLogSpaceTicks?:boolean; // if log scale for an axis, then this prop determines whether the ticks are shown in post-log coordinate, or original data coordinate space
+    axisLabel?:string;
+    fontFamily?:string;
+    sortOrder:SortOrder;
+    pivotThreshold?:number;
+}
+
+const DEFAULT_FONT_FAMILY = "Verdana,Arial,sans-serif";
+export const LEGEND_Y = 30
+const RIGHT_PADDING = 120; // room for correlation info and legend
+const NUM_AXIS_TICKS = 8;
+const PLOT_DATA_PADDING_PIXELS = 50;
+const MIN_LOG_ARGUMENT = 0.01;
+const LEFT_PADDING = 25;
+const LABEL_OFFSET_FRACTION = .02;
+const LABEL_SIZE_MULTIPLIER = 1.5;
+const labelStyle = {
+    fill: "#ffffff",
+    stroke: "#000000",
+    strokeWidth: 1,
+    strokeOpacity: 1,
+    size: 3
+}
+
+
+@observer
+export default class WaterfallPlot<D extends IBaseWaterfallPlotData> extends React.Component<IWaterfallPlotProps<D>, {}> {
+
+    @observable.ref tooltipModel:any|null = null;
+    @observable pointHovered:boolean = false;
+
+    private mouseEvents:any = this.makeMouseEvents();
+
+    @observable.ref private container:HTMLDivElement;
+
+    @bind
+    private containerRef(container:HTMLDivElement) {
+        this.container = container;
+    }
+
+    private makeMouseEvents() {
+        let disappearTimeout:Timer | null = null;
+        const disappearDelayMs = 250;
+
+        return [{
+            target: "data",
+            eventHandlers: {
+                onMouseOver: () => {
+                    return [
+                        {
+                            target: "data",
+                            mutation: (props: any) => {
+
+                                // swap x and y label pos when in horizontal mode
+                                if (this.props.horizontal) {
+                                    const x = props.x;
+                                    props.x = props.y;
+                                    props.y = x;
+                                }
+
+                                this.tooltipModel = props;
+                                this.pointHovered = true;
+
+                                if (disappearTimeout !== null) {
+                                    clearTimeout(disappearTimeout);
+                                    disappearTimeout = null;
+                                }
+
+                                return { active: true };
+                            }
+                        }
+                    ];
+                },
+                onMouseOut: () => {
+                    return [
+                        {
+                            target: "data",
+                            mutation: () => {
+                                if (disappearTimeout !== null) {
+                                    clearTimeout(disappearTimeout);
+                                }
+
+                                disappearTimeout = setTimeout(()=>{
+                                    this.pointHovered = false;
+                                }, disappearDelayMs);
+
+                                return { active: false };
+                            }
+                        }
+                    ];
+                }
+            }
+        }];
+    }
+
+    @computed get fontFamily() {
+        return this.props.fontFamily || DEFAULT_FONT_FAMILY;
+    }
+
+    private get title() {
+        if (this.props.title) {
+            return (
+                <VictoryLabel
+                    style={{
+                        fontWeight:"bold",
+                        fontFamily: this.fontFamily,
+                        textAnchor: "middle"
+                    }}
+                    x={this.svgWidth/2}
+                    y="1.2em"
+                    text={this.props.title}
+                />
+            );
+        } else {
+            return null;
+        }
+    }
+
+    @computed get legendX() {
+        return this.props.chartWidth - 20;
+    }
+
+    private get legend() {
+        const x = this.legendX;
+        const topPadding = 30;
+        const approximateCorrelationInfoHeight = 30;
+        if (this.props.legendData && this.props.legendData.length) {
+            return (
+                <VictoryLegend
+                    orientation="vertical"
+                    data={this.props.legendData}
+                    x={x}
+                    y={LEGEND_Y}
+                    width={RIGHT_PADDING}
+                />
+            );
+        } else {
+            return null;
+        }
+    }
+
+    @computed get plotDomain():{value:number[], order:number[]} {
+        // data extremes
+        let max = _(this.data).map('pivot_adjusted_value').max() || 0;
+        let min = _(this.data).map('pivot_adjusted_value').min() || 0;
+
+        return {
+            value: [min!, max!],
+            order: [1, this.data.length]  // return range defined by the number of samples for the x-axis
+        };
+    }
+
+    @computed get plotDomainX() {
+        if (this.props.horizontal) {
+            return this.plotDomain.value;
+        }
+        return this.plotDomain.order;
+    }
+
+    @computed get plotDomainY() {
+        if (this.props.horizontal) {
+            return this.plotDomain.order;
+        }
+        return this.plotDomain.value;
+    }
+
+    @computed get rightPadding() {
+        return RIGHT_PADDING;
+    }
+
+    @computed get svgWidth() {
+        return LEFT_PADDING + this.props.chartWidth + this.rightPadding;
+    }
+
+    @computed get svgHeight() {
+        return this.props.chartHeight;
+    }
+
+    private log10Scale(x:number) {
+        return Math.log10(x);
+    }
+
+    private invLog10Scale(x:number) {
+        return Math.pow(10, x);
+    }
+
+    @bind
+    private datumAccessorY(d:IBaseWaterfallPlotData) {
+        return d.pivot_adjusted_value;
+    }
+
+    @bind
+    private datumAccessorX(d:IBaseWaterfallPlotData) {
+        return d.order;
+    }
+
+    @bind
+    private datumAccessorLabelY(d:IBaseWaterfallPlotData) {
+        return d.labely;
+    }
+
+    @bind
+    private datumAccessorLabelX(d:IBaseWaterfallPlotData) {
+        return d.labelx;
+    }
+
+    @bind
+    private datumAccessorSearchIndicatorY(d:IBaseWaterfallPlotData) {
+        return d.searchindicatory;
+    }
+
+    @bind
+    private datumAccessorSearchIndicatorX(d:IBaseWaterfallPlotData) {
+        return d.searchindicatorx;
+    }
+
+    @computed get size() {
+        const highlight = this.props.highlight;
+        const size = this.props.size;
+        // need to regenerate this function whenever highlight changes in order to trigger immediate Victory rerender
+        return makePlotSizeFunction(highlight, size);
+    }
+
+    private tickFormat(t:number, ticks:number[], logScale:boolean) {
+        if (logScale && !this.props.useLogSpaceTicks) {
+            t = this.invLog10Scale(t);
+            ticks = ticks.map(x=>this.invLog10Scale(x));
+        }
+        return tickFormatNumeral(t, ticks);
+    }
+
+    @bind
+    private tickFormatX(t:number, i:number, ticks:number[]) {
+        if (this.props.horizontal) {
+            return this.tickFormat(t, ticks, !!this.props.log);
+        }
+        return undefined;
+    }
+
+    @bind
+    private tickFormatY(t:number, i:number, ticks:number[]) {
+        if (this.props.horizontal) {
+            return undefined;
+        }
+        return this.tickFormat(t, ticks, !!this.props.log);
+    }
+
+    @computed get data() {
+
+        // sort datapoints according to value
+        // default sort order for sortBy is ascending (a.k.a 'ASC') order
+        let dataPoints = _.sortBy(this.props.data, (d:IBaseWaterfallPlotData) => d.value);
+        if (this.props.sortOrder === SortOrder.DESC) {
+            dataPoints = _.reverse(dataPoints);
+        }
+        // assign a x value (equivalent to position in array)
+        _.each(dataPoints, (d:IBaseWaterfallPlotData, index:number) => d.order = index + 1 );
+
+        // subtract the pivotThreshold from each value and apply log-transformation if applicable
+        const delta = this.props.pivotThreshold || 0;
+        
+        // for log transformation one should handle negative numbers
+        // this is done by transposing all data so that negative numbers no
+        // longer occur. Als include the pivotThreshold.
+        const values =  _.map(dataPoints, 'value').concat([delta]);
+        const minValue = _.min(values);
+        const offset = Math.abs(minValue!);
+
+        _.each(dataPoints, (d:IBaseWaterfallPlotData) => {
+            if (this.props.log) {
+                if (minValue! <= 0) {
+                    d.pivot_adjusted_value = this.log10Scale(d.value+offset+0.001) - this.log10Scale(delta+offset+0.001);
+                } else {
+                    d.pivot_adjusted_value = this.log10Scale(d.value) - this.log10Scale(delta);
+                }
+            } else {
+                d.pivot_adjusted_value = d.value - delta;
+            }
+        });
+
+        // add style information to each point
+        _.each(dataPoints, (d:IBaseWaterfallPlotData) => {
+            d.fill = this.resolveStyleOptionType<string>(d, this.props.fill);
+            d.fillOpacity = this.resolveStyleOptionType<number>(d, this.props.fillOpacity);
+            d.stroke = this.resolveStyleOptionType<string>(d, this.props.stroke);
+            d.strokeOpacity = this.resolveStyleOptionType<number>(d, this.props.strokeOpacity);
+            d.strokeWidth = this.resolveStyleOptionType<number>(d, this.props.strokeWidth);
+            d.symbol = this.resolveStyleOptionType<string>(d, this.props.symbol);
+            d.labelVisibility = this.resolveStyleOptionType<boolean>(d, this.props.labelVisibility);
+        });
+
+        return dataPoints;
+    }
+
+    resolveStyleOptionType<T>(datum:IBaseWaterfallPlotData, styleOption:any):T {
+        if (typeof styleOption === 'function') {
+            return styleOption(datum);
+        }
+        return styleOption;
+    }
+
+    @computed get truncationLabels() {
+
+        // filter out data points that are truncted
+        // these will get a symbol above the resp. bar
+        const labelData = _.filter(this.data, (d) => d.labelVisibility);
+
+        const range = this.props.horizontal ? this.plotDomainX : this.plotDomainY;
+        const min_value = range[0];
+        const max_value = range[1];
+        let offset:number = (max_value - min_value) * LABEL_OFFSET_FRACTION;// determine magnitude of offset for symbols
+
+        // add offset information for possible labels above the bars
+        _.each(labelData, (d:IBaseWaterfallPlotData) => {
+
+            const offsetLocal = d.pivot_adjusted_value! >= 0 ? offset : offset*-1; // determine direction of offset for symbols (above or below)
+            const labelPos = d.pivot_adjusted_value! + offsetLocal;
+
+            if (this.props.horizontal) {
+                d.labelx = labelPos;
+                d.labely = d.order;
+            } else { // ! this.props.horizontal
+                d.labelx = d.order;
+                d.labely = labelPos;
+            }
+        });
+
+        return labelData;
+    }
+
+    @computed get sampleSearchLabels() {
+
+        if (! this.props.highlight) {
+            return [];
+        }
+
+        const searchLabels = _.filter(this.data, (d:any) => this.props.highlight!(d) );
+
+        const range = this.props.horizontal ? this.plotDomainX : this.plotDomainY;
+        const min_value = range[0];
+        const max_value = range[1];
+
+        // determine magnitude of offset for symbols
+        let offset:number = (max_value - min_value) * LABEL_OFFSET_FRACTION;
+
+        // add offset information for search labels to datapoints
+        _.each(searchLabels, (d:IBaseWaterfallPlotData) => {
+
+            // determine direction of offset for symbols (above or below line y=0)
+            const labelPos = d.pivot_adjusted_value! <= 0 ? offset : offset*-1;
+
+            if (labelPos > 0) {
+                d.symbol = "triangleDown"
+            } else {
+                d.symbol = "triangleUp"
+            }
+
+            if (this.props.horizontal) {
+                d.searchindicatorx = labelPos;
+                d.searchindicatory = d.order;
+            } else { // ! this.props.horizontal
+                d.searchindicatorx = d.order;
+                d.searchindicatory = labelPos;
+            }
+
+        });
+
+        return searchLabels;
+    }
+    
+    @bind
+    private getChart() {
+        return (
+            <div
+                ref={this.containerRef}
+                style={{width: this.svgWidth, height: this.svgHeight}}
+            >
+                <svg
+                    id={this.props.svgId || ""}
+                    style={{
+                        width: this.svgWidth,
+                        height: this.svgHeight,
+                        pointerEvents: "all"
+                    }}
+                    height={this.svgHeight}
+                    width={this.svgWidth}
+                    role="img"
+                    viewBox={`0 0 ${this.svgWidth} ${this.svgHeight}`}
+                >
+                    <g
+                        transform={`translate(${LEFT_PADDING},0)`}
+                    >
+                        <VictoryChart
+                            theme={CBIOPORTAL_VICTORY_THEME}
+                            width={this.props.chartWidth}
+                            height={this.props.chartHeight}
+                            standalone={false}
+                            domainPadding={PLOT_DATA_PADDING_PIXELS}
+                            singleQuadrantDomainPadding={false}
+                        >
+                            {this.title}
+                            {this.legend}
+                            {this.props.horizontal && <VictoryAxis
+                                domain={this.plotDomainX}
+                                orientation="bottom"
+                                offsetY={50}
+                                crossAxis={false}
+                                tickCount={NUM_AXIS_TICKS}
+                                tickFormat={this.tickFormatX}
+                                axisLabelComponent={<VictoryLabel dy={25}/>}
+                                label={this.props.axisLabel}
+                            />}
+                           {!this.props.horizontal && <VictoryAxis
+                                domain={this.plotDomainY}
+                                offsetX={50}
+                                orientation="left"
+                                crossAxis={false}
+                                tickCount={NUM_AXIS_TICKS}
+                                tickFormat={this.tickFormatY}
+                                dependentAxis={true}
+                                axisLabelComponent={<VictoryLabel dy={-35}/>}
+                                label={this.props.axisLabel}
+                            />}
+                            <VictoryBar
+                                // barRatio={1} // removes spaces between bars
+                                style={{
+                                    data: {
+                                        fill: (d:D) => d.fill,
+                                        stroke: (d:D) => d.stroke,
+                                        strokeWidth: (d:D) => d.strokeWidth,
+                                        strokeOpacity: (d:D) => d.strokeOpacity,
+                                        fillOpacity: (d:D) => d.fillOpacity
+                                    }
+                                }}
+                                horizontal={this.props.horizontal}
+                                data={this.data}
+                                size={this.size}
+                                events={this.mouseEvents}
+                                x={this.datumAccessorX} // for x-axis reference accessor function
+                                y={this.datumAccessorY} // for y-axis reference accessor function
+                            />
+                            <VictoryScatter
+                                style={{
+                                    data: {
+                                        fill: labelStyle.fill,
+                                        stroke: labelStyle.stroke,
+                                        strokeWidth: labelStyle.strokeWidth,
+                                        strokeOpacity: labelStyle.strokeOpacity,
+                                        symbol: (d:D) => d.symbol
+                                    }
+                                }}
+                                size={labelStyle.size}
+                                data={this.truncationLabels}
+                                x={this.datumAccessorLabelX}
+                                y={this.datumAccessorLabelY}
+                            />
+                            <VictoryScatter
+                                style={{
+                                    data: {
+                                        fill: "white",
+                                        stroke: "red",
+                                        strokeWidth: 1*LABEL_SIZE_MULTIPLIER,
+                                        strokeOpacity: 1,
+                                        symbol: (d:D) => d.symbol
+                                    }
+                                }}
+                                size={labelStyle.size * LABEL_SIZE_MULTIPLIER}
+                                data={this.sampleSearchLabels}
+                                x={this.datumAccessorSearchIndicatorX}
+                                y={this.datumAccessorSearchIndicatorY}
+                            />
+                        </VictoryChart>
+                    </g>
+                </svg>
+            </div>
+        );
+    }
+
+    render() {
+        if (!this.props.data.length) {
+            return <div className={'alert alert-info'}>No data to plot.</div>;
+        }
+        return (
+            <div>
+                <Observer>
+                    {this.getChart}
+                </Observer>
+                {this.container && this.tooltipModel && this.props.tooltip && (
+                    <WaterfallPlotTooltip
+                        container={this.container}
+                        targetHovered={this.pointHovered}
+                        targetCoords={{x: this.tooltipModel.x + LEFT_PADDING, y: this.tooltipModel.y}}
+                        overlay={this.props.tooltip(this.tooltipModel.datum)}
+                    />
+                )}
+            </div>
+        );
+    }
+}

--- a/src/shared/components/plots/WaterfallPlotTooltip.tsx
+++ b/src/shared/components/plots/WaterfallPlotTooltip.tsx
@@ -1,0 +1,55 @@
+import {observer} from "mobx-react";
+import * as React from "react";
+import {observable} from "mobx";
+import {Popover} from "react-bootstrap";
+import bind from "bind-decorator";
+import classnames from "classnames";
+
+export interface IWaterfallPlotTooltipProps {
+    container:HTMLDivElement;
+    overlay:JSX.Element;
+    targetCoords:{x:number, y:number};
+    targetHovered?:boolean;
+    className?:string;
+    placement?:string;
+}
+
+@observer
+export default class WaterfallPlotTooltip extends React.Component<IWaterfallPlotTooltipProps, {}> {
+    @observable isHovered = false; // allows persistence when mouse rolls over tooltip
+
+    @bind
+    private onMouseEnter() {
+        this.isHovered = true;
+    }
+
+    @bind
+    private onMouseLeave() {
+        this.isHovered = false;
+    }
+
+    render() {
+        const arrowOffsetTop = 30; // experimentally determined
+        const arrowOffsetLeft = 24; // experimentally determined
+        const leftPadding = 5;
+        const horizontal = !this.props.placement || this.props.placement === "left" || this.props.placement === "right";
+        if (this.props.targetHovered || this.isHovered) {
+            return (
+                <Popover
+                    className={classnames("cbioportal-frontend", "cbioTooltip", this.props.className)}
+                    positionLeft={this.props.targetCoords.x + this.props.container.offsetLeft + leftPadding - (!horizontal ? arrowOffsetLeft + 6 : 0)}
+                    positionTop={this.props.targetCoords.y + this.props.container.offsetTop - (horizontal ? arrowOffsetTop : -5)}
+                    onMouseEnter={this.onMouseEnter}
+                    onMouseLeave={this.onMouseLeave}
+                    arrowOffsetTop={horizontal ? arrowOffsetTop : undefined}
+                    arrowOffsetLeft={!horizontal ? arrowOffsetLeft : undefined}
+                    placement={this.props.placement}
+                >
+                    {this.props.overlay}
+                </Popover>
+            );
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -60,6 +60,7 @@ export type CancerStudyQueryUrlParams = {
     genetic_profile_ids_PROFILE_METHYLATION: string,
     genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: string,
     genetic_profile_ids_PROFILE_GENESET_SCORE: string,
+    genetic_profile_ids_PROFILE_TREATMENT_RESPONSE: string,
     Z_SCORE_THRESHOLD: string,
     RPPA_SCORE_THRESHOLD: string,
     data_priority: '0' | '1' | '2',
@@ -67,6 +68,7 @@ export type CancerStudyQueryUrlParams = {
     case_ids: string,
     gene_list: string,
     geneset_list?: string,
+    treatment_list?: string,
     tab_index: 'tab_download' | 'tab_visualize',
     transpose_matrix?: 'on',
     Action: 'Submit',
@@ -96,7 +98,8 @@ export type CancerStudyQueryParams = Pick<QueryStore,
     'caseIds' |
     'caseIdsMode' |
     'geneQuery' |
-    'genesetQuery'>;
+    'genesetQuery' |
+	'treatmentQuery'>;
 export const QueryParamsKeys: (keyof CancerStudyQueryParams)[] = [
     'searchText',
     'selectableSelectedStudyIds',
@@ -109,6 +112,7 @@ export const QueryParamsKeys: (keyof CancerStudyQueryParams)[] = [
     'caseIdsMode',
     'geneQuery',
     'genesetQuery',
+	'treatmentQuery'
 ];
 
 type GenesetId = string;
@@ -374,6 +378,18 @@ export class QueryStore {
         // clear error when gene query is modified
         this.genesetQueryErrorDisplayStatus = 'unfocused';
         this._genesetQuery = value;
+	}
+	
+	@observable _treatmentQuery = '';
+    get treatmentQuery()
+    {
+        return this._treatmentQuery;
+    }
+    set treatmentQuery(value:string)
+    {
+        // clear error when gene query is modified
+        this.treatmentQueryErrorDisplayStatus = 'unfocused';
+        this._treatmentQuery = value;
     }
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -382,6 +398,7 @@ export class QueryStore {
 
     @observable geneQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
     @observable genesetQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
+    @observable treatmentQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
     @observable showMutSigPopup = false;
     @observable showGisticPopup = false;
     @observable showGenesetsHierarchyPopup = false;
@@ -1520,6 +1537,7 @@ export class QueryStore {
             params.genetic_profile_ids_PROFILE_METHYLATION,
             params.genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION,
             params.genetic_profile_ids_PROFILE_GENESET_SCORE,
+            params.genetic_profile_ids_PROFILE_TREATMENT_RESPONSE
         ];
 
         let queriedStudies = params.cancer_study_list ? params.cancer_study_list.split(",") : (params.cancer_study_id ? [params.cancer_study_id] : []);
@@ -1535,6 +1553,7 @@ export class QueryStore {
         this.caseIdsMode = 'sample'; // url always contains sample IDs
         this.geneQuery = normalizeQuery(decodeURIComponent(params.gene_list || ''));
         this.genesetQuery = normalizeQuery(decodeURIComponent(params[QueryParameter.GENESET_LIST] || ''));
+        this.treatmentQuery = decodeURIComponent(params[QueryParameter.TREATMENT_LIST] || ''); // pvannierop: removed the conversion to uppercase
         this.forDownloadTab = params.tab_index === 'tab_download';
         this.initiallySelected.profileIds = true;
         this.initiallySelected.sampleListId = true;

--- a/src/shared/components/query/QueryStoreUtils.ts
+++ b/src/shared/components/query/QueryStoreUtils.ts
@@ -6,12 +6,13 @@ import { VirtualStudy } from "shared/model/VirtualStudy";
 
 export type NonMolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
     'cancer_study_id' | 'cancer_study_list' | 'Z_SCORE_THRESHOLD' | 'RPPA_SCORE_THRESHOLD' | 'data_priority' |
-    'case_set_id' | 'case_ids' | 'gene_list' | 'geneset_list' | 'tab_index' | 'transpose_matrix' | 'Action'>;
+    'case_set_id' | 'case_ids' | 'gene_list' | 'geneset_list' | 'treatment_list' | 'tab_index' | 'transpose_matrix' | 'Action'>;
 
 export type MolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
     'genetic_profile_ids_PROFILE_MUTATION_EXTENDED' | 'genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION' |
     'genetic_profile_ids_PROFILE_MRNA_EXPRESSION' | 'genetic_profile_ids_PROFILE_METHYLATION' |
-    'genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION' | 'genetic_profile_ids_PROFILE_GENESET_SCORE'>;
+    'genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION' | 'genetic_profile_ids_PROFILE_GENESET_SCORE' |
+    'genetic_profile_ids_PROFILE_TREATMENT_RESPONSE' >;
 
 
 export function currentQueryParams(store:QueryStore) {
@@ -52,6 +53,7 @@ export function nonMolecularProfileParams(store:QueryStore, whitespace_separated
         case_ids,
         gene_list: encodeURIComponent(normalizeQuery(store.geneQuery) || ' '), // empty string won't work
         geneset_list: normalizeQuery(store.genesetQuery) || ' ', //empty string won't work
+        treatment_list: normalizeQuery(store.treatmentQuery) || ' ', //empty string won't work
         tab_index: store.forDownloadTab ? 'tab_download' : 'tab_visualize' as any,
         transpose_matrix: store.transposeDataMatrix ? 'on' : undefined,
         Action: 'Submit',
@@ -71,7 +73,8 @@ export function molecularProfileParams(store:QueryStore, molecularProfileIds?:Re
         genetic_profile_ids_PROFILE_MRNA_EXPRESSION: store.getSelectedProfileIdFromMolecularAlterationType("MRNA_EXPRESSION", molecularProfileIds),
         genetic_profile_ids_PROFILE_METHYLATION: store.getSelectedProfileIdFromMolecularAlterationType("METHYLATION", molecularProfileIds) || store.getSelectedProfileIdFromMolecularAlterationType("METHYLATION_BINARY", molecularProfileIds),
         genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: store.getSelectedProfileIdFromMolecularAlterationType("PROTEIN_LEVEL", molecularProfileIds),
-        genetic_profile_ids_PROFILE_GENESET_SCORE: store.getSelectedProfileIdFromMolecularAlterationType("GENESET_SCORE", molecularProfileIds)
+        genetic_profile_ids_PROFILE_GENESET_SCORE: store.getSelectedProfileIdFromMolecularAlterationType("GENESET_SCORE", molecularProfileIds),
+        genetic_profile_ids_PROFILE_TREATMENT_RESPONSE: store.getSelectedProfileIdFromMolecularAlterationType("TREATMENT_RESPONSE", molecularProfileIds)
     };
 }
 

--- a/src/shared/lib/ExtendedRouterStore.ts
+++ b/src/shared/lib/ExtendedRouterStore.ts
@@ -60,6 +60,7 @@ export enum QueryParameter {
     CANCER_STUDY_ID="cancer_study_id",
     DATA_PRIORITY="data_priority",
     GENESET_LIST="geneset_list",
+    TREATMENT_LIST="treatment_list",
     TAB_INDEX="tab_index",
     TRANSPOSE_MATRIX="transpose_matrix",
     ACTION="Action"


### PR DESCRIPTION
# What? Why?
This PR will implement handling of the new `treatment response` (genetic entity) data type by the PlotsTab component. A new plot type _Watefall plot_ is added.

## Changes
- `Treatment` is shown in data type select boxes of the horz. and vert. axis menu's (when available in cBioPortal db). When selected treatment response genetic profiles are shown in the data source select menu's (see Fig.1). Only treatments selected in the oncoprint heatmap menu are available for selection. 
- Treatment data points can be _truncated_ (real value lies beyond a certain value) which can be indicated by `>` or `<` prefixes to values (for example _>8.00_, see [this backend PR](https://github.com/cBioPortal/cbioportal/pull/5460)). Bar, scatter and waterfall (see below) plot types contain a legend option `Truncated Value` when one or more data points in the plot are truncated. Enabling this legend option represents truncated data points as triangles (see Fig.1). This option is enabled by default and is re-enabled after each axis menu change. When __enabled__ truncated data values are __excluded__ from calculations of correlation coefficients in the scatter plot legend. 
- When `Treatment` data type is selected a `--`option is shown in the other data type menu that represents no data type selected for the corresponding axis (see Fig.1). For treatment data the `Apply log scale` option is displayed in the axis menu's. When the `Treatment` and `--` combination is selected by the user, a new plot type `Waterfall plot` is displayed.
- A new plot type `Waterfall plot` is implemented (see Fig.2). This plot type represents a sorted (asc or desc) bar graph of response values expressed relative to a given threshold value a.k.a. `pivot_threshold `. The `pivot_threshold` is set on a profile level scope and is passed from the cbioportal backend. When no `pivot_threshold` is passed unmodified values are represented. When a waterfall plot is shown `Log-scale` and `Sort Order` controls are shown in the corresponding axis menu that control log10-transformation and asc-desc sorting, respectively. The legend options for this plot type include a new gene selection box that controls for which gene the mutation or CNA information is represented in the plot. For the waterfall plot the mutation and CNA styling options are mutually exclusive. The selected gene is represented in the title of the plot. When legend option `Truncated Value` is enabled truncated data points are marked by a black triangle above respective bars. Sample and mutation queries are represented by red triangles below respective bars. The width of the waterfall plot is dynamic with a max-width of 1000px. Download of waterfall plot data includes raw and `pivot_threshold`-adjusted values and the sort order.

## Images
### Figure 1
1. treatment data type
2. `--` data type option in other menu
3. `Truncated Value` legend option
4. truncated data points styled as triangles
5. `Log scale` control for treatment profile values
![screenshot from 2019-02-20 09-59-16](https://user-images.githubusercontent.com/745885/53080393-e16c0f80-34f8-11e9-97bb-d5dcfbcd04dd.png)

### Figure 2
1. waterfall plot (at max width)
2. `Truncated Value` legend option
3.  truncated data points styled as triangles above bars
4. Gene selection box for mutation or CNA styling
5. Selected gene represented in title
6. `Log Scale` and `Sort Order` controls for treatment profile values
7. Sample search as red triangle
![screenshot from 2019-02-20 10-24-21](https://user-images.githubusercontent.com/745885/53081128-80453b80-34fa-11e9-9c24-afffdd9bac70.png)
 