### PR TITLE
[READY TO MERGE] Making plot tabs more compact vertically

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -1025,11 +1025,11 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
         }
 
         return (
-            <form>
-                <h4>{vertical ? "Vertical" : "Horizontal"} Axis</h4>
+            <form className="main-form">
+                <h4 className="tab-title">{vertical ? "Vertical" : "Horizontal"} Axis</h4>
                 <div>
-                    <div className="form-group">
-                        <label>Data Type</label>
+                <div style={{marginBottom:"5px"}} className="form-group">
+                    <label className="label-text">Data Type</label>
                         <ReactSelect
                             name={`${vertical ? "v" : "h"}-profile-type-selector`}
                             value={axisSelection.dataType}
@@ -1039,8 +1039,8 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                             searchable={false}
                         />
                     </div>
-                    <div className="form-group">
-                        <label>{dataSourceLabel}</label>
+                    <div style={{marginBottom:"5px"}} className="form-group ">
+                        <label className="label-text">{dataSourceLabel}</label>
                         <div style={{display:"flex", flexDirection:"row"}}>
                             <ReactSelect
                                 className="data-source-id"
@@ -1066,7 +1066,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                         </label></div>
                     )}
                     {(axisSelection.dataType !== GENESET_DATA_TYPE) && (<div className="form-group" style={{opacity:(axisSelection.dataType === CLIN_ATTR_DATA_TYPE ? 0 : 1)}}>
-                        <label>Gene</label>
+                    <label className="label-text">Gene</label>
                         <div style={{display:"flex", flexDirection:"row"}}>
                             <ReactSelect
                                 name={`${vertical ? "v" : "h"}-gene-selector`}
@@ -1163,39 +1163,6 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                                 onClick={this.onInputClick}
                             /> Horizontal Bars
                         </label></div>
-                    )}
-                    {showSampleColoringOptions && (
-                        <div>
-                            <label style={{marginBottom:0}}>Color Samples By</label>
-                            <div style={{marginLeft:14, marginTop:-4}}>
-                                {this.mutationDataCanBeShown && (
-                                    <div className="checkbox"><label>
-                                        <input
-                                            data-test="ViewMutationType"
-                                            type="checkbox"
-                                            name="utilities_viewMutationType"
-                                            value={EventKey.utilities_viewMutationType}
-                                            checked={this.viewMutationType}
-                                            onClick={this.onInputClick}
-                                            disabled={!this.mutationDataExists.isComplete || !this.mutationDataExists.result}
-                                        /> Mutation Type *
-                                    </label></div>
-                                )}
-                                {this.cnaDataCanBeShown && (
-                                    <div className="checkbox"><label>
-                                        <input
-                                            data-test="ViewCopyNumber"
-                                            type="checkbox"
-                                            name="utilities_viewCopyNumber"
-                                            value={EventKey.utilities_viewCopyNumber}
-                                            checked={this.viewCopyNumber}
-                                            onClick={this.onInputClick}
-                                            disabled={!this.cnaDataExists.isComplete || !this.cnaDataExists.result}
-                                        /> Copy Number Alteration
-                                    </label></div>
-                                )}
-                            </div>
-                        </div>
                     )}
                     {showRegression && (
                         <div className="checkbox" style={{marginTop:14}}><label>
@@ -1396,6 +1363,8 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
         const groupStatus = getMobxPromiseGroupStatus(...promises);
         const isPercentage = this.discreteVsDiscretePlotType === DiscreteVsDiscretePlotType.PercentageStackedBar;
         const isStacked = isPercentage || this.discreteVsDiscretePlotType === DiscreteVsDiscretePlotType.StackedBar;
+        const showSampleColoringOptions = this.mutationDataCanBeShown || this.cnaDataCanBeShown;
+
         switch (groupStatus) {
             case "pending":
                 return <LoadingIndicator isLoading={true} center={true} size={"big"}/>;
@@ -1541,6 +1510,39 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                                 <div ref={this.assignScrollPaneRef} style={{position:"relative", display:"inline-block"}}>
                                 {plotElt}
                                 </div>
+                                {showSampleColoringOptions && (
+                        <div>
+                            <label style={{marginBottom:0}}>Color Samples By</label>
+                            <div style={{marginLeft:14, marginTop:-4}}>
+                                {this.mutationDataCanBeShown && (
+                                    <div className="checkbox"><label>
+                                        <input
+                                            data-test="ViewMutationType"
+                                            type="checkbox"
+                                            name="utilities_viewMutationType"
+                                            value={EventKey.utilities_viewMutationType}
+                                            checked={this.viewMutationType}
+                                            onClick={this.onInputClick}
+                                            disabled={!this.mutationDataExists.isComplete || !this.mutationDataExists.result}
+                                        /> Mutation Type *
+                                    </label></div>
+                                )}
+                                {this.cnaDataCanBeShown && (
+                                    <div className="checkbox"><label>
+                                        <input
+                                            data-test="ViewCopyNumber"
+                                            type="checkbox"
+                                            name="utilities_viewCopyNumber"
+                                            value={EventKey.utilities_viewCopyNumber}
+                                            checked={this.viewCopyNumber}
+                                            onClick={this.onInputClick}
+                                            disabled={!this.cnaDataExists.isComplete || !this.cnaDataExists.result}
+                                        /> Copy Number Alteration
+                                    </label></div>
+                                )}
+                            </div>
+                        </div>
+                    )}
                         </div>
                         {this.mutationDataCanBeShown && (
                             <div style={{marginTop:5}}>* Driver annotation settings are located in the Mutation Color menu of the Oncoprint.</div>

--- a/src/pages/resultsView/plots/styles.scss
+++ b/src/pages/resultsView/plots/styles.scss
@@ -34,10 +34,32 @@
     .axisBlock {
       background:#eee;
       border-radius:4px;
+      padding-bottom: 0;
     }
-
-  }
-
-
-
+    .tab-title {
+      font-size: 14px;
+    }
+    
+    .label-text {
+      font-size: 13px;
+      color: #333333;
+      margin-bottom: 5px;
+      padding: 0px;
+    }
+    
+    .form-group-bspace {
+      margin-bottom: 5px;
+    }
+    
+    .PlotsTab {
+      width: 120%;
+    }
+    
+    .color-samples{
+      right: 10px;
+      bottom: 0;
+      position: absolute;
+    }  
+  } 
 }
+


### PR DESCRIPTION
fixing https://github.com/cbioportal/cbioportal/issues/5633

Making plot tabs slightly more compact vertically so that it fits a 13 inch screen easily.
Made it compact, decrease font-size, decrease white spaces and moved the colour-samples-options inside the plot and made the styles not applied to be global

Changes proposed in this pull request:
- Made it compact
- Decreased font-size
- Removed extra white space
- Moved colour sample options inside plot.

# Screenshots
<img width="1440" alt="Screenshot 2019-03-21 at 12 11 09 AM" src="https://user-images.githubusercontent.com/35633575/54710526-e65ec600-4b6d-11e9-9e96-c3be15a0f2fa.png">
<img width="1440" alt="Screenshot 2019-03-21 at 12 11 18 AM" src="https://user-images.githubusercontent.com/35633575/54710530-e8c12000-4b6d-11e9-8138-91f03422c5c0.png">

# Notify reviewers
@schultzn @jjgao @alisman @adamabeshouse  
