### PR TITLE
Hide oncoprint tooltip when e2e test is on

### DIFF
--- a/src/globalStyles/e2etest.scss
+++ b/src/globalStyles/e2etest.scss
@@ -12,4 +12,9 @@
   .simple-table tbody>tr:nth-of-type(even).clickable:hover {
     background-color: #FFFFFF !important;
   }
+
+  .oncoprintjs__tooltip {
+    display:none !important;
+  }
+
 }


### PR DESCRIPTION
Tooltip is introducing some flakiness to e2e tests, so just hide it