### PR TITLE
Always use AppConfig.frontendUrl as base path for network tab assets

### DIFF
--- a/src/pages/resultsView/network/Network.tsx
+++ b/src/pages/resultsView/network/Network.tsx
@@ -43,12 +43,8 @@ export default class Network extends React.Component<INetworkTabParams, {}> {
 
         };
 
-        let path = (/\/\/localhost|127\.0\.0\.1/.test(AppConfig.frontendUrl!)) ?
-            AppConfig.frontendUrl! :
-            `//${AppConfig.baseUrl!}`;
-
         const strParams = encodeURIComponent(JSON.stringify(networkParams));
-        return `${trimTrailingSlash(path)}/reactapp/network/network.htm?${AppConfig.serverConfig.app_version}&apiHost=${encodeURIComponent(AppConfig.apiRoot!.replace(/^http[s]?:\/\//,''))}#${strParams}`;
+        return `${trimTrailingSlash(AppConfig.frontendUrl!)}/reactapp/network/network.htm?${AppConfig.serverConfig.app_version}&apiHost=${encodeURIComponent(AppConfig.apiRoot!.replace(/^http[s]?:\/\//,''))}#${strParams}`;
     }
 
     render(){


### PR DESCRIPTION
This undoes a workaround necessary when MSK hosted frontend assets locally (non CDN).  We can now always just use frontendUrl