### PR TITLE
Added link on tutorial page to google drive folder

### DIFF
--- a/src/pages/staticPages/tutorials/Tutorials.tsx
+++ b/src/pages/staticPages/tutorials/Tutorials.tsx
@@ -23,6 +23,8 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <i>Sci. Signal.</i> 6, pl1 (2013).
                 [<a href={getNCBIlink('/pubmed/23550210')}>Reprint</a>].</p>
 
+            <hr />
+            <h2>View tutorial slides below or download slides <a href="https://drive.google.com/drive/u/0/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA">here</a>.</h2>
             <hr/>
 
             <h2>Tutorial #1: Single Study Exploration</h2>
@@ -54,9 +56,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 src="https://docs.google.com/presentation/d/1U39xgVujtBodwW20qIfcGu4E5n2zzaKkl2KmzzHqj4A/embed?startfalse&loop=false&delayms=60000"
                 frameBorder="0" width="720" height="434"
                 allowFullScreen={true}></iframe>
-            <hr />
-            <h2>Get the sildes <a href="https://drive.google.com/drive/u/0/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA">here</a>!</h2>
-
+            
 
         </PageLayout>
 

--- a/src/pages/staticPages/tutorials/Tutorials.tsx
+++ b/src/pages/staticPages/tutorials/Tutorials.tsx
@@ -54,6 +54,8 @@ export default class Tutorials extends React.Component<{}, {}> {
                 src="https://docs.google.com/presentation/d/1U39xgVujtBodwW20qIfcGu4E5n2zzaKkl2KmzzHqj4A/embed?startfalse&loop=false&delayms=60000"
                 frameBorder="0" width="720" height="434"
                 allowFullScreen={true}></iframe>
+            <hr />
+            <h2>Get the sildes <a href="https://drive.google.com/drive/u/0/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA">here</a>!</h2>
 
 
         </PageLayout>


### PR DESCRIPTION
 What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/5865

Changes proposed in this pull request:
- Added link on tutorial page to google drive folder 

# Any screenshots or GIFs?
Before:-
![Screenshot from 2019-03-17 22-44-05](https://user-images.githubusercontent.com/34533741/54495068-89150b80-4906-11e9-9d3b-6f283f3ffae4.png)

After:-
![Screenshot from 2019-03-17 22-45-50](https://user-images.githubusercontent.com/34533741/54495060-78fd2c00-4906-11e9-86c8-4c6a5252761f.png)


