### PR TITLE
Rewrite Overlap Venn diagram so that we can highlight set complements

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,6 @@
     "underscore": "^1.8.3",
     "url": "^0.11.0",
     "url-loader": "^1.1.2",
-    "venn.js": "^0.2.20",
     "victory": "30.0.0",
     "webpack": "^3.10.0",
     "webpack-fail-plugin": "^1.0.5",

--- a/src/pages/groupComparison/GroupComparisonUtils.tsx
+++ b/src/pages/groupComparison/GroupComparisonUtils.tsx
@@ -346,6 +346,9 @@ export const SURVIVAL_TOO_MANY_GROUPS_MSG =
 
 export const DUPLICATE_GROUP_NAME_MSG = "Another group already has this name.";
 
+export const OVERLAP_NOT_ENOUGH_GROUPS_MSG =
+    "We can't show overlap for 1 group. Please select more groups from the 'Active Groups' section above.";
+
 export function getDefaultGroupName(
     filters:StudyViewFilter,
     entrezGeneIdToGene:{[entrez:number]:GeneIdentifier}

--- a/src/pages/groupComparison/Overlap.tsx
+++ b/src/pages/groupComparison/Overlap.tsx
@@ -11,7 +11,12 @@ import DownloadControls from 'shared/components/downloadControls/DownloadControl
 import {MakeMobxView} from "../../shared/components/MobxView";
 import Loader from "../../shared/components/loadingIndicator/LoadingIndicator";
 import ErrorMessage from "../../shared/components/ErrorMessage";
-import {getCombinations, getSampleIdentifiers} from "./GroupComparisonUtils";
+import {
+    ENRICHMENTS_NOT_2_GROUPS_MSG,
+    getCombinations,
+    getSampleIdentifiers,
+    OVERLAP_NOT_ENOUGH_GROUPS_MSG
+} from "./GroupComparisonUtils";
 import {remoteData} from "../../shared/api/remoteData";
 
 export interface IOverlapProps {
@@ -40,6 +45,27 @@ export default class Overlap extends React.Component<IOverlapProps, {}> {
     componentDidUpdate() {
         this.plotExists = !!this.getSvg();
     }
+
+    readonly tabUI = MakeMobxView({
+        await:()=>{
+            if (this.props.store.activeGroups.isComplete &&
+                this.props.store.activeGroups.result.length < 2) {
+                // dont bother loading data for and computing overlap if not enough groups for it
+                return [this.props.store.activeGroups];
+            } else {
+                return [this.props.store.activeGroups, this.overlapUI];
+            }
+        },
+        render:()=>{
+            if (this.props.store.activeGroups.result!.length < 2) {
+                return <span>{OVERLAP_NOT_ENOUGH_GROUPS_MSG}</span>;
+            } else {
+                return this.overlapUI.component;
+            }
+        },
+        renderPending:()=><Loader isLoading={true} centerRelativeToContainer={true} size={"big"}/>,
+        renderError:()=><ErrorMessage/>
+    });
 
     @autobind
     private getSvg() {
@@ -124,7 +150,7 @@ export default class Overlap extends React.Component<IOverlapProps, {}> {
         renderError:()=><ErrorMessage/>
     });
 
-    readonly tabUI = MakeMobxView({
+    readonly overlapUI = MakeMobxView({
         await:()=>[this.plot],
         render:()=>(
             <div>
@@ -144,7 +170,7 @@ export default class Overlap extends React.Component<IOverlapProps, {}> {
                 </div>
             </div>
         ),
-        renderPending:()=><LoadingIndicator center={true} isLoading={true} size="big"/>,
+        renderPending:()=><LoadingIndicator isLoading={true} centerRelativeToContainer={true} size="big"/>,
         renderError:()=><ErrorMessage/>
     });
 

--- a/src/pages/groupComparison/OverlapVenn.tsx
+++ b/src/pages/groupComparison/OverlapVenn.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { observer } from "mobx-react";
-import * as d3 from 'd3';
-import autobind from 'autobind-decorator';
-const venn = require('venn.js');
 import { VictoryLabel, VictoryLegend } from 'victory';
 import CBIOPORTAL_VICTORY_THEME from 'shared/theme/cBioPoralTheme';
 import _ from "lodash";
 import { computed } from 'mobx';
-import {ComparisonGroup, getCombinations, getVennPlotData} from './GroupComparisonUtils';
+import {ComparisonGroup} from './GroupComparisonUtils';
+import VennSimple from "./VennSimple";
 
 export interface IVennProps {
     svgId?: string;
@@ -22,99 +20,28 @@ export interface IVennProps {
     uidToGroup: { [uid: string]: ComparisonGroup };
 }
 
-const VENN_PLOT_WIDTH = 250;
-const PADDING_BTWN_SAMPLE_AND_PATIENT = 50;
-const VENN_PLOT_HEIGHT = 200;
+const VENN_PLOT_WIDTH = 400;
+const PADDING_BTWN_SAMPLE_AND_PATIENT = 10;
+const VENN_PLOT_HEIGHT = 400;
+const PADDING_BTWN_VENN_AND_LEGEND = 20;
+const LEGEND_WIDTH = 180;
+
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {
+            feDropShadow:any; // for some reason typescript doesnt know about this SVG tag
+        }
+    }
+}
 
 @observer
 export default class Venn extends React.Component<IVennProps, {}> {
-
-    constructor(props: IVennProps, context: any) {
-        super(props, context);
-    }
-
-    componentDidMount() {
-        this.createVennDiagram(this.sampleSets, 'sampleVennDiagram')
-        this.createVennDiagram(this.patientSets, 'patientVennDiagram')
-    }
-
-    componentDidUpdate() {
-        this.createVennDiagram(this.sampleSets, 'sampleVennDiagram')
-        this.createVennDiagram(this.patientSets, 'patientVennDiagram')
-    }
-
-    @computed get sampleSets() {
-        return getVennPlotData(getCombinations(this.props.sampleGroups));
-    }
-
-    @computed get patientSets() {
-        return getVennPlotData(getCombinations(this.props.patientGroups));
-    }
-
-    @autobind
-    getColor(categories: string[]) {
-        return categories.length === 1 ? this.props.uidToGroup[categories[0]].color : undefined
-    }
-
-    @autobind
-    private createVennDiagram(sets: {
-        label: string;
-        size: number;
-        sets: string[];
-    }[], id: string) {
-        let self = this
-
-        let vennDiagram = venn.VennDiagram();
-        vennDiagram.width(VENN_PLOT_WIDTH);
-        vennDiagram.height(VENN_PLOT_HEIGHT);
-        vennDiagram.padding(5);
-        vennDiagram.fontSize('14px');
-
-        let vennDiagramDiv = d3.select(`#${id}`)
-        vennDiagramDiv.datum(sets).call(vennDiagram);
-
-        vennDiagramDiv.selectAll(".venn-circle path")
-            .style("fill-opacity", .8)
-            .style("fill", function (d: any) { return self.getColor(d.sets); });
-
-        vennDiagramDiv.selectAll(".venn-intersection text")
-            .style("font-size", '10px');
-
-        vennDiagramDiv.selectAll("text")
-            .style("fill", "black")
-
-        vennDiagramDiv.selectAll("path")
-            .style("stroke-opacity", 0)
-            .style("stroke", "#fff")
-            .style("stroke-width", 3);
-
-        vennDiagramDiv.selectAll("g")
-            .on("mouseover", function (d: any) {
-                // highlight the current path
-                d3.select(this)
-                    .select("path")
-                    .style("fill-opacity", d.sets.length == 1 ? .4 : .1)
-                    .style("stroke-opacity", 1);
-            })
-            .on("mouseout", function (d: any) {
-                d3.select(this)
-                    .select("path")
-                    .style("fill-opacity", d.sets.length == 1 ? .8 : .0)
-                    .style("stroke-opacity", 0);
-            });
-
-    }
-
     @computed get chartWidth() {
-        return this.vennPlotAreaWidth + 200;
+        return this.vennPlotAreaWidth + PADDING_BTWN_VENN_AND_LEGEND + LEGEND_WIDTH;
     }
 
     @computed get chartHeight() {
         return 500;
-    }
-
-    @computed get topPadding() {
-        return 100
     }
 
     @computed get legendData() {
@@ -136,21 +63,20 @@ export default class Venn extends React.Component<IVennProps, {}> {
     }
 
     public render() {
-        return (<div
-            style={{ width: this.chartWidth, height: this.chartHeight }}
-        >
+        return (
             <svg
                 id={this.props.svgId || ""}
-                style={{
-                    width: this.chartWidth,
-                    height: this.chartHeight,
-                    pointerEvents: "all"
-                }}
-                height={this.chartHeight}
+                xmlns="http://www.w3.org/2000/svg"
                 width={this.chartWidth}
+                height={this.chartHeight}
                 role="img"
                 viewBox={`0 0 ${this.chartWidth} ${this.chartHeight}`}
             >
+                <defs>
+                    <filter x="0" y="0" width="100" height="100" id="caseCountBackground">
+                        <feDropShadow as any dx="0" dy="0" floodColor="white" stdDeviation="2" floodOpacity="0.5"/>
+                    </filter>
+                </defs>
                 <VictoryLabel
                     style={{
                         fontWeight: "bold",
@@ -161,7 +87,16 @@ export default class Venn extends React.Component<IVennProps, {}> {
                     y="1.2em"
                     text={'Samples overlap'}
                 />
-                <g id="sampleVennDiagram" transform={`translate(0,${this.topPadding})`} />
+                <VennSimple
+                    x={0}
+                    y={15}
+                    groups={this.props.sampleGroups}
+                    uidToGroup={this.props.uidToGroup}
+                    width={VENN_PLOT_WIDTH}
+                    height={VENN_PLOT_HEIGHT}
+                    caseCountFilterName="caseCountBackground"
+                    onClickRegion={()=>{}}
+                />
 
                 <VictoryLabel
                     style={{
@@ -174,18 +109,28 @@ export default class Venn extends React.Component<IVennProps, {}> {
                     y="1.2em"
                     text={'Patients overlap'}
                 />
-                <g id="patientVennDiagram" transform={`translate(${VENN_PLOT_WIDTH+PADDING_BTWN_SAMPLE_AND_PATIENT},${this.topPadding})`} />
+
+                <VennSimple
+                    x={VENN_PLOT_WIDTH+PADDING_BTWN_SAMPLE_AND_PATIENT}
+                    y={15}
+                    groups={this.props.patientGroups}
+                    uidToGroup={this.props.uidToGroup}
+                    width={VENN_PLOT_WIDTH}
+                    height={VENN_PLOT_HEIGHT}
+                    caseCountFilterName="caseCountBackground"
+                    onClickRegion={()=>{}}
+                />
 
                 {this.legendData.length > 0 && (
                     <VictoryLegend
-                        x={this.vennPlotAreaWidth}
-                        y={this.topPadding}
+                        x={this.vennPlotAreaWidth + PADDING_BTWN_VENN_AND_LEGEND}
+                        y={100}
                         theme={CBIOPORTAL_VICTORY_THEME}
                         standalone={false}
                         data={this.legendData}
                     />
                 )}
             </svg>
-        </div>)
+        );
     }
 }

--- a/src/pages/groupComparison/VennSimple.tsx
+++ b/src/pages/groupComparison/VennSimple.tsx
@@ -1,0 +1,264 @@
+import * as React from "react";
+import {observer} from "mobx-react";
+import {computed, observable} from "mobx";
+import autobind from "autobind-decorator";
+import {ComparisonGroup} from "./GroupComparisonUtils";
+import * as d3 from 'd3';
+import _ from "lodash";
+import LazyMemo from "../../shared/lib/LazyMemo";
+import MemoizedHandlerFactory from "../../shared/lib/MemoizedHandlerFactory";
+
+export interface IVennSimpleProps {
+    groups: {
+        uid: string;
+        cases: string[];
+    }[]; // either 2 or 3
+    x:number;
+    y:number;
+    width:number;
+    height:number;
+    uidToGroup: { [uid: string]: ComparisonGroup };
+    onClickRegion:(regionParams:{ intersectedUids:string[], excludedUids:string[] })=>void;
+    caseCountFilterName:string;
+}
+
+function blendColors(colors:string[]) {
+    // helper function for venn diagram drawing. In order to highlight set complements,
+    //  we draw things from the bottom up - the visual exclusion simulates the complement,
+    //  even though we don't explicitly draw the set complements in SVG. In order to make
+    //  this work, no element can have less than 1 opacity - it would show that the entire
+    //  set, not just the complement, is being highlighted and ruin the effect. Therefore...
+
+    // TL;DR: We use this function to blend colors between groups, for the intersection regions.
+
+    switch (colors.length) {
+        case 1:
+            // for 1 color, no blending necessary
+            return colors[0];
+        case 2:
+            // for 2 colors, easy linear blend in Lab space
+            return d3.interpolateLab(colors[0], colors[1])(0.5);
+        case 3:
+        default:
+            // for 3 colors, linear blend between the first two,
+            //  then linear blend between the first-two-blend, and the third.
+            return d3.interpolateLab(
+                d3.interpolateLab(colors[0], colors[1])(0.5),
+                colors[2]
+            )(0.5);
+    }
+}
+
+function regionMouseOver(e:any) {
+    e.target.setAttribute("fill", e.target.getAttribute("data-hover-fill"));
+}
+
+function regionMouseOut(e:any) {
+    e.target.setAttribute("fill", e.target.getAttribute("data-default-fill"));
+}
+
+function getExcludedIndexes(combination:number[], numGroupsTotal:number) {
+    // get all indexes not in the given combination
+
+    const excl = [];
+    for (let i=0; i<numGroupsTotal; i++) {
+        if (!combination.includes(i)) {
+            excl.push(i);
+        }
+    }
+    return excl;
+}
+
+@observer
+export default class VennSimple extends React.Component<IVennSimpleProps, {}> {
+    @observable.ref svg:SVGElement|null;
+    private regionClickHandlers = MemoizedHandlerFactory(
+        (params:{
+            combination:number[],
+            numGroupsTotal:number
+        }) => this.props.onClickRegion({
+            intersectedUids: params.combination.map(index=>this.props.groups[index].uid),
+            excludedUids:getExcludedIndexes(params.combination, params.numGroupsTotal).map(index=>this.props.groups[index].uid)
+        })
+    );
+
+    @autobind private svgRef(_svg:SVGElement|null) {
+        this.svg = _svg;
+    }
+
+    @computed get maxCircleRadius() {
+        return Math.min(this.props.width, this.props.height) / 4;
+    }
+
+    @computed get minCircleRadius() {
+        return this.maxCircleRadius - 30;
+    }
+
+    @computed get circleRadii() {
+        const maxVal = Math.max(...this.props.groups.map((g:IVennSimpleProps["groups"][0])=>g.cases.length));
+        const minVal = maxVal / 10;
+
+        const radius = (numCases:number)=>{
+            const x = Math.max(numCases, minVal);
+
+            // Linear scale where biggest group gets max circle radius, and anything smaller than
+            //  10% max group size gets min circle radius
+            return (1 - ((maxVal - x)/(maxVal - minVal))) * (this.maxCircleRadius - this.minCircleRadius) + this.minCircleRadius;
+        };
+
+        return this.props.groups.reduce((map, group)=>{
+            map[group.uid] = radius(group.cases.length);
+            return map;
+        }, {} as {[uid:string]:number});
+    }
+
+    @computed get angleIncrement() {
+        // divide the circle (2PI radians) into (# groups), in order
+        //  to arrange the group circles evenly spaced in a circle
+        return Math.PI*2 / this.props.groups.length;
+    }
+
+    @computed get circleCenters() {
+        // arrange the circles evenly spaced in a circle around the center of the svg
+        const svgCenter = { x: this.props.width / 2, y: this.props.height / 2 };
+        return this.props.groups.reduce((map, group, index)=>{
+            const distanceFromCenter = 0.7*this.circleRadii[group.uid];
+            // distance from center is less than the full radius, so that there are intersection regions
+            map[group.uid] = {
+                x: svgCenter.x + distanceFromCenter*Math.cos(this.angleIncrement*index),
+                y: svgCenter.y + distanceFromCenter*Math.sin(this.angleIncrement*index)
+            };
+            return map;
+        }, {} as {[uid:string]:{x:number, y:number}});
+    }
+
+    @computed get displayElements() {
+        // Compute all of the display elements of the venn diagram - the outline, the fills, and the text
+
+        // compute the clip paths corresponding to each group circle
+        const clipPaths = this.props.groups.map((group, index)=>(
+            <clipPath id={`circle_${index}`}>
+                <circle
+                    cx={this.circleCenters[group.uid].x}
+                    cy={this.circleCenters[group.uid].y}
+                    r={this.circleRadii[group.uid]}
+                />
+            </clipPath>
+        ));
+
+        // each region corresponds to a combination of groups that it represents
+        let combinations:number[][]; // in painting order so that mouse interactions look right
+        switch (this.props.groups.length) {
+            case 2:
+                // all combinations of two groups
+                combinations = [[0], [1], [0,1]];
+                break;
+            case 3:
+            default:
+                // all combinations of three groups
+                combinations = [[0],[1],[2],[0,1],[0,2],[1,2],[0,1,2]];
+                break;
+        }
+        return _.flattenDeep<any>((clipPaths as any).concat(combinations.map(comb=>{
+            // FOR EACH REGION: generate the filled area, and the "# cases" text for it
+            // Each region is specified by the combination of groups corresponding to it, which is our iteration param.
+
+            // compute the fill based on the colors of the included groups
+            const fill = blendColors(comb.map(index=>this.props.uidToGroup[this.props.groups[index].uid].color));
+
+            // compute the cases in this region
+            let casesInRegion = _.intersection(...comb.map(index=>this.props.groups[index].cases));
+            for (const i of getExcludedIndexes(comb, this.props.groups.length)) {
+                _.pullAll(casesInRegion, this.props.groups[i].cases);
+            }
+
+            // generate clipped hover area by iteratively nesting a rect in all the clip paths
+            //  corresponding to groups in this area. This clips out, one by one, everything
+            //  except for the intersection.
+            let hoverArea:JSX.Element = (
+                <rect
+                    x="0"
+                    y="0"
+                    height={this.props.height}
+                    width={this.props.width}
+                    fill={casesInRegion.length === 0 ? "white" : fill}
+                    data-default-fill={fill}
+                    data-hover-fill={d3.hsl(fill).brighter(1).rgb()}
+                    onMouseOver={casesInRegion.length > 0 ? regionMouseOver : undefined}
+                    onMouseOut={casesInRegion.length > 0 ? regionMouseOut : undefined}
+                    onClick={this.regionClickHandlers({ combination: comb, numGroupsTotal: this.props.groups.length })}
+                />
+            );
+            for (const index of comb) {
+                hoverArea = (
+                    <g clipPath={`url(#circle_${index})`}>
+                        {hoverArea}
+                    </g>
+                );
+            }
+
+            // compute location of the "# cases" text
+            let x:number, y:number;
+            if (comb.length === this.props.groups.length) {
+                // center intersection
+                x = this.props.width/2;
+                y = this.props.height/2;
+            } else if (comb.length === 1) {
+                // single group
+                const group = this.props.groups[comb[0]];
+                const angle = comb[0]*this.angleIncrement;
+                x = this.props.width/2 + 1.25*this.circleRadii[group.uid]*Math.cos(angle);
+                y = this.props.height/2 + 1.25*this.circleRadii[group.uid]*Math.sin(angle);
+            } else {
+                // two groups out of three
+                let angleMultiple;
+                if (comb[1] - comb[0] === 1) {
+                    angleMultiple = (comb[0] + comb[1]) / 2;
+                } else {
+                    // have to manually handle case of 0 and 2 because
+                    //  angles wrap at 2*PI making average mess up in this case
+                    angleMultiple = 2.5;
+                }
+                const angle = angleMultiple*this.angleIncrement;
+                const radius = 0.7*Math.min(
+                    this.circleRadii[this.props.groups[comb[0]].uid],
+                    this.circleRadii[this.props.groups[comb[1]].uid]
+                );
+                x = this.props.width/2 + radius*Math.cos(angle);
+                y = this.props.height/2 + radius*Math.sin(angle);
+            }
+            return [
+                hoverArea,
+                <text
+                    x={x}
+                    y={y}
+                    fontWeight={casesInRegion.length > 0 ? "bold" : "normal"}
+                    filter={`url(#${this.props.caseCountFilterName})`}
+                    pointerEvents="none"
+                >
+                    {casesInRegion.length}
+                </text>
+            ];
+        })).concat(this.props.groups.map(group=>(
+            // draw the outlines of the circles
+            <circle
+                cx={this.circleCenters[group.uid].x}
+                cy={this.circleCenters[group.uid].y}
+                r={this.circleRadii[group.uid]}
+                fill="none"
+                stroke="black"
+                strokeWidth={2}
+            />
+        ))));
+    }
+
+    render() {
+        return (
+            <g
+                transform={`translate(${this.props.x},${this.props.y})`}
+            >
+                {this.displayElements}
+            </g>
+        );
+    }
+}

--- a/src/shared/components/loadingIndicator/LoadingIndicator.tsx
+++ b/src/shared/components/loadingIndicator/LoadingIndicator.tsx
@@ -13,6 +13,7 @@ export interface ILoader {
     big?: boolean;
     inline?: boolean;
     center?: boolean;
+    centerRelativeToContainer?:boolean;
     size?: "big" | "small"
     className?:string;
 }
@@ -35,7 +36,8 @@ export default class LoadingIndicator extends React.Component<ILoader, {}> {
 
         const parentStyles = {
             [styles.centered]:this.props.center,
-            [styles["centered-with-children"]]:this.props.center && (React.Children.count(this.props.children) > 0),
+            [styles["centered-relative-to-container"]]:this.props.centerRelativeToContainer,
+            [styles["centered-with-children"]]:(this.props.center || this.props.centerRelativeToContainer) && (React.Children.count(this.props.children) > 0),
             inlineBlock: this.props.inline
         };
 

--- a/src/shared/components/loadingIndicator/styles.module.scss
+++ b/src/shared/components/loadingIndicator/styles.module.scss
@@ -12,6 +12,15 @@
 
 }
 
+.centered-relative-to-container {
+  position:absolute;
+  top: 300px;
+  left:50%;
+  z-index:10000;
+  text-align:center;
+  transform: translateX(-50%);
+}
+
 .centered-with-children {
   // fixes blurry text bug to have an even # of pixels in width
   width:600px;

--- a/src/shared/lib/MemoizedHandlerFactory.ts
+++ b/src/shared/lib/MemoizedHandlerFactory.ts
@@ -1,0 +1,19 @@
+import LazyMemo from "./LazyMemo";
+
+function shallowAlphabeticalStringify(obj:any) {
+    return JSON.stringify(obj, Object.keys(obj).sort());
+}
+
+export default function MemoizedHandlerFactory<Params>(
+    handler:(params:Params)=>void,
+    key:(params:Params)=>string = shallowAlphabeticalStringify
+) {
+    const memo = new LazyMemo<Params, ()=>void>(
+        key,
+        (params:Params)=>{
+            return ()=>handler(params);
+        }
+    );
+
+    return (params:Params)=>memo.get(params);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,11 +3138,6 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-contour_plot@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/contour_plot/-/contour_plot-0.0.1.tgz#475870f032b8e338412aa5fc507880f0bf495c77"
-  integrity sha1-R1hw8DK44zhBKqX8UHiA8L9JXHc=
-
 contrast@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/contrast/-/contrast-1.0.1.tgz#839c66d8852269d33f4eb0a1b92d994bdd16385e"
@@ -3657,11 +3652,6 @@ d3-dsv@1.0.8:
     iconv-lite "0.4"
     rw "1"
 
-d3-ease@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.5.tgz#8ce59276d81241b1b72042d6af2d40e76d936ffb"
-  integrity sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ==
-
 d3-ease@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
@@ -3732,11 +3722,6 @@ d3-scale@^2.0.0:
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@^1.0.2, d3-selection@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.0.tgz#ab9ac1e664cf967ebf1b479cc07e28ce9908c474"
-  integrity sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg==
-
 d3-shape@^1.0.0, d3-shape@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
@@ -3760,18 +3745,6 @@ d3-timer@1, d3-timer@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.7.tgz#df9650ca587f6c96607ff4e60cc38229e8dd8531"
   integrity sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA==
-
-d3-transition@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.2.0.tgz#f538c0e21b2aa1f05f3e965f8567e81284b3b2b8"
-  integrity sha512-VJ7cmX/FPIPJYuaL2r1o1EMHLttvoIuZhhuAlRoOxDzogV8iQS6jYulDm3xEU3TqL80IZIhI551/ebmCMrkvhw==
-  dependencies:
-    d3-color "1"
-    d3-dispatch "1"
-    d3-ease "1"
-    d3-interpolate "1"
-    d3-selection "^1.1.0"
-    d3-timer "1"
 
 d3-voronoi@^1.1.2:
   version "1.1.2"
@@ -5376,17 +5349,6 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-fmin@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/fmin/-/fmin-0.0.2.tgz#59bbb40d43ffdc1c94cd00a568c41f95f1973017"
-  integrity sha1-Wbu0DUP/3ByUzQClaMQflfGXMBc=
-  dependencies:
-    contour_plot "^0.0.1"
-    json2module "^0.0.3"
-    rollup "^0.25.8"
-    tape "^4.5.1"
-    uglify-js "^2.6.2"
-
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -6148,7 +6110,7 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@~7.1.1, glob@~7.1.2, glob@~7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@~7.1.1, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -7617,13 +7579,6 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-
-json2module@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/json2module/-/json2module-0.0.3.tgz#00fb5f4a9b7adfc3f0647c29cb17bcd1979be9b2"
-  integrity sha1-APtfSpt638PwZHwpyxe80Zeb6bI=
-  dependencies:
-    rw "^1.3.2"
 
 json3@3.3.2, json3@^3.3.2:
   version "3.3.2"
@@ -12100,7 +12055,7 @@ resolve@^1.5.0, resolve@^1.6.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.8.1, resolve@~1.10.0:
+resolve@^1.8.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -12276,15 +12231,6 @@ robust-sum@^1.0.0:
   resolved "https://registry.yarnpkg.com/robust-sum/-/robust-sum-1.0.0.tgz#16646e525292b4d25d82757a286955e0bbfa53d9"
   integrity sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k=
 
-rollup@^0.25.8:
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.25.8.tgz#bf6ce83b87510d163446eeaa577ed6a6fc5835e0"
-  integrity sha1-v2zoO4dRDRY0Ru6qV37WpvxYNeA=
-  dependencies:
-    chalk "^1.1.1"
-    minimist "^1.2.0"
-    source-map-support "^0.3.2"
-
 route-parser@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/route-parser/-/route-parser-0.0.5.tgz#7d1d09d335e49094031ea16991a4a79b01bbe1f4"
@@ -12305,7 +12251,7 @@ run-async@^0.1.0:
   dependencies:
     once "^1.3.0"
 
-rw@1, rw@^1.3.2, rw@^1.3.3:
+rw@1, rw@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
@@ -12916,13 +12862,6 @@ source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.3.2:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.3.3.tgz#34900977d5ba3f07c7757ee72e73bb1a9b53754f"
-  integrity sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=
-  dependencies:
-    source-map "0.1.32"
-
 source-map-support@^0.4.15:
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.16.tgz#16fecf98212467d017d586a2af68d628b9421cd8"
@@ -12934,13 +12873,6 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
-
-source-map@0.1.32:
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
-  integrity sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=
-  dependencies:
-    amdefine ">=0.0.4"
 
 source-map@0.5.6:
   version "0.5.6"
@@ -13530,25 +13462,6 @@ tape@^4.0.0, tape@^4.6.0:
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
-tape@^4.5.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.10.1.tgz#f73be60888dcb120f08b57f947af65a829506a5f"
-  integrity sha512-G0DywYV1jQeY3axeYnXUOt6ktnxS9OPJh97FGR3nrua8lhWi1zPflLxcAHavZ7Jf3qUfY7cxcVIVFa4mY2IY1w==
-  dependencies:
-    deep-equal "~1.0.1"
-    defined "~1.0.0"
-    for-each "~0.3.3"
-    function-bind "~1.1.1"
-    glob "~7.1.3"
-    has "~1.0.3"
-    inherits "~2.0.3"
-    minimist "~1.2.0"
-    object-inspect "~1.6.0"
-    resolve "~1.10.0"
-    resumer "~0.0.0"
-    string.prototype.trim "~1.1.2"
-    through "~2.3.8"
-
 tar@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -13954,7 +13867,7 @@ uglify-js@3.4.x:
     commander "~2.17.1"
     source-map "~0.6.1"
 
-uglify-js@^2.6.0, uglify-js@^2.6.2, uglify-js@^2.8.27, uglify-js@^2.8.29:
+uglify-js@^2.6.0, uglify-js@^2.8.27, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
@@ -14310,15 +14223,6 @@ vendors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.1.tgz#37ad73c8ee417fb3d580e785312307d274847f22"
   integrity sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=
-
-venn.js@^0.2.20:
-  version "0.2.20"
-  resolved "https://registry.yarnpkg.com/venn.js/-/venn.js-0.2.20.tgz#3f0e50cc75cba1f58692a8a32f67bd7aaf1aa6fa"
-  integrity sha512-bb5SYq/wamY9fvcuErb9a0FJkgIFHJjkLZWonQ+DoKKuDX3WPH2B4ouI1ce4K2iejBklQy6r1ly8nOGIyOCO6w==
-  dependencies:
-    d3-selection "^1.0.2"
-    d3-transition "^1.0.1"
-    fmin "0.0.2"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Venn.js doesn't support interaction with set complements (i.e. only group A, only group B)

It's hard to support set complements in SVG. I'm doing it by
(1) building regions for each intersection (good support in SVG)
(2) drawing the regions in order so that each lower intersection corresponds to the complement of it with what comes next

![image](https://user-images.githubusercontent.com/636232/55248066-6c8aa480-521f-11e9-8b50-1b2b7de89816.png)

![image](https://user-images.githubusercontent.com/636232/55248087-73191c00-521f-11e9-937f-ec2571b82e10.png)
