### PR TITLE
Handle case where query includes a study but has no associated sample…

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -2935,7 +2935,8 @@ export class ResultsViewPageStore {
             ],
             invoke: ()=>{
                 const dqf = this.molecularProfileIdToDataQueryFilter.result![q.molecularProfileId];
-                if (dqf) {
+                // it's possible that sampleIds is empty
+                if (dqf && dqf.sampleIds && dqf.sampleIds.length) {
                     return client.fetchAllMolecularDataInMolecularProfileUsingPOST({
                         molecularProfileId: q.molecularProfileId,
                         molecularDataFilter: {


### PR DESCRIPTION
A user can select studies and then specify a custom list of samples that leaves some of the studies without samples.  

For example:

http://localhost:3000/results/expression?session_id=5c93b3d5e4b046111fee28bb

These queries are broken and produce 400 errors on certain api endpoints