### PR TITLE
don't show the quick-search and download tabs when modify the query

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -80,7 +80,7 @@ export default class HomePage extends React.Component<IResultsViewPageProps, {}>
             <PageLayout className="homePageLayout" noMargin={true} rightBar={<RightBar queryStore={this.queryStore} />}>
 
                 <div className={"skinBlurb"} dangerouslySetInnerHTML={{__html:AppConfig.serverConfig.skin_blurb!}}></div>
-                <QueryAndDownloadTabs getQueryStore={this.getQueryStore} showQuickSearchTab={AppConfig.serverConfig.quick_search_enabled} />
+                <QueryAndDownloadTabs getQueryStore={this.getQueryStore} showQuickSearchTab={AppConfig.serverConfig.quick_search_enabled} showDownloadTab={true}/>
 
             </PageLayout>
         )

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -144,7 +144,8 @@ export default class QuerySummary extends React.Component<{ routingStore:Extende
     @computed get queryForm(){
         return <div style={{marginTop:10}}>
             <QueryAndDownloadTabs onSubmit={this.onSubmit}
-                                  showQuickSearchTab={AppConfig.serverConfig.quick_search_enabled}
+                                  showQuickSearchTab={false}
+                                  showDownloadTab={false}
                                   showAlerts={true}
                                   getQueryStore={()=>createQueryStore(getBrowserWindow().routingStore.query)}
             />

--- a/src/shared/components/query/QueryAndDownloadTab.spec.tsx
+++ b/src/shared/components/query/QueryAndDownloadTab.spec.tsx
@@ -8,10 +8,10 @@ import {QueryStore} from "./QueryStore";
 
 describe('QueryAndDownloadTabs', () => {
 
-    it.skip('Hides download tab if prop showDownloadTab is false', ()=>{
-        const comp = shallow(<QueryAndDownloadTabs getQueryStore={()=>({} as QueryStore)} showQuickSearchTab={true} />);
-        assert.equal(comp.find(Tab).length, 2);
-        comp.setProps({ showQuickSearchTab:false });
+    it.skip('only show query tab if prop showQuickSearchTab and showDownloadTab are false', ()=>{
+        const comp = shallow(<QueryAndDownloadTabs getQueryStore={()=>({} as QueryStore)} showQuickSearchTab={true} showDownloadTab={true}/>);
+        assert.equal(comp.find(Tab).length, 3);
+        comp.setProps({ showQuickSearchTab: false, showDownloadTab:false });
         assert.equal(comp.find(Tab).length, 1);
     });
 

--- a/src/shared/components/query/QueryAndDownloadTabs.tsx
+++ b/src/shared/components/query/QueryAndDownloadTabs.tsx
@@ -25,6 +25,7 @@ interface IQueryAndDownloadTabsProps
 {
 	onSubmit?:()=>void;
 	showQuickSearchTab:boolean;
+	showDownloadTab:boolean;
     getQueryStore:()=>QueryStore;
     showAlerts?:boolean;
 }
@@ -37,7 +38,7 @@ export default class QueryAndDownloadTabs extends React.Component<IQueryAndDownl
 	constructor(props:IQueryAndDownloadTabsProps){
 		super();
 
-		if (getBrowserWindow().localStorage.getItem(QUICK_SEARCH_LS_KEY) === QUICK_SEARCH_TAB_ID) {
+		if (props.showQuickSearchTab && getBrowserWindow().localStorage.getItem(QUICK_SEARCH_LS_KEY) === QUICK_SEARCH_TAB_ID) {
 			this.activeTabId = getBrowserWindow().localStorage.getItem(QUICK_SEARCH_LS_KEY);
 		}
 
@@ -59,8 +60,10 @@ export default class QueryAndDownloadTabs extends React.Component<IQueryAndDownl
 	@autobind
 	setDefaultTab(tabId:string|undefined){
 		// right now we only care if quick search or NOT
-		getBrowserWindow().localStorage.defaultHomePageTab =
-			(tabId === QUICK_SEARCH_TAB_ID) ? QUICK_SEARCH_TAB_ID : undefined;
+		if (this.props.showQuickSearchTab) {
+			getBrowserWindow().localStorage.defaultHomePageTab =
+				(tabId === QUICK_SEARCH_TAB_ID) ? QUICK_SEARCH_TAB_ID : undefined;
+		}
 	}
 
 	trackQuickSearch(){
@@ -96,7 +99,7 @@ export default class QueryAndDownloadTabs extends React.Component<IQueryAndDownl
 							<QuickSearch/>
                         </div>
 					</MSKTab>
-					<MSKTab id={DOWNLOAD} linkText={"Download"} onTabDidMount={()=>this.setDefaultTab(undefined)}>
+					<MSKTab id={DOWNLOAD} linkText={"Download"} hide={!this.props.showDownloadTab} onTabDidMount={()=>this.setDefaultTab(undefined)}>
                         <QueryContainer onSubmit={this.props.onSubmit} store={this.store}/>
 					</MSKTab>
 				</MSKTabs>


### PR DESCRIPTION
Don't show the quick-search and download tabs when modifying the query
Fix https://github.com/cBioPortal/cbioportal/issues/5897.
