### PR TITLE
Fix the properties to set defaults for Oncoprint mutation annotations

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -29,11 +29,13 @@ export interface IServerConfig {
     "app_version": string|null;   // default: "1.0"
     "authenticationMethod": string | undefined;
     "bitly_access_token": string|null;
-    "binary_custom_driver_annotation_menu_label": string|null; // default:
+    "oncoprint_custom_driver_annotation_binary_menu_label": string|null; // default:
     "disabled_tabs": string|null;
     "custom_tabs": any[];
-    "oncoprint_custom_driver_annotation_default": boolean;
-    "oncoprint_oncokb_hotspots_default": string | undefined;
+    "oncoprint_custom_driver_annotation_binary_default": boolean;
+    "oncoprint_custom_driver_annotation_tiers_default": boolean;
+    "oncoprint_oncokb_default": boolean;
+    "oncoprint_hotspots_default": boolean;
     "genomenexus_url": string|null;
     "mygene_info_url": string|null;
     "g2s_url": string|null;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -17,7 +17,8 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
 
     mygene_info_url: "https://mygene.info/v3/gene/<%= entrezGeneId %>?fields=uniprot",
 
-    oncoprint_oncokb_hotspots_default:undefined,
+    oncoprint_oncokb_default:true,
+    oncoprint_hotspots_default:true,
     oncoprint_hide_vus_default:false,
     oncokb_public_api_url:"oncokb.org/api/v1",
 

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -268,6 +268,7 @@ describe("ResultsViewPageStoreUtils", ()=>{
                 { tiers: [] } as any,
                 mutationAnnotationSettings,
                 false,
+                false,
                 false
             );
 
@@ -285,6 +286,7 @@ describe("ResultsViewPageStoreUtils", ()=>{
                 { tiers: ["a","b","c"] } as any,
                 mutationAnnotationSettings,
                 enableCustomTiers,
+                false,
                 false
             );
 
@@ -296,6 +298,7 @@ describe("ResultsViewPageStoreUtils", ()=>{
                 { tiers: ["a","b","c"] } as any,
                 mutationAnnotationSettings,
                 enableCustomTiers,
+                false,
                 false
             );
 
@@ -312,6 +315,7 @@ describe("ResultsViewPageStoreUtils", ()=>{
                 {hasBinary: false, tiers: []} as any,
                 mutationAnnotationSettings,
                 false,
+                true,
                 true
             );
 
@@ -329,6 +333,7 @@ describe("ResultsViewPageStoreUtils", ()=>{
                 {hasBinary: true, tiers: []} as any,
                 mutationAnnotationSettings,
                 false,
+                true,
                 true
             );
             assert.isFalse(mutationAnnotationSettings.hotspots);
@@ -337,6 +342,7 @@ describe("ResultsViewPageStoreUtils", ()=>{
                 {hasBinary: false, tiers: ["a"]} as any,
                 mutationAnnotationSettings,
                 false,
+                true,
                 true
             );
             assert.isFalse(mutationAnnotationSettings.hotspots);
@@ -352,7 +358,8 @@ describe("ResultsViewPageStoreUtils", ()=>{
                 {hasBinary: true, tiers: []} as any,
                 mutationAnnotationSettings,
                 false,
-                true
+                false,
+                false
             );
             assert.isFalse(mutationAnnotationSettings.hotspots);
             assert.isFalse(mutationAnnotationSettings.oncoKb);

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.ts
@@ -81,17 +81,20 @@ export const initializeCustomDriverAnnotationSettings = action((
     report:CustomDriverAnnotationReport,
     mutationAnnotationSettings:any,
     enableCustomTiers:boolean,
-    enableOncoKbAndHotspotsIfNoCustomAnnotations:boolean
+    enableOncoKb:boolean,
+    enableHotspots:boolean
 )=>{
     // initialize keys with all available tiers
     for (const tier of report.tiers) {
         mutationAnnotationSettings.driverTiers.set(tier, enableCustomTiers);
     }
 
-    if (enableOncoKbAndHotspotsIfNoCustomAnnotations && !report.hasBinary && !report.tiers.length) {
-        // enable hotspots and oncokb if there are no custom annotations
-        mutationAnnotationSettings.hotspots = true;
+    if (enableOncoKb) {
         mutationAnnotationSettings.oncoKb = true;
+    }
+
+    if (enableHotspots) {
+        mutationAnnotationSettings.hotspots = true;
     }
 });
 

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -305,7 +305,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                 return self.heatmapGeneInputValue;
             },
             get customDriverAnnotationBinaryMenuLabel() {
-                const label = AppConfig.serverConfig.binary_custom_driver_annotation_menu_label;
+                const label = AppConfig.serverConfig.oncoprint_custom_driver_annotation_binary_menu_label;
                 const customDriverReport = self.props.store.customDriverAnnotationReport.result;
                 if (label && customDriverReport && customDriverReport.hasBinary) {
                     return label;
@@ -331,7 +331,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                 }
             },
             get annotateCustomDriverBinary() {
-                return self.props.store.driverAnnotationSettings.driverFilter;
+                return self.props.store.driverAnnotationSettings.customBinary;
             },
             get selectedCustomDriverAnnotationTiers() {
                 return self.props.store.driverAnnotationSettings.driverTiers;
@@ -398,7 +398,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                     this.props.store.driverAnnotationSettings.hotspots = false;
                     this.props.store.driverAnnotationSettings.cbioportalCount = false;
                     this.props.store.driverAnnotationSettings.cosmicCount = false;
-                    this.props.store.driverAnnotationSettings.driverFilter = false;
+                    this.props.store.driverAnnotationSettings.customBinary = false;
                     this.props.store.driverAnnotationSettings.driverTiers.forEach((value, key)=>{
                         this.props.store.driverAnnotationSettings.driverTiers.set(key, false);
                     });
@@ -412,7 +412,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
 
                     this.props.store.driverAnnotationSettings.cbioportalCount = true;
                     this.props.store.driverAnnotationSettings.cosmicCount = true;
-                    this.props.store.driverAnnotationSettings.driverFilter = true;
+                    this.props.store.driverAnnotationSettings.customBinary = true;
                     this.props.store.driverAnnotationSettings.driverTiers.forEach((value, key)=>{
                         this.props.store.driverAnnotationSettings.driverTiers.set(key, true);
                     });
@@ -440,7 +440,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                 this.controlsHandlers.onSelectAnnotateCOSMIC && this.controlsHandlers.onSelectAnnotateCOSMIC(true);
             }),
             onSelectCustomDriverAnnotationBinary:action((s:boolean)=>{
-                this.props.store.driverAnnotationSettings.driverFilter = s;
+                this.props.store.driverAnnotationSettings.customBinary = s;
             }),
             onSelectCustomDriverAnnotationTier:action((value:string, checked:boolean)=>{
                 this.props.store.driverAnnotationSettings.driverTiers.set(value, checked);


### PR DESCRIPTION
The current properties `oncoprint.custom_driver_annotation.default`, `oncoprint.custom_driver_tiers_annotation.default` and `oncoprint.oncokb_hotspots.default` do not work as expected in the [documentation](https://github.com/cBioPortal/cbioportal/blob/master/docs/portal.properties-Reference.md). 

This PR proposes to fix this and change some of the name properties so that it is more clear what they do. All properties are boolean, if they are set to `true`, then the checkbox in the "Mutations" menu of the Oncoprint will be checked by default:

- `oncoprint.custom_driver_annotation.binary.default`: referring to the "binary" custom annotations.
- `oncoprint.custom_driver_annotation.tiers.default`: referring to the tiers custom annotations.
- `oncoprint.oncokb.default`: referring to the OncoKB annotations.
- `oncoprint.hotspots.default`: referring to Hotspots annotations.

This PR goes together with cBioportal/cbioportal#5795.
