### PR TITLE
Keep search text

### DIFF
--- a/src/shared/components/query/quickSearch/QuickSearch.tsx
+++ b/src/shared/components/query/quickSearch/QuickSearch.tsx
@@ -194,7 +194,10 @@ export default class QuickSearch extends React.Component {
                 this.genePageMultiplier = 0;
                 this.patientPageMultiplier = 0;
             }
-            this.inputValue = inputValue;
+            // allow user to click and edit the search text
+            if (action === "input-change") {
+                this.inputValue = inputValue;
+            }
         }
     }
 


### PR DESCRIPTION
For the quick search, allow the user to click the input field again and modified the existing text.
Fix https://github.com/cBioPortal/cbioportal/issues/5827.