### PR TITLE
Fixing two small issues with group comparison

### DIFF
--- a/src/pages/groupComparison/ClinicalData.tsx
+++ b/src/pages/groupComparison/ClinicalData.tsx
@@ -282,7 +282,7 @@ export default class ClinicalData extends React.Component<IClinicalDataProps, {}
         const groupStatus = getMobxPromiseGroupStatus(...promises);
         switch (groupStatus) {
             case "pending":
-                return <LoadingIndicator isLoading={true} center={true} size={"big"} />;
+                return <LoadingIndicator isLoading={true} size={"big"} />;
             case "error":
                 return <span>Error loading plot data.</span>;
             default: {
@@ -318,7 +318,7 @@ export default class ClinicalData extends React.Component<IClinicalDataProps, {}
                     } else if (this.boxPlotData.isError) {
                         return <span>Error loading plot data.</span>;
                     } else {
-                        return <LoadingIndicator isLoading={true} center={true} size={"big"} />;
+                        return <LoadingIndicator isLoading={true} size={"big"} />;
                     }
                 } else {
                     plotElt = <StackedBarPlot
@@ -394,7 +394,7 @@ export default class ClinicalData extends React.Component<IClinicalDataProps, {}
 
     public render() {
         if (this.props.store.clinicalDataEnrichments.isPending) {
-            return <LoadingIndicator isLoading={true} size={"big"} center={true} />;
+            return <LoadingIndicator isLoading={true} size={"big"} />;
         }
         return (
             <div className="clearfix" style={{ display: "flex", marginTop: 6 }}>

--- a/src/pages/groupComparison/CopyNumberEnrichments.tsx
+++ b/src/pages/groupComparison/CopyNumberEnrichments.tsx
@@ -39,7 +39,7 @@ export default class CopyNumberEnrichments extends React.Component<ICopyNumberEn
                 return this.enrichmentsUI.component;
             }
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 
@@ -72,7 +72,7 @@ export default class CopyNumberEnrichments extends React.Component<ICopyNumberEn
                 </div>
             );
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 

--- a/src/pages/groupComparison/GroupComparisonLoading.tsx
+++ b/src/pages/groupComparison/GroupComparisonLoading.tsx
@@ -45,7 +45,7 @@ export default class GroupComparisonLoading extends React.Component<IGroupCompar
 
     render() {
         return (
-            <LoadingIndicator isLoading={true} center={true} size="big">
+            <LoadingIndicator isLoading={true} size="big">
                 <div style={{marginTop:20}}>
                     {this.message}
                 </div>

--- a/src/pages/groupComparison/MRNAEnrichments.tsx
+++ b/src/pages/groupComparison/MRNAEnrichments.tsx
@@ -43,7 +43,7 @@ export default class MRNAEnrichments extends React.Component<IMRNAEnrichmentsPro
                 return this.enrichmentsUI.component;
             }
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 
@@ -72,7 +72,7 @@ export default class MRNAEnrichments extends React.Component<IMRNAEnrichmentsPro
                 </div>
             );
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 

--- a/src/pages/groupComparison/MutationEnrichments.tsx
+++ b/src/pages/groupComparison/MutationEnrichments.tsx
@@ -39,7 +39,7 @@ export default class MutationEnrichments extends React.Component<IMutationEnrich
                 return this.enrichmentsUI.component;
             }
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 
@@ -71,7 +71,7 @@ export default class MutationEnrichments extends React.Component<IMutationEnrich
                 </div>
             );
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 

--- a/src/pages/groupComparison/Overlap.tsx
+++ b/src/pages/groupComparison/Overlap.tsx
@@ -120,7 +120,7 @@ export default class Overlap extends React.Component<IOverlapProps, {}> {
             }
             return plotElt;
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 
@@ -144,7 +144,7 @@ export default class Overlap extends React.Component<IOverlapProps, {}> {
                 </div>
             </div>
         ),
-        renderPending:()=><LoadingIndicator isLoading={true} center={true} size="big"/>,
+        renderPending:()=><LoadingIndicator isLoading={true} size="big"/>,
         renderError:()=><ErrorMessage/>
     });
 

--- a/src/pages/groupComparison/OverlapStackedBar.tsx
+++ b/src/pages/groupComparison/OverlapStackedBar.tsx
@@ -38,6 +38,7 @@ export default class OverlapStackedBar extends React.Component<IOverlapStackedBa
     private mouseEvents: any = this.makeMouseEvents();
 
     @observable.ref private container: HTMLDivElement;
+    @observable legendWidth = 0;
 
     private makeMouseEvents() {
         let disappearTimeout: Timer | null = null;
@@ -161,15 +162,11 @@ export default class OverlapStackedBar extends React.Component<IOverlapStackedBa
     }
 
     @computed get chartWidth() {
-        return 2 * STACKBAR_WIDTH + 200;
+        return 2 * STACKBAR_WIDTH;
     }
 
     @computed get chartHeight() {
         return 500;
-    }
-
-    @computed get topPadding() {
-        return 100
     }
 
     @autobind
@@ -225,33 +222,50 @@ export default class OverlapStackedBar extends React.Component<IOverlapStackedBa
         )
     }
 
+    @computed
+    get svgWidth() {
+        return this.chartWidth + this.legendWidth;
+    }
+
+    componentDidUpdate() {
+        if (this.container) {
+            const legend = this.container.getElementsByClassName("overlapStackedBarLegend").item(0);
+            if (legend) {
+                this.legendWidth = legend.getBoundingClientRect().width;
+            }
+        }
+    }
+
     @autobind
     private getChart() {
         return (
             <div
                 ref={this.containerRef}
-                style={{ width: this.chartWidth, height: this.chartHeight }}
+                style={{ width: this.svgWidth, height: this.chartHeight }}
             >
                 <svg
                     id={this.props.svgId || ""}
                     style={{
-                        width: this.chartWidth,
+                        width: this.svgWidth,
                         height: this.chartHeight,
                         pointerEvents: "all"
                     }}
                     height={this.chartHeight}
-                    width={this.chartWidth}
+                    width={this.svgWidth}
                     role="img"
-                    viewBox={`0 0 ${this.chartWidth} ${this.chartHeight}`}
+                    viewBox={`0 0 ${this.svgWidth} ${this.chartHeight}`}
                 >
                     {this.getStackedBar(this.sampleStackedBarData, 'Samples Overlap', this.totalSamplesCount, 0)}
                     {this.getStackedBar(this.patientStackedBarData, 'Patients Overlap', this.totalPatientsCount, 1)}
                     <VictoryLegend
-                        x={2 * STACKBAR_WIDTH}
-                        y={this.topPadding}
+                        x={this.chartWidth}
+                        y={70}
                         theme={CBIOPORTAL_VICTORY_THEME}
                         standalone={false}
-                        data={this.legendData} />
+                        data={this.legendData}
+                        groupComponent={<g className="overlapStackedBarLegend"/>}
+                        itemsPerRow={14}
+                    />
                 </svg>
             </div>
         );

--- a/src/pages/groupComparison/ProteinEnrichments.tsx
+++ b/src/pages/groupComparison/ProteinEnrichments.tsx
@@ -42,7 +42,7 @@ export default class ProteinEnrichments extends React.Component<IProteinEnrichme
                 return this.enrichmentsUI.component;
             }
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 
@@ -71,7 +71,7 @@ export default class ProteinEnrichments extends React.Component<IProteinEnrichme
                 </div>
             );
         },
-        renderPending:()=><Loader isLoading={true} center={true} size={"big"}/>,
+        renderPending:()=><Loader isLoading={true} size={"big"}/>,
         renderError:()=><ErrorMessage/>
     });
 

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -37,7 +37,7 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
             this.props.store.diseaseFreePatientSurvivals.isPending ||
             this.analysisGroups.isPending ||
             this.props.store.patientToAnalysisGroups.isPending) {
-            return <LoadingIndicator isLoading={true} size={"big"} center={true} />;
+            return <LoadingIndicator isLoading={true} size={"big"} />;
         }
 
         let content: any = [];


### PR DESCRIPTION
(1) dont use centered loading indicator - its page centered, looks weird. we can center these later properly, but for now lets just remove that.

(2) dont make overlap chart legend run off screen when there are many groups