### PR TITLE
CircleCI: cache dist/ folder, src/ as hash key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,14 @@ jobs:
             node --version
             yarn --version
       - checkout
+      # cache build artifacts. Use concatenation of all source files as cache
+      # key. If there are no changes to src/ and yarn.lock, no need to rebuild
+      - run:
+          name: "Concatenate all source files to use as hash key for caching dist folder"
+          command: "cat yarn.lock $(find src/ -type f | sort) > has_source_changed"
       - restore_cache:
           keys:
+          - v1-dependencies-plus-dist-{{ checksum "has_source_changed" }}
           - v1-dependencies-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
@@ -38,8 +44,14 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
       - run:
-          name: "Run build"
-          command: 'yarn run build'
+          name: "Run build if no dist folder"
+          command: 'ls dist || yarn run build'
+      - save_cache:
+          paths:
+            - node_modules
+            - dist
+            - common-dist
+          key: v1-dependencies-plus-dist-{{ checksum "has_source_changed" }}
       - persist_to_workspace:
           root: /tmp
           paths:


### PR DESCRIPTION
Cache the artifacts in dist folder. No need to recompile if src/ folder hasn't
changed.

This has the advantage that when sending a PR that doesn't change the src code, one doesn't have to wait for the build complete.

That's 8m40s vs 1m16s

https://circleci.com/workflow-run/bc39c9bd-014d-483d-bcc6-b8a021d0031e

vs

https://circleci.com/workflow-run/514b3afb-534f-4e4b-a29b-bb26c7b1d04b

Unf saving to the cache does not work on forked PRs, but if u send a PR from a branch from the main repo, it also gives the advantage that when just changing e.g. e2e tests or unit tests one doesn't have to wait for the build phase again.