### PR TITLE
[READY TO MERGE] Fixed tooltip size for profile description

### DIFF
--- a/src/shared/components/defaultTooltip/styles.scss
+++ b/src/shared/components/defaultTooltip/styles.scss
@@ -1,3 +1,4 @@
 .rc-tooltip-inner {
   min-height: initial;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
# What? Why?
fixed https://github.com/cBioPortal/cbioportal/issues/5320

Changes proposed in this pull request:
- Fixed tooltip size for profile description 

# Before 
<img width="951" alt="48937632-0a3b3380-ef0f-11e8-88ba-871c76e79dab" src="https://user-images.githubusercontent.com/35633575/54834302-e97cc200-4ce5-11e9-9f9d-5fde8d859f67.png">

# After 
<img width="1440" alt="Screenshot 2019-03-22 at 9 01 37 PM" src="https://user-images.githubusercontent.com/35633575/54834354-00bbaf80-4ce6-11e9-9246-2ca53cebfc53.png">

# Notify reviewers
@alisman @adamabeshouse @jjgao @zhx828 