### PR TITLE
Integration of treatment response data in OncoPrint tab

### DIFF
--- a/env/custom.sh
+++ b/env/custom.sh
@@ -1,2 +1,2 @@
-# set e.g.
-# export CBIOPORTAL_URL="http://localhost:8080"
+export CBIOPORTAL_URL="http://localhost:3000"
+export GENOME_NEXUS_URL="https://www.genomenexus.org"

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "node-sass": "^4.9.3",
     "numeral": "^2.0.6",
     "object-sizeof": "^1.2.0",
-    "oncoprintjs": "^1.1.16",
+    "oncoprintjs": "^2.0.0",
     "parameter-validator": "^1.0.2",
     "pdfobject": "^2.0.201604172",
     "pegjs": "^0.10.0",

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -78,8 +78,10 @@ import {MergedGeneQuery} from '../../shared/lib/oql/oql-parser';
 import GeneMolecularDataCache from "../../shared/cache/GeneMolecularDataCache";
 import GenesetMolecularDataCache from "../../shared/cache/GenesetMolecularDataCache";
 import GenesetCorrelatedGeneCache from "../../shared/cache/GenesetCorrelatedGeneCache";
+import TreatmentMolecularDataCache from "../../shared/cache/TreatmentMolecularDataCache";
 import GeneCache from "../../shared/cache/GeneCache";
 import GenesetCache from "../../shared/cache/GenesetCache";
+import TreatmentCache from "../../shared/cache/TreatmentCache";
 import {IHotspotIndex} from "../../shared/model/CancerHotspots";
 import {IOncoKbData} from "../../shared/model/OncoKB";
 import {generateQueryVariantId} from "../../shared/lib/OncoKbUtils";
@@ -89,7 +91,8 @@ import {
     ExpressionEnrichment,
     Geneset, 
     GenesetDataFilterCriteria,
-    GenesetMolecularData
+    GenesetMolecularData,
+    Treatment
 } from "../../shared/api/generated/CBioPortalAPIInternal";
 import internalClient from "../../shared/api/cbioportalInternalClientInstance";
 import {IndicatorQueryResp} from "../../shared/api/generated/OncoKbAPI";
@@ -155,7 +158,8 @@ export const AlterationTypeConstants = {
     PROTEIN_LEVEL: 'PROTEIN_LEVEL',
     FUSION: 'FUSION',
     GENESET_SCORE: 'GENESET_SCORE',
-    METHYLATION: 'METHYLATION'
+    METHYLATION: 'METHYLATION',
+    TREATMENT_RESPONSE: 'TREATMENT_RESPONSE'
 };
 
 export const AlterationTypeDisplayConstants = {
@@ -810,7 +814,8 @@ export class ResultsViewPageStore {
             this.molecularProfilesInStudies,
             this.studyToDataQueryFilter,
             this.genes,
-            this.genesets
+            this.genesets,
+            this.treatments
         ],
         invoke:async()=>{
             const ret:MolecularProfile[] = [];
@@ -844,7 +849,9 @@ export class ResultsViewPageStore {
                             ret.push(profile);
                         }
                     }));
-                } else if (profile.molecularAlterationType === AlterationTypeConstants.GENESET_SCORE) {
+                } else if (profile.molecularAlterationType === AlterationTypeConstants.GENESET_SCORE
+                            || profile.molecularAlterationType === AlterationTypeConstants.TREATMENT_RESPONSE
+                    ) {
                     // geneset profile, we dont have the META projection for geneset data, so just add it
                     /*promises.push(internalClient.fetchGeneticDataItemsUsingPOST({
                         geneticProfileId: molecularProfileId,
@@ -1968,6 +1975,7 @@ export class ResultsViewPageStore {
             const MRNA_EXPRESSION = AlterationTypeConstants.MRNA_EXPRESSION;
             const PROTEIN_LEVEL = AlterationTypeConstants.PROTEIN_LEVEL;
             const METHYLATION = AlterationTypeConstants.METHYLATION;
+            const TREATMENT_RESPONSE = AlterationTypeConstants.TREATMENT_RESPONSE;
             const selectedMolecularProfileIds = stringListToSet(
                 this.selectedMolecularProfiles.result!.map((profile)=>profile.molecularProfileId)
             );
@@ -1975,12 +1983,13 @@ export class ResultsViewPageStore {
             const expressionHeatmaps = _.sortBy(
                 _.filter(this.molecularProfilesInStudies.result!, profile=>{
                     return ((profile.molecularAlterationType === MRNA_EXPRESSION ||
-                        profile.molecularAlterationType === PROTEIN_LEVEL) && profile.showProfileInAnalysisTab) ||
-                        profile.molecularAlterationType === METHYLATION;
+                        profile.molecularAlterationType === PROTEIN_LEVEL ||
+                        profile.molecularAlterationType === TREATMENT_RESPONSE) && profile.showProfileInAnalysisTab) ||
+                        profile.molecularAlterationType === METHYLATION
                     }
                 ),
                 profile=>{
-                    // Sort order: selected and [mrna, protein, methylation], unselected and [mrna, protein, meth]
+                    // Sort order: selected and [mrna, protein, methylation, treatment], unselected and [mrna, protein, meth, treatment]
                     if (profile.molecularProfileId in selectedMolecularProfileIds) {
                         switch (profile.molecularAlterationType) {
                             case MRNA_EXPRESSION:
@@ -1989,6 +1998,8 @@ export class ResultsViewPageStore {
                                 return 1;
                             case METHYLATION:
                                 return 2;
+                            case TREATMENT_RESPONSE:
+                                return 3;
                         }
                     } else {
                         switch(profile.molecularAlterationType) {
@@ -1998,6 +2009,8 @@ export class ResultsViewPageStore {
                                 return 4;
                             case METHYLATION:
                                 return 5;
+                            case TREATMENT_RESPONSE:
+                                return 6;
                         }
                     }
                 }
@@ -2165,6 +2178,24 @@ export class ResultsViewPageStore {
                     geneticEntityId: geneset.genesetId, cytoband: "-", geneticEntityData: geneset});
             }
             return Promise.resolve(res);
+
+        }
+    });
+
+    readonly treatments = remoteData<Treatment[]>({
+        invoke: async () => {
+            return internalClient.getAllTreatmentsUsingGET({});
+        },
+        onResult:(treatments:Treatment[])=>{
+            this.treatmentCache.addData(treatments);
+        }
+    });
+
+    readonly selectedTreatments = remoteData<Treatment[]>({
+        await: ()=>[this.treatments],
+        invoke: () => {
+            const treatmentIdFromUrl =  this.rvQuery.treatmentIds;
+            return Promise.resolve(_.filter(this.treatments.result, (d:Treatment) => { treatmentIdFromUrl.includes(d.treatmentId) } ));
         }
     });
 
@@ -2182,6 +2213,23 @@ export class ResultsViewPageStore {
                 const linkMap: {[genesetId: string]: string} = {};
                 genesets.forEach(({genesetId, refLink}) => {
                     linkMap[genesetId] = refLink;
+                });
+                return linkMap;
+            } else {
+                return {};
+            }
+        }
+    });
+
+    readonly treatmentLinkMap = remoteData<{[treatmentId: string]: string}>({
+        invoke: async () => {
+            if (this.rvQuery.treatmentIds && this.rvQuery.treatmentIds.length) {
+                const treatments = await internalClient.fetchTreatmentsUsingPOST(
+                    {treatmentIds: this.rvQuery.treatmentIds.slice()}
+                );
+                const linkMap: {[treatmentId: string]: string} = {};
+                treatments.forEach(({treatmentId, refLink}) => {
+                    linkMap[treatmentId] = refLink;
                 });
                 return linkMap;
             } else {
@@ -2971,12 +3019,27 @@ export class ResultsViewPageStore {
         )
     });
 
+    readonly treatmentMolecularDataCache = remoteData({
+        await:() => [
+            this.molecularProfileIdToDataQueryFilter
+        ],
+        invoke: () => Promise.resolve(
+            new TreatmentMolecularDataCache(
+                this.molecularProfileIdToDataQueryFilter.result!
+            )
+        )
+    });
+
     @cached get geneCache() {
         return new GeneCache();
     }
 
     @cached get genesetCache() {
         return new GenesetCache();
+    }
+
+    @cached get treatmentCache() {
+        return new TreatmentCache();
     }
 
     public numericGeneMolecularDataCache = new MobxPromiseCache<{entrezGeneId:number, molecularProfileId:string}, NumericGeneMolecularData[]>(

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.ts
@@ -389,7 +389,8 @@ export function getMolecularProfiles(query:any){
         query.genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION,
         query.genetic_profile_ids_PROFILE_MRNA_EXPRESSION,
         query.genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION,
-        query.genetic_profile_ids_PROFILE_GENESET_SCORE
+        query.genetic_profile_ids_PROFILE_GENESET_SCORE,
+        query.genetic_profile_ids_TREATMENT_RESPONSE
     ].filter((profile:string|undefined)=>!!profile);
 
     // append 'genetic_profile_ids' which is sometimes in use

--- a/src/pages/resultsView/ResultsViewQuery.ts
+++ b/src/pages/resultsView/ResultsViewQuery.ts
@@ -15,6 +15,7 @@ export class ResultsViewQuery {
     @observable public _rppaScoreThreshold:number|undefined;
     @observable public _zScoreThreshold:number|undefined;
     @observable public genesetIds:string[] = [];
+    @observable public treatmentIds:string[] = [];
     @observable public cohortIdsList:string[] = [];//queried id(any combination of physical and virtual studies)
     @observable public oqlQuery:string = "";
 
@@ -100,6 +101,14 @@ export function updateResultsViewQuery(
         const parsedGeneSetList = urlQuery.geneset_list.trim().length ? (urlQuery.geneset_list.trim().split(/\s+/)) : [];
         if (!_.isEqual(parsedGeneSetList, rvQuery.genesetIds)) {
             rvQuery.genesetIds = parsedGeneSetList;
+        }
+    }
+
+    if (urlQuery.treatment_list) {
+        // we have to trim because for some reason we get a single space from submission
+        const parsedTreatmentList = urlQuery.treatment_list.trim().length ? (urlQuery.treatment_list.trim().split(/;/)) : [];
+        if (!_.isEqual(parsedTreatmentList, rvQuery.treatmentIds)) {
+            rvQuery.treatmentIds = parsedTreatmentList;
         }
     }
 

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -1104,7 +1104,8 @@ export function logScalePossible(
         // molecular profile
         return !!(
             axisSelection.dataSourceId &&
-            logScalePossibleForProfile(axisSelection.dataSourceId)
+            !(/zscore/i.test(axisSelection.dataSourceId)) &&
+            /rna_seq/i.test(axisSelection.dataSourceId)
         );
     } else {
         // clinical attribute

--- a/src/shared/api/generated/CBioPortalAPI-docs.json
+++ b/src/shared/api/generated/CBioPortalAPI-docs.json
@@ -4550,7 +4550,8 @@
             "PROTEIN_LEVEL",
             "PROTEIN_ARRAY_PROTEIN_LEVEL",
             "PROTEIN_ARRAY_PHOSPHORYLATION",
-            "GENESET_SCORE"
+            "GENESET_SCORE",
+            "TREATMENT_RESPONSE"
           ]
         },
         "molecularProfileId": {

--- a/src/shared/api/generated/CBioPortalAPI.ts
+++ b/src/shared/api/generated/CBioPortalAPI.ts
@@ -1,4 +1,5 @@
 import * as request from "superagent";
+import { SortOrder, Treatment } from "./CBioPortalAPIInternal";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type CancerStudy = {
@@ -286,7 +287,7 @@ export type MolecularProfile = {
 
         'description': string
 
-        'molecularAlterationType': "MUTATION_EXTENDED" | "MUTATION_UNCALLED" | "FUSION" | "STRUCTURAL_VARIANT" | "COPY_NUMBER_ALTERATION" | "MICRO_RNA_EXPRESSION" | "MRNA_EXPRESSION" | "MRNA_EXPRESSION_NORMALS" | "RNA_EXPRESSION" | "METHYLATION" | "METHYLATION_BINARY" | "PHOSPHORYLATION" | "PROTEIN_LEVEL" | "PROTEIN_ARRAY_PROTEIN_LEVEL" | "PROTEIN_ARRAY_PHOSPHORYLATION" | "GENESET_SCORE"
+        'molecularAlterationType': "MUTATION_EXTENDED" | "MUTATION_UNCALLED" | "FUSION" | "STRUCTURAL_VARIANT" | "COPY_NUMBER_ALTERATION" | "MICRO_RNA_EXPRESSION" | "MRNA_EXPRESSION" | "MRNA_EXPRESSION_NORMALS" | "RNA_EXPRESSION" | "METHYLATION" | "METHYLATION_BINARY" | "PHOSPHORYLATION" | "PROTEIN_LEVEL" | "PROTEIN_ARRAY_PROTEIN_LEVEL" | "PROTEIN_ARRAY_PHOSPHORYLATION" | "GENESET_SCORE" | "TREATMENT_RESPONSE"
 
         'molecularProfileId': string
 
@@ -297,6 +298,10 @@ export type MolecularProfile = {
         'study': CancerStudy
 
         'studyId': string
+
+        'pivotThreshold': number
+
+        'sortOrder': SortOrder
 
 };
 export type MolecularProfileFilter = {

--- a/src/shared/api/generated/CBioPortalAPIInternal.ts
+++ b/src/shared/api/generated/CBioPortalAPIInternal.ts
@@ -1,5 +1,9 @@
 import * as request from "superagent";
 
+export enum SortOrder {
+    UNDEFINED, ASC, DESC
+}
+
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type AlterationEnrichment = {
     'alteredCount': number
@@ -270,6 +274,44 @@ export type GenesetMolecularData = {
 
         'value': string
 
+};
+export type Treatment = {
+    'treatmentId': string
+
+    'name': string
+
+    'description': string
+
+    'refLink': string
+
+};
+export type TreatmentDataFilterCriteria = {
+    'treatmentIds': Array < string >
+
+    'sampleIds': Array < string >
+
+    'sampleListId': string
+
+};
+export type TreatmentMolecularData = {
+    'treatmentId': string
+
+    'geneticProfileId': string
+
+    'patientId': string
+
+    'sampleId': string
+
+    'studyId': string
+
+    'uniquePatientKey': string
+
+    'uniqueSampleKey': string
+
+    'value': any
+
+    'truncation': string | undefined
+    
 };
 export type Gistic = {
     'amp': boolean
@@ -1591,6 +1633,351 @@ export default class CBioPortalAPIInternal {
         let keys = Object.keys(queryParameters);
         return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
     };
+
+    getAllTreatmentsUsingGETURL(parameters: {
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        'pageSize' ? : number,
+        'pageNumber' ? : number,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/treatments';
+        if (parameters['projection'] !== undefined) {
+            queryParameters['projection'] = parameters['projection'];
+        }
+
+        if (parameters['pageSize'] !== undefined) {
+            queryParameters['pageSize'] = parameters['pageSize'];
+        }
+
+        if (parameters['pageNumber'] !== undefined) {
+            queryParameters['pageNumber'] = parameters['pageNumber'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Get all treatments
+     * @method
+     * @name CBioPortalAPIInternal#getAllTreatmentsUsingGET
+     * @param {string} projection - Level of detail of the response
+     * @param {integer} pageSize - Page size of the result list
+     * @param {integer} pageNumber - Page number of the result list
+     */
+    getAllTreatmentsUsingGETWithHttpInfo(parameters: {
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        'pageSize' ? : number,
+        'pageNumber' ? : number,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/treatments';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+
+            if (parameters['projection'] !== undefined) {
+                queryParameters['projection'] = parameters['projection'];
+            }
+
+            if (parameters['pageSize'] !== undefined) {
+                queryParameters['pageSize'] = parameters['pageSize'];
+            }
+
+            if (parameters['pageNumber'] !== undefined) {
+                queryParameters['pageNumber'] = parameters['pageNumber'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Get all treatments
+     * @method
+     * @name CBioPortalAPIInternal#getAllTreatmentsUsingGET
+     * @param {string} projection - Level of detail of the response
+     * @param {integer} pageSize - Page size of the result list
+     * @param {integer} pageNumber - Page number of the result list
+     */
+    getAllTreatmentsUsingGET(parameters: {
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        'pageSize' ? : number,
+        'pageNumber' ? : number,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < Array < Treatment >
+    > {
+        return this.getAllTreatmentsUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+    fetchTreatmentsUsingPOSTURL(parameters: {
+        'treatmentIds': Array < string > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/treatments/fetch';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Fetch treatments by ID
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentsUsingPOST
+     * @param {} treatmentIds - List of Treatment IDs
+     */
+    fetchTreatmentsUsingPOSTWithHttpInfo(parameters: {
+        'treatmentIds': Array < string > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/treatments/fetch';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['treatmentIds'] !== undefined) {
+                body = parameters['treatmentIds'];
+            }
+
+            if (parameters['treatmentIds'] === undefined) {
+                reject(new Error('Missing required  parameter: treatmentIds'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Fetch treatments by ID
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentsUsingPOST
+     * @param {} treatmentIds - List of Treatment IDs
+     */
+    fetchTreatmentsUsingPOST(parameters: {
+            'treatmentIds': Array < string > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < Treatment >
+        > {
+            return this.fetchTreatmentsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+    getTreatmentUsingGETURL(parameters: {
+        'treatmentId': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/treatments/{treatmentId}';
+
+        path = path.replace('{treatmentId}', parameters['treatmentId'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Get a treatment
+     * @method
+     * @name CBioPortalAPIInternal#getTreatmentUsingGETWithHttpInfo
+     * @param {string} treatmentId - Treatment ID e.g. GNF2_ZAP70
+     */
+    getTreatmentUsingGETWithHttpInfo(parameters: {
+        'treatmentId': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/treatments/{treatmentId}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+
+            path = path.replace('{treatmentId}', parameters['treatmentId'] + '');
+
+            if (parameters['treatmentId'] === undefined) {
+                reject(new Error('Missing required  parameter: treatmentId'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Get a treatment
+     * @method
+     * @name CBioPortalAPIInternal#getTreatmentUsingGET
+     * @param {string} treatmentId - Treatment ID e.g. GNF2_ZAP70
+     */
+    getTreatmentUsingGET(parameters: {
+        'treatmentId': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < Treatment > {
+        return this.getTreatmentUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    fetchTreatmentDataItemsUsingPOSTURL(parameters: {
+        'geneticProfileId': string,
+        'treatmentDataFilterCriteria': TreatmentDataFilterCriteria,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/genetic-profiles/{geneticProfileId}/treatment-genetic-data/fetch';
+
+        path = path.replace('{geneticProfileId}', parameters['geneticProfileId'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Fetch treatment "genetic data" items (treatment scores) by profile Id, treatment ids and sample ids
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentDataItemsUsingPOST
+     * @param {string} geneticProfileId - Genetic profile ID, e.g. gbm_tcga_treatment_ic50
+     * @param {} treatmentDataFilterCriteria - Search criteria to return the values for a given set of samples and treatment items. treatmentIds: The list of identifiers for the treatments of interest, e.g. `17-AAG`. Use one of these if you want to specify a subset of samples:(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01
+     */
+    fetchTreatmentDataItemsUsingPOSTWithHttpInfo(parameters: {
+        'geneticProfileId': string,
+        'treatmentDataFilterCriteria': TreatmentDataFilterCriteria,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/genetic-profiles/{geneticProfileId}/treatment-genetic-data/fetch';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            path = path.replace('{geneticProfileId}', parameters['geneticProfileId'] + '');
+
+            if (parameters['geneticProfileId'] === undefined) {
+                reject(new Error('Missing required  parameter: geneticProfileId'));
+                return;
+            }
+
+            if (parameters['treatmentDataFilterCriteria'] !== undefined) {
+                body = parameters['treatmentDataFilterCriteria'];
+            }
+
+            if (parameters['treatmentDataFilterCriteria'] === undefined) {
+                reject(new Error('Missing required  parameter: treatmentDataFilterCriteria'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Fetch treatment "genetic data" items (treatment scores) by profile Id, treatment ids and sample ids
+     * @method
+     * @name CBioPortalAPIInternal#fetchTreatmentDataItemsUsingPOST
+     * @param {string} geneticProfileId - Genetic profile ID, e.g. gbm_tcga_treatment_ic50
+     * @param {} treatmentDataFilterCriteria - Search criteria to return the values for a given set of samples and treatment items. treatmentIds: The list of identifiers for the treatments of interest, e.g. `17-AAG`. Use one of these if you want to specify a subset of samples:(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01
+     */
+    fetchTreatmentDataItemsUsingPOST(parameters: {
+            'geneticProfileId': string,
+            'treatmentDataFilterCriteria': TreatmentDataFilterCriteria,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < TreatmentMolecularData >
+        > {
+            return this.fetchTreatmentDataItemsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
 
     /**
      * Get the genes in a gene set that have expression correlated to the gene set scores (calculated using Spearman's correlation)

--- a/src/shared/cache/TreatmentCache.ts
+++ b/src/shared/cache/TreatmentCache.ts
@@ -1,0 +1,22 @@
+import LazyMobXCache from "../lib/LazyMobXCache";
+import {Treatment} from "../api/generated/CBioPortalAPIInternal";
+import internalClient from "../api/cbioportalInternalClientInstance";
+
+type Query = {
+    treatmentId:string;
+};
+
+function key(o:{treatmentId:string}) {
+    return o.treatmentId.toUpperCase();
+}
+
+async function fetch(queries:Query[]) {
+    return internalClient.fetchTreatmentsUsingPOST({treatmentIds: queries.map(q=>q.treatmentId.toUpperCase())});
+}
+
+export default class TreatmentCache extends LazyMobXCache<Treatment, Query> {
+
+    constructor() {
+        super(key, key, fetch);
+    }
+}

--- a/src/shared/cache/TreatmentMolecularDataCache.ts
+++ b/src/shared/cache/TreatmentMolecularDataCache.ts
@@ -1,0 +1,95 @@
+import LazyMobXCache, {AugmentedData} from "../lib/LazyMobXCache";
+import {TreatmentMolecularData, TreatmentDataFilterCriteria} from "../api/generated/CBioPortalAPIInternal";
+import client from "shared/api/cbioportalInternalClientInstance";
+import _ from "lodash";
+import {IDataQueryFilter} from "../lib/StoreUtils";
+
+interface IQuery {
+    treatmentId: string;
+    molecularProfileId: string;
+}
+
+type SampleFilterByProfile = {
+    [molecularProfileId: string]: IDataQueryFilter
+};
+
+function queryToKey(q: IQuery) {
+    return `${q.molecularProfileId}~${q.treatmentId}`;
+}
+
+function dataToKey(d:TreatmentMolecularData[], q:IQuery) {
+    return `${q.molecularProfileId}~${q.treatmentId}`;
+}
+
+/**
+/* Pairs each IQuery with an (array-wrapped) array of any matching data.
+*/
+function augmentQueryResults(queries: IQuery[], results: TreatmentMolecularData[][]) {
+    const keyedAugments: {[key: string]: AugmentedData<TreatmentMolecularData[], IQuery>} = {};
+    for (const query of queries) {
+        keyedAugments[queryToKey(query)] = {
+            data: [[]],
+            meta: query
+        };
+    }
+    for (const queryResult of results) {
+        for (let datum of queryResult) {
+            datum = handleValueTruncation(datum);
+            keyedAugments[
+                queryToKey({
+                    molecularProfileId: datum.geneticProfileId,
+                    treatmentId: datum.treatmentId
+                })
+            ].data[0].push(datum);
+        }
+    }
+    return _.values(keyedAugments);
+}
+
+// values are passed as strings from the REST facility
+// check for value truncators ('>' or '<') to appear in front of values
+// and convert to a numeric value and a separate truncation indicator
+function handleValueTruncation(datum:TreatmentMolecularData) {
+    let value = datum.value;
+    var matches = /([><]*)(.+)/.exec(value as string);
+    if (matches) {
+        datum.value = Number(matches[2]);
+        datum.truncation = (matches[1].length > 0) ? matches[1] : undefined;
+    } else {
+        datum.value = Number(value);
+        datum.truncation = undefined;
+    }
+    return datum;
+}
+
+async function fetch(
+    queries:IQuery[],
+    sampleFilterByProfile: SampleFilterByProfile
+): Promise<AugmentedData<TreatmentMolecularData[], IQuery>[]> {
+    const treatmentIdsByProfile = _.mapValues(
+        _.groupBy(queries, q => q.molecularProfileId),
+        profileQueries => profileQueries.map(q => q.treatmentId)
+    );
+    const params = Object.keys(treatmentIdsByProfile)
+        .map(profileId => ({
+            geneticProfileId: profileId,
+            // the Swagger-generated type expected by the client method below
+            // incorrectly requires both samples and a sample list;
+            // use 'as' to tell TypeScript that this object really does fit.
+            // tslint:disable-next-line: no-object-literal-type-assertion
+            treatmentDataFilterCriteria: {
+                treatmentIds: treatmentIdsByProfile[profileId],
+                ...sampleFilterByProfile[profileId]
+            } as TreatmentDataFilterCriteria
+        })
+    );
+    const dataPromises = params.map(param => client.fetchTreatmentDataItemsUsingPOST(param));
+    const results: TreatmentMolecularData[][] = await Promise.all(dataPromises);
+    return augmentQueryResults(queries, results);
+}
+
+export default class TreatmentMolecularDataCache extends LazyMobXCache<TreatmentMolecularData[], IQuery, IQuery>{
+    constructor(molecularProfileIdToSampleFilter: SampleFilterByProfile) {
+        super(queryToKey, dataToKey, fetch, molecularProfileIdToSampleFilter);
+    }
+}

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -280,7 +280,7 @@ export function fillHeatmapTrackDatum<T extends IBaseHeatmapTrackDatum, K extend
     featureKey: K,
     featureId: T[K],
     case_:Sample|Patient,
-    data?: {value: number}[]
+    data?: {value: number, truncation?: string}[]
 ) {
     trackDatum[featureKey] = featureId;
     trackDatum.study = case_.studyId;
@@ -289,6 +289,8 @@ export function fillHeatmapTrackDatum<T extends IBaseHeatmapTrackDatum, K extend
         trackDatum.na = true;
     } else if (data.length === 1) {
         trackDatum.profile_data = data[0].value;
+        trackDatum.truncation = data[0].truncation;
+        trackDatum.category = trackDatum.profile_data && trackDatum.truncation? `${trackDatum.truncation}${trackDatum.profile_data.toFixed(2)}` : undefined;
     } else {
         if (isSample(case_)) {
             throw Error("Unexpectedly received multiple heatmap profile data for one sample");
@@ -313,7 +315,7 @@ export function makeHeatmapTrackData<T extends IBaseHeatmapTrackDatum, K extends
     featureKey: K,
     featureId: T[K],
     cases:Sample[]|Patient[],
-    data: {value: number, uniquePatientKey: string, uniqueSampleKey: string}[]
+    data: {value: number, uniquePatientKey: string, uniqueSampleKey: string, truncation?: string}[]
 ): T[] {
     if (!cases.length) {
         return [];

--- a/src/shared/components/oncoprint/DeltaUtils.spec.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.spec.ts
@@ -9,7 +9,7 @@ import OncoprintJS from "oncoprintjs";
 import {
     CLINICAL_TRACK_GROUP_INDEX,
     GENETIC_TRACK_GROUP_INDEX,
-    IGeneHeatmapTrackSpec,
+    IHeatmapTrackSpec,
     IOncoprintProps
 } from "./Oncoprint";
 

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import OncoprintJS, {TrackId, CustomTrackOption} from "oncoprintjs";
 import {GenePanelData, MolecularProfile} from "../../api/generated/CBioPortalAPI";
+import {SortOrder} from "../../api/generated/CBioPortalAPIInternal";
 import {observer} from "mobx-react";
 import {computed} from "mobx";
 import {transition} from "./DeltaUtils";
@@ -51,12 +52,17 @@ export interface IBaseHeatmapTrackDatum {
     study: string;
     uid: string;
     na?:boolean;
+    category?:string
+    truncation?:string;
 }
 export interface IGeneHeatmapTrackDatum extends IBaseHeatmapTrackDatum {
     hugo_gene_symbol: string;
 }
 export interface IGenesetHeatmapTrackDatum extends IBaseHeatmapTrackDatum {
     geneset_id: string;
+}
+export interface ITreatmentHeatmapTrackDatum extends IBaseHeatmapTrackDatum {
+    treatment_id: string;
 }
 
 export type GeneticTrackDatum_Data =
@@ -99,7 +105,7 @@ export type GeneticTrackSpec = {
     labelColor?: string;
 };
 
-interface IBaseHeatmapTrackSpec {
+export interface IBaseHeatmapTrackSpec {
     key: string; // for efficient diffing, just like in React. must be unique
     label: string;
     molecularProfileId: string; // source
@@ -108,16 +114,24 @@ interface IBaseHeatmapTrackSpec {
     data: IBaseHeatmapTrackDatum[];
     trackGroupIndex: number;
 }
-export interface IGeneHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
-    data: IGeneHeatmapTrackDatum[];
-    onRemove: () => void;
+
+export interface IHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
+    data: IBaseHeatmapTrackDatum[]; // can be IGeneHeatmapTrackDatum or ITreatmentHeatmapTrackDatum
     info?: string;
     labelColor?: string;
+    trackLinkUrl?: string | undefined;
+    onRemove: () => void;
+    molecularProfileName?: String
+    pivotThreshold?: number;
+    sortOrder?: SortOrder;
+    maxProfileValue?: number;
+    ruleSetTrackId?: number;
+    category?:string;
 }
 export interface IGenesetHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     data: IGenesetHeatmapTrackDatum[];
     trackLinkUrl: string | undefined;
-    expansionTrackList: IGeneHeatmapTrackSpec[];
+    expansionTrackList: IHeatmapTrackSpec[];
     expansionCallback: () => void;
 }
 
@@ -131,7 +145,7 @@ export interface IOncoprintProps {
     geneticTracks: GeneticTrackSpec[];
     geneticTracksOrder?:string[]; // track keys
     genesetHeatmapTracks: IGenesetHeatmapTrackSpec[];
-    heatmapTracks: IGeneHeatmapTrackSpec[];
+    heatmapTracks: IHeatmapTrackSpec[];
     divId:string;
     width:number;
 

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -8,7 +8,8 @@ import client from "shared/api/cbioportalClientInstance";
 import {ClinicalTrackSpec, GeneticTrackDatum} from "./Oncoprint";
 import {
     AnnotatedExtendedAlteration, AnnotatedMutation, AnnotatedNumericGeneMolecularData,
-    ExtendedAlteration
+    ExtendedAlteration,
+    AlterationTypeConstants
 } from "../../../pages/resultsView/ResultsViewPageStore";
 import _ from "lodash";
 import {alterationTypeToProfiledForText} from "./ResultsViewOncoprintUtils";
@@ -97,18 +98,21 @@ export function makeHeatmapTrackTooltip(genetic_alteration_type:MolecularProfile
         let data_header = '';
         let profile_data = 'N/A';
         switch(genetic_alteration_type) {
-            case "MRNA_EXPRESSION":
+            case AlterationTypeConstants.MRNA_EXPRESSION:
                 data_header = 'MRNA: ';
                 break;
-            case "PROTEIN_LEVEL":
+            case AlterationTypeConstants.PROTEIN_LEVEL:
                 data_header = 'PROT: ';
                 break;
-            case "METHYLATION":
+            case AlterationTypeConstants.METHYLATION:
                 data_header = 'METHYLATION: ';
+                break;
+            case AlterationTypeConstants.TREATMENT_RESPONSE:
+                data_header = 'TREATMENT: ';
                 break;
         }
         if ((d.profile_data !== null) && (typeof d.profile_data !== "undefined")) {
-            profile_data = d.profile_data.toFixed(2);
+            profile_data = d.category || d.profile_data.toFixed(2);
         }
         let ret = data_header + '<b>' + profile_data + '</b><br>';
         ret += (d.sample ? (link_id ? sampleViewAnchorTag(d.study, d.sample) : d.sample) : (link_id ? patientViewAnchorTag(d.study, d.patient) : d.patient));

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -98,6 +98,7 @@ export interface IOncoprintControlsState {
     selectedHeatmapProfile?:string;
     heatmapIsDynamicallyQueried?:boolean;
     heatmapGeneInputValue?: string;
+    addToHeatmapButtonName?:string;
     clusterHeatmapButtonActive?:boolean;
     hideClusterHeatmapButton?:boolean;
     hideHeatmapMenu?:boolean;
@@ -447,7 +448,7 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
                                 className="btn btn-sm btn-default"
                                 name={EVENT_KEY.addGenesToHeatmap}
                                 onClick={this.onButtonClick}
-                             >Add Genes to Heatmap</button>,
+                            >{this.props.state.addToHeatmapButtonName}</button>,
 
                             <button
                                 key="removeHeatmapButton"

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -1,10 +1,11 @@
-import Oncoprint, {ClinicalTrackSpec, GeneticTrackSpec, IGeneHeatmapTrackSpec} from "./Oncoprint";
+import Oncoprint, {ClinicalTrackSpec, GeneticTrackSpec, IHeatmapTrackSpec, IGenesetHeatmapTrackSpec, IBaseHeatmapTrackSpec} from "./Oncoprint";
 import fileDownload from "react-file-download";
 
 export default function tabularDownload(
     geneticTracks:GeneticTrackSpec[],
     clinicalTracks:ClinicalTrackSpec[],
-    heatmapTracks:IGeneHeatmapTrackSpec[],
+    heatmapTracks: IHeatmapTrackSpec[],
+    genesetTracks: IGenesetHeatmapTrackSpec[],
     uidOrder:string[],
     getCaseId:(uid:string)=>string,
     columnMode:"sample"|"patient",
@@ -131,7 +132,8 @@ export default function tabularDownload(
     }
 
     //Add heatmap data
-    for (const heatmapTrack of heatmapTracks) {
+    const exportedHeatmapTracks = (heatmapTracks as IBaseHeatmapTrackSpec[]).concat(genesetTracks as IBaseHeatmapTrackSpec[]);
+    for (const heatmapTrack of exportedHeatmapTracks) {
         const currentHeatmapGene = heatmapTrack.label;
         const currentHeatmapType = "HEATMAP "+heatmapTrack.molecularAlterationType+' '+ heatmapTrack.datatype;
         const currentHeatmapTrackData = heatmapTrack.data;

--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -605,7 +605,7 @@ export default class BoxScatterPlot<D extends IBaseBoxScatterPlotPoint> extends 
                                 data={this.boxPlotData}
                                 horizontal={this.props.horizontal}
                             />
-                            {this.scatterPlotData.map(dataWithAppearance=>(
+                            {this.scatterPlotData.map((dataWithAppearance:any)=>(
                                 <VictoryScatter
                                     key={`${dataWithAppearance.fill},${dataWithAppearance.stroke},${dataWithAppearance.strokeWidth},${dataWithAppearance.strokeOpacity},${dataWithAppearance.fillOpacity}`}
                                     style={{

--- a/src/shared/components/plots/PlotUtils.ts
+++ b/src/shared/components/plots/PlotUtils.ts
@@ -174,7 +174,7 @@ export function separateScatterDataByAppearance<D>(
     stroke:string,
     strokeWidth:number,
     strokeOpacity:number,
-    fillOpacity:number
+    fillOpacity:number,
 }[] {
     let buckets:{
         data:D[],
@@ -187,7 +187,7 @@ export function separateScatterDataByAppearance<D>(
     }[] = [];
 
     let d_fill:string, d_stroke:string, d_strokeWidth:number, d_strokeOpacity:number, d_fillOpacity:number,
-        d_sortBy:any[], bucketFound:boolean;
+        d_symbol:string, d_sortBy:any[], bucketFound:boolean;
 
     for (const datum of data) {
         // compute appearance for datum
@@ -247,4 +247,11 @@ export function computeCorrelationPValue(correlation:number, numSamples:number) 
     } else {
         return null;
     }
+}
+
+export function dataPointIsTruncated(point:any) {
+    let o = (point.xtruncation !== undefined && point.xtruncation !== "")
+    || (point.ytruncation !== undefined && point.ytruncation !== "")
+    || (point.truncation !== undefined && point.truncation !== "");
+    return o;
 }

--- a/src/shared/components/plots/ScatterPlot.tsx
+++ b/src/shared/components/plots/ScatterPlot.tsx
@@ -383,7 +383,7 @@ export default class ScatterPlot<D extends IBaseScatterPlotData> extends React.C
                                 axisLabelComponent={<VictoryLabel dy={-35}/>}
                                 label={this.props.axisLabelY}
                             />
-                            { this.data.map(dataWithAppearance=>(
+                            { this.data.map( (dataWithAppearance:any)=>(
                                 <VictoryScatter
                                     key={`${dataWithAppearance.fill},${dataWithAppearance.stroke},${dataWithAppearance.strokeWidth},${dataWithAppearance.strokeOpacity},${dataWithAppearance.fillOpacity}`}
                                     style={{

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -60,6 +60,7 @@ export type CancerStudyQueryUrlParams = {
     genetic_profile_ids_PROFILE_METHYLATION: string,
     genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: string,
     genetic_profile_ids_PROFILE_GENESET_SCORE: string,
+    genetic_profile_ids_PROFILE_TREATMENT_RESPONSE: string,
     Z_SCORE_THRESHOLD: string,
     RPPA_SCORE_THRESHOLD: string,
     data_priority: '0' | '1' | '2',
@@ -67,6 +68,7 @@ export type CancerStudyQueryUrlParams = {
     case_ids: string,
     gene_list: string,
     geneset_list?: string,
+    treatment_list?: string,
     tab_index: 'tab_download' | 'tab_visualize',
     transpose_matrix?: 'on',
     Action: 'Submit',
@@ -96,7 +98,8 @@ export type CancerStudyQueryParams = Pick<QueryStore,
     'caseIds' |
     'caseIdsMode' |
     'geneQuery' |
-    'genesetQuery'>;
+    'genesetQuery' |
+	'treatmentQuery'>;
 export const QueryParamsKeys: (keyof CancerStudyQueryParams)[] = [
     'searchText',
     'selectableSelectedStudyIds',
@@ -109,6 +112,7 @@ export const QueryParamsKeys: (keyof CancerStudyQueryParams)[] = [
     'caseIdsMode',
     'geneQuery',
     'genesetQuery',
+	'treatmentQuery'
 ];
 
 type GenesetId = string;
@@ -374,6 +378,18 @@ export class QueryStore {
         // clear error when gene query is modified
         this.genesetQueryErrorDisplayStatus = 'unfocused';
         this._genesetQuery = value;
+	}
+	
+	@observable _treatmentQuery = '';
+    get treatmentQuery()
+    {
+        return this._treatmentQuery;
+    }
+    set treatmentQuery(value:string)
+    {
+        // clear error when gene query is modified
+        this.treatmentQueryErrorDisplayStatus = 'unfocused';
+        this._treatmentQuery = value;
     }
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -382,6 +398,7 @@ export class QueryStore {
 
     @observable geneQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
     @observable genesetQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
+    @observable treatmentQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
     @observable showMutSigPopup = false;
     @observable showGisticPopup = false;
     @observable showGenesetsHierarchyPopup = false;
@@ -1520,6 +1537,7 @@ export class QueryStore {
             params.genetic_profile_ids_PROFILE_METHYLATION,
             params.genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION,
             params.genetic_profile_ids_PROFILE_GENESET_SCORE,
+            params.genetic_profile_ids_PROFILE_TREATMENT_RESPONSE
         ];
 
         let queriedStudies = params.cancer_study_list ? params.cancer_study_list.split(",") : (params.cancer_study_id ? [params.cancer_study_id] : []);
@@ -1535,6 +1553,7 @@ export class QueryStore {
         this.caseIdsMode = 'sample'; // url always contains sample IDs
         this.geneQuery = normalizeQuery(decodeURIComponent(params.gene_list || ''));
         this.genesetQuery = normalizeQuery(decodeURIComponent(params[QueryParameter.GENESET_LIST] || ''));
+        this.treatmentQuery = decodeURIComponent(params[QueryParameter.TREATMENT_LIST] || ''); // pvannierop: removed the conversion to uppercase
         this.forDownloadTab = params.tab_index === 'tab_download';
         this.initiallySelected.profileIds = true;
         this.initiallySelected.sampleListId = true;

--- a/src/shared/components/query/QueryStoreUtils.ts
+++ b/src/shared/components/query/QueryStoreUtils.ts
@@ -6,12 +6,13 @@ import { VirtualStudy } from "shared/model/VirtualStudy";
 
 export type NonMolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
     'cancer_study_id' | 'cancer_study_list' | 'Z_SCORE_THRESHOLD' | 'RPPA_SCORE_THRESHOLD' | 'data_priority' |
-    'case_set_id' | 'case_ids' | 'gene_list' | 'geneset_list' | 'tab_index' | 'transpose_matrix' | 'Action'>;
+    'case_set_id' | 'case_ids' | 'gene_list' | 'geneset_list' | 'treatment_list' | 'tab_index' | 'transpose_matrix' | 'Action'>;
 
 export type MolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
     'genetic_profile_ids_PROFILE_MUTATION_EXTENDED' | 'genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION' |
     'genetic_profile_ids_PROFILE_MRNA_EXPRESSION' | 'genetic_profile_ids_PROFILE_METHYLATION' |
-    'genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION' | 'genetic_profile_ids_PROFILE_GENESET_SCORE'>;
+    'genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION' | 'genetic_profile_ids_PROFILE_GENESET_SCORE' |
+    'genetic_profile_ids_PROFILE_TREATMENT_RESPONSE' >;
 
 
 export function currentQueryParams(store:QueryStore) {
@@ -52,6 +53,7 @@ export function nonMolecularProfileParams(store:QueryStore, whitespace_separated
         case_ids,
         gene_list: encodeURIComponent(normalizeQuery(store.geneQuery) || ' '), // empty string won't work
         geneset_list: normalizeQuery(store.genesetQuery) || ' ', //empty string won't work
+        treatment_list: normalizeQuery(store.treatmentQuery) || ' ', //empty string won't work
         tab_index: store.forDownloadTab ? 'tab_download' : 'tab_visualize' as any,
         transpose_matrix: store.transposeDataMatrix ? 'on' : undefined,
         Action: 'Submit',
@@ -71,7 +73,8 @@ export function molecularProfileParams(store:QueryStore, molecularProfileIds?:Re
         genetic_profile_ids_PROFILE_MRNA_EXPRESSION: store.getSelectedProfileIdFromMolecularAlterationType("MRNA_EXPRESSION", molecularProfileIds),
         genetic_profile_ids_PROFILE_METHYLATION: store.getSelectedProfileIdFromMolecularAlterationType("METHYLATION", molecularProfileIds) || store.getSelectedProfileIdFromMolecularAlterationType("METHYLATION_BINARY", molecularProfileIds),
         genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: store.getSelectedProfileIdFromMolecularAlterationType("PROTEIN_LEVEL", molecularProfileIds),
-        genetic_profile_ids_PROFILE_GENESET_SCORE: store.getSelectedProfileIdFromMolecularAlterationType("GENESET_SCORE", molecularProfileIds)
+        genetic_profile_ids_PROFILE_GENESET_SCORE: store.getSelectedProfileIdFromMolecularAlterationType("GENESET_SCORE", molecularProfileIds),
+        genetic_profile_ids_PROFILE_TREATMENT_RESPONSE: store.getSelectedProfileIdFromMolecularAlterationType("TREATMENT_RESPONSE", molecularProfileIds)
     };
 }
 

--- a/src/shared/lib/ExtendedRouterStore.ts
+++ b/src/shared/lib/ExtendedRouterStore.ts
@@ -60,6 +60,7 @@ export enum QueryParameter {
     CANCER_STUDY_ID="cancer_study_id",
     DATA_PRIORITY="data_priority",
     GENESET_LIST="geneset_list",
+    TREATMENT_LIST="treatment_list",
     TAB_INDEX="tab_index",
     TRANSPOSE_MATRIX="transpose_matrix",
     ACTION="Action"


### PR DESCRIPTION
# What? Why?
This PR will implement handling of the new `treatment response` (genetic entity) data type by the OncoPrint component (see [this backend PR](https://github.com/cBioPortal/cbioportal/pull/5460)).

## Changes
- Treatment response profiles are shown in the heatmap menu (when available in cBioPortal db) (see Fig.1). When a treatment response value is selected, treatments can be added as a heatmap track by pressing the `Add Treatments to Heatmap` button.
- Treatment data points can be _truncated_ (real value lies beyond a certain value) which can be indicated by `>` or `<` prefixes to values. Heatmap track for treatment profiles are represented with a new legend type that shows continuous values (gradient) and truncated values (categories) (see Fig.2). Clustering of treatment heatmap tracks that contain truncated values used the truncated value for respective samples (for example _8_ represents truncated value _>8_). 
- Tooltips on a treatment heatmap track contain an url to external websites (when defined in cbioportal db) (see Fig.2).

## Notes
- In this PR treatments are entered by typing the stable_id of treatments in the text box in the heatmap menu. A new input menu for treatments that allows users to search for treatments is implemented in a different PR.
- This PR is dependent on an updated version of oncoprintjs (v2.0.0).

## Images
### Figure 1
1. Treatment profile shown in heatmap menu
2. Button name shows `Add Treatments to Heatmap` when treatment profile is selected
![screenshot from 2019-02-20 13-10-22](https://user-images.githubusercontent.com/745885/53091507-631c6700-3512-11e9-98b3-47dab934972c.png)

### Figure 2
1. Treatment profile shown as heatmap track
2. New legend type with continuous and truncated values
3. URL in tooltip of treatment heatmap tracks
![screenshot from 2019-02-20 13-16-24](https://user-images.githubusercontent.com/745885/53091672-d625dd80-3512-11e9-9b34-8ff8e5a9250d.png)
 