### PR TITLE
Increase node memory size to avoid out-of-memory errors in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && cross-env NODE_ENV=development webpack-dev-server",
     "startSSL": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && cross-env NODE_ENV=development webpack-dev-server --https",
     "clean": "rimraf dist tsDist common-dist",
-    "build": "yarn run clean && yarn run compileOqlParser && yarn run buildDLL:prod && cross-env NODE_ENV=production webpack --progress --colors",
+    "build": "yarn run clean && yarn run compileOqlParser && yarn run buildDLL:prod && cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 webpack --progress --colors",
     "buildDLL:prod": "yarn run clean && cross-env NODE_ENV=production webpack --config vendor-bundles.webpack.config.js",
     "buildDLL:dev": "yarn run clean && cross-env NODE_ENV=development webpack --config vendor-bundles.webpack.config.js",
     "build:size": "yarn run clean && yarn run buildDLL:prod && cross-env NODE_ENV=production webpack --json > stats.json",


### PR DESCRIPTION
Many devs have experienced out-of-memory issues when building project locally.  