### PR TITLE
Tooltip size fix for profile description

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -1025,11 +1025,11 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
         }
 
         return (
-            <form>
-                <h4>{vertical ? "Vertical" : "Horizontal"} Axis</h4>
+            <form className="main-form">
+                <h4 className="tab-title">{vertical ? "Vertical" : "Horizontal"} Axis</h4>
                 <div>
-                    <div className="form-group">
-                        <label>Data Type</label>
+                <div style={{marginBottom:"5px"}} className="form-group">
+                    <label className="label-text">Data Type</label>
                         <ReactSelect
                             name={`${vertical ? "v" : "h"}-profile-type-selector`}
                             value={axisSelection.dataType}
@@ -1039,8 +1039,8 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                             searchable={false}
                         />
                     </div>
-                    <div className="form-group">
-                        <label>{dataSourceLabel}</label>
+                    <div style={{marginBottom:"5px"}} className="form-group ">
+                        <label className="label-text">{dataSourceLabel}</label>
                         <div style={{display:"flex", flexDirection:"row"}}>
                             <ReactSelect
                                 className="data-source-id"
@@ -1066,7 +1066,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                         </label></div>
                     )}
                     {(axisSelection.dataType !== GENESET_DATA_TYPE) && (<div className="form-group" style={{opacity:(axisSelection.dataType === CLIN_ATTR_DATA_TYPE ? 0 : 1)}}>
-                        <label>Gene</label>
+                        <label className="label-text">Gene</label>
                         <div style={{display:"flex", flexDirection:"row"}}>
                             <ReactSelect
                                 name={`${vertical ? "v" : "h"}-gene-selector`}
@@ -1164,39 +1164,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                             /> Horizontal Bars
                         </label></div>
                     )}
-                    {showSampleColoringOptions && (
-                        <div>
-                            <label style={{marginBottom:0}}>Color Samples By</label>
-                            <div style={{marginLeft:14, marginTop:-4}}>
-                                {this.mutationDataCanBeShown && (
-                                    <div className="checkbox"><label>
-                                        <input
-                                            data-test="ViewMutationType"
-                                            type="checkbox"
-                                            name="utilities_viewMutationType"
-                                            value={EventKey.utilities_viewMutationType}
-                                            checked={this.viewMutationType}
-                                            onClick={this.onInputClick}
-                                            disabled={!this.mutationDataExists.isComplete || !this.mutationDataExists.result}
-                                        /> Mutation Type *
-                                    </label></div>
-                                )}
-                                {this.cnaDataCanBeShown && (
-                                    <div className="checkbox"><label>
-                                        <input
-                                            data-test="ViewCopyNumber"
-                                            type="checkbox"
-                                            name="utilities_viewCopyNumber"
-                                            value={EventKey.utilities_viewCopyNumber}
-                                            checked={this.viewCopyNumber}
-                                            onClick={this.onInputClick}
-                                            disabled={!this.cnaDataExists.isComplete || !this.cnaDataExists.result}
-                                        /> Copy Number Alteration
-                                    </label></div>
-                                )}
-                            </div>
-                        </div>
-                    )}
+                    
                     {showRegression && (
                         <div className="checkbox" style={{marginTop:14}}><label>
                             <input
@@ -1229,7 +1197,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                     </Observer>
                 </div>
                 <div style={{ textAlign:'center'}}>
-                    <button className="btn btn-default" data-test="swapHorzVertButton" onClick={this.swapHorzVertSelections}><i className="fa fa-arrow-up"></i> Swap Axes <i className="fa fa-arrow-down"></i></button>
+                    <button className="btn-sm btn-default" data-test="swapHorzVertButton" onClick={this.swapHorzVertSelections}><i className="fa fa-arrow-up"></i> Swap Axes <i className="fa fa-arrow-down"></i></button>
                 </div>
                 <div className="axisBlock">
                     <Observer>
@@ -1396,6 +1364,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
         const groupStatus = getMobxPromiseGroupStatus(...promises);
         const isPercentage = this.discreteVsDiscretePlotType === DiscreteVsDiscretePlotType.PercentageStackedBar;
         const isStacked = isPercentage || this.discreteVsDiscretePlotType === DiscreteVsDiscretePlotType.StackedBar;
+        const showSampleColoringOptions = this.mutationDataCanBeShown || this.cnaDataCanBeShown;
         switch (groupStatus) {
             case "pending":
                 return <LoadingIndicator isLoading={true} center={true} size={"big"}/>;
@@ -1520,7 +1489,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                         return <span>Not implemented yet</span>
                 }
                 return (
-                    <div>
+                    <div className="PlotsTab">
                         <div data-test="PlotsTabPlotDiv" className="borderedChart posRelative">
                             <ScrollBar style={{position:'relative', top:-5}} getScrollEl={this.getScrollPane} />
                             {this.plotExists && (
@@ -1541,6 +1510,39 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                                 <div ref={this.assignScrollPaneRef} style={{position:"relative", display:"inline-block"}}>
                                 {plotElt}
                                 </div>
+                                {showSampleColoringOptions && (
+                        <div className="color-samples">
+                            <label style={{marginBottom:0 }}>Color Samples By</label>
+                            <div style={{marginLeft:14, marginTop:-4}}>
+                                {this.mutationDataCanBeShown && (
+                                    <div className="checkbox"><label>
+                                        <input
+                                            data-test="ViewMutationType"
+                                            type="checkbox"
+                                            name="utilities_viewMutationType"
+                                            value={EventKey.utilities_viewMutationType}
+                                            checked={this.viewMutationType}
+                                            onClick={this.onInputClick}
+                                            disabled={!this.mutationDataExists.isComplete || !this.mutationDataExists.result}
+                                        /> Mutation Type *
+                                    </label></div>
+                                )}
+                                {this.cnaDataCanBeShown && (
+                                    <div className="checkbox"><label>
+                                        <input
+                                            data-test="ViewCopyNumber"
+                                            type="checkbox"
+                                            name="utilities_viewCopyNumber"
+                                            value={EventKey.utilities_viewCopyNumber}
+                                            checked={this.viewCopyNumber}
+                                            onClick={this.onInputClick}
+                                            disabled={!this.cnaDataExists.isComplete || !this.cnaDataExists.result}
+                                        /> Copy Number Alteration
+                                    </label></div>
+                                )}
+                            </div>
+                        </div>
+                    )}
                         </div>
                         {this.mutationDataCanBeShown && (
                             <div style={{marginTop:5}}>* Driver annotation settings are located in the Mutation Color menu of the Oncoprint.</div>

--- a/src/pages/resultsView/plots/styles.scss
+++ b/src/pages/resultsView/plots/styles.scss
@@ -34,10 +34,32 @@
     .axisBlock {
       background:#eee;
       border-radius:4px;
+      padding-bottom: 0;
     }
-
-  }
-
-
-
+  } 
 }
+
+.tab-title {
+  font-size: 14px;
+}
+
+.label-text {
+  font-size: 13px;
+  color: #333333;
+  margin-bottom: 5px;
+  padding: 0px;
+}
+
+.form-group-bspace {
+  margin-bottom: 5px;
+}
+
+.PlotsTab {
+  width: 120%;
+}
+
+.color-samples{
+  right: 10px;
+  bottom: 0;
+  position: absolute;
+} 

--- a/src/shared/components/defaultTooltip/styles.scss
+++ b/src/shared/components/defaultTooltip/styles.scss
@@ -1,3 +1,4 @@
 .rc-tooltip-inner {
   min-height: initial;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
Fixing issue https://github.com/cBioPortal/cbioportal/issues/5320

Changes proposed in this pull request:
- Made Tooltip of normal size for profile description

# Before 
<img width="951" alt="48937632-0a3b3380-ef0f-11e8-88ba-871c76e79dab" src="https://user-images.githubusercontent.com/35633575/54711975-270c0e80-4b71-11e9-8b26-01b1959f96eb.png">


# After
<img width="1440" alt="Screenshot 2019-03-21 at 12 32 55 AM" src="https://user-images.githubusercontent.com/35633575/54711918-080d7c80-4b71-11e9-9629-83326531cf4d.png">


# Notify reviewers
@schultzn @jjgao @alisman @adamabeshouse  
