### PR TITLE
Allele frequency value now rounds upto 4 decimals

### DIFF
--- a/src/pages/resultsView/network/files/mutationMapper.js
+++ b/src/pages/resultsView/network/files/mutationMapper.js
@@ -1112,17 +1112,18 @@ var MutationDetailsTableFormatter = (function()
 	{
 		var text = "NA";
 		var total = alt + ref;
-		var style = "";
-		var tipStyle = "";
 
-		if (frequency)
-		{
-			style = "mutation_table_allele_freq";
-			text = frequency.toFixed(2);
-			tipStyle = tipClass;
-		}
-
-		return {text: text, total: total, style: style, tipClass: tipStyle};
+		if (frequency) {
+			if (frequency>=0.01)
+			{
+				text = frequency.toFixed(2);
+			}
+			else
+			{
+				text = frequency.toFixed(4);
+			}
+		}	
+		return {text: text, total: total, style: "mutation_table_allele_freq", tipStyle: tipClass};
 	}
 
 	function getPdbMatchLink(mutation)


### PR DESCRIPTION
# What? Why?
Fixed issue https://github.com/cBioPortal/cbioportal/issues/5864 .

Changes proposed in this pull request:
- Now the allele frequency now rounds upto 4 decimals if the value of frequency is less than 0.01 and if the frequency is greater than 0.01 then it rounds upto only 2 decimals.

# Screenshots
- Cannot add screenshots because in most of the cases allele frequency is greater than 0.01

# Notify reviewers
@jjgao @alisman @adamabeshouse @dippindots 
