### PR TITLE
Add netlify as another place for loading frontend

### DIFF
--- a/src/pages/resultsView/network/files/load-frontend.js
+++ b/src/pages/resultsView/network/files/load-frontend.js
@@ -3,6 +3,7 @@ function clearDevState(e){
     localStorage.removeItem('localdev');
     localStorage.removeItem('localdist');
     localStorage.removeItem('heroku');
+    localStorage.removeItem('netlify');
     window.location.reload();
 }
 
@@ -35,7 +36,7 @@ window.loadReactApp = function(config) {
             console.log('ERROR: No frontend URL defined, should at least be empty string');
         }
     }
-    if (window.localdev || window.localdist || localStorage.heroku) {
+    if (window.localdev || window.localdist || localStorage.heroku || localStorage.netlify) {
         showFrontendPopup(window.frontendConfig.frontendUrl);
     }
     document.write('<link rel="stylesheet" type="text/css" href="' + window.frontendConfig.frontendUrl + 'reactapp/prefixed-bootstrap.min.css?'+ window.frontendConfig.appVersion +'" />');


### PR DESCRIPTION
Similar to Heroku, but use Netlify. Netlify builds frontend artifacts
automatically, so it will save some time having to wait for heroku deployments
to build. The instances don't sleep either, so this makes the testing
experience a little smoother.