### PR TITLE
group comparison - combine amp and del into one component in CNA tab

### DIFF
--- a/src/pages/groupComparison/CopyNumberEnrichments.tsx
+++ b/src/pages/groupComparison/CopyNumberEnrichments.tsx
@@ -9,6 +9,7 @@ import {MakeMobxView} from "../../shared/components/MobxView";
 import Loader from "../../shared/components/loadingIndicator/LoadingIndicator";
 import ErrorMessage from "../../shared/components/ErrorMessage";
 import { ENRICHMENTS_NOT_2_GROUPS_MSG } from "./GroupComparisonUtils";
+import {AlterationEnrichmentTableColumnType} from "../resultsView/enrichments/AlterationEnrichmentsTable";
 
 export interface ICopyNumberEnrichmentsProps {
     store: GroupComparisonStore
@@ -44,35 +45,29 @@ export default class CopyNumberEnrichments extends React.Component<ICopyNumberEn
 
     readonly enrichmentsUI = MakeMobxView({
         await:()=>[
-            this.props.store.copyNumberHomdelEnrichmentData,
-            this.props.store.copyNumberAmpEnrichmentData,
+            this.props.store.copyNumberData,
             this.props.store.copyNumberEnrichmentProfile,
             this.props.store.enrichmentsGroup1,
             this.props.store.enrichmentsGroup2
         ],
         render:()=>{
+            const group1Name = this.props.store.enrichmentsGroup1.result!.name;
+            const group2Name = this.props.store.enrichmentsGroup2.result!.name;
             return (
                 <div data-test="GroupComparisonCopyNumberEnrichments">
                     <EnrichmentsDataSetDropdown dataSets={this.props.store.copyNumberEnrichmentProfiles} onChange={this.onChangeProfile}
                                                 selectedValue={this.props.store.copyNumberEnrichmentProfile.result!.molecularProfileId}/>
-                    <AlterationEnrichmentContainer data={this.props.store.copyNumberHomdelEnrichmentData.result!}
-                                                totalAlteredCount={this.props.store.enrichmentsGroup1.result!.sampleIdentifiers.length}
-                                                totalUnalteredCount={this.props.store.enrichmentsGroup2.result!.sampleIdentifiers.length}
-                                                alteredGroupName={this.props.store.enrichmentsGroup1.result!.name}
-                                                unalteredGroupName={this.props.store.enrichmentsGroup2.result!.name}
-                                                selectedProfile={this.props.store.copyNumberEnrichmentProfile.result!}
-                                                headerName={"Deep Deletion - " + this.props.store.copyNumberEnrichmentProfile.result!.name}
-                                                alterationType="a deep deletion"/>
-                    <hr />
-                    <AlterationEnrichmentContainer data={this.props.store.copyNumberAmpEnrichmentData.result!}
-                                                totalAlteredCount={this.props.store.enrichmentsGroup1.result!.sampleIdentifiers.length}
-                                                totalUnalteredCount={this.props.store.enrichmentsGroup2.result!.sampleIdentifiers.length}
-                                                alteredGroupName={this.props.store.enrichmentsGroup1.result!.name}
-                                                unalteredGroupName={this.props.store.enrichmentsGroup2.result!.name}
-                                                selectedProfile={this.props.store.copyNumberEnrichmentProfile.result!}
-                                                headerName={"Amplification - " + this.props.store.copyNumberEnrichmentProfile.result!.name}
-                                                alterationType="an amplification"
-                                               showMutexTendencyInTable={false}
+                    <AlterationEnrichmentContainer data={this.props.store.copyNumberData.result!}
+                                                   totalGroup1Count={this.props.store.enrichmentsGroup1.result!.sampleIdentifiers.length}
+                                                   totalGroup2Count={this.props.store.enrichmentsGroup2.result!.sampleIdentifiers.length}
+                                                   group1Name={group1Name}
+                                                   group2Name={group2Name}
+                                                   group1Description={`in ${group1Name} that have the listed alteration in the listed gene.`}
+                                                   group2Description={`in ${group2Name} that have the listed alteration in the listed gene.`}
+                                                   selectedProfile={this.props.store.copyNumberEnrichmentProfile.result!}
+                                                   headerName={this.props.store.copyNumberEnrichmentProfile.result!.name}
+                                                   showMutexTendencyInTable={false}
+                                                   showCNAInTable={true}
                     />
                 </div>
             );

--- a/src/pages/groupComparison/GroupComparisonUtils.ts
+++ b/src/pages/groupComparison/GroupComparisonUtils.ts
@@ -5,6 +5,7 @@ import _ from "lodash";
 import {ResultsViewTab} from "../resultsView/ResultsViewPageHelpers";
 import {GroupComparisonTab} from "./GroupComparisonPage";
 import {StudyViewFilter} from "../../shared/api/generated/CBioPortalAPIInternal";
+import {AlterationEnrichmentWithQ} from "../resultsView/enrichments/EnrichmentsUtil";
 
 export type ComparisonSampleGroup = {
     // mandatory:
@@ -22,6 +23,8 @@ export type ComparisonGroup = ComparisonSampleGroup & {
     hasOverlappingSamples?:boolean; // whether the group has had samples filtered out because they overlapped in the selection
     hasOverlappingPatients?:boolean; // whether the group has had patients filtered out because they overlapped in the selection
 };
+
+export type CopyNumberEnrichment = AlterationEnrichmentWithQ & { value:number };
 
 export function getCombinations(groups: { name: string, cases: string[] }[]) {
     let combinations: { groups: string[], cases: string[] }[] = [];

--- a/src/pages/groupComparison/MRNAEnrichments.tsx
+++ b/src/pages/groupComparison/MRNAEnrichments.tsx
@@ -55,13 +55,17 @@ export default class MRNAEnrichments extends React.Component<IMRNAEnrichmentsPro
             this.props.store.enrichmentsGroup2
         ],
         render:()=>{
+            const group1Name = this.props.store.enrichmentsGroup1.result!.name;
+            const group2Name = this.props.store.enrichmentsGroup2.result!.name;
             return (
                 <div data-test="GroupComparisonMRNAEnrichments">
                     <EnrichmentsDataSetDropdown dataSets={this.props.store.mRNAEnrichmentProfiles} onChange={this.onChangeProfile}
                                                 selectedValue={this.props.store.mRNAEnrichmentProfile.result!.molecularProfileId}/>
                     <ExpressionEnrichmentContainer data={this.props.store.mRNAEnrichmentData.result!}
-                                                   alteredGroupName={this.props.store.enrichmentsGroup1.result!.name}
-                                                   unalteredGroupName={this.props.store.enrichmentsGroup2.result!.name}
+                                                   group1Name={group1Name}
+                                                   group2Name={group2Name}
+                                                   group1Description={`samples in ${group1Name}.`}
+                                                   group2Description={`samples in ${group2Name}.`}
                                                    selectedProfile={this.props.store.mRNAEnrichmentProfile.result!}
                                                    showMutexTendencyInTable={false}
                     />

--- a/src/pages/groupComparison/MutationEnrichments.tsx
+++ b/src/pages/groupComparison/MutationEnrichments.tsx
@@ -52,19 +52,22 @@ export default class MutationEnrichments extends React.Component<IMutationEnrich
             this.props.store.activeComparisonGroups
         ],
         render:()=>{
+            const group1Name = this.props.store.enrichmentsGroup1.result!.name;
+            const group2Name = this.props.store.enrichmentsGroup2.result!.name;
             return (
                 <div data-test="GroupComparisonMutationEnrichments">
                     <EnrichmentsDataSetDropdown dataSets={this.props.store.mutationEnrichmentProfiles} onChange={this.onChangeProfile}
                                                 selectedValue={this.props.store.mutationEnrichmentProfile.result!.molecularProfileId}/>
                     <AlterationEnrichmentContainer data={this.props.store.mutationEnrichmentData.result!}
-                                                totalAlteredCount={this.props.store.enrichmentsGroup1.result!.sampleIdentifiers.length}
-                                                totalUnalteredCount={this.props.store.enrichmentsGroup2.result!.sampleIdentifiers.length}
-                                                alteredGroupName={this.props.store.enrichmentsGroup1.result!.name}
-                                                unalteredGroupName={this.props.store.enrichmentsGroup2.result!.name}
-                                                selectedProfile={this.props.store.mutationEnrichmentProfile.result!}
-                                                headerName={this.props.store.mutationEnrichmentProfile.result!.name}
-                                                alterationType="a mutation"
-                                                showMutexTendencyInTable={false}
+                                                   totalGroup1Count={this.props.store.enrichmentsGroup1.result!.sampleIdentifiers.length}
+                                                   totalGroup2Count={this.props.store.enrichmentsGroup2.result!.sampleIdentifiers.length}
+                                                   group1Name={group1Name}
+                                                   group2Name={group2Name}
+                                                   group1Description={`in ${group1Name} that have a mutation in the listed gene.`}
+                                                   group2Description={`in ${group2Name} that have a mutation in the listed gene.`}
+                                                   selectedProfile={this.props.store.mutationEnrichmentProfile.result!}
+                                                   headerName={this.props.store.mutationEnrichmentProfile.result!.name}
+                                                   showMutexTendencyInTable={false}
                     />
                 </div>
             );

--- a/src/pages/groupComparison/ProteinEnrichments.tsx
+++ b/src/pages/groupComparison/ProteinEnrichments.tsx
@@ -54,13 +54,17 @@ export default class ProteinEnrichments extends React.Component<IProteinEnrichme
             this.props.store.enrichmentsGroup2
         ],
         render:()=>{
+            const group1Name = this.props.store.enrichmentsGroup1.result!.name;
+            const group2Name = this.props.store.enrichmentsGroup2.result!.name;
             return (
                 <div data-test="GroupComparisonProteinEnrichments">
                     <EnrichmentsDataSetDropdown dataSets={this.props.store.proteinEnrichmentProfiles} onChange={this.onChangeProfile}
                                                 selectedValue={this.props.store.proteinEnrichmentProfile.result!.molecularProfileId}/>
                     <ExpressionEnrichmentContainer data={this.props.store.proteinEnrichmentData.result!}
-                                                   alteredGroupName={this.props.store.enrichmentsGroup1.result!.name}
-                                                   unalteredGroupName={this.props.store.enrichmentsGroup2.result!.name}
+                                                   group1Name={this.props.store.enrichmentsGroup1.result!.name}
+                                                   group2Name={this.props.store.enrichmentsGroup2.result!.name}
+                                                   group1Description={`samples in ${group1Name}.`}
+                                                   group2Description={`samples in ${group2Name}.`}
                                                    selectedProfile={this.props.store.proteinEnrichmentProfile.result!}
                                                    showMutexTendencyInTable={false}
                     />

--- a/src/pages/resultsView/enrichments/CopyNumberEnrichmentsTab.tsx
+++ b/src/pages/resultsView/enrichments/CopyNumberEnrichmentsTab.tsx
@@ -37,15 +37,15 @@ export default class CopyNumberEnrichmentsTab extends React.Component<ICopyNumbe
                                                     selectedValue={this.props.store.selectedEnrichmentCopyNumberProfile.molecularProfileId}
                                                     molecularProfileIdToProfiledSampleCount={this.props.store.molecularProfileIdToProfiledSampleCount}/>
                         <AlterationEnrichmentContainer data={this.props.store.copyNumberHomdelEnrichmentData.result!}
-                                                       totalAlteredCount={this.props.store.alteredSampleKeys.result!.length}
-                                                       totalUnalteredCount={this.props.store.unalteredSampleKeys.result!.length}
+                                                       totalGroup1Count={this.props.store.alteredSampleKeys.result!.length}
+                                                       totalGroup2Count={this.props.store.unalteredSampleKeys.result!.length}
                                                        selectedProfile={this.props.store.selectedEnrichmentCopyNumberProfile}
                                                        headerName={"Deep Deletion - " + this.props.store.selectedEnrichmentCopyNumberProfile.name}
                                                        store={this.props.store} alterationType="a deep deletion"/>
                         <hr />
                         <AlterationEnrichmentContainer data={this.props.store.copyNumberAmpEnrichmentData.result!}
-                                                       totalAlteredCount={this.props.store.alteredSampleKeys.result!.length}
-                                                       totalUnalteredCount={this.props.store.unalteredSampleKeys.result!.length}
+                                                       totalGroup1Count={this.props.store.alteredSampleKeys.result!.length}
+                                                       totalGroup2Count={this.props.store.unalteredSampleKeys.result!.length}
                                                        selectedProfile={this.props.store.selectedEnrichmentCopyNumberProfile}
                                                        headerName={"Amplification - " + this.props.store.selectedEnrichmentCopyNumberProfile.name}
                                                        store={this.props.store} alterationType="an amplification"/>

--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.spec.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.spec.tsx
@@ -56,7 +56,8 @@ const exampleAlterationEnrichmentRowData = [
         "unalteredPercentage": 0,
         "logRatio": Infinity,
         "pValue": 0.00003645111904935468,
-        "qValue": 0.2521323904643863
+        "qValue": 0.2521323904643863,
+        "value":undefined
     },
     {
         "checked": false,
@@ -70,7 +71,8 @@ const exampleAlterationEnrichmentRowData = [
         "unalteredPercentage": 0,
         "logRatio": Infinity,
         "pValue": 0.0015673981191222392,
-        "qValue": 0.9385345997286061
+        "qValue": 0.9385345997286061,
+        "value":undefined
     }, 
     {
         "checked": false,
@@ -84,7 +86,8 @@ const exampleAlterationEnrichmentRowData = [
         "unalteredPercentage": 0,
         "logRatio": Infinity,
         "pValue": 0.0015673981191222392,
-        "qValue": 0.9385345997286061
+        "qValue": 0.9385345997286061,
+        "value":undefined
     }
 ];
 

--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
@@ -14,7 +14,7 @@ import {filterAndSortProfiles} from "../coExpression/CoExpressionTabUtils";
 const LOG_VALUE = "LOG-VALUE";
 const LOG2_VALUE = "LOG2-VALUE";
 
-export type AlterationEnrichmentWithQ = AlterationEnrichment & { qValue:number };
+export type AlterationEnrichmentWithQ = AlterationEnrichment & { qValue:number, value?:number /* used for copy number in group comparison */ };
 export type ExpressionEnrichmentWithQ = ExpressionEnrichment & { qValue:number };
 
 export function calculateAlterationTendency(logOddsRatio: number): string {
@@ -82,7 +82,8 @@ export function getAlterationRowData(alterationEnrichments: AlterationEnrichment
             unalteredPercentage: alterationEnrichment.unalteredCount / totalUnaltered * 100,
             logRatio: Number(alterationEnrichment.logRatio), 
             pValue: alterationEnrichment.pValue,
-            qValue: alterationEnrichment.qValue
+            qValue: alterationEnrichment.qValue,
+            value: alterationEnrichment.value
         };
     });
 }

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsContainer.tsx
@@ -24,8 +24,10 @@ import { EnrichmentsTableDataStore } from 'pages/resultsView/enrichments/Enrichm
 export interface IExpressionEnrichmentContainerProps {
     data: ExpressionEnrichmentWithQ[];
     selectedProfile: MolecularProfile;
-    alteredGroupName?:string;
-    unalteredGroupName?:string;
+    group1Name?:string;
+    group2Name?:string;
+    group1Description?:string;
+    group2Description?:string;
     store?: ResultsViewPageStore;
     showMutexTendencyInTable?:boolean;
 }
@@ -34,8 +36,10 @@ export interface IExpressionEnrichmentContainerProps {
 export default class ExpressionEnrichmentContainer extends React.Component<IExpressionEnrichmentContainerProps, {}> {
 
     static defaultProps:Partial<IExpressionEnrichmentContainerProps> = {
-        alteredGroupName: "altered group",
-        unalteredGroupName: "unaltered group",
+        group1Name: "altered group",
+        group2Name: "unaltered group",
+        group1Description: "samples that have alterations in the query gene(s).",
+        group2Description: "samples that do not have alterations in the query gene(s).",
         showMutexTendencyInTable: true
     };
 
@@ -173,8 +177,10 @@ export default class ExpressionEnrichmentContainer extends React.Component<IExpr
                         </Checkbox>
                     </div>
                     <ExpressionEnrichmentTable data={this.filteredData} onCheckGene={this.props.store ? this.onCheckGene : undefined}
-                       onGeneNameClick={this.props.store ? this.onGeneNameClick : undefined} dataStore={this.dataStore} alteredGroupName={this.props.alteredGroupName!} unalteredGroupName={this.props.unalteredGroupName!}
-                       mutexTendency={this.props.showMutexTendencyInTable}
+                                               onGeneNameClick={this.props.store ? this.onGeneNameClick : undefined} dataStore={this.dataStore} group1Name={this.props.group1Name!} group2Name={this.props.group2Name!}
+                                               mutexTendency={this.props.showMutexTendencyInTable}
+                                               group1Description={this.props.group1Description!}
+                                               group2Description={this.props.group2Description!}
                     />
                 </div>
             </div>

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsTable.tsx
@@ -20,18 +20,20 @@ export interface IExpressionEnrichmentTableProps {
     dataStore: EnrichmentsTableDataStore;
     onCheckGene?: (hugoGeneSymbol: string) => void;
     onGeneNameClick?: (hugoGeneSymbol: string, entrezGeneId: number) => void;
-    alteredGroupName:string;
-    unalteredGroupName:string;
+    group1Name:string;
+    group2Name:string;
+    group1Description:string;
+    group2Description:string;
     mutexTendency?:boolean;
 }
 
 export enum ExpressionEnrichmentTableColumnType {
     GENE,
     CYTOBAND,
-    MEAN_IN_ALTERED,
-    MEAN_IN_UNALTERED,
-    STANDARD_DEVIATION_IN_ALTERED,
-    STANDARD_DEVIATION_IN_UNALTERED,
+    MEAN_IN_GROUP1,
+    MEAN_IN_GROUP2,
+    STANDARD_DEVIATION_IN_GROUP1,
+    STANDARD_DEVIATION_IN_GROUP2,
     LOG_RATIO,
     P_VALUE,
     Q_VALUE,
@@ -50,10 +52,10 @@ export default class ExpressionEnrichmentTable extends React.Component<IExpressi
         columns: [
             ExpressionEnrichmentTableColumnType.GENE,
             ExpressionEnrichmentTableColumnType.CYTOBAND,
-            ExpressionEnrichmentTableColumnType.MEAN_IN_ALTERED,
-            ExpressionEnrichmentTableColumnType.MEAN_IN_UNALTERED,
-            ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_ALTERED,
-            ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_UNALTERED,
+            ExpressionEnrichmentTableColumnType.MEAN_IN_GROUP1,
+            ExpressionEnrichmentTableColumnType.MEAN_IN_GROUP2,
+            ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_GROUP1,
+            ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_GROUP2,
             ExpressionEnrichmentTableColumnType.LOG_RATIO,
             ExpressionEnrichmentTableColumnType.P_VALUE,
             ExpressionEnrichmentTableColumnType.Q_VALUE,
@@ -102,34 +104,34 @@ export default class ExpressionEnrichmentTable extends React.Component<IExpressi
             download: (d: ExpressionEnrichmentRow) => d.cytoband
         };
 
-        columns[ExpressionEnrichmentTableColumnType.MEAN_IN_ALTERED] = {
-            name: `μ in ${this.props.alteredGroupName}`,
+        columns[ExpressionEnrichmentTableColumnType.MEAN_IN_GROUP1] = {
+            name: `μ in ${this.props.group1Name}`,
             render: (d: ExpressionEnrichmentRow) => <span>{d.meanExpressionInAlteredGroup.toFixed(2)}</span>,
-            tooltip: <span>Mean expression of the listed gene in samples that have alterations in the query gene(s).</span>,
+            tooltip: <span>Mean expression of the listed gene in {this.props.group1Description}</span>,
             sortBy: (d: ExpressionEnrichmentRow) => d.meanExpressionInAlteredGroup,
             download: (d: ExpressionEnrichmentRow) => d.meanExpressionInAlteredGroup.toFixed(2)
         };
 
-        columns[ExpressionEnrichmentTableColumnType.MEAN_IN_UNALTERED] = {
-            name: `μ in ${this.props.unalteredGroupName}`,
+        columns[ExpressionEnrichmentTableColumnType.MEAN_IN_GROUP2] = {
+            name: `μ in ${this.props.group2Name}`,
             render: (d: ExpressionEnrichmentRow) => <span>{d.meanExpressionInUnalteredGroup.toFixed(2)}</span>,
-            tooltip: <span>Mean expression of the listed gene in samples that do not have alterations in the query gene(s).</span>,
+            tooltip: <span>Mean expression of the listed gene in {this.props.group2Description}</span>,
             sortBy: (d: ExpressionEnrichmentRow) => d.meanExpressionInUnalteredGroup,
             download: (d: ExpressionEnrichmentRow) => d.meanExpressionInUnalteredGroup.toFixed(2)
         };
 
-        columns[ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_ALTERED] = {
-            name: `σ in ${this.props.alteredGroupName}`,
+        columns[ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_GROUP1] = {
+            name: `σ in ${this.props.group1Name}`,
             render: (d: ExpressionEnrichmentRow) => <span>{d.standardDeviationInAlteredGroup.toFixed(2)}</span>,
-            tooltip: <span>Standard deviation of expression of the listed gene in samples that have alterations in the query gene(s).</span>,
+            tooltip: <span>Standard deviation of expression of the listed gene in {this.props.group1Description}</span>,
             sortBy: (d: ExpressionEnrichmentRow) => d.standardDeviationInAlteredGroup,
             download: (d: ExpressionEnrichmentRow) => d.standardDeviationInAlteredGroup.toFixed(2)
         };
 
-        columns[ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_UNALTERED] = {
-            name: `σ in ${this.props.unalteredGroupName}`,
+        columns[ExpressionEnrichmentTableColumnType.STANDARD_DEVIATION_IN_GROUP2] = {
+            name: `σ in ${this.props.group2Name}`,
             render: (d: ExpressionEnrichmentRow) => <span>{d.standardDeviationInUnalteredGroup.toFixed(2)}</span>,
-            tooltip: <span>Standard deviation of expression of the listed gene in samples that do not have alterations in the query gene(s).</span>,
+            tooltip: <span>Standard deviation of expression of the listed gene in {this.props.group2Description}</span>,
             sortBy: (d: ExpressionEnrichmentRow) => d.standardDeviationInUnalteredGroup,
             download: (d: ExpressionEnrichmentRow) => d.standardDeviationInUnalteredGroup.toFixed(2)
         };
@@ -161,7 +163,7 @@ export default class ExpressionEnrichmentTable extends React.Component<IExpressi
         columns[ExpressionEnrichmentTableColumnType.TENDENCY] = {
             name: this.props.mutexTendency ? "Tendency" : "Enriched in",
             render: (d: ExpressionEnrichmentRow) => <div className={styles.Tendency}>
-                {this.props.mutexTendency ? calculateExpressionTendency(Number(d.logRatio)) : calculateGenericTendency(Number(d.logRatio), this.props.alteredGroupName, this.props.unalteredGroupName)}
+                {this.props.mutexTendency ? calculateExpressionTendency(Number(d.logRatio)) : calculateGenericTendency(Number(d.logRatio), this.props.group1Name, this.props.group2Name)}
                 {d.qValue < 0.05 ? <Badge style={{
                     backgroundColor: '#58ACFA', fontSize: 8, marginBottom: 2
                 }}>Significant</Badge> : ""}</div>,
@@ -169,11 +171,11 @@ export default class ExpressionEnrichmentTable extends React.Component<IExpressi
                 <table>
                     <tr>
                         <td>Log ratio > 0</td>
-                        <td>: Over-expressed in {this.props.alteredGroupName}</td>
+                        <td>: Over-expressed in {this.props.group1Name}</td>
                     </tr>
                     <tr>
                         <td>Log ratio &lt;= 0</td>
-                        <td>: Under-expressed in {this.props.alteredGroupName}</td>
+                        <td>: Under-expressed in {this.props.group1Name}</td>
                     </tr>
                     <tr>
                         <td>q-Value &lt; 0.05</td>

--- a/src/pages/resultsView/enrichments/MutationEnrichmentsTab.tsx
+++ b/src/pages/resultsView/enrichments/MutationEnrichmentsTab.tsx
@@ -34,11 +34,11 @@ export default class MutationEnrichmentsTab extends React.Component<IMutationEnr
                         selectedValue={this.props.store.selectedEnrichmentMutationProfile.molecularProfileId}
                         molecularProfileIdToProfiledSampleCount={this.props.store.molecularProfileIdToProfiledSampleCount}/>
                     <AlterationEnrichmentContainer data={this.props.store.mutationEnrichmentData.result!}
-                        totalAlteredCount={this.props.store.alteredSampleKeys.result!.length}
-                        totalUnalteredCount={this.props.store.unalteredSampleKeys.result!.length}
-                        selectedProfile={this.props.store.selectedEnrichmentMutationProfile}
-                        headerName={this.props.store.selectedEnrichmentMutationProfile.name}
-                        store={this.props.store} alterationType="a mutation"/>
+                                                   totalGroup1Count={this.props.store.alteredSampleKeys.result!.length}
+                                                   totalGroup2Count={this.props.store.unalteredSampleKeys.result!.length}
+                                                   selectedProfile={this.props.store.selectedEnrichmentMutationProfile}
+                                                   headerName={this.props.store.selectedEnrichmentMutationProfile.name}
+                                                   store={this.props.store} alterationType="a mutation"/>
                 </div>
             );
         }

--- a/src/pages/studyView/chartHeader/ChartHeader.tsx
+++ b/src/pages/studyView/chartHeader/ChartHeader.tsx
@@ -198,7 +198,7 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
                                    onClick={() => this.props.changeChartType(ChartTypeEnum.PIE_CHART)}></i>
                             </DefaultTooltip>
                         </If>
-                        <If condition={this.props.chartControls && true}>
+                        <If condition={this.props.chartControls && this.props.chartControls.showComparisonPageIcon}>
                             <DefaultTooltip
                                 placement={tooltipPosition}
                                 align={tooltipAlign}

--- a/src/shared/model/AlterationEnrichmentRow.ts
+++ b/src/shared/model/AlterationEnrichmentRow.ts
@@ -11,4 +11,5 @@ export interface AlterationEnrichmentRow {
     logRatio: number;
     pValue: number;
     qValue: number;
+    value?:number; // for copy number, used in group comparison
 }


### PR DESCRIPTION
Also do some refactoring of enrichments components to not use "altered" and "unaltered"

Also fix bug where comparison page icon was appearing on non-pie charts