### PR TITLE
Updating Tables to show number of genes profiled in tooltip

### DIFF
--- a/src/pages/studyView/table/CNAGenesTable.tsx
+++ b/src/pages/studyView/table/CNAGenesTable.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import * as _ from "lodash";
-import {CNAGenesData, CopyNumberAlterationIdentifier} from "pages/studyView/StudyViewPageStore";
-import {action, computed, IReactionDisposer, observable, reaction} from "mobx";
-import {observer} from "mobx-react";
+import { CNAGenesData, CopyNumberAlterationIdentifier } from "pages/studyView/StudyViewPageStore";
+import { action, computed, IReactionDisposer, observable, reaction } from "mobx";
+import { observer } from "mobx-react";
 import styles from "./tables.module.scss";
-import {CopyNumberCountByGene, CopyNumberGeneFilterElement} from "shared/api/generated/CBioPortalAPIInternal";
+import { CopyNumberCountByGene, CopyNumberGeneFilterElement } from "shared/api/generated/CBioPortalAPIInternal";
 import MobxPromise from "mobxpromise";
-import {If} from 'react-if';
+import { If } from 'react-if';
 import classnames from 'classnames';
 import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
 import LabeledCheckbox from "shared/components/labeledCheckbox/LabeledCheckbox";
@@ -22,11 +22,11 @@ import {
     getFrequencyStr,
     getQValue
 } from "../StudyViewUtils";
-import {SortDirection} from "../../../shared/components/lazyMobXTable/LazyMobXTable";
-import {DEFAULT_SORTING_COLUMN} from "../StudyViewConfig";
+import { SortDirection } from "../../../shared/components/lazyMobXTable/LazyMobXTable";
+import { DEFAULT_SORTING_COLUMN } from "../StudyViewConfig";
 
 
-export type  CNAGenesTableUserSelectionWithIndex = CopyNumberAlterationIdentifier & {
+export type CNAGenesTableUserSelectionWithIndex = CopyNumberAlterationIdentifier & {
     rowIndex: number;
 }
 
@@ -65,7 +65,7 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
         [ColumnKey.FREQ]: 0,
     };
 
-    private reactions:IReactionDisposer[] = [];
+    private reactions: IReactionDisposer[] = [];
 
     constructor(props: ICNAGenesTablePros) {
         super(props);
@@ -73,12 +73,12 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
         this.reactions.push(
             reaction(() => this.columnsWidth, () => {
                 this.updateCellMargin();
-            }, {fireImmediately: true})
+            }, { fireImmediately: true })
         );
         this.reactions.push(
             reaction(() => this.props.promise.result, () => {
                 this.updateCellMargin();
-            }, {fireImmediately: true})
+            }, { fireImmediately: true })
         );
     }
 
@@ -113,7 +113,7 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
                 getFixedHeaderNumberCellMargin(
                     this.columnsWidth[ColumnKey.FREQ],
                     getFrequencyStr(
-                        _.max(this.props.promise.result!.map(item => item.frequency))!
+                        _.max(this.props.promise.result!.map(item => (item.countByEntity / item.numberOfSamplesProfiled * 100)))!
                     )
                 )
             );
@@ -129,7 +129,7 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
                 const addGeneOverlay = () =>
                     <span>{`Click ${data.hugoGeneSymbol} to ${_.includes(this.props.selectedGenes, data.hugoGeneSymbol) ? 'remove from' : 'add to'} your query`}</span>;
                 const qvalOverlay = () =>
-                    <div><b>Gistic</b><br/><i>Q-value: </i><span>{getQValue(data.qValue)}</span></div>;
+                    <div><b>Gistic</b><br /><i>Q-value: </i><span>{getQValue(data.qValue)}</span></div>;
                 return (
                     <div className={classnames(styles.displayFlex)}>
                         <DefaultTooltip
@@ -149,8 +149,8 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
                                 overlay={qvalOverlay}
                                 destroyTooltipOnHide={true}
                             >
-                                    <span><img src={require("./images/gistic.png")}
-                                               className={styles.gistic}></img></span>
+                                <span><img src={require("./images/gistic.png")}
+                                    className={styles.gistic}></img></span>
                             </DefaultTooltip>
                         </If>
                     </div>
@@ -176,7 +176,7 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
             name: ColumnKey.CNA,
             tooltip: (<span>Copy number alteration, only amplifications and deep deletions are shown</span>),
             render: (data: CopyNumberCountByGene) =>
-                <span style={{color: getCNAColorByAlteration(data.alteration), fontWeight: 'bold'}}>
+                <span style={{ color: getCNAColorByAlteration(data.alteration), fontWeight: 'bold' }}>
                     {getCNAByAlteration(data.alteration)}
                 </span>,
             sortBy: (data: CopyNumberCountByGene) => data.alteration,
@@ -189,7 +189,7 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
             name: ColumnKey.NUMBER,
             tooltip: (<span>Number of samples with the listed copy number alteration</span>),
             headerRender: () => {
-                return <div style={{marginLeft: this.cellMargin[ColumnKey.NUMBER]}}>#</div>
+                return <div style={{ marginLeft: this.cellMargin[ColumnKey.NUMBER] }}>#</div>
             },
             render: (data: CopyNumberCountByGene) =>
                 <LabeledCheckbox
@@ -220,18 +220,32 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
             name: ColumnKey.FREQ,
             tooltip: (<span>Percentage of samples with the listed copy number alteration</span>),
             headerRender: () => {
-                return <div style={{marginLeft: this.cellMargin[ColumnKey.FREQ]}}>Freq</div>
+                return <div style={{ marginLeft: this.cellMargin[ColumnKey.FREQ] }}>Freq</div>
             },
-            render: (data: CopyNumberCountByGene) => <span
-                style={{
-                    flexDirection: 'row-reverse',
-                    display: 'flex',
-                    marginRight: this.cellMargin[ColumnKey.FREQ]
-                }}>{getFrequencyStr(data.frequency)}</span>,
-            sortBy: (data: CopyNumberCountByGene) => data.frequency,
+            render: (data: CopyNumberCountByGene) => {
+                const addTotalProfiledOverlay = () =>
+                    <span>{`# of samples profiled for CNA in this gene: ${data.numberOfSamplesProfiled}`}</span>;
+                return (
+                    <div className={styles.displayFlex}>
+                        <DefaultTooltip
+                            placement="right"
+                            overlay={addTotalProfiledOverlay}
+                            destroyTooltipOnHide={true}
+                        >
+                            <span
+                                style={{
+                                    flexDirection: 'row-reverse',
+                                    display: 'flex',
+                                    marginRight: this.cellMargin[ColumnKey.FREQ]
+                                }}>{getFrequencyStr(data.countByEntity / data.numberOfSamplesProfiled * 100)}
+                            </span>
+                        </DefaultTooltip>
+                    </div>)
+            },
+            sortBy: (data: CopyNumberCountByGene) => data.countByEntity / data.numberOfSamplesProfiled * 100,
             defaultSortDirection: 'desc' as 'desc',
             filter: (data: CopyNumberCountByGene, filterString: string) => {
-                return _.toString(getFrequencyStr(data.frequency)).includes(filterString);
+                return _.toString(getFrequencyStr(data.countByEntity / data.numberOfSamplesProfiled * 100)).includes(filterString);
             },
             width: 70
         }]
@@ -299,7 +313,7 @@ export class CNAGenesTable extends React.Component<ICNAGenesTablePros, {}> {
             return [];
         } else {
             return _.reduce(this.props.promise.result, (acc: CNAGenesTableUserSelectionWithIndex[], row: CopyNumberCountByGene, index: number) => {
-                if (_.some(this.props.filters, {entrezGeneId: row.entrezGeneId, alteration: row.alteration})) {
+                if (_.some(this.props.filters, { entrezGeneId: row.entrezGeneId, alteration: row.alteration })) {
                     acc.push({
                         rowIndex: index,
                         entrezGeneId: row.entrezGeneId,

--- a/src/pages/studyView/table/MutatedGenesTable.tsx
+++ b/src/pages/studyView/table/MutatedGenesTable.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
-import {GeneIdentifier, MutatedGenesData} from "pages/studyView/StudyViewPageStore";
-import {observer} from "mobx-react";
+import { GeneIdentifier, MutatedGenesData } from "pages/studyView/StudyViewPageStore";
+import { observer } from "mobx-react";
 import styles from "./tables.module.scss";
-import {MutationCountByGene} from "shared/api/generated/CBioPortalAPIInternal";
+import { MutationCountByGene } from "shared/api/generated/CBioPortalAPIInternal";
 import LabeledCheckbox from "../../../shared/components/labeledCheckbox/LabeledCheckbox";
 import MobxPromise from "mobxpromise";
-import {If} from 'react-if';
+import { If } from 'react-if';
 import * as _ from 'lodash';
 import classnames from 'classnames';
 import DefaultTooltip from "shared/components/defaultTooltip/DefaultTooltip";
 import FixedHeaderTable from "./FixedHeaderTable";
-import {action, computed, IReactionDisposer, observable, reaction} from "mobx";
+import { action, computed, IReactionDisposer, observable, reaction } from "mobx";
 import autobind from 'autobind-decorator';
 import {
     correctMargin,
@@ -20,8 +20,8 @@ import {
     getFrequencyStr,
     getQValue
 } from "../StudyViewUtils";
-import {SortDirection} from "../../../shared/components/lazyMobXTable/LazyMobXTable";
-import {DEFAULT_SORTING_COLUMN} from "../StudyViewConfig";
+import { SortDirection } from "../../../shared/components/lazyMobXTable/LazyMobXTable";
+import { DEFAULT_SORTING_COLUMN } from "../StudyViewConfig";
 
 export interface IMutatedGenesTablePros {
     promise: MobxPromise<MutatedGenesData>;
@@ -62,19 +62,19 @@ export class MutatedGenesTable extends React.Component<IMutatedGenesTablePros, {
         [ColumnKey.FREQ]: 0,
     };
 
-    private reactions:IReactionDisposer[] = [];
+    private reactions: IReactionDisposer[] = [];
 
     constructor(props: IMutatedGenesTablePros) {
         super(props);
         this.reactions.push(
             reaction(() => this.columnsWidth, () => {
                 this.updateCellMargin();
-            }, {fireImmediately: true})
+            }, { fireImmediately: true })
         );
         this.reactions.push(
             reaction(() => this.props.promise.result, () => {
                 this.updateCellMargin();
-            }, {fireImmediately: true})
+            }, { fireImmediately: true })
         );
     }
 
@@ -106,14 +106,14 @@ export class MutatedGenesTable extends React.Component<IMutatedGenesTablePros, {
             );
             this.cellMargin[ColumnKey.NUMBER] = correctMargin(
                 (this.columnsWidth[ColumnKey.NUMBER] - 10 - (
-                        getFixedHeaderTableMaxLengthStringPixel(
-                            _.max(this.props.promise.result!.map(item => item.countByEntity))!.toLocaleString()
-                        ) + 20)
+                    getFixedHeaderTableMaxLengthStringPixel(
+                        _.max(this.props.promise.result!.map(item => item.countByEntity))!.toLocaleString()
+                    ) + 20)
                 ) / 2);
             this.cellMargin[ColumnKey.FREQ] = correctMargin(
                 getFixedHeaderNumberCellMargin(
                     this.columnsWidth[ColumnKey.FREQ],
-                    getFrequencyStr(_.max(this.props.promise.result!.map(item => item.frequency))!)
+                    getFrequencyStr(_.max(this.props.promise.result!.map(item => item.countByEntity / item.numberOfSamplesProfiled * 100))!)
                 )
             );
         }
@@ -128,7 +128,7 @@ export class MutatedGenesTable extends React.Component<IMutatedGenesTablePros, {
                 const addGeneOverlay = () =>
                     <span>{`Click ${data.hugoGeneSymbol} to ${_.includes(this.props.selectedGenes, data.hugoGeneSymbol) ? 'remove from' : 'add to'} your query`}</span>;
                 const qvalOverlay = () =>
-                    <div><b>MutSig</b><br/><i>Q-value: </i><span>{getQValue(data.qValue)}</span></div>;
+                    <div><b>MutSig</b><br /><i>Q-value: </i><span>{getQValue(data.qValue)}</span></div>;
                 return (
                     <div className={styles.displayFlex}>
                         <DefaultTooltip
@@ -148,8 +148,8 @@ export class MutatedGenesTable extends React.Component<IMutatedGenesTablePros, {
                                 overlay={qvalOverlay}
                                 destroyTooltipOnHide={true}
                             >
-                                    <span><img src={require("./images/mutsig.png")}
-                                               className={styles.mutSig}></img></span>
+                                <span><img src={require("./images/mutsig.png")}
+                                    className={styles.mutSig}></img></span>
                             </DefaultTooltip>
                         </If>
                     </div>
@@ -165,7 +165,7 @@ export class MutatedGenesTable extends React.Component<IMutatedGenesTablePros, {
             name: ColumnKey.NUMBER_MUTATIONS,
             tooltip: (<span>Total number of mutations</span>),
             headerRender: () => {
-                return <div style={{marginLeft: this.cellMargin[ColumnKey.NUMBER_MUTATIONS]}}># Mut</div>
+                return <div style={{ marginLeft: this.cellMargin[ColumnKey.NUMBER_MUTATIONS] }}># Mut</div>
             },
             render: (data: MutationCountByGene) => <span
                 style={{
@@ -183,7 +183,7 @@ export class MutatedGenesTable extends React.Component<IMutatedGenesTablePros, {
             name: ColumnKey.NUMBER,
             tooltip: (<span>Number of samples with one or more mutations</span>),
             headerRender: () => {
-                return <div style={{marginLeft: this.cellMargin[ColumnKey.NUMBER]}}>#</div>
+                return <div style={{ marginLeft: this.cellMargin[ColumnKey.NUMBER] }}>#</div>
             },
             render: (data: MutationCountByGene) =>
                 <LabeledCheckbox
@@ -214,18 +214,32 @@ export class MutatedGenesTable extends React.Component<IMutatedGenesTablePros, {
             name: ColumnKey.FREQ,
             tooltip: (<span>Percentage of samples with one or more mutations</span>),
             headerRender: () => {
-                return <div style={{marginLeft: this.cellMargin[ColumnKey.FREQ]}}>Freq</div>
+                return <div style={{ marginLeft: this.cellMargin[ColumnKey.FREQ] }}>Freq</div>
             },
-            render: (data: MutationCountByGene) => <span
-                style={{
-                    flexDirection: 'row-reverse',
-                    display: 'flex',
-                    marginRight: this.cellMargin[ColumnKey.FREQ]
-                }}>{getFrequencyStr(data.frequency)}</span>,
-            sortBy: (data: MutationCountByGene) => data.frequency,
+            render: (data: MutationCountByGene) => {
+                const addTotalProfiledOverlay = () =>
+                    <span>{`# of samples profiled for mutations in this gene: ${data.numberOfSamplesProfiled}`}</span>;
+                return (
+                    <div className={styles.displayFlex}>
+                        <DefaultTooltip
+                            placement="right"
+                            overlay={addTotalProfiledOverlay}
+                            destroyTooltipOnHide={true}
+                        >
+                            <span
+                                style={{
+                                    flexDirection: 'row-reverse',
+                                    display: 'flex',
+                                    marginRight: this.cellMargin[ColumnKey.FREQ]
+                                }}>{getFrequencyStr(data.countByEntity / data.numberOfSamplesProfiled * 100)}
+                            </span>
+                        </DefaultTooltip>
+                    </div>)
+            },
+            sortBy: (data: MutationCountByGene) => data.countByEntity / data.numberOfSamplesProfiled * 100,
             defaultSortDirection: 'desc' as 'desc',
             filter: (data: MutationCountByGene, filterString: string) => {
-                return _.toString(getFrequencyStr(data.frequency)).includes(filterString);
+                return _.toString(getFrequencyStr(data.countByEntity / data.numberOfSamplesProfiled * 100)).includes(filterString);
             },
             width: this.columnsWidth[ColumnKey.FREQ]
         }];

--- a/src/shared/api/generated/CBioPortalAPI-docs.json
+++ b/src/shared/api/generated/CBioPortalAPI-docs.json
@@ -1,5073 +1,5073 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "description": "A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.",
-    "version": "1.0 (beta)",
-    "title": "cBioPortal web API [Beta]",
-    "contact": {
-      "name": "cBioPortal",
-      "url": "http://www.cbioportal.org",
-      "email": "cbioportal@googlegroups.com"
+    "swagger": "2.0",
+    "info": {
+        "description": "A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.",
+        "version": "1.0 (beta)",
+        "title": "cBioPortal web API [Beta]",
+        "contact": {
+            "name": "cBioPortal",
+            "url": "http://www.cbioportal.org",
+            "email": "cbioportal@googlegroups.com"
+        },
+        "license": {
+            "name": "License",
+            "url": "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE"
+        }
     },
-    "license": {
-      "name": "License",
-      "url": "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE"
+    "tags": [
+        {
+            "name": "Cancer Types",
+            "description": " "
+        },
+        {
+            "name": "Clinical Attributes",
+            "description": " "
+        },
+        {
+            "name": "Clinical Data",
+            "description": " "
+        },
+        {
+            "name": "Clinical Events",
+            "description": " "
+        },
+        {
+            "name": "Copy Number Segments",
+            "description": " "
+        },
+        {
+            "name": "Discrete Copy Number Alterations",
+            "description": " "
+        },
+        {
+            "name": "Gene Panels",
+            "description": " "
+        },
+        {
+            "name": "Genes",
+            "description": " "
+        },
+        {
+            "name": "Molecular Data",
+            "description": " "
+        },
+        {
+            "name": "Molecular Profiles",
+            "description": " "
+        },
+        {
+            "name": "Mutations",
+            "description": " "
+        },
+        {
+            "name": "Patients",
+            "description": " "
+        },
+        {
+            "name": "Sample Lists",
+            "description": " "
+        },
+        {
+            "name": "Samples",
+            "description": " "
+        },
+        {
+            "name": "Studies",
+            "description": " "
+        }
+    ],
+    "schemes": [
+        "http",
+        "https"
+    ],
+    "paths": {
+        "/cancer-types": {
+            "get": {
+                "tags": [
+                    "Cancer Types"
+                ],
+                "summary": "Get all cancer types",
+                "operationId": "getAllCancerTypesUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "cancerTypeId",
+                            "name",
+                            "clinicalTrialKeywords",
+                            "dedicatedColor",
+                            "shortName",
+                            "parent"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/TypeOfCancer"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/cancer-types/{cancerTypeId}": {
+            "get": {
+                "tags": [
+                    "Cancer Types"
+                ],
+                "summary": "Get a cancer type",
+                "operationId": "getCancerTypeUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "cancerTypeId",
+                        "in": "path",
+                        "description": "Cancer Type ID e.g. acc",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/TypeOfCancer"
+                        }
+                    }
+                }
+            }
+        },
+        "/clinical-attributes": {
+            "get": {
+                "tags": [
+                    "Clinical Attributes"
+                ],
+                "summary": "Get all clinical attributes",
+                "operationId": "getAllClinicalAttributesUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "clinicalAttributeId",
+                            "displayName",
+                            "description",
+                            "datatype",
+                            "patientAttribute",
+                            "priority",
+                            "studyId"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalAttribute"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/clinical-attributes/counts/fetch": {
+            "post": {
+                "tags": [
+                    "Clinical Attributes"
+                ],
+                "summary": "Get counts for clinical attributes according to their data availability for selected samples/patients",
+                "operationId": "getClinicalAttributeCountsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "clinicalAttributeCountFilter",
+                        "description": "List of SampleIdentifiers or Sample List ID",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ClinicalAttributeCountFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalAttributeCount"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/clinical-attributes/fetch": {
+            "post": {
+                "tags": [
+                    "Clinical Attributes"
+                ],
+                "summary": "Fetch clinical attributes",
+                "operationId": "fetchClinicalAttributesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "studyIds",
+                        "description": "List of Study IDs",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalAttribute"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/clinical-data/fetch": {
+            "post": {
+                "tags": [
+                    "Clinical Data"
+                ],
+                "summary": "Fetch clinical data by patient IDs or sample IDs (all studies)",
+                "operationId": "fetchClinicalDataUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "clinicalDataType",
+                        "in": "query",
+                        "description": "Type of the clinical data",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "clinicalDataMultiStudyFilter",
+                        "description": "List of patient or sample identifiers and attribute IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ClinicalDataMultiStudyFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/copy-number-segments/fetch": {
+            "post": {
+                "tags": [
+                    "Copy Number Segments"
+                ],
+                "summary": "Fetch copy number segments by sample ID",
+                "operationId": "fetchCopyNumberSegmentsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "sampleIdentifiers",
+                        "description": "List of sample identifiers",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SampleIdentifier"
+                            }
+                        }
+                    },
+                    {
+                        "name": "chromosome",
+                        "in": "query",
+                        "description": "Chromosome",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CopyNumberSeg"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/gene-panel-data/fetch": {
+            "post": {
+                "tags": [
+                    "Gene Panels"
+                ],
+                "summary": "Fetch gene panel data",
+                "operationId": "fetchGenePanelDataInMultipleMolecularProfilesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "genePanelMultipleStudyFilter",
+                        "description": "List of Molecular Profile ID and Sample ID pairs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GenePanelMultipleStudyFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenePanelData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/gene-panels": {
+            "get": {
+                "tags": [
+                    "Gene Panels"
+                ],
+                "summary": "Get all gene panels",
+                "operationId": "getAllGenePanelsUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "genePanelId",
+                            "description"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenePanel"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/gene-panels/fetch": {
+            "post": {
+                "tags": [
+                    "Gene Panels"
+                ],
+                "summary": "Get gene panel",
+                "operationId": "fetchGenePanelsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "genePanelIds",
+                        "description": "List of Gene Panel IDs",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenePanel"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/gene-panels/{genePanelId}": {
+            "get": {
+                "tags": [
+                    "Gene Panels"
+                ],
+                "summary": "Get gene panel",
+                "operationId": "getGenePanelUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "genePanelId",
+                        "in": "path",
+                        "description": "Gene Panel ID e.g. NSCLC_UNITO_2016_PANEL",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/GenePanel"
+                        }
+                    }
+                }
+            }
+        },
+        "/genes": {
+            "get": {
+                "tags": [
+                    "Genes"
+                ],
+                "summary": "Get all genes",
+                "operationId": "getAllGenesUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "keyword",
+                        "in": "query",
+                        "description": "Search keyword that applies to hugo gene symbol of the genes",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "alias",
+                        "in": "query",
+                        "description": "Alias of the gene",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 100000,
+                        "maximum": 100000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "entrezGeneId",
+                            "hugoGeneSymbol",
+                            "type",
+                            "cytoband",
+                            "length"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Gene"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/genes/fetch": {
+            "post": {
+                "tags": [
+                    "Genes"
+                ],
+                "summary": "Fetch genes by ID",
+                "operationId": "fetchGenesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "geneIdType",
+                        "in": "query",
+                        "description": "Type of gene ID",
+                        "required": false,
+                        "type": "string",
+                        "default": "ENTREZ_GENE_ID",
+                        "enum": [
+                            "ENTREZ_GENE_ID",
+                            "HUGO_GENE_SYMBOL"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "geneIds",
+                        "description": "List of Entrez Gene IDs or Hugo Gene Symbols",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Gene"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/genes/{geneId}": {
+            "get": {
+                "tags": [
+                    "Genes"
+                ],
+                "summary": "Get a gene",
+                "operationId": "getGeneUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "geneId",
+                        "in": "path",
+                        "description": "Entrez Gene ID or Hugo Gene Symbol e.g. 1 or A1BG",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Gene"
+                        }
+                    }
+                }
+            }
+        },
+        "/genes/{geneId}/aliases": {
+            "get": {
+                "tags": [
+                    "Genes"
+                ],
+                "summary": "Get aliases of a gene",
+                "operationId": "getAliasesOfGeneUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "geneId",
+                        "in": "path",
+                        "description": "Entrez Gene ID or Hugo Gene Symbol e.g. 1 or A1BG",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-data/fetch": {
+            "post": {
+                "tags": [
+                    "Molecular Data"
+                ],
+                "summary": "Fetch molecular data",
+                "operationId": "fetchMolecularDataInMultipleMolecularProfilesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "molecularDataMultipleStudyFilter",
+                        "description": "List of Molecular Profile ID and Sample ID pairs or List of MolecularProfile IDs and Entrez Gene IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MolecularDataMultipleStudyFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NumericGeneMolecularData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles": {
+            "get": {
+                "tags": [
+                    "Molecular Profiles"
+                ],
+                "summary": "Get all molecular profiles",
+                "operationId": "getAllMolecularProfilesUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "molecularProfileId",
+                            "molecularAlterationType",
+                            "datatype",
+                            "name",
+                            "description",
+                            "showProfileInAnalysisTab"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MolecularProfile"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/fetch": {
+            "post": {
+                "tags": [
+                    "Molecular Profiles"
+                ],
+                "summary": "Fetch molecular profiles",
+                "operationId": "fetchMolecularProfilesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "molecularProfileFilter",
+                        "description": "List of Molecular Profile IDs or List of Study IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MolecularProfileFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MolecularProfile"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}": {
+            "get": {
+                "tags": [
+                    "Molecular Profiles"
+                ],
+                "summary": "Get molecular profile",
+                "operationId": "getMolecularProfileUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/MolecularProfile"
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/discrete-copy-number": {
+            "get": {
+                "tags": [
+                    "Discrete Copy Number Alterations"
+                ],
+                "summary": "Get discrete copy number alterations in a molecular profile",
+                "operationId": "getDiscreteCopyNumbersInMolecularProfileUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_gistic",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "sampleListId",
+                        "in": "query",
+                        "description": "Sample List ID e.g. acc_tcga_all",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "discreteCopyNumberEventType",
+                        "in": "query",
+                        "description": "Type of the copy number event",
+                        "required": false,
+                        "type": "string",
+                        "default": "HOMDEL_AND_AMP",
+                        "enum": [
+                            "HOMDEL_AND_AMP",
+                            "HOMDEL",
+                            "AMP",
+                            "GAIN",
+                            "HETLOSS",
+                            "DIPLOID",
+                            "ALL"
+                        ]
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DiscreteCopyNumberData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/discrete-copy-number-counts/fetch": {
+            "post": {
+                "tags": [
+                    "Discrete Copy Number Alterations"
+                ],
+                "summary": "Get counts of specific genes and alterations within a CNA molecular profile",
+                "operationId": "fetchCopyNumberCountsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_gistic",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "copyNumberCountIdentifiers",
+                        "description": "List of copy number count identifiers",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CopyNumberCountIdentifier"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CopyNumberCount"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/discrete-copy-number/fetch": {
+            "post": {
+                "tags": [
+                    "Discrete Copy Number Alterations"
+                ],
+                "summary": "Fetch discrete copy number alterations in a molecular profile by sample ID",
+                "operationId": "fetchDiscreteCopyNumbersInMolecularProfileUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_gistic",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "discreteCopyNumberEventType",
+                        "in": "query",
+                        "description": "Type of the copy number event",
+                        "required": false,
+                        "type": "string",
+                        "default": "HOMDEL_AND_AMP",
+                        "enum": [
+                            "HOMDEL_AND_AMP",
+                            "HOMDEL",
+                            "AMP",
+                            "GAIN",
+                            "HETLOSS",
+                            "DIPLOID",
+                            "ALL"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "discreteCopyNumberFilter",
+                        "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/DiscreteCopyNumberFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DiscreteCopyNumberData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/gene-panel-data/fetch": {
+            "post": {
+                "tags": [
+                    "Gene Panels"
+                ],
+                "summary": "Get gene panel data",
+                "operationId": "getGenePanelDataUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. nsclc_unito_2016_mutations",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "genePanelDataFilter",
+                        "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GenePanelDataFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenePanelData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/molecular-data": {
+            "get": {
+                "tags": [
+                    "Molecular Data"
+                ],
+                "summary": "Get all molecular data in a molecular profile",
+                "operationId": "getAllMolecularDataInMolecularProfileUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "sampleListId",
+                        "in": "query",
+                        "description": "Sample List ID e.g. acc_tcga_all",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "entrezGeneId",
+                        "in": "query",
+                        "description": "Entrez Gene ID e.g. 1",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NumericGeneMolecularData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/molecular-data/fetch": {
+            "post": {
+                "tags": [
+                    "Molecular Data"
+                ],
+                "summary": "Fetch molecular data in a molecular profile",
+                "operationId": "fetchAllMolecularDataInMolecularProfileUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "molecularDataFilter",
+                        "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MolecularDataFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NumericGeneMolecularData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/mutations": {
+            "get": {
+                "tags": [
+                    "Mutations"
+                ],
+                "summary": "Get mutations in a molecular profile by Sample List ID",
+                "operationId": "getMutationsInMolecularProfileBySampleListIdUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "sampleListId",
+                        "in": "query",
+                        "description": "Sample List ID e.g. acc_tcga_all",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "entrezGeneId",
+                        "in": "query",
+                        "description": "Entrez Gene ID",
+                        "required": false,
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "entrezGeneId",
+                            "center",
+                            "mutationStatus",
+                            "validationStatus",
+                            "tumorAltCount",
+                            "tumorRefCount",
+                            "normalAltCount",
+                            "normalRefCount",
+                            "aminoAcidChange",
+                            "startPosition",
+                            "endPosition",
+                            "referenceAllele",
+                            "variantAllele",
+                            "proteinChange",
+                            "mutationType",
+                            "ncbiBuild",
+                            "variantType",
+                            "refseqMrnaId",
+                            "proteinPosStart",
+                            "proteinPosEnd",
+                            "keyword"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Mutation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/mutations/fetch": {
+            "post": {
+                "tags": [
+                    "Mutations"
+                ],
+                "summary": "Fetch mutations in a molecular profile",
+                "operationId": "fetchMutationsInMolecularProfileUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "mutationFilter",
+                        "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MutationFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "entrezGeneId",
+                            "center",
+                            "mutationStatus",
+                            "validationStatus",
+                            "tumorAltCount",
+                            "tumorRefCount",
+                            "normalAltCount",
+                            "normalRefCount",
+                            "aminoAcidChange",
+                            "startPosition",
+                            "endPosition",
+                            "referenceAllele",
+                            "variantAllele",
+                            "proteinChange",
+                            "mutationType",
+                            "ncbiBuild",
+                            "variantType",
+                            "refseqMrnaId",
+                            "proteinPosStart",
+                            "proteinPosEnd",
+                            "keyword"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Mutation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/mutation-counts-by-position/fetch": {
+            "post": {
+                "tags": [
+                    "Mutations"
+                ],
+                "summary": "Fetch mutation counts in all studies by gene and position",
+                "operationId": "fetchMutationCountsByPositionUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "mutationPositionIdentifiers",
+                        "description": "List of gene and positions",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MutationPositionIdentifier"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MutationCountByPosition"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/mutations/fetch": {
+            "post": {
+                "tags": [
+                    "Mutations"
+                ],
+                "summary": "Fetch mutations in multiple molecular profiles by sample IDs",
+                "operationId": "fetchMutationsInMultipleMolecularProfilesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "mutationMultipleStudyFilter",
+                        "description": "List of Molecular Profile IDs or List of Molecular Profile ID / Sample ID pairs, and List of Entrez Gene IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MutationMultipleStudyFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "entrezGeneId",
+                            "center",
+                            "mutationStatus",
+                            "validationStatus",
+                            "tumorAltCount",
+                            "tumorRefCount",
+                            "normalAltCount",
+                            "normalRefCount",
+                            "aminoAcidChange",
+                            "startPosition",
+                            "endPosition",
+                            "referenceAllele",
+                            "variantAllele",
+                            "proteinChange",
+                            "mutationType",
+                            "ncbiBuild",
+                            "variantType",
+                            "refseqMrnaId",
+                            "proteinPosStart",
+                            "proteinPosEnd",
+                            "keyword"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Mutation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/patients": {
+            "get": {
+                "tags": [
+                    "Patients"
+                ],
+                "summary": "Get all patients",
+                "operationId": "getAllPatientsUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "keyword",
+                        "in": "query",
+                        "description": "Search keyword that applies to ID of the patients",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "patientId"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Patient"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/patients/fetch": {
+            "post": {
+                "tags": [
+                    "Patients"
+                ],
+                "summary": "Fetch patients by ID",
+                "operationId": "fetchPatientsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "patientFilter",
+                        "description": "List of patient identifiers",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/PatientFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Patient"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sample-lists": {
+            "get": {
+                "tags": [
+                    "Sample Lists"
+                ],
+                "summary": "Get all sample lists",
+                "operationId": "getAllSampleListsUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "sampleListId",
+                            "category",
+                            "studyId",
+                            "name",
+                            "description"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SampleList"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sample-lists/fetch": {
+            "post": {
+                "tags": [
+                    "Sample Lists"
+                ],
+                "summary": "Fetch sample lists by ID",
+                "operationId": "fetchSampleListsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "sampleListIds",
+                        "description": "List of sample list IDs",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SampleList"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sample-lists/{sampleListId}": {
+            "get": {
+                "tags": [
+                    "Sample Lists"
+                ],
+                "summary": "Get sample list",
+                "operationId": "getSampleListUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "sampleListId",
+                        "in": "path",
+                        "description": "Sample List ID e.g. acc_tcga_all",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/SampleList"
+                        }
+                    }
+                }
+            }
+        },
+        "/sample-lists/{sampleListId}/sample-ids": {
+            "get": {
+                "tags": [
+                    "Sample Lists"
+                ],
+                "summary": "Get all sample IDs in a sample list",
+                "operationId": "getAllSampleIdsInSampleListUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "sampleListId",
+                        "in": "path",
+                        "description": "Sample List ID e.g. acc_tcga_all",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/samples/fetch": {
+            "post": {
+                "tags": [
+                    "Samples"
+                ],
+                "summary": "Fetch samples by ID",
+                "operationId": "fetchSamplesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "sampleFilter",
+                        "description": "List of sample identifiers",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/SampleFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Sample"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies": {
+            "get": {
+                "tags": [
+                    "Studies"
+                ],
+                "summary": "Get all studies",
+                "operationId": "getAllStudiesUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "keyword",
+                        "in": "query",
+                        "description": "Search keyword that applies to name and cancer type of the studies",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "studyId",
+                            "cancerTypeId",
+                            "name",
+                            "shortName",
+                            "description",
+                            "publicStudy",
+                            "pmid",
+                            "citation",
+                            "groups",
+                            "status",
+                            "importDate"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CancerStudy"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/fetch": {
+            "post": {
+                "tags": [
+                    "Studies"
+                ],
+                "summary": "Fetch studies by IDs",
+                "operationId": "fetchStudiesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "studyIds",
+                        "description": "List of Study IDs",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CancerStudy"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/tags/fetch": {
+            "post": {
+                "tags": [
+                    "Studies"
+                ],
+                "summary": "Get the study tags by IDs",
+                "operationId": "getTagsForMultipleStudiesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "studyIds",
+                        "description": "List of Study IDs",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CancerStudyTags"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}": {
+            "get": {
+                "tags": [
+                    "Studies"
+                ],
+                "summary": "Get a study",
+                "operationId": "getStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/CancerStudy"
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/clinical-attributes": {
+            "get": {
+                "tags": [
+                    "Clinical Attributes"
+                ],
+                "summary": "Get all clinical attributes in the specified study",
+                "operationId": "getAllClinicalAttributesInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "clinicalAttributeId",
+                            "displayName",
+                            "description",
+                            "datatype",
+                            "patientAttribute",
+                            "priority",
+                            "studyId"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalAttribute"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/clinical-attributes/{clinicalAttributeId}": {
+            "get": {
+                "tags": [
+                    "Clinical Attributes"
+                ],
+                "summary": "Get specified clinical attribute",
+                "operationId": "getClinicalAttributeInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "clinicalAttributeId",
+                        "in": "path",
+                        "description": "Clinical Attribute ID e.g. CANCER_TYPE",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ClinicalAttribute"
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/clinical-data": {
+            "get": {
+                "tags": [
+                    "Clinical Data"
+                ],
+                "summary": "Get all clinical data in a study",
+                "operationId": "getAllClinicalDataInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "attributeId",
+                        "in": "query",
+                        "description": "Attribute ID e.g. CANCER_TYPE",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "clinicalDataType",
+                        "in": "query",
+                        "description": "Type of the clinical data",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "clinicalAttributeId",
+                            "value"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/clinical-data/fetch": {
+            "post": {
+                "tags": [
+                    "Clinical Data"
+                ],
+                "summary": "Fetch clinical data by patient IDs or sample IDs (specific study)",
+                "operationId": "fetchAllClinicalDataInStudyUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "clinicalDataType",
+                        "in": "query",
+                        "description": "Type of the clinical data",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "clinicalDataSingleStudyFilter",
+                        "description": "List of patient or sample IDs and attribute IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ClinicalDataSingleStudyFilter"
+                        }
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/molecular-profiles": {
+            "get": {
+                "tags": [
+                    "Molecular Profiles"
+                ],
+                "summary": "Get all molecular profiles in a study",
+                "operationId": "getAllMolecularProfilesInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "molecularProfileId",
+                            "molecularAlterationType",
+                            "datatype",
+                            "name",
+                            "description",
+                            "showProfileInAnalysisTab"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MolecularProfile"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/patients": {
+            "get": {
+                "tags": [
+                    "Patients"
+                ],
+                "summary": "Get all patients in a study",
+                "operationId": "getAllPatientsInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "patientId"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Patient"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/patients/{patientId}": {
+            "get": {
+                "tags": [
+                    "Patients"
+                ],
+                "summary": "Get a patient in a study",
+                "operationId": "getPatientInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "patientId",
+                        "in": "path",
+                        "description": "Patient ID e.g. TCGA-OR-A5J2",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Patient"
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/patients/{patientId}/clinical-data": {
+            "get": {
+                "tags": [
+                    "Clinical Data"
+                ],
+                "summary": "Get all clinical data of a patient in a study",
+                "operationId": "getAllClinicalDataOfPatientInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "patientId",
+                        "in": "path",
+                        "description": "Patient ID e.g. TCGA-OR-A5J2",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "attributeId",
+                        "in": "query",
+                        "description": "Attribute ID e.g. AGE",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "clinicalAttributeId",
+                            "value"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/patients/{patientId}/clinical-events": {
+            "get": {
+                "tags": [
+                    "Clinical Events"
+                ],
+                "summary": "Get all clinical events of a patient in a study",
+                "operationId": "getAllClinicalEventsOfPatientInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. lgg_ucsf_2014",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "patientId",
+                        "in": "path",
+                        "description": "Patient ID e.g. P01",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "eventType",
+                            "startNumberOfDaysSinceDiagnosis",
+                            "endNumberOfDaysSinceDiagnosis"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalEvent"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/patients/{patientId}/samples": {
+            "get": {
+                "tags": [
+                    "Samples"
+                ],
+                "summary": "Get all samples of a patient in a study",
+                "operationId": "getAllSamplesOfPatientInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "patientId",
+                        "in": "path",
+                        "description": "Patient ID e.g. TCGA-OR-A5J2",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "sampleId",
+                            "sampleType"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Sample"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/sample-lists": {
+            "get": {
+                "tags": [
+                    "Sample Lists"
+                ],
+                "summary": "Get all sample lists in a study",
+                "operationId": "getAllSampleListsInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "sampleListId",
+                            "category",
+                            "studyId",
+                            "name",
+                            "description"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SampleList"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/samples": {
+            "get": {
+                "tags": [
+                    "Samples"
+                ],
+                "summary": "Get all samples in a study",
+                "operationId": "getAllSamplesInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "sampleId",
+                            "sampleType"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Sample"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/samples/{sampleId}": {
+            "get": {
+                "tags": [
+                    "Samples"
+                ],
+                "summary": "Get a sample in a study",
+                "operationId": "getSampleInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "sampleId",
+                        "in": "path",
+                        "description": "Sample ID e.g. TCGA-OR-A5J2-01",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Sample"
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/samples/{sampleId}/clinical-data": {
+            "get": {
+                "tags": [
+                    "Clinical Data"
+                ],
+                "summary": "Get all clinical data of a sample in a study",
+                "operationId": "getAllClinicalDataOfSampleInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "sampleId",
+                        "in": "path",
+                        "description": "Sample ID e.g. TCGA-OR-A5J2-01",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "attributeId",
+                        "in": "query",
+                        "description": "Attribute ID e.g. CANCER_TYPE",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 10000000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "clinicalAttributeId",
+                            "value"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/samples/{sampleId}/copy-number-segments": {
+            "get": {
+                "tags": [
+                    "Copy Number Segments"
+                ],
+                "summary": "Get copy number segments in a sample in a study",
+                "operationId": "getCopyNumberSegmentsInSampleInStudyUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "sampleId",
+                        "in": "path",
+                        "description": "Sample ID e.g. TCGA-OR-A5J2-01",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "chromosome",
+                        "in": "query",
+                        "description": "Chromosome",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 20000,
+                        "maximum": 20000,
+                        "exclusiveMaximum": false,
+                        "minimum": 1,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "chromosome",
+                            "start",
+                            "end",
+                            "numberOfProbes",
+                            "segmentMean"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CopyNumberSeg"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/tags": {
+            "get": {
+                "tags": [
+                    "Studies"
+                ],
+                "summary": "Get the tags of a study",
+                "operationId": "getTagsUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "CancerStudy": {
+            "type": "object",
+            "required": [
+                "studyId"
+            ],
+            "properties": {
+                "allSampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "cancerType": {
+                    "$ref": "#/definitions/TypeOfCancer"
+                },
+                "cancerTypeId": {
+                    "type": "string"
+                },
+                "citation": {
+                    "type": "string"
+                },
+                "cnaSampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "completeSampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "groups": {
+                    "type": "string"
+                },
+                "importDate": {
+                    "type": "string",
+                    "example": "yyyy-MM-dd HH:mm:ss"
+                },
+                "methylationHm27SampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "miRnaSampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "mrnaMicroarraySampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "mrnaRnaSeqSampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "mrnaRnaSeqV2SampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "pmid": {
+                    "type": "string"
+                },
+                "publicStudy": {
+                    "type": "boolean"
+                },
+                "rppaSampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "sequencedSampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "shortName": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "CancerStudy"
+        },
+        "CancerStudyTags": {
+            "type": "object",
+            "properties": {
+                "cancerStudyId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "tags": {
+                    "type": "string"
+                }
+            },
+            "title": "CancerStudyTags"
+        },
+        "ClinicalAttribute": {
+            "type": "object",
+            "required": [
+                "clinicalAttributeId",
+                "displayName",
+                "patientAttribute",
+                "studyId"
+            ],
+            "properties": {
+                "clinicalAttributeId": {
+                    "type": "string"
+                },
+                "datatype": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "patientAttribute": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalAttribute"
+        },
+        "ClinicalAttributeCount": {
+            "type": "object",
+            "properties": {
+                "clinicalAttributeId": {
+                    "type": "string"
+                },
+                "count": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "ClinicalAttributeCount"
+        },
+        "ClinicalAttributeCountFilter": {
+            "type": "object",
+            "properties": {
+                "sampleIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SampleIdentifier"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalAttributeCountFilter"
+        },
+        "ClinicalData": {
+            "type": "object",
+            "required": [
+                "clinicalAttributeId",
+                "patientId",
+                "studyId"
+            ],
+            "properties": {
+                "clinicalAttribute": {
+                    "$ref": "#/definitions/ClinicalAttribute"
+                },
+                "clinicalAttributeId": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalData"
+        },
+        "ClinicalDataIdentifier": {
+            "type": "object",
+            "properties": {
+                "entityId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalDataIdentifier"
+        },
+        "ClinicalDataMultiStudyFilter": {
+            "type": "object",
+            "properties": {
+                "attributeIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "identifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalDataIdentifier"
+                    }
+                }
+            },
+            "title": "ClinicalDataMultiStudyFilter"
+        },
+        "ClinicalDataSingleStudyFilter": {
+            "type": "object",
+            "properties": {
+                "attributeIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "title": "ClinicalDataSingleStudyFilter"
+        },
+        "ClinicalEvent": {
+            "type": "object",
+            "required": [
+                "eventType",
+                "patientId",
+                "studyId"
+            ],
+            "properties": {
+                "attributes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalEventData"
+                    }
+                },
+                "endNumberOfDaysSinceDiagnosis": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "eventType": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "startNumberOfDaysSinceDiagnosis": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalEvent"
+        },
+        "ClinicalEventData": {
+            "type": "object",
+            "required": [
+                "key",
+                "value"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalEventData"
+        },
+        "CopyNumberCount": {
+            "type": "object",
+            "required": [
+                "alteration",
+                "entrezGeneId",
+                "molecularProfileId",
+                "numberOfSamples",
+                "numberOfSamplesWithAlterationInGene"
+            ],
+            "properties": {
+                "alteration": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "numberOfSamples": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfSamplesWithAlterationInGene": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "CopyNumberCount"
+        },
+        "CopyNumberCountIdentifier": {
+            "type": "object",
+            "properties": {
+                "alteration": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "CopyNumberCountIdentifier"
+        },
+        "CopyNumberSeg": {
+            "type": "object",
+            "required": [
+                "chromosome",
+                "end",
+                "numberOfProbes",
+                "patientId",
+                "sampleId",
+                "segmentMean",
+                "start",
+                "studyId"
+            ],
+            "properties": {
+                "chromosome": {
+                    "type": "string"
+                },
+                "end": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfProbes": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "segmentMean": {
+                    "type": "number"
+                },
+                "start": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "CopyNumberSeg"
+        },
+        "DiscreteCopyNumberData": {
+            "type": "object",
+            "required": [
+                "alteration",
+                "entrezGeneId",
+                "molecularProfileId",
+                "patientId",
+                "sampleId",
+                "studyId"
+            ],
+            "properties": {
+                "alteration": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "gene": {
+                    "$ref": "#/definitions/Gene"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "DiscreteCopyNumberData"
+        },
+        "DiscreteCopyNumberFilter": {
+            "type": "object",
+            "properties": {
+                "entrezGeneIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 1,
+                        "maximum": 50000
+                    }
+                },
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "DiscreteCopyNumberFilter"
+        },
+        "Gene": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "hugoGeneSymbol"
+            ],
+            "properties": {
+                "chromosome": {
+                    "type": "string"
+                },
+                "cytoband": {
+                    "type": "string"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "length": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "title": "Gene"
+        },
+        "GenePanel": {
+            "type": "object",
+            "required": [
+                "genePanelId"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "genePanelId": {
+                    "type": "string"
+                },
+                "genes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/GenePanelToGene"
+                    }
+                }
+            },
+            "title": "GenePanel"
+        },
+        "GenePanelData": {
+            "type": "object",
+            "required": [
+                "molecularProfileId",
+                "patientId",
+                "profiled",
+                "sampleId",
+                "studyId"
+            ],
+            "properties": {
+                "genePanelId": {
+                    "type": "string"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "profiled": {
+                    "type": "boolean"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "GenePanelData"
+        },
+        "GenePanelDataFilter": {
+            "type": "object",
+            "properties": {
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "GenePanelDataFilter"
+        },
+        "GenePanelMultipleStudyFilter": {
+            "type": "object",
+            "required": [
+                "sampleMolecularIdentifiers"
+            ],
+            "properties": {
+                "sampleMolecularIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SampleMolecularIdentifier"
+                    }
+                }
+            },
+            "title": "GenePanelMultipleStudyFilter"
+        },
+        "GenePanelToGene": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "hugoGeneSymbol"
+            ],
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                }
+            },
+            "title": "GenePanelToGene"
+        },
+        "MolecularDataFilter": {
+            "type": "object",
+            "properties": {
+                "entrezGeneIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 1,
+                        "maximum": 10000000
+                    }
+                },
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "MolecularDataFilter"
+        },
+        "MolecularDataMultipleStudyFilter": {
+            "type": "object",
+            "properties": {
+                "entrezGeneIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 1,
+                        "maximum": 10000000
+                    }
+                },
+                "molecularProfileIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleMolecularIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SampleMolecularIdentifier"
+                    }
+                }
+            },
+            "title": "MolecularDataMultipleStudyFilter"
+        },
+        "MolecularProfile": {
+            "type": "object",
+            "required": [
+                "molecularProfileId",
+                "studyId"
+            ],
+            "properties": {
+                "datatype": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "molecularAlterationType": {
+                    "type": "string",
+                    "enum": [
+                        "MUTATION_EXTENDED",
+                        "MUTATION_UNCALLED",
+                        "FUSION",
+                        "STRUCTURAL_VARIANT",
+                        "COPY_NUMBER_ALTERATION",
+                        "MICRO_RNA_EXPRESSION",
+                        "MRNA_EXPRESSION",
+                        "MRNA_EXPRESSION_NORMALS",
+                        "RNA_EXPRESSION",
+                        "METHYLATION",
+                        "METHYLATION_BINARY",
+                        "PHOSPHORYLATION",
+                        "PROTEIN_LEVEL",
+                        "PROTEIN_ARRAY_PROTEIN_LEVEL",
+                        "PROTEIN_ARRAY_PHOSPHORYLATION",
+                        "GENESET_SCORE"
+                    ]
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "showProfileInAnalysisTab": {
+                    "type": "boolean"
+                },
+                "study": {
+                    "$ref": "#/definitions/CancerStudy"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "MolecularProfile"
+        },
+        "MolecularProfileFilter": {
+            "type": "object",
+            "properties": {
+                "molecularProfileIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "studyIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "title": "MolecularProfileFilter"
+        },
+        "Mutation": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "molecularProfileId",
+                "patientId",
+                "sampleId",
+                "studyId"
+            ],
+            "properties": {
+                "aminoAcidChange": {
+                    "type": "string"
+                },
+                "center": {
+                    "type": "string"
+                },
+                "driverFilter": {
+                    "type": "string"
+                },
+                "driverFilterAnnotation": {
+                    "type": "string"
+                },
+                "driverTiersFilter": {
+                    "type": "string"
+                },
+                "driverTiersFilterAnnotation": {
+                    "type": "string"
+                },
+                "endPosition": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "fisValue": {
+                    "type": "number"
+                },
+                "functionalImpactScore": {
+                    "type": "string"
+                },
+                "gene": {
+                    "$ref": "#/definitions/Gene"
+                },
+                "keyword": {
+                    "type": "string"
+                },
+                "linkMsa": {
+                    "type": "string"
+                },
+                "linkPdb": {
+                    "type": "string"
+                },
+                "linkXvar": {
+                    "type": "string"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "mutationStatus": {
+                    "type": "string"
+                },
+                "mutationType": {
+                    "type": "string"
+                },
+                "ncbiBuild": {
+                    "type": "string"
+                },
+                "normalAltCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "normalRefCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "proteinChange": {
+                    "type": "string"
+                },
+                "proteinPosEnd": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "proteinPosStart": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "referenceAllele": {
+                    "type": "string"
+                },
+                "refseqMrnaId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "startPosition": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "tumorAltCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "tumorRefCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                },
+                "validationStatus": {
+                    "type": "string"
+                },
+                "variantAllele": {
+                    "type": "string"
+                },
+                "variantType": {
+                    "type": "string"
+                }
+            },
+            "title": "Mutation"
+        },
+        "MutationCountByPosition": {
+            "type": "object",
+            "required": [
+                "count",
+                "entrezGeneId",
+                "proteinPosEnd",
+                "proteinPosStart"
+            ],
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "proteinPosEnd": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "proteinPosStart": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "MutationCountByPosition"
+        },
+        "MutationFilter": {
+            "type": "object",
+            "properties": {
+                "entrezGeneIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 1,
+                        "maximum": 10000000
+                    }
+                },
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "MutationFilter"
+        },
+        "MutationMultipleStudyFilter": {
+            "type": "object",
+            "properties": {
+                "entrezGeneIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 1,
+                        "maximum": 10000000
+                    }
+                },
+                "molecularProfileIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleMolecularIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SampleMolecularIdentifier"
+                    }
+                }
+            },
+            "title": "MutationMultipleStudyFilter"
+        },
+        "MutationPositionIdentifier": {
+            "type": "object",
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "proteinPosEnd": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "proteinPosStart": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "MutationPositionIdentifier"
+        },
+        "NumericGeneMolecularData": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "molecularProfileId",
+                "patientId",
+                "sampleId",
+                "studyId",
+                "value"
+            ],
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "gene": {
+                    "$ref": "#/definitions/Gene"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number"
+                }
+            },
+            "title": "NumericGeneMolecularData"
+        },
+        "Patient": {
+            "type": "object",
+            "required": [
+                "patientId",
+                "studyId"
+            ],
+            "properties": {
+                "cancerStudy": {
+                    "$ref": "#/definitions/CancerStudy"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "Patient"
+        },
+        "PatientFilter": {
+            "type": "object",
+            "properties": {
+                "patientIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PatientIdentifier"
+                    }
+                },
+                "uniquePatientKeys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "title": "PatientFilter"
+        },
+        "PatientIdentifier": {
+            "type": "object",
+            "properties": {
+                "patientId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "PatientIdentifier"
+        },
+        "Sample": {
+            "type": "object",
+            "required": [
+                "patientId",
+                "sampleId",
+                "studyId"
+            ],
+            "properties": {
+                "copyNumberSegmentPresent": {
+                    "type": "boolean"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "sampleType": {
+                    "type": "string",
+                    "enum": [
+                        "Primary Solid Tumor",
+                        "Recurrent Solid Tumor",
+                        "Primary Blood Tumor",
+                        "Recurrent Blood Tumor",
+                        "Metastatic",
+                        "Blood Derived Normal",
+                        "Solid Tissues Normal"
+                    ]
+                },
+                "sequenced": {
+                    "type": "boolean"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "Sample"
+        },
+        "SampleFilter": {
+            "type": "object",
+            "properties": {
+                "sampleIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SampleIdentifier"
+                    }
+                },
+                "sampleListIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "uniqueSampleKeys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "title": "SampleFilter"
+        },
+        "SampleIdentifier": {
+            "type": "object",
+            "properties": {
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "SampleIdentifier"
+        },
+        "SampleList": {
+            "type": "object",
+            "required": [
+                "sampleListId"
+            ],
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sampleCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "SampleList"
+        },
+        "SampleMolecularIdentifier": {
+            "type": "object",
+            "properties": {
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                }
+            },
+            "title": "SampleMolecularIdentifier"
+        },
+        "TypeOfCancer": {
+            "type": "object",
+            "required": [
+                "cancerTypeId"
+            ],
+            "properties": {
+                "cancerTypeId": {
+                    "type": "string"
+                },
+                "clinicalTrialKeywords": {
+                    "type": "string"
+                },
+                "dedicatedColor": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parent": {
+                    "type": "string"
+                },
+                "shortName": {
+                    "type": "string"
+                }
+            },
+            "title": "TypeOfCancer"
+        }
     }
-  },
-  "tags": [
-    {
-      "name": "Cancer Types",
-      "description": " "
-    },
-    {
-      "name": "Clinical Attributes",
-      "description": " "
-    },
-    {
-      "name": "Clinical Data",
-      "description": " "
-    },
-    {
-      "name": "Clinical Events",
-      "description": " "
-    },
-    {
-      "name": "Copy Number Segments",
-      "description": " "
-    },
-    {
-      "name": "Discrete Copy Number Alterations",
-      "description": " "
-    },
-    {
-      "name": "Gene Panels",
-      "description": " "
-    },
-    {
-      "name": "Genes",
-      "description": " "
-    },
-    {
-      "name": "Molecular Data",
-      "description": " "
-    },
-    {
-      "name": "Molecular Profiles",
-      "description": " "
-    },
-    {
-      "name": "Mutations",
-      "description": " "
-    },
-    {
-      "name": "Patients",
-      "description": " "
-    },
-    {
-      "name": "Sample Lists",
-      "description": " "
-    },
-    {
-      "name": "Samples",
-      "description": " "
-    },
-    {
-      "name": "Studies",
-      "description": " "
-    }
-  ],
-  "schemes": [
-    "http",
-    "https"
-  ],
-  "paths": {
-    "/cancer-types": {
-      "get": {
-        "tags": [
-          "Cancer Types"
-        ],
-        "summary": "Get all cancer types",
-        "operationId": "getAllCancerTypesUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "cancerTypeId",
-              "name",
-              "clinicalTrialKeywords",
-              "dedicatedColor",
-              "shortName",
-              "parent"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/TypeOfCancer"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/cancer-types/{cancerTypeId}": {
-      "get": {
-        "tags": [
-          "Cancer Types"
-        ],
-        "summary": "Get a cancer type",
-        "operationId": "getCancerTypeUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "cancerTypeId",
-            "in": "path",
-            "description": "Cancer Type ID e.g. acc",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/TypeOfCancer"
-            }
-          }
-        }
-      }
-    },
-    "/clinical-attributes": {
-      "get": {
-        "tags": [
-          "Clinical Attributes"
-        ],
-        "summary": "Get all clinical attributes",
-        "operationId": "getAllClinicalAttributesUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "clinicalAttributeId",
-              "displayName",
-              "description",
-              "datatype",
-              "patientAttribute",
-              "priority",
-              "studyId"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalAttribute"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/clinical-attributes/counts/fetch": {
-      "post": {
-        "tags": [
-          "Clinical Attributes"
-        ],
-        "summary": "Get counts for clinical attributes according to their data availability for selected samples/patients",
-        "operationId": "getClinicalAttributeCountsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "clinicalAttributeCountFilter",
-            "description": "List of SampleIdentifiers or Sample List ID",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ClinicalAttributeCountFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalAttributeCount"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/clinical-attributes/fetch": {
-      "post": {
-        "tags": [
-          "Clinical Attributes"
-        ],
-        "summary": "Fetch clinical attributes",
-        "operationId": "fetchClinicalAttributesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "studyIds",
-            "description": "List of Study IDs",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalAttribute"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/clinical-data/fetch": {
-      "post": {
-        "tags": [
-          "Clinical Data"
-        ],
-        "summary": "Fetch clinical data by patient IDs or sample IDs (all studies)",
-        "operationId": "fetchClinicalDataUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "clinicalDataType",
-            "in": "query",
-            "description": "Type of the clinical data",
-            "required": false,
-            "type": "string",
-            "default": "SAMPLE",
-            "enum": [
-              "SAMPLE",
-              "PATIENT"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "clinicalDataMultiStudyFilter",
-            "description": "List of patient or sample identifiers and attribute IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ClinicalDataMultiStudyFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/copy-number-segments/fetch": {
-      "post": {
-        "tags": [
-          "Copy Number Segments"
-        ],
-        "summary": "Fetch copy number segments by sample ID",
-        "operationId": "fetchCopyNumberSegmentsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "sampleIdentifiers",
-            "description": "List of sample identifiers",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SampleIdentifier"
-              }
-            }
-          },
-          {
-            "name": "chromosome",
-            "in": "query",
-            "description": "Chromosome",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CopyNumberSeg"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gene-panel-data/fetch": {
-      "post": {
-        "tags": [
-          "Gene Panels"
-        ],
-        "summary": "Fetch gene panel data",
-        "operationId": "fetchGenePanelDataInMultipleMolecularProfilesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "genePanelMultipleStudyFilter",
-            "description": "List of Molecular Profile ID and Sample ID pairs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GenePanelMultipleStudyFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenePanelData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gene-panels": {
-      "get": {
-        "tags": [
-          "Gene Panels"
-        ],
-        "summary": "Get all gene panels",
-        "operationId": "getAllGenePanelsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "genePanelId",
-              "description"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenePanel"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gene-panels/fetch": {
-      "post": {
-        "tags": [
-          "Gene Panels"
-        ],
-        "summary": "Get gene panel",
-        "operationId": "fetchGenePanelsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "genePanelIds",
-            "description": "List of Gene Panel IDs",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenePanel"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gene-panels/{genePanelId}": {
-      "get": {
-        "tags": [
-          "Gene Panels"
-        ],
-        "summary": "Get gene panel",
-        "operationId": "getGenePanelUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "genePanelId",
-            "in": "path",
-            "description": "Gene Panel ID e.g. NSCLC_UNITO_2016_PANEL",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/GenePanel"
-            }
-          }
-        }
-      }
-    },
-    "/genes": {
-      "get": {
-        "tags": [
-          "Genes"
-        ],
-        "summary": "Get all genes",
-        "operationId": "getAllGenesUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "Search keyword that applies to hugo gene symbol of the genes",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "alias",
-            "in": "query",
-            "description": "Alias of the gene",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 100000,
-            "maximum": 100000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "entrezGeneId",
-              "hugoGeneSymbol",
-              "type",
-              "cytoband",
-              "length"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Gene"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/genes/fetch": {
-      "post": {
-        "tags": [
-          "Genes"
-        ],
-        "summary": "Fetch genes by ID",
-        "operationId": "fetchGenesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "geneIdType",
-            "in": "query",
-            "description": "Type of gene ID",
-            "required": false,
-            "type": "string",
-            "default": "ENTREZ_GENE_ID",
-            "enum": [
-              "ENTREZ_GENE_ID",
-              "HUGO_GENE_SYMBOL"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "geneIds",
-            "description": "List of Entrez Gene IDs or Hugo Gene Symbols",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Gene"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/genes/{geneId}": {
-      "get": {
-        "tags": [
-          "Genes"
-        ],
-        "summary": "Get a gene",
-        "operationId": "getGeneUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "geneId",
-            "in": "path",
-            "description": "Entrez Gene ID or Hugo Gene Symbol e.g. 1 or A1BG",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/Gene"
-            }
-          }
-        }
-      }
-    },
-    "/genes/{geneId}/aliases": {
-      "get": {
-        "tags": [
-          "Genes"
-        ],
-        "summary": "Get aliases of a gene",
-        "operationId": "getAliasesOfGeneUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "geneId",
-            "in": "path",
-            "description": "Entrez Gene ID or Hugo Gene Symbol e.g. 1 or A1BG",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-data/fetch": {
-      "post": {
-        "tags": [
-          "Molecular Data"
-        ],
-        "summary": "Fetch molecular data",
-        "operationId": "fetchMolecularDataInMultipleMolecularProfilesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "molecularDataMultipleStudyFilter",
-            "description": "List of Molecular Profile ID and Sample ID pairs or List of MolecularProfile IDs and Entrez Gene IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MolecularDataMultipleStudyFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/NumericGeneMolecularData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles": {
-      "get": {
-        "tags": [
-          "Molecular Profiles"
-        ],
-        "summary": "Get all molecular profiles",
-        "operationId": "getAllMolecularProfilesUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "molecularProfileId",
-              "molecularAlterationType",
-              "datatype",
-              "name",
-              "description",
-              "showProfileInAnalysisTab"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MolecularProfile"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/fetch": {
-      "post": {
-        "tags": [
-          "Molecular Profiles"
-        ],
-        "summary": "Fetch molecular profiles",
-        "operationId": "fetchMolecularProfilesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "molecularProfileFilter",
-            "description": "List of Molecular Profile IDs or List of Study IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MolecularProfileFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MolecularProfile"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}": {
-      "get": {
-        "tags": [
-          "Molecular Profiles"
-        ],
-        "summary": "Get molecular profile",
-        "operationId": "getMolecularProfileUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/MolecularProfile"
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/discrete-copy-number": {
-      "get": {
-        "tags": [
-          "Discrete Copy Number Alterations"
-        ],
-        "summary": "Get discrete copy number alterations in a molecular profile",
-        "operationId": "getDiscreteCopyNumbersInMolecularProfileUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_gistic",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "sampleListId",
-            "in": "query",
-            "description": "Sample List ID e.g. acc_tcga_all",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "discreteCopyNumberEventType",
-            "in": "query",
-            "description": "Type of the copy number event",
-            "required": false,
-            "type": "string",
-            "default": "HOMDEL_AND_AMP",
-            "enum": [
-              "HOMDEL_AND_AMP",
-              "HOMDEL",
-              "AMP",
-              "GAIN",
-              "HETLOSS",
-              "DIPLOID",
-              "ALL"
-            ]
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/DiscreteCopyNumberData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/discrete-copy-number-counts/fetch": {
-      "post": {
-        "tags": [
-          "Discrete Copy Number Alterations"
-        ],
-        "summary": "Get counts of specific genes and alterations within a CNA molecular profile",
-        "operationId": "fetchCopyNumberCountsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_gistic",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "copyNumberCountIdentifiers",
-            "description": "List of copy number count identifiers",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CopyNumberCountIdentifier"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CopyNumberCount"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/discrete-copy-number/fetch": {
-      "post": {
-        "tags": [
-          "Discrete Copy Number Alterations"
-        ],
-        "summary": "Fetch discrete copy number alterations in a molecular profile by sample ID",
-        "operationId": "fetchDiscreteCopyNumbersInMolecularProfileUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_gistic",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "discreteCopyNumberEventType",
-            "in": "query",
-            "description": "Type of the copy number event",
-            "required": false,
-            "type": "string",
-            "default": "HOMDEL_AND_AMP",
-            "enum": [
-              "HOMDEL_AND_AMP",
-              "HOMDEL",
-              "AMP",
-              "GAIN",
-              "HETLOSS",
-              "DIPLOID",
-              "ALL"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "discreteCopyNumberFilter",
-            "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/DiscreteCopyNumberFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/DiscreteCopyNumberData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/gene-panel-data/fetch": {
-      "post": {
-        "tags": [
-          "Gene Panels"
-        ],
-        "summary": "Get gene panel data",
-        "operationId": "getGenePanelDataUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. nsclc_unito_2016_mutations",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "genePanelDataFilter",
-            "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GenePanelDataFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenePanelData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/molecular-data": {
-      "get": {
-        "tags": [
-          "Molecular Data"
-        ],
-        "summary": "Get all molecular data in a molecular profile",
-        "operationId": "getAllMolecularDataInMolecularProfileUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "sampleListId",
-            "in": "query",
-            "description": "Sample List ID e.g. acc_tcga_all",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "entrezGeneId",
-            "in": "query",
-            "description": "Entrez Gene ID e.g. 1",
-            "required": true,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/NumericGeneMolecularData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/molecular-data/fetch": {
-      "post": {
-        "tags": [
-          "Molecular Data"
-        ],
-        "summary": "Fetch molecular data in a molecular profile",
-        "operationId": "fetchAllMolecularDataInMolecularProfileUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "molecularDataFilter",
-            "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MolecularDataFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/NumericGeneMolecularData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/mutations": {
-      "get": {
-        "tags": [
-          "Mutations"
-        ],
-        "summary": "Get mutations in a molecular profile by Sample List ID",
-        "operationId": "getMutationsInMolecularProfileBySampleListIdUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "sampleListId",
-            "in": "query",
-            "description": "Sample List ID e.g. acc_tcga_all",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "entrezGeneId",
-            "in": "query",
-            "description": "Entrez Gene ID",
-            "required": false,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "entrezGeneId",
-              "center",
-              "mutationStatus",
-              "validationStatus",
-              "tumorAltCount",
-              "tumorRefCount",
-              "normalAltCount",
-              "normalRefCount",
-              "aminoAcidChange",
-              "startPosition",
-              "endPosition",
-              "referenceAllele",
-              "variantAllele",
-              "proteinChange",
-              "mutationType",
-              "ncbiBuild",
-              "variantType",
-              "refseqMrnaId",
-              "proteinPosStart",
-              "proteinPosEnd",
-              "keyword"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Mutation"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/mutations/fetch": {
-      "post": {
-        "tags": [
-          "Mutations"
-        ],
-        "summary": "Fetch mutations in a molecular profile",
-        "operationId": "fetchMutationsInMolecularProfileUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "mutationFilter",
-            "description": "List of Sample IDs/Sample List ID and Entrez Gene IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MutationFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "entrezGeneId",
-              "center",
-              "mutationStatus",
-              "validationStatus",
-              "tumorAltCount",
-              "tumorRefCount",
-              "normalAltCount",
-              "normalRefCount",
-              "aminoAcidChange",
-              "startPosition",
-              "endPosition",
-              "referenceAllele",
-              "variantAllele",
-              "proteinChange",
-              "mutationType",
-              "ncbiBuild",
-              "variantType",
-              "refseqMrnaId",
-              "proteinPosStart",
-              "proteinPosEnd",
-              "keyword"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Mutation"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/mutation-counts-by-position/fetch": {
-      "post": {
-        "tags": [
-          "Mutations"
-        ],
-        "summary": "Fetch mutation counts in all studies by gene and position",
-        "operationId": "fetchMutationCountsByPositionUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "mutationPositionIdentifiers",
-            "description": "List of gene and positions",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MutationPositionIdentifier"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MutationCountByPosition"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/mutations/fetch": {
-      "post": {
-        "tags": [
-          "Mutations"
-        ],
-        "summary": "Fetch mutations in multiple molecular profiles by sample IDs",
-        "operationId": "fetchMutationsInMultipleMolecularProfilesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "mutationMultipleStudyFilter",
-            "description": "List of Molecular Profile IDs or List of Molecular Profile ID / Sample ID pairs, and List of Entrez Gene IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MutationMultipleStudyFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "entrezGeneId",
-              "center",
-              "mutationStatus",
-              "validationStatus",
-              "tumorAltCount",
-              "tumorRefCount",
-              "normalAltCount",
-              "normalRefCount",
-              "aminoAcidChange",
-              "startPosition",
-              "endPosition",
-              "referenceAllele",
-              "variantAllele",
-              "proteinChange",
-              "mutationType",
-              "ncbiBuild",
-              "variantType",
-              "refseqMrnaId",
-              "proteinPosStart",
-              "proteinPosEnd",
-              "keyword"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Mutation"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/patients": {
-      "get": {
-        "tags": [
-          "Patients"
-        ],
-        "summary": "Get all patients",
-        "operationId": "getAllPatientsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "Search keyword that applies to ID of the patients",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "patientId"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Patient"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/patients/fetch": {
-      "post": {
-        "tags": [
-          "Patients"
-        ],
-        "summary": "Fetch patients by ID",
-        "operationId": "fetchPatientsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "patientFilter",
-            "description": "List of patient identifiers",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/PatientFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Patient"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sample-lists": {
-      "get": {
-        "tags": [
-          "Sample Lists"
-        ],
-        "summary": "Get all sample lists",
-        "operationId": "getAllSampleListsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "sampleListId",
-              "category",
-              "studyId",
-              "name",
-              "description"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SampleList"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sample-lists/fetch": {
-      "post": {
-        "tags": [
-          "Sample Lists"
-        ],
-        "summary": "Fetch sample lists by ID",
-        "operationId": "fetchSampleListsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "sampleListIds",
-            "description": "List of sample list IDs",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SampleList"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sample-lists/{sampleListId}": {
-      "get": {
-        "tags": [
-          "Sample Lists"
-        ],
-        "summary": "Get sample list",
-        "operationId": "getSampleListUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "sampleListId",
-            "in": "path",
-            "description": "Sample List ID e.g. acc_tcga_all",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/SampleList"
-            }
-          }
-        }
-      }
-    },
-    "/sample-lists/{sampleListId}/sample-ids": {
-      "get": {
-        "tags": [
-          "Sample Lists"
-        ],
-        "summary": "Get all sample IDs in a sample list",
-        "operationId": "getAllSampleIdsInSampleListUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "sampleListId",
-            "in": "path",
-            "description": "Sample List ID e.g. acc_tcga_all",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/samples/fetch": {
-      "post": {
-        "tags": [
-          "Samples"
-        ],
-        "summary": "Fetch samples by ID",
-        "operationId": "fetchSamplesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "sampleFilter",
-            "description": "List of sample identifiers",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SampleFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Sample"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies": {
-      "get": {
-        "tags": [
-          "Studies"
-        ],
-        "summary": "Get all studies",
-        "operationId": "getAllStudiesUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "Search keyword that applies to name and cancer type of the studies",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "studyId",
-              "cancerTypeId",
-              "name",
-              "shortName",
-              "description",
-              "publicStudy",
-              "pmid",
-              "citation",
-              "groups",
-              "status",
-              "importDate"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CancerStudy"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/fetch": {
-      "post": {
-        "tags": [
-          "Studies"
-        ],
-        "summary": "Fetch studies by IDs",
-        "operationId": "fetchStudiesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "studyIds",
-            "description": "List of Study IDs",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CancerStudy"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/tags/fetch": {
-      "post": {
-        "tags": [
-          "Studies"
-        ],
-        "summary": "Get the study tags by IDs",
-        "operationId": "getTagsForMultipleStudiesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "studyIds",
-            "description": "List of Study IDs",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CancerStudyTags"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}": {
-      "get": {
-        "tags": [
-          "Studies"
-        ],
-        "summary": "Get a study",
-        "operationId": "getStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/CancerStudy"
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/clinical-attributes": {
-      "get": {
-        "tags": [
-          "Clinical Attributes"
-        ],
-        "summary": "Get all clinical attributes in the specified study",
-        "operationId": "getAllClinicalAttributesInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "clinicalAttributeId",
-              "displayName",
-              "description",
-              "datatype",
-              "patientAttribute",
-              "priority",
-              "studyId"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalAttribute"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/clinical-attributes/{clinicalAttributeId}": {
-      "get": {
-        "tags": [
-          "Clinical Attributes"
-        ],
-        "summary": "Get specified clinical attribute",
-        "operationId": "getClinicalAttributeInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "clinicalAttributeId",
-            "in": "path",
-            "description": "Clinical Attribute ID e.g. CANCER_TYPE",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/ClinicalAttribute"
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/clinical-data": {
-      "get": {
-        "tags": [
-          "Clinical Data"
-        ],
-        "summary": "Get all clinical data in a study",
-        "operationId": "getAllClinicalDataInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "attributeId",
-            "in": "query",
-            "description": "Attribute ID e.g. CANCER_TYPE",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "clinicalDataType",
-            "in": "query",
-            "description": "Type of the clinical data",
-            "required": false,
-            "type": "string",
-            "default": "SAMPLE",
-            "enum": [
-              "SAMPLE",
-              "PATIENT"
-            ]
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "clinicalAttributeId",
-              "value"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/clinical-data/fetch": {
-      "post": {
-        "tags": [
-          "Clinical Data"
-        ],
-        "summary": "Fetch clinical data by patient IDs or sample IDs (specific study)",
-        "operationId": "fetchAllClinicalDataInStudyUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "clinicalDataType",
-            "in": "query",
-            "description": "Type of the clinical data",
-            "required": false,
-            "type": "string",
-            "default": "SAMPLE",
-            "enum": [
-              "SAMPLE",
-              "PATIENT"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "clinicalDataSingleStudyFilter",
-            "description": "List of patient or sample IDs and attribute IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ClinicalDataSingleStudyFilter"
-            }
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/molecular-profiles": {
-      "get": {
-        "tags": [
-          "Molecular Profiles"
-        ],
-        "summary": "Get all molecular profiles in a study",
-        "operationId": "getAllMolecularProfilesInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "molecularProfileId",
-              "molecularAlterationType",
-              "datatype",
-              "name",
-              "description",
-              "showProfileInAnalysisTab"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MolecularProfile"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/patients": {
-      "get": {
-        "tags": [
-          "Patients"
-        ],
-        "summary": "Get all patients in a study",
-        "operationId": "getAllPatientsInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "patientId"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Patient"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/patients/{patientId}": {
-      "get": {
-        "tags": [
-          "Patients"
-        ],
-        "summary": "Get a patient in a study",
-        "operationId": "getPatientInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "patientId",
-            "in": "path",
-            "description": "Patient ID e.g. TCGA-OR-A5J2",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/Patient"
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/patients/{patientId}/clinical-data": {
-      "get": {
-        "tags": [
-          "Clinical Data"
-        ],
-        "summary": "Get all clinical data of a patient in a study",
-        "operationId": "getAllClinicalDataOfPatientInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "patientId",
-            "in": "path",
-            "description": "Patient ID e.g. TCGA-OR-A5J2",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "attributeId",
-            "in": "query",
-            "description": "Attribute ID e.g. AGE",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "clinicalAttributeId",
-              "value"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/patients/{patientId}/clinical-events": {
-      "get": {
-        "tags": [
-          "Clinical Events"
-        ],
-        "summary": "Get all clinical events of a patient in a study",
-        "operationId": "getAllClinicalEventsOfPatientInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. lgg_ucsf_2014",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "patientId",
-            "in": "path",
-            "description": "Patient ID e.g. P01",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "eventType",
-              "startNumberOfDaysSinceDiagnosis",
-              "endNumberOfDaysSinceDiagnosis"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalEvent"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/patients/{patientId}/samples": {
-      "get": {
-        "tags": [
-          "Samples"
-        ],
-        "summary": "Get all samples of a patient in a study",
-        "operationId": "getAllSamplesOfPatientInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "patientId",
-            "in": "path",
-            "description": "Patient ID e.g. TCGA-OR-A5J2",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "sampleId",
-              "sampleType"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Sample"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/sample-lists": {
-      "get": {
-        "tags": [
-          "Sample Lists"
-        ],
-        "summary": "Get all sample lists in a study",
-        "operationId": "getAllSampleListsInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "sampleListId",
-              "category",
-              "studyId",
-              "name",
-              "description"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SampleList"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/samples": {
-      "get": {
-        "tags": [
-          "Samples"
-        ],
-        "summary": "Get all samples in a study",
-        "operationId": "getAllSamplesInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "sampleId",
-              "sampleType"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Sample"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/samples/{sampleId}": {
-      "get": {
-        "tags": [
-          "Samples"
-        ],
-        "summary": "Get a sample in a study",
-        "operationId": "getSampleInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "sampleId",
-            "in": "path",
-            "description": "Sample ID e.g. TCGA-OR-A5J2-01",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/Sample"
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/samples/{sampleId}/clinical-data": {
-      "get": {
-        "tags": [
-          "Clinical Data"
-        ],
-        "summary": "Get all clinical data of a sample in a study",
-        "operationId": "getAllClinicalDataOfSampleInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "sampleId",
-            "in": "path",
-            "description": "Sample ID e.g. TCGA-OR-A5J2-01",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "attributeId",
-            "in": "query",
-            "description": "Attribute ID e.g. CANCER_TYPE",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "clinicalAttributeId",
-              "value"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/samples/{sampleId}/copy-number-segments": {
-      "get": {
-        "tags": [
-          "Copy Number Segments"
-        ],
-        "summary": "Get copy number segments in a sample in a study",
-        "operationId": "getCopyNumberSegmentsInSampleInStudyUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "sampleId",
-            "in": "path",
-            "description": "Sample ID e.g. TCGA-OR-A5J2-01",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "chromosome",
-            "in": "query",
-            "description": "Chromosome",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 20000,
-            "maximum": 20000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "chromosome",
-              "start",
-              "end",
-              "numberOfProbes",
-              "segmentMean"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CopyNumberSeg"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/tags": {
-      "get": {
-        "tags": [
-          "Studies"
-        ],
-        "summary": "Get the tags of a study",
-        "operationId": "getTagsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "object"
-            }
-          }
-        }
-      }
-    }
-  },
-  "definitions": {
-    "CancerStudy": {
-      "type": "object",
-      "required": [
-        "studyId"
-      ],
-      "properties": {
-        "allSampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "cancerType": {
-          "$ref": "#/definitions/TypeOfCancer"
-        },
-        "cancerTypeId": {
-          "type": "string"
-        },
-        "citation": {
-          "type": "string"
-        },
-        "cnaSampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "completeSampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "description": {
-          "type": "string"
-        },
-        "groups": {
-          "type": "string"
-        },
-        "importDate": {
-          "type": "string",
-          "example": "yyyy-MM-dd HH:mm:ss"
-        },
-        "methylationHm27SampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "miRnaSampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "mrnaMicroarraySampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "mrnaRnaSeqSampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "mrnaRnaSeqV2SampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "name": {
-          "type": "string"
-        },
-        "pmid": {
-          "type": "string"
-        },
-        "publicStudy": {
-          "type": "boolean"
-        },
-        "rppaSampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "sequencedSampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "shortName": {
-          "type": "string"
-        },
-        "status": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "CancerStudy"
-    },
-    "CancerStudyTags": {
-      "type": "object",
-      "properties": {
-        "cancerStudyId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "tags": {
-          "type": "string"
-        }
-      },
-      "title": "CancerStudyTags"
-    },
-    "ClinicalAttribute": {
-      "type": "object",
-      "required": [
-        "clinicalAttributeId",
-        "displayName",
-        "patientAttribute",
-        "studyId"
-      ],
-      "properties": {
-        "clinicalAttributeId": {
-          "type": "string"
-        },
-        "datatype": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "displayName": {
-          "type": "string"
-        },
-        "patientAttribute": {
-          "type": "boolean"
-        },
-        "priority": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalAttribute"
-    },
-    "ClinicalAttributeCount": {
-      "type": "object",
-      "properties": {
-        "clinicalAttributeId": {
-          "type": "string"
-        },
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "ClinicalAttributeCount"
-    },
-    "ClinicalAttributeCountFilter": {
-      "type": "object",
-      "properties": {
-        "sampleIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SampleIdentifier"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalAttributeCountFilter"
-    },
-    "ClinicalData": {
-      "type": "object",
-      "required": [
-        "clinicalAttributeId",
-        "patientId",
-        "studyId"
-      ],
-      "properties": {
-        "clinicalAttribute": {
-          "$ref": "#/definitions/ClinicalAttribute"
-        },
-        "clinicalAttributeId": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalData"
-    },
-    "ClinicalDataIdentifier": {
-      "type": "object",
-      "properties": {
-        "entityId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalDataIdentifier"
-    },
-    "ClinicalDataMultiStudyFilter": {
-      "type": "object",
-      "properties": {
-        "attributeIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "identifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalDataIdentifier"
-          }
-        }
-      },
-      "title": "ClinicalDataMultiStudyFilter"
-    },
-    "ClinicalDataSingleStudyFilter": {
-      "type": "object",
-      "properties": {
-        "attributeIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "title": "ClinicalDataSingleStudyFilter"
-    },
-    "ClinicalEvent": {
-      "type": "object",
-      "required": [
-        "eventType",
-        "patientId",
-        "studyId"
-      ],
-      "properties": {
-        "attributes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalEventData"
-          }
-        },
-        "endNumberOfDaysSinceDiagnosis": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "eventType": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "startNumberOfDaysSinceDiagnosis": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalEvent"
-    },
-    "ClinicalEventData": {
-      "type": "object",
-      "required": [
-        "key",
-        "value"
-      ],
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalEventData"
-    },
-    "CopyNumberCount": {
-      "type": "object",
-      "required": [
-        "alteration",
-        "entrezGeneId",
-        "molecularProfileId",
-        "numberOfSamples",
-        "numberOfSamplesWithAlterationInGene"
-      ],
-      "properties": {
-        "alteration": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "numberOfSamples": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfSamplesWithAlterationInGene": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "CopyNumberCount"
-    },
-    "CopyNumberCountIdentifier": {
-      "type": "object",
-      "properties": {
-        "alteration": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "CopyNumberCountIdentifier"
-    },
-    "CopyNumberSeg": {
-      "type": "object",
-      "required": [
-        "chromosome",
-        "end",
-        "numberOfProbes",
-        "patientId",
-        "sampleId",
-        "segmentMean",
-        "start",
-        "studyId"
-      ],
-      "properties": {
-        "chromosome": {
-          "type": "string"
-        },
-        "end": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfProbes": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "segmentMean": {
-          "type": "number"
-        },
-        "start": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "CopyNumberSeg"
-    },
-    "DiscreteCopyNumberData": {
-      "type": "object",
-      "required": [
-        "alteration",
-        "entrezGeneId",
-        "molecularProfileId",
-        "patientId",
-        "sampleId",
-        "studyId"
-      ],
-      "properties": {
-        "alteration": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "gene": {
-          "$ref": "#/definitions/Gene"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "DiscreteCopyNumberData"
-    },
-    "DiscreteCopyNumberFilter": {
-      "type": "object",
-      "properties": {
-        "entrezGeneIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 50000
-          }
-        },
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "DiscreteCopyNumberFilter"
-    },
-    "Gene": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "hugoGeneSymbol"
-      ],
-      "properties": {
-        "chromosome": {
-          "type": "string"
-        },
-        "cytoband": {
-          "type": "string"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "length": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "type": {
-          "type": "string"
-        }
-      },
-      "title": "Gene"
-    },
-    "GenePanel": {
-      "type": "object",
-      "required": [
-        "genePanelId"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "genePanelId": {
-          "type": "string"
-        },
-        "genes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/GenePanelToGene"
-          }
-        }
-      },
-      "title": "GenePanel"
-    },
-    "GenePanelData": {
-      "type": "object",
-      "required": [
-        "molecularProfileId",
-        "patientId",
-        "profiled",
-        "sampleId",
-        "studyId"
-      ],
-      "properties": {
-        "genePanelId": {
-          "type": "string"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "profiled": {
-          "type": "boolean"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "GenePanelData"
-    },
-    "GenePanelDataFilter": {
-      "type": "object",
-      "properties": {
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "GenePanelDataFilter"
-    },
-    "GenePanelMultipleStudyFilter": {
-      "type": "object",
-      "required": [
-        "sampleMolecularIdentifiers"
-      ],
-      "properties": {
-        "sampleMolecularIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SampleMolecularIdentifier"
-          }
-        }
-      },
-      "title": "GenePanelMultipleStudyFilter"
-    },
-    "GenePanelToGene": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "hugoGeneSymbol"
-      ],
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        }
-      },
-      "title": "GenePanelToGene"
-    },
-    "MolecularDataFilter": {
-      "type": "object",
-      "properties": {
-        "entrezGeneIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 10000000
-          }
-        },
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "MolecularDataFilter"
-    },
-    "MolecularDataMultipleStudyFilter": {
-      "type": "object",
-      "properties": {
-        "entrezGeneIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 10000000
-          }
-        },
-        "molecularProfileIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleMolecularIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SampleMolecularIdentifier"
-          }
-        }
-      },
-      "title": "MolecularDataMultipleStudyFilter"
-    },
-    "MolecularProfile": {
-      "type": "object",
-      "required": [
-        "molecularProfileId",
-        "studyId"
-      ],
-      "properties": {
-        "datatype": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "molecularAlterationType": {
-          "type": "string",
-          "enum": [
-            "MUTATION_EXTENDED",
-            "MUTATION_UNCALLED",
-            "FUSION",
-            "STRUCTURAL_VARIANT",
-            "COPY_NUMBER_ALTERATION",
-            "MICRO_RNA_EXPRESSION",
-            "MRNA_EXPRESSION",
-            "MRNA_EXPRESSION_NORMALS",
-            "RNA_EXPRESSION",
-            "METHYLATION",
-            "METHYLATION_BINARY",
-            "PHOSPHORYLATION",
-            "PROTEIN_LEVEL",
-            "PROTEIN_ARRAY_PROTEIN_LEVEL",
-            "PROTEIN_ARRAY_PHOSPHORYLATION",
-            "GENESET_SCORE"
-          ]
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "showProfileInAnalysisTab": {
-          "type": "boolean"
-        },
-        "study": {
-          "$ref": "#/definitions/CancerStudy"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "MolecularProfile"
-    },
-    "MolecularProfileFilter": {
-      "type": "object",
-      "properties": {
-        "molecularProfileIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "studyIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "title": "MolecularProfileFilter"
-    },
-    "Mutation": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "molecularProfileId",
-        "patientId",
-        "sampleId",
-        "studyId"
-      ],
-      "properties": {
-        "aminoAcidChange": {
-          "type": "string"
-        },
-        "center": {
-          "type": "string"
-        },
-        "driverFilter": {
-          "type": "string"
-        },
-        "driverFilterAnnotation": {
-          "type": "string"
-        },
-        "driverTiersFilter": {
-          "type": "string"
-        },
-        "driverTiersFilterAnnotation": {
-          "type": "string"
-        },
-        "endPosition": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "fisValue": {
-          "type": "number"
-        },
-        "functionalImpactScore": {
-          "type": "string"
-        },
-        "gene": {
-          "$ref": "#/definitions/Gene"
-        },
-        "keyword": {
-          "type": "string"
-        },
-        "linkMsa": {
-          "type": "string"
-        },
-        "linkPdb": {
-          "type": "string"
-        },
-        "linkXvar": {
-          "type": "string"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "mutationStatus": {
-          "type": "string"
-        },
-        "mutationType": {
-          "type": "string"
-        },
-        "ncbiBuild": {
-          "type": "string"
-        },
-        "normalAltCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "normalRefCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "proteinChange": {
-          "type": "string"
-        },
-        "proteinPosEnd": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "proteinPosStart": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "referenceAllele": {
-          "type": "string"
-        },
-        "refseqMrnaId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "startPosition": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "tumorAltCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "tumorRefCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        },
-        "validationStatus": {
-          "type": "string"
-        },
-        "variantAllele": {
-          "type": "string"
-        },
-        "variantType": {
-          "type": "string"
-        }
-      },
-      "title": "Mutation"
-    },
-    "MutationCountByPosition": {
-      "type": "object",
-      "required": [
-        "count",
-        "entrezGeneId",
-        "proteinPosEnd",
-        "proteinPosStart"
-      ],
-      "properties": {
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "proteinPosEnd": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "proteinPosStart": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "MutationCountByPosition"
-    },
-    "MutationFilter": {
-      "type": "object",
-      "properties": {
-        "entrezGeneIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 10000000
-          }
-        },
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "MutationFilter"
-    },
-    "MutationMultipleStudyFilter": {
-      "type": "object",
-      "properties": {
-        "entrezGeneIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 10000000
-          }
-        },
-        "molecularProfileIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleMolecularIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SampleMolecularIdentifier"
-          }
-        }
-      },
-      "title": "MutationMultipleStudyFilter"
-    },
-    "MutationPositionIdentifier": {
-      "type": "object",
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "proteinPosEnd": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "proteinPosStart": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "MutationPositionIdentifier"
-    },
-    "NumericGeneMolecularData": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "molecularProfileId",
-        "patientId",
-        "sampleId",
-        "studyId",
-        "value"
-      ],
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "gene": {
-          "$ref": "#/definitions/Gene"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        },
-        "value": {
-          "type": "number"
-        }
-      },
-      "title": "NumericGeneMolecularData"
-    },
-    "Patient": {
-      "type": "object",
-      "required": [
-        "patientId",
-        "studyId"
-      ],
-      "properties": {
-        "cancerStudy": {
-          "$ref": "#/definitions/CancerStudy"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "Patient"
-    },
-    "PatientFilter": {
-      "type": "object",
-      "properties": {
-        "patientIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PatientIdentifier"
-          }
-        },
-        "uniquePatientKeys": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "title": "PatientFilter"
-    },
-    "PatientIdentifier": {
-      "type": "object",
-      "properties": {
-        "patientId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "PatientIdentifier"
-    },
-    "Sample": {
-      "type": "object",
-      "required": [
-        "patientId",
-        "sampleId",
-        "studyId"
-      ],
-      "properties": {
-        "copyNumberSegmentPresent": {
-          "type": "boolean"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "sampleType": {
-          "type": "string",
-          "enum": [
-            "Primary Solid Tumor",
-            "Recurrent Solid Tumor",
-            "Primary Blood Tumor",
-            "Recurrent Blood Tumor",
-            "Metastatic",
-            "Blood Derived Normal",
-            "Solid Tissues Normal"
-          ]
-        },
-        "sequenced": {
-          "type": "boolean"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "Sample"
-    },
-    "SampleFilter": {
-      "type": "object",
-      "properties": {
-        "sampleIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SampleIdentifier"
-          }
-        },
-        "sampleListIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "uniqueSampleKeys": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "title": "SampleFilter"
-    },
-    "SampleIdentifier": {
-      "type": "object",
-      "properties": {
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "SampleIdentifier"
-    },
-    "SampleList": {
-      "type": "object",
-      "required": [
-        "sampleListId"
-      ],
-      "properties": {
-        "category": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "sampleCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "SampleList"
-    },
-    "SampleMolecularIdentifier": {
-      "type": "object",
-      "properties": {
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        }
-      },
-      "title": "SampleMolecularIdentifier"
-    },
-    "TypeOfCancer": {
-      "type": "object",
-      "required": [
-        "cancerTypeId"
-      ],
-      "properties": {
-        "cancerTypeId": {
-          "type": "string"
-        },
-        "clinicalTrialKeywords": {
-          "type": "string"
-        },
-        "dedicatedColor": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "parent": {
-          "type": "string"
-        },
-        "shortName": {
-          "type": "string"
-        }
-      },
-      "title": "TypeOfCancer"
-    }
-  }
 }

--- a/src/shared/api/generated/CBioPortalAPIInternal-docs.json
+++ b/src/shared/api/generated/CBioPortalAPIInternal-docs.json
@@ -18,6 +18,10 @@
     "basePath": "/cbioportal/api",
     "tags": [
         {
+            "name": "Clinical Data Enrichments",
+            "description": " "
+        },
+        {
             "name": "Co-Expressions",
             "description": " "
         },
@@ -281,6 +285,43 @@
                 }
             }
         },
+        "/clinical-data-enrichments/fetch": {
+            "post": {
+                "tags": [
+                    "Clinical Data Enrichments"
+                ],
+                "summary": "Fetch clinical data enrichments for the sample groups",
+                "operationId": "fetchClinicalEnrichmentsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "groupFilter",
+                        "description": "List of altered and unaltered Sample/Patient IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GroupFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalDataEnrichment"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/cna-genes/fetch": {
             "post": {
                 "tags": [
@@ -312,6 +353,67 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/CopyNumberCountByGene"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/copy-number-enrichments/fetch": {
+            "post": {
+                "tags": [
+                    "Copy Number Enrichments"
+                ],
+                "summary": "Fetch copy number enrichments in a molecular profile",
+                "operationId": "fetchCopyNumberEnrichmentsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "copyNumberEventType",
+                        "in": "query",
+                        "description": "Type of the copy number event",
+                        "required": false,
+                        "type": "string",
+                        "default": "HOMDEL",
+                        "enum": [
+                            "HOMDEL",
+                            "AMP"
+                        ]
+                    },
+                    {
+                        "name": "enrichmentType",
+                        "in": "query",
+                        "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "multipleStudiesEnrichmentFilter",
+                        "description": "List of entities",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MultipleStudiesEnrichmentFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AlterationEnrichment"
                             }
                         }
                     }
@@ -766,12 +868,12 @@
                 }
             }
         },
-        "/molecular-profiles/{molecularProfileId}/co-expressions/fetch": {
+        "/molecular-profiles/co-expressions/fetch": {
             "post": {
                 "tags": [
                     "Co-Expressions"
                 ],
-                "summary": "Fetch co-expressions in a molecular profile",
+                "summary": "Calculates correlations between a genetic entity from a specific profile and another profile from the same study",
                 "operationId": "fetchCoExpressionsUsingPOST",
                 "consumes": [
                     "application/json"
@@ -781,28 +883,27 @@
                 ],
                 "parameters": [
                     {
-                        "name": "molecularProfileId",
-                        "in": "path",
-                        "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
+                        "name": "molecularProfileIdA",
+                        "in": "query",
+                        "description": "Molecular Profile ID from the Genetic Entity referenced in the co-expression filter e.g. acc_tcga_rna_seq_v2_mrna",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "molecularProfileIdB",
+                        "in": "query",
+                        "description": "Molecular Profile ID (can be the same as molecularProfileIdA) e.g. acc_tcga_rna_seq_v2_mrna",
                         "required": true,
                         "type": "string"
                     },
                     {
                         "in": "body",
                         "name": "coExpressionFilter",
-                        "description": "List of Sample IDs/Sample List ID",
+                        "description": "List of Sample IDs/Sample List ID and Entrez Gene ID/Gene set ID",
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/CoExpressionFilter"
                         }
-                    },
-                    {
-                        "name": "entrezGeneId",
-                        "in": "query",
-                        "description": "Entrez Gene ID",
-                        "required": true,
-                        "type": "integer",
-                        "format": "int32"
                     },
                     {
                         "name": "threshold",
@@ -821,74 +922,6 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/CoExpression"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/molecular-profiles/{molecularProfileId}/copy-number-enrichments/fetch": {
-            "post": {
-                "tags": [
-                    "Copy Number Enrichments"
-                ],
-                "summary": "Fetch copy number enrichments in a molecular profile",
-                "operationId": "fetchCopyNumberEnrichmentsUsingPOST",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "molecularProfileId",
-                        "in": "path",
-                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "copyNumberEventType",
-                        "in": "query",
-                        "description": "Type of the copy number event",
-                        "required": false,
-                        "type": "string",
-                        "default": "HOMDEL",
-                        "enum": [
-                            "HOMDEL",
-                            "AMP"
-                        ]
-                    },
-                    {
-                        "name": "enrichmentType",
-                        "in": "query",
-                        "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
-                        "required": false,
-                        "type": "string",
-                        "default": "SAMPLE",
-                        "enum": [
-                            "SAMPLE",
-                            "PATIENT"
-                        ]
-                    },
-                    {
-                        "in": "body",
-                        "name": "enrichmentFilter",
-                        "description": "List of altered and unaltered Sample/Patient IDs",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/EnrichmentFilter"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/AlterationEnrichment"
                             }
                         }
                     }
@@ -1000,62 +1033,6 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/MrnaPercentile"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/molecular-profiles/{molecularProfileId}/mutation-enrichments/fetch": {
-            "post": {
-                "tags": [
-                    "Mutation Enrichments"
-                ],
-                "summary": "Fetch mutation enrichments in a molecular profile",
-                "operationId": "fetchMutationEnrichmentsUsingPOST",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "molecularProfileId",
-                        "in": "path",
-                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "enrichmentType",
-                        "in": "query",
-                        "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
-                        "required": false,
-                        "type": "string",
-                        "default": "SAMPLE",
-                        "enum": [
-                            "SAMPLE",
-                            "PATIENT"
-                        ]
-                    },
-                    {
-                        "in": "body",
-                        "name": "enrichmentFilter",
-                        "description": "List of altered and unaltered Sample/Patient IDs",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/EnrichmentFilter"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/AlterationEnrichment"
                             }
                         }
                     }
@@ -1184,6 +1161,55 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/MutationCountByGene"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/mutation-enrichments/fetch": {
+            "post": {
+                "tags": [
+                    "Mutation Enrichments"
+                ],
+                "summary": "Fetch mutation enrichments in a molecular profile",
+                "operationId": "fetchMutationEnrichmentsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "enrichmentType",
+                        "in": "query",
+                        "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "multipleStudiesEnrichmentFilter",
+                        "description": "List of entities",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MultipleStudiesEnrichmentFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AlterationEnrichment"
                             }
                         }
                     }
@@ -1423,18 +1449,14 @@
         "AlterationEnrichment": {
             "type": "object",
             "required": [
-                "alteredCount",
                 "entrezGeneId",
                 "hugoGeneSymbol",
                 "logRatio",
                 "pValue",
-                "unalteredCount"
+                "set1CountSummary",
+                "set2CountSummary"
             ],
             "properties": {
-                "alteredCount": {
-                    "type": "integer",
-                    "format": "int32"
-                },
                 "cytoband": {
                     "type": "string"
                 },
@@ -1451,12 +1473,47 @@
                 "pValue": {
                     "type": "number"
                 },
-                "unalteredCount": {
-                    "type": "integer",
-                    "format": "int32"
+                "set1CountSummary": {
+                    "$ref": "#/definitions/CountSummary"
+                },
+                "set2CountSummary": {
+                    "$ref": "#/definitions/CountSummary"
                 }
             },
             "title": "AlterationEnrichment"
+        },
+        "ClinicalAttribute": {
+            "type": "object",
+            "required": [
+                "clinicalAttributeId",
+                "displayName",
+                "patientAttribute",
+                "studyId"
+            ],
+            "properties": {
+                "clinicalAttributeId": {
+                    "type": "string"
+                },
+                "datatype": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "patientAttribute": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalAttribute"
         },
         "ClinicalDataBinCountFilter": {
             "type": "object",
@@ -1557,6 +1614,30 @@
             },
             "title": "ClinicalDataCountItem"
         },
+        "ClinicalDataEnrichment": {
+            "type": "object",
+            "required": [
+                "clinicalAttribute",
+                "method",
+                "pValue",
+                "score"
+            ],
+            "properties": {
+                "clinicalAttribute": {
+                    "$ref": "#/definitions/ClinicalAttribute"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "pValue": {
+                    "type": "number"
+                },
+                "score": {
+                    "type": "number"
+                }
+            },
+            "title": "ClinicalDataEnrichment"
+        },
         "ClinicalDataEqualityFilter": {
             "type": "object",
             "properties": {
@@ -1638,8 +1719,9 @@
             "type": "object",
             "required": [
                 "cytoband",
-                "entrezGeneId",
-                "hugoGeneSymbol",
+                "geneticEntityId",
+                "geneticEntityName",
+                "geneticEntityType",
                 "pValue",
                 "spearmansCorrelation"
             ],
@@ -1647,12 +1729,18 @@
                 "cytoband": {
                     "type": "string"
                 },
-                "entrezGeneId": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "hugoGeneSymbol": {
+                "geneticEntityId": {
                     "type": "string"
+                },
+                "geneticEntityName": {
+                    "type": "string"
+                },
+                "geneticEntityType": {
+                    "type": "string",
+                    "enum": [
+                        "GENE",
+                        "GENESET"
+                    ]
                 },
                 "pValue": {
                     "type": "number"
@@ -1666,6 +1754,13 @@
         "CoExpressionFilter": {
             "type": "object",
             "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "genesetId": {
+                    "type": "string"
+                },
                 "sampleIds": {
                     "type": "array",
                     "items": {
@@ -1685,10 +1780,6 @@
                     "type": "integer",
                     "format": "int32"
                 },
-                "countByEntity": {
-                    "type": "integer",
-                    "format": "int32"
-                },
                 "cytoband": {
                     "type": "string"
                 },
@@ -1698,6 +1789,10 @@
                 },
                 "hugoGeneSymbol": {
                     "type": "string"
+                },
+                "numberOfAlteredCases": {
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "numberOfSamplesProfiled": {
                     "type": "integer",
@@ -1762,6 +1857,24 @@
                 }
             },
             "title": "CosmicMutation"
+        },
+        "CountSummary": {
+            "type": "object",
+            "required": [
+                "alteredCount",
+                "profiledCount"
+            ],
+            "properties": {
+                "alteredCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "profiledCount": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "CountSummary"
         },
         "DataBin": {
             "type": "object",
@@ -1990,6 +2103,9 @@
                 "value"
             ],
             "properties": {
+                "geneset": {
+                    "$ref": "#/definitions/Geneset"
+                },
                 "genesetId": {
                     "type": "string"
                 },
@@ -2000,6 +2116,9 @@
                     "type": "string"
                 },
                 "sampleId": {
+                    "type": "string"
+                },
+                "stableId": {
                     "type": "string"
                 },
                 "studyId": {
@@ -2079,6 +2198,33 @@
             },
             "title": "GisticToGene"
         },
+        "Group": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "sampleIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SampleIdentifier"
+                    }
+                }
+            },
+            "title": "Group"
+        },
+        "GroupFilter": {
+            "type": "object",
+            "properties": {
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Group"
+                    }
+                }
+            },
+            "title": "GroupFilter"
+        },
         "Info": {
             "type": "object",
             "required": [
@@ -2134,6 +2280,22 @@
                 }
             },
             "title": "Info"
+        },
+        "MolecularProfileCaseIdentifier": {
+            "type": "object",
+            "required": [
+                "caseId",
+                "molecularProfileId"
+            ],
+            "properties": {
+                "caseId": {
+                    "type": "string"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                }
+            },
+            "title": "MolecularProfileCaseIdentifier"
         },
         "MolecularProfileSampleCount": {
             "type": "object",
@@ -2204,6 +2366,28 @@
             },
             "title": "MrnaPercentile"
         },
+        "MultipleStudiesEnrichmentFilter": {
+            "type": "object",
+            "required": [
+                "molecularProfileCaseSet1",
+                "molecularProfileCaseSet2"
+            ],
+            "properties": {
+                "molecularProfileCaseSet1": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MolecularProfileCaseIdentifier"
+                    }
+                },
+                "molecularProfileCaseSet2": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MolecularProfileCaseIdentifier"
+                    }
+                }
+            },
+            "title": "MultipleStudiesEnrichmentFilter"
+        },
         "MutSig": {
             "type": "object",
             "required": [
@@ -2246,16 +2430,16 @@
         "MutationCountByGene": {
             "type": "object",
             "properties": {
-                "countByEntity": {
-                    "type": "integer",
-                    "format": "int32"
-                },
                 "entrezGeneId": {
                     "type": "integer",
                     "format": "int32"
                 },
                 "hugoGeneSymbol": {
                     "type": "string"
+                },
+                "numberOfAlteredCases": {
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "numberOfSamplesProfiled": {
                     "type": "integer",

--- a/src/shared/api/generated/CBioPortalAPIInternal-docs.json
+++ b/src/shared/api/generated/CBioPortalAPIInternal-docs.json
@@ -1,2532 +1,2536 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "description": "A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.",
-    "version": "1.0 (beta)",
-    "title": "cBioPortal web API [Beta]",
-    "contact": {
-      "name": "cBioPortal",
-      "url": "http://www.cbioportal.org",
-      "email": "cbioportal@googlegroups.com"
+    "swagger": "2.0",
+    "info": {
+        "description": "A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.",
+        "version": "1.0 (beta)",
+        "title": "cBioPortal web API [Beta]",
+        "contact": {
+            "name": "cBioPortal",
+            "url": "http://www.cbioportal.org",
+            "email": "cbioportal@googlegroups.com"
+        },
+        "license": {
+            "name": "License",
+            "url": "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE"
+        }
     },
-    "license": {
-      "name": "License",
-      "url": "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE"
+    "host": "localhost:8080",
+    "basePath": "/cbioportal/api",
+    "tags": [
+        {
+            "name": "Co-Expressions",
+            "description": " "
+        },
+        {
+            "name": "Copy Number Enrichments",
+            "description": " "
+        },
+        {
+            "name": "Cosmic Counts",
+            "description": " "
+        },
+        {
+            "name": "Expression Enrichments",
+            "description": " "
+        },
+        {
+            "name": "Gene Set Correlation",
+            "description": " "
+        },
+        {
+            "name": "Gene Set Hierarchy",
+            "description": " "
+        },
+        {
+            "name": "Gene Set Scores",
+            "description": " "
+        },
+        {
+            "name": "Gene Sets",
+            "description": " "
+        },
+        {
+            "name": "Info",
+            "description": " "
+        },
+        {
+            "name": "Mutation Enrichments",
+            "description": " "
+        },
+        {
+            "name": "Mutation Spectrums",
+            "description": " "
+        },
+        {
+            "name": "Significant Copy Number Regions",
+            "description": " "
+        },
+        {
+            "name": "Significantly Mutated Genes",
+            "description": " "
+        },
+        {
+            "name": "Study View",
+            "description": " "
+        },
+        {
+            "name": "Variant Counts",
+            "description": " "
+        },
+        {
+            "name": "mRNA Percentile",
+            "description": " "
+        }
+    ],
+    "schemes": [
+        "http",
+        "https"
+    ],
+    "paths": {
+        "/clinical-data-bin-counts/fetch": {
+            "post": {
+                "tags": [
+                    "Study View"
+                ],
+                "summary": "Fetch clinical data bin counts by study view filter",
+                "operationId": "fetchClinicalDataBinCountsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "dataBinMethod",
+                        "in": "query",
+                        "description": "Method for data binning",
+                        "required": false,
+                        "type": "string",
+                        "default": "DYNAMIC",
+                        "enum": [
+                            "STATIC",
+                            "DYNAMIC"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "clinicalDataBinCountFilter",
+                        "description": "Clinical data bin count filter",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ClinicalDataBinCountFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DataBin"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/clinical-data-counts/fetch": {
+            "post": {
+                "tags": [
+                    "Study View"
+                ],
+                "summary": "Fetch clinical data counts by study view filter",
+                "operationId": "fetchClinicalDataCountsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "clinicalDataCountFilter",
+                        "description": "Clinical data count filter",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ClinicalDataCountFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClinicalDataCountItem"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/clinical-data-density-plot/fetch": {
+            "post": {
+                "tags": [
+                    "Study View"
+                ],
+                "summary": "Fetch clinical data density plot bins by study view filter",
+                "operationId": "fetchClinicalDataDensityPlotUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "xAxisAttributeId",
+                        "in": "query",
+                        "description": "Clinical Attribute ID of the X axis",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "xAxisBinCount",
+                        "in": "query",
+                        "description": "Number of the bins in X axis",
+                        "required": false,
+                        "type": "integer",
+                        "default": 50,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "xAxisStart",
+                        "in": "query",
+                        "description": "Starting point of the X axis, if different than smallest value",
+                        "required": false,
+                        "type": "number"
+                    },
+                    {
+                        "name": "xAxisEnd",
+                        "in": "query",
+                        "description": "Starting point of the X axis, if different than largest value",
+                        "required": false,
+                        "type": "number"
+                    },
+                    {
+                        "name": "yAxisAttributeId",
+                        "in": "query",
+                        "description": "Clinical Attribute ID of the Y axis",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "yAxisBinCount",
+                        "in": "query",
+                        "description": "Number of the bins in Y axis",
+                        "required": false,
+                        "type": "integer",
+                        "default": 50,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "yAxisStart",
+                        "in": "query",
+                        "description": "Starting point of the Y axis, if different than smallest value",
+                        "required": false,
+                        "type": "number"
+                    },
+                    {
+                        "name": "yAxisEnd",
+                        "in": "query",
+                        "description": "Starting point of the Y axis, if different than largest value",
+                        "required": false,
+                        "type": "number"
+                    },
+                    {
+                        "name": "clinicalDataType",
+                        "in": "query",
+                        "description": "Clinical data type of both attributes",
+                        "required": true,
+                        "type": "string",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "studyViewFilter",
+                        "description": "Study view filter",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/StudyViewFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DensityPlotBin"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/cna-genes/fetch": {
+            "post": {
+                "tags": [
+                    "Study View"
+                ],
+                "summary": "Fetch CNA genes by study view filter",
+                "operationId": "fetchCNAGenesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "studyViewFilter",
+                        "description": "Study view filter",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/StudyViewFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CopyNumberCountByGene"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/cosmic-counts/fetch": {
+            "post": {
+                "tags": [
+                    "Cosmic Counts"
+                ],
+                "summary": "Get counts within the COSMIC database by keywords",
+                "operationId": "fetchCosmicCountsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "keywords",
+                        "description": "List of keywords",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CosmicMutation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/filtered-samples/fetch": {
+            "post": {
+                "tags": [
+                    "Study View"
+                ],
+                "summary": "Fetch sample IDs by study view filter",
+                "operationId": "fetchFilteredSamplesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "negateFilters",
+                        "in": "query",
+                        "description": "Whether to negate the study view filters",
+                        "required": false,
+                        "type": "boolean",
+                        "default": false
+                    },
+                    {
+                        "in": "body",
+                        "name": "studyViewFilter",
+                        "description": "Study view filter",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/StudyViewFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Sample"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/geneset-hierarchy/fetch": {
+            "post": {
+                "tags": [
+                    "Gene Set Hierarchy"
+                ],
+                "summary": "Get gene set hierarchical organization information. I.e. how different gene sets relate to other gene sets, in a hierarchy",
+                "operationId": "fetchGenesetHierarchyInfoUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "geneticProfileId",
+                        "in": "query",
+                        "description": "Genetic Profile ID e.g. gbm_tcga_gsva_scores. The final hierarchy  will only include gene sets scored in the specified profile.",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "percentile",
+                        "in": "query",
+                        "description": "Percentile (for score calculation). Which percentile to use when determining the *representative score*",
+                        "required": false,
+                        "type": "integer",
+                        "default": 75,
+                        "maximum": 100.0,
+                        "exclusiveMaximum": false,
+                        "minimum": 1.0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "scoreThreshold",
+                        "in": "query",
+                        "description": "Gene set score threshold (for absolute score value). Filters out gene sets where the GSVA(like) *representative score* is under this threshold.",
+                        "required": false,
+                        "type": "number",
+                        "default": 0.4,
+                        "maximum": 1.0,
+                        "exclusiveMaximum": false,
+                        "minimum": 0.0,
+                        "exclusiveMinimum": false,
+                        "format": "double"
+                    },
+                    {
+                        "name": "pvalueThreshold",
+                        "in": "query",
+                        "description": "p-value threshold. Filters out gene sets for which the score p-value is higher than this threshold.",
+                        "required": false,
+                        "type": "number",
+                        "default": 0.05,
+                        "maximum": 1.0,
+                        "exclusiveMaximum": false,
+                        "minimum": 0.0,
+                        "exclusiveMinimum": false,
+                        "format": "double"
+                    },
+                    {
+                        "name": "sampleListId",
+                        "in": "query",
+                        "description": "Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "sampleIds",
+                        "description": "Fill this one if you want to specify a subset of samples: sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenesetHierarchyInfo"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/genesets": {
+            "get": {
+                "tags": [
+                    "Gene Sets"
+                ],
+                "summary": "Get all gene sets",
+                "operationId": "getAllGenesetsUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 2147483647,
+                        "exclusiveMaximum": false,
+                        "minimum": 1.0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0.0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Geneset"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/genesets/fetch": {
+            "post": {
+                "tags": [
+                    "Gene Sets"
+                ],
+                "summary": "Fetch gene sets by ID",
+                "operationId": "fetchGenesetsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "genesetIds",
+                        "description": "List of Gene set IDs",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Geneset"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/genesets/{genesetId}": {
+            "get": {
+                "tags": [
+                    "Gene Sets"
+                ],
+                "summary": "Get a gene set",
+                "operationId": "getGenesetUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "genesetId",
+                        "in": "path",
+                        "description": "Gene set ID e.g. GNF2_ZAP70",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Geneset"
+                        }
+                    }
+                }
+            }
+        },
+        "/genesets/{genesetId}/expression-correlation/fetch": {
+            "post": {
+                "tags": [
+                    "Gene Set Correlation"
+                ],
+                "summary": "Get the genes in a gene set that have expression correlated to the gene set scores (calculated using Spearman's correlation)",
+                "operationId": "fetchCorrelatedGenesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "genesetId",
+                        "in": "path",
+                        "description": "Gene set ID, e.g. HINATA_NFKB_MATRIX.",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "geneticProfileId",
+                        "in": "query",
+                        "description": "Genetic Profile ID e.g. gbm_tcga_gsva_scores",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "correlationThreshold",
+                        "in": "query",
+                        "description": "Correlation threshold (for absolute correlation value, Spearman correlation)",
+                        "required": false,
+                        "type": "number",
+                        "default": 0.3,
+                        "maximum": 1.0,
+                        "exclusiveMaximum": false,
+                        "minimum": 0.0,
+                        "exclusiveMinimum": false,
+                        "format": "double"
+                    },
+                    {
+                        "name": "sampleListId",
+                        "in": "query",
+                        "description": "Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "sampleIds",
+                        "description": "Fill this one if you want to specify a subset of samples: sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenesetCorrelation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/genetic-profiles/{geneticProfileId}/geneset-genetic-data/fetch": {
+            "post": {
+                "tags": [
+                    "Gene Set Scores"
+                ],
+                "summary": "Fetch gene set \"genetic data\" items (gene set scores) by profile Id, gene set ids and sample ids",
+                "operationId": "fetchGeneticDataItemsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "geneticProfileId",
+                        "in": "path",
+                        "description": "Genetic profile ID, e.g. gbm_tcga_gsva_scores",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "genesetDataFilterCriteria",
+                        "description": "Search criteria to return the values for a given set of samples and gene set items. genesetIds: The list of identifiers for the gene sets of interest, e.g. HINATA_NFKB_MATRIX. Use one of these if you want to specify a subset of samples:(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GenesetDataFilterCriteria"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenesetMolecularData"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/info": {
+            "get": {
+                "tags": [
+                    "Info"
+                ],
+                "summary": "Get information about the running instance",
+                "operationId": "getInfoUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Info"
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/co-expressions/fetch": {
+            "post": {
+                "tags": [
+                    "Co-Expressions"
+                ],
+                "summary": "Fetch co-expressions in a molecular profile",
+                "operationId": "fetchCoExpressionsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "coExpressionFilter",
+                        "description": "List of Sample IDs/Sample List ID",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CoExpressionFilter"
+                        }
+                    },
+                    {
+                        "name": "entrezGeneId",
+                        "in": "query",
+                        "description": "Entrez Gene ID",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    {
+                        "name": "threshold",
+                        "in": "query",
+                        "description": "Threshold",
+                        "required": false,
+                        "type": "number",
+                        "default": 0.3,
+                        "format": "double"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CoExpression"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/copy-number-enrichments/fetch": {
+            "post": {
+                "tags": [
+                    "Copy Number Enrichments"
+                ],
+                "summary": "Fetch copy number enrichments in a molecular profile",
+                "operationId": "fetchCopyNumberEnrichmentsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "copyNumberEventType",
+                        "in": "query",
+                        "description": "Type of the copy number event",
+                        "required": false,
+                        "type": "string",
+                        "default": "HOMDEL",
+                        "enum": [
+                            "HOMDEL",
+                            "AMP"
+                        ]
+                    },
+                    {
+                        "name": "enrichmentType",
+                        "in": "query",
+                        "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "enrichmentFilter",
+                        "description": "List of altered and unaltered Sample/Patient IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/EnrichmentFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AlterationEnrichment"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/expression-enrichments/fetch": {
+            "post": {
+                "tags": [
+                    "Expression Enrichments"
+                ],
+                "summary": "Fetch expression enrichments in a molecular profile",
+                "operationId": "fetchExpressionEnrichmentsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "enrichmentType",
+                        "in": "query",
+                        "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "enrichmentFilter",
+                        "description": "List of altered and unaltered Sample/Patient IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/EnrichmentFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ExpressionEnrichment"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/mrna-percentile/fetch": {
+            "post": {
+                "tags": [
+                    "mRNA Percentile"
+                ],
+                "summary": "Get mRNA expression percentiles for list of genes for a sample",
+                "operationId": "fetchMrnaPercentileUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "sampleId",
+                        "in": "query",
+                        "description": "Sample ID e.g. TCGA-OR-A5J2-01",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "entrezGeneIds",
+                        "description": "List of Entrez Gene IDs",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int32"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MrnaPercentile"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/mutation-enrichments/fetch": {
+            "post": {
+                "tags": [
+                    "Mutation Enrichments"
+                ],
+                "summary": "Fetch mutation enrichments in a molecular profile",
+                "operationId": "fetchMutationEnrichmentsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "enrichmentType",
+                        "in": "query",
+                        "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
+                        "required": false,
+                        "type": "string",
+                        "default": "SAMPLE",
+                        "enum": [
+                            "SAMPLE",
+                            "PATIENT"
+                        ]
+                    },
+                    {
+                        "in": "body",
+                        "name": "enrichmentFilter",
+                        "description": "List of altered and unaltered Sample/Patient IDs",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/EnrichmentFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AlterationEnrichment"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/mutation-spectrums/fetch": {
+            "post": {
+                "tags": [
+                    "Mutation Spectrums"
+                ],
+                "summary": "Fetch mutation spectrums in a molecular profile",
+                "operationId": "fetchMutationSpectrumsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "mutationSpectrumFilter",
+                        "description": "List of Sample IDs/Sample List ID",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/MutationSpectrumFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MutationSpectrum"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/molecular-profiles/{molecularProfileId}/variant-counts/fetch": {
+            "post": {
+                "tags": [
+                    "Variant Counts"
+                ],
+                "summary": "Get counts of specific variants within a mutation molecular profile",
+                "operationId": "fetchVariantCountsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "molecularProfileId",
+                        "in": "path",
+                        "description": "Molecular Profile ID e.g. acc_tcga_mutations",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "variantCountIdentifiers",
+                        "description": "List of variant count identifiers",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VariantCountIdentifier"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VariantCount"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/mutated-genes/fetch": {
+            "post": {
+                "tags": [
+                    "Study View"
+                ],
+                "summary": "Fetch mutated genes by study view filter",
+                "operationId": "fetchMutatedGenesUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "studyViewFilter",
+                        "description": "Study view filter",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/StudyViewFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MutationCountByGene"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sample-counts/fetch": {
+            "post": {
+                "tags": [
+                    "Study View"
+                ],
+                "summary": "Fetch sample counts by study view filter",
+                "operationId": "fetchMolecularProfileSampleCountsUsingPOST",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "studyViewFilter",
+                        "description": "Study view filter",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/StudyViewFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/MolecularProfileSampleCount"
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/significant-copy-number-regions": {
+            "get": {
+                "tags": [
+                    "Significant Copy Number Regions"
+                ],
+                "summary": "Get significant copy number alteration regions in a study",
+                "operationId": "getSignificantCopyNumberRegionsUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 1.0E+7,
+                        "exclusiveMaximum": false,
+                        "minimum": 1.0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0.0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "chromosome",
+                            "cytoband",
+                            "widePeakStart",
+                            "widePeakEnd",
+                            "qValue",
+                            "amp"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Gistic"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/studies/{studyId}/significantly-mutated-genes": {
+            "get": {
+                "tags": [
+                    "Significantly Mutated Genes"
+                ],
+                "summary": "Get significantly mutated genes in a study",
+                "operationId": "getSignificantlyMutatedGenesUsingGET",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "studyId",
+                        "in": "path",
+                        "description": "Study ID e.g. acc_tcga",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "projection",
+                        "in": "query",
+                        "description": "Level of detail of the response",
+                        "required": false,
+                        "type": "string",
+                        "default": "SUMMARY",
+                        "enum": [
+                            "ID",
+                            "SUMMARY",
+                            "DETAILED",
+                            "META"
+                        ]
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "description": "Page size of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 10000000,
+                        "maximum": 1.0E+7,
+                        "exclusiveMaximum": false,
+                        "minimum": 1.0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number of the result list",
+                        "required": false,
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0.0,
+                        "exclusiveMinimum": false,
+                        "format": "int32"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Name of the property that the result list is sorted by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "entrezGeneId",
+                            "hugoGeneSymbol",
+                            "rank",
+                            "numberOfMutations",
+                            "pValue",
+                            "qValue"
+                        ]
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Direction of the sort",
+                        "required": false,
+                        "type": "string",
+                        "default": "ASC",
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MutSig"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "AlterationEnrichment": {
+            "type": "object",
+            "required": [
+                "alteredCount",
+                "entrezGeneId",
+                "hugoGeneSymbol",
+                "logRatio",
+                "pValue",
+                "unalteredCount"
+            ],
+            "properties": {
+                "alteredCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "cytoband": {
+                    "type": "string"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "logRatio": {
+                    "type": "string"
+                },
+                "pValue": {
+                    "type": "number"
+                },
+                "unalteredCount": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "AlterationEnrichment"
+        },
+        "ClinicalDataBinCountFilter": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalDataBinFilter"
+                    }
+                },
+                "studyViewFilter": {
+                    "$ref": "#/definitions/StudyViewFilter"
+                }
+            },
+            "title": "ClinicalDataBinCountFilter"
+        },
+        "ClinicalDataBinFilter": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "type": "string"
+                },
+                "clinicalDataType": {
+                    "type": "string",
+                    "enum": [
+                        "SAMPLE",
+                        "PATIENT"
+                    ]
+                },
+                "customBins": {
+                    "type": "array",
+                    "items": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "disableLogScale": {
+                    "type": "boolean"
+                },
+                "end": {
+                    "type": "number",
+                    "format": "double"
+                },
+                "start": {
+                    "type": "number",
+                    "format": "double"
+                }
+            },
+            "title": "ClinicalDataBinFilter"
+        },
+        "ClinicalDataCount": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalDataCount"
+        },
+        "ClinicalDataCountFilter": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalDataFilter"
+                    }
+                },
+                "studyViewFilter": {
+                    "$ref": "#/definitions/StudyViewFilter"
+                }
+            },
+            "title": "ClinicalDataCountFilter"
+        },
+        "ClinicalDataCountItem": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "type": "string"
+                },
+                "clinicalDataType": {
+                    "type": "string",
+                    "enum": [
+                        "SAMPLE",
+                        "PATIENT"
+                    ]
+                },
+                "counts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalDataCount"
+                    }
+                }
+            },
+            "title": "ClinicalDataCountItem"
+        },
+        "ClinicalDataEqualityFilter": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "type": "string"
+                },
+                "clinicalDataType": {
+                    "type": "string",
+                    "enum": [
+                        "SAMPLE",
+                        "PATIENT"
+                    ]
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "title": "ClinicalDataEqualityFilter"
+        },
+        "ClinicalDataFilter": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "type": "string"
+                },
+                "clinicalDataType": {
+                    "type": "string",
+                    "enum": [
+                        "SAMPLE",
+                        "PATIENT"
+                    ]
+                }
+            },
+            "title": "ClinicalDataFilter"
+        },
+        "ClinicalDataIntervalFilter": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "type": "string"
+                },
+                "clinicalDataType": {
+                    "type": "string",
+                    "enum": [
+                        "SAMPLE",
+                        "PATIENT"
+                    ]
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalDataIntervalFilterValue"
+                    }
+                }
+            },
+            "title": "ClinicalDataIntervalFilter"
+        },
+        "ClinicalDataIntervalFilterValue": {
+            "type": "object",
+            "properties": {
+                "end": {
+                    "type": "number",
+                    "format": "double"
+                },
+                "start": {
+                    "type": "number",
+                    "format": "double"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "ClinicalDataIntervalFilterValue"
+        },
+        "CoExpression": {
+            "type": "object",
+            "required": [
+                "cytoband",
+                "entrezGeneId",
+                "hugoGeneSymbol",
+                "pValue",
+                "spearmansCorrelation"
+            ],
+            "properties": {
+                "cytoband": {
+                    "type": "string"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "pValue": {
+                    "type": "number"
+                },
+                "spearmansCorrelation": {
+                    "type": "number"
+                }
+            },
+            "title": "CoExpression"
+        },
+        "CoExpressionFilter": {
+            "type": "object",
+            "properties": {
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "CoExpressionFilter"
+        },
+        "CopyNumberCountByGene": {
+            "type": "object",
+            "properties": {
+                "alteration": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "countByEntity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "cytoband": {
+                    "type": "string"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "numberOfSamplesProfiled": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "qValue": {
+                    "type": "number"
+                },
+                "totalCount": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "CopyNumberCountByGene"
+        },
+        "CopyNumberGeneFilter": {
+            "type": "object",
+            "properties": {
+                "alterations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CopyNumberGeneFilterElement"
+                    }
+                }
+            },
+            "title": "CopyNumberGeneFilter"
+        },
+        "CopyNumberGeneFilterElement": {
+            "type": "object",
+            "properties": {
+                "alteration": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "CopyNumberGeneFilterElement"
+        },
+        "CosmicMutation": {
+            "type": "object",
+            "required": [
+                "cosmicMutationId",
+                "count",
+                "proteinChange"
+            ],
+            "properties": {
+                "cosmicMutationId": {
+                    "type": "string"
+                },
+                "count": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "keyword": {
+                    "type": "string"
+                },
+                "proteinChange": {
+                    "type": "string"
+                }
+            },
+            "title": "CosmicMutation"
+        },
+        "DataBin": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "type": "string"
+                },
+                "clinicalDataType": {
+                    "type": "string",
+                    "enum": [
+                        "SAMPLE",
+                        "PATIENT"
+                    ]
+                },
+                "count": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "end": {
+                    "type": "number",
+                    "format": "double"
+                },
+                "specialValue": {
+                    "type": "string"
+                },
+                "start": {
+                    "type": "number",
+                    "format": "double"
+                }
+            },
+            "title": "DataBin"
+        },
+        "DensityPlotBin": {
+            "type": "object",
+            "properties": {
+                "binX": {
+                    "type": "number"
+                },
+                "binY": {
+                    "type": "number"
+                },
+                "count": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "maxX": {
+                    "type": "number"
+                },
+                "maxY": {
+                    "type": "number"
+                },
+                "minX": {
+                    "type": "number"
+                },
+                "minY": {
+                    "type": "number"
+                }
+            },
+            "title": "DensityPlotBin"
+        },
+        "EnrichmentFilter": {
+            "type": "object",
+            "required": [
+                "alteredIds",
+                "unalteredIds"
+            ],
+            "properties": {
+                "alteredIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unalteredIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "title": "EnrichmentFilter"
+        },
+        "ExpressionEnrichment": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "hugoGeneSymbol",
+                "meanExpressionInAlteredGroup",
+                "meanExpressionInUnalteredGroup",
+                "pValue",
+                "standardDeviationInAlteredGroup",
+                "standardDeviationInUnalteredGroup"
+            ],
+            "properties": {
+                "cytoband": {
+                    "type": "string"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "meanExpressionInAlteredGroup": {
+                    "type": "number"
+                },
+                "meanExpressionInUnalteredGroup": {
+                    "type": "number"
+                },
+                "pValue": {
+                    "type": "number"
+                },
+                "standardDeviationInAlteredGroup": {
+                    "type": "number"
+                },
+                "standardDeviationInUnalteredGroup": {
+                    "type": "number"
+                }
+            },
+            "title": "ExpressionEnrichment"
+        },
+        "Geneset": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "genesetId": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "refLink": {
+                    "type": "string"
+                },
+                "representativePvalue": {
+                    "type": "number",
+                    "format": "double"
+                },
+                "representativeScore": {
+                    "type": "number",
+                    "format": "double"
+                }
+            },
+            "title": "Geneset"
+        },
+        "GenesetCorrelation": {
+            "type": "object",
+            "properties": {
+                "correlationValue": {
+                    "type": "number",
+                    "format": "double"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "expressionGeneticProfileId": {
+                    "type": "string"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "zScoreGeneticProfileId": {
+                    "type": "string"
+                }
+            },
+            "title": "GenesetCorrelation"
+        },
+        "GenesetDataFilterCriteria": {
+            "type": "object",
+            "properties": {
+                "genesetIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "GenesetDataFilterCriteria"
+        },
+        "GenesetHierarchyInfo": {
+            "type": "object",
+            "properties": {
+                "genesets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Geneset"
+                    }
+                },
+                "nodeId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "nodeName": {
+                    "type": "string"
+                },
+                "parentId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "parentNodeName": {
+                    "type": "string"
+                }
+            },
+            "title": "GenesetHierarchyInfo"
+        },
+        "GenesetMolecularData": {
+            "type": "object",
+            "required": [
+                "geneticProfileId",
+                "patientId",
+                "sampleId",
+                "studyId",
+                "value"
+            ],
+            "properties": {
+                "genesetId": {
+                    "type": "string"
+                },
+                "geneticProfileId": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "GenesetMolecularData"
+        },
+        "Gistic": {
+            "type": "object",
+            "required": [
+                "amp",
+                "chromosome",
+                "cytoband",
+                "qValue",
+                "studyId",
+                "widePeakEnd",
+                "widePeakStart"
+            ],
+            "properties": {
+                "amp": {
+                    "type": "boolean"
+                },
+                "chromosome": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "cytoband": {
+                    "type": "string"
+                },
+                "genes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/GisticToGene"
+                    }
+                },
+                "qValue": {
+                    "type": "number"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "widePeakEnd": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "widePeakStart": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "Gistic"
+        },
+        "GisticToGene": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "hugoGeneSymbol"
+            ],
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                }
+            },
+            "title": "GisticToGene"
+        },
+        "Info": {
+            "type": "object",
+            "required": [
+                "dbVersion",
+                "gitBranch",
+                "gitCommitId",
+                "gitCommitIdAbbrev",
+                "gitCommitIdDescribe",
+                "gitCommitIdDescribeShort",
+                "gitCommitMessageFull",
+                "gitCommitMessageShort",
+                "gitCommitMessageUserEmail",
+                "gitCommitMessageUserName",
+                "gitDirty",
+                "portalVersion"
+            ],
+            "properties": {
+                "dbVersion": {
+                    "type": "string"
+                },
+                "gitBranch": {
+                    "type": "string"
+                },
+                "gitCommitId": {
+                    "type": "string"
+                },
+                "gitCommitIdAbbrev": {
+                    "type": "string"
+                },
+                "gitCommitIdDescribe": {
+                    "type": "string"
+                },
+                "gitCommitIdDescribeShort": {
+                    "type": "string"
+                },
+                "gitCommitMessageFull": {
+                    "type": "string"
+                },
+                "gitCommitMessageShort": {
+                    "type": "string"
+                },
+                "gitCommitMessageUserEmail": {
+                    "type": "string"
+                },
+                "gitCommitMessageUserName": {
+                    "type": "string"
+                },
+                "gitDirty": {
+                    "type": "boolean"
+                },
+                "portalVersion": {
+                    "type": "string"
+                }
+            },
+            "title": "Info"
+        },
+        "MolecularProfileSampleCount": {
+            "type": "object",
+            "properties": {
+                "numberOfCNAProfiledSamples": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfCNAUnprofiledSamples": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfCNSegmentSamples": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfMutationProfiledSamples": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfMutationUnprofiledSamples": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "MolecularProfileSampleCount"
+        },
+        "MrnaPercentile": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "molecularProfileId",
+                "patientId",
+                "percentile",
+                "sampleId",
+                "studyId",
+                "zScore"
+            ],
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "percentile": {
+                    "type": "number"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                },
+                "zScore": {
+                    "type": "number"
+                }
+            },
+            "title": "MrnaPercentile"
+        },
+        "MutSig": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "hugoGeneSymbol",
+                "numberOfMutations",
+                "pValue",
+                "qValue",
+                "rank",
+                "studyId"
+            ],
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "numberOfMutations": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "pValue": {
+                    "type": "number"
+                },
+                "qValue": {
+                    "type": "number"
+                },
+                "rank": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "MutSig"
+        },
+        "MutationCountByGene": {
+            "type": "object",
+            "properties": {
+                "countByEntity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hugoGeneSymbol": {
+                    "type": "string"
+                },
+                "numberOfSamplesProfiled": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "qValue": {
+                    "type": "number"
+                },
+                "totalCount": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "MutationCountByGene"
+        },
+        "MutationGeneFilter": {
+            "type": "object",
+            "properties": {
+                "entrezGeneIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                }
+            },
+            "title": "MutationGeneFilter"
+        },
+        "MutationSpectrum": {
+            "type": "object",
+            "required": [
+                "CtoA",
+                "CtoG",
+                "CtoT",
+                "TtoA",
+                "TtoC",
+                "TtoG",
+                "molecularProfileId",
+                "patientId",
+                "sampleId",
+                "studyId"
+            ],
+            "properties": {
+                "CtoA": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "CtoG": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "CtoT": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "TtoA": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "TtoC": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "TtoG": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "MutationSpectrum"
+        },
+        "MutationSpectrumFilter": {
+            "type": "object",
+            "properties": {
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sampleListId": {
+                    "type": "string"
+                }
+            },
+            "title": "MutationSpectrumFilter"
+        },
+        "RectangleBounds": {
+            "type": "object",
+            "properties": {
+                "xEnd": {
+                    "type": "number"
+                },
+                "xStart": {
+                    "type": "number"
+                },
+                "yEnd": {
+                    "type": "number"
+                },
+                "yStart": {
+                    "type": "number"
+                }
+            },
+            "title": "RectangleBounds"
+        },
+        "Sample": {
+            "type": "object",
+            "required": [
+                "patientId",
+                "sampleId",
+                "studyId"
+            ],
+            "properties": {
+                "copyNumberSegmentPresent": {
+                    "type": "boolean"
+                },
+                "patientId": {
+                    "type": "string"
+                },
+                "sampleId": {
+                    "type": "string"
+                },
+                "sampleType": {
+                    "type": "string",
+                    "enum": [
+                        "Primary Solid Tumor",
+                        "Recurrent Solid Tumor",
+                        "Primary Blood Tumor",
+                        "Recurrent Blood Tumor",
+                        "Metastatic",
+                        "Blood Derived Normal",
+                        "Solid Tissues Normal"
+                    ]
+                },
+                "sequenced": {
+                    "type": "boolean"
+                },
+                "studyId": {
+                    "type": "string"
+                },
+                "uniquePatientKey": {
+                    "type": "string"
+                },
+                "uniqueSampleKey": {
+                    "type": "string"
+                }
+            },
+            "title": "Sample"
+        },
+        "SampleIdentifier": {
+            "type": "object",
+            "properties": {
+                "sampleId": {
+                    "type": "string"
+                },
+                "studyId": {
+                    "type": "string"
+                }
+            },
+            "title": "SampleIdentifier"
+        },
+        "StudyViewFilter": {
+            "type": "object",
+            "properties": {
+                "clinicalDataEqualityFilters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalDataEqualityFilter"
+                    }
+                },
+                "clinicalDataIntervalFilters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClinicalDataIntervalFilter"
+                    }
+                },
+                "cnaGenes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CopyNumberGeneFilter"
+                    }
+                },
+                "mutatedGenes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MutationGeneFilter"
+                    }
+                },
+                "mutationCountVsCNASelection": {
+                    "$ref": "#/definitions/RectangleBounds"
+                },
+                "sampleIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SampleIdentifier"
+                    }
+                },
+                "studyIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "withCNAData": {
+                    "type": "boolean"
+                },
+                "withMutationData": {
+                    "type": "boolean"
+                }
+            },
+            "title": "StudyViewFilter"
+        },
+        "VariantCount": {
+            "type": "object",
+            "required": [
+                "entrezGeneId",
+                "molecularProfileId",
+                "numberOfSamples",
+                "numberOfSamplesWithKeyword",
+                "numberOfSamplesWithMutationInGene"
+            ],
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "keyword": {
+                    "type": "string"
+                },
+                "molecularProfileId": {
+                    "type": "string"
+                },
+                "numberOfSamples": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfSamplesWithKeyword": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "numberOfSamplesWithMutationInGene": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            },
+            "title": "VariantCount"
+        },
+        "VariantCountIdentifier": {
+            "type": "object",
+            "properties": {
+                "entrezGeneId": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "keyword": {
+                    "type": "string"
+                }
+            },
+            "title": "VariantCountIdentifier"
+        }
     }
-  },
-  "tags": [
-    {
-      "name": "Co-Expressions",
-      "description": " "
-    },
-    {
-      "name": "Copy Number Enrichments",
-      "description": " "
-    },
-    {
-      "name": "Cosmic Counts",
-      "description": " "
-    },
-    {
-      "name": "Expression Enrichments",
-      "description": " "
-    },
-    {
-      "name": "Gene Set Correlation",
-      "description": " "
-    },
-    {
-      "name": "Gene Set Hierarchy",
-      "description": " "
-    },
-    {
-      "name": "Gene Set Scores",
-      "description": " "
-    },
-    {
-      "name": "Gene Sets",
-      "description": " "
-    },
-    {
-      "name": "Info",
-      "description": " "
-    },
-    {
-      "name": "Mutation Enrichments",
-      "description": " "
-    },
-    {
-      "name": "Mutation Spectrums",
-      "description": " "
-    },
-    {
-      "name": "Significant Copy Number Regions",
-      "description": " "
-    },
-    {
-      "name": "Significantly Mutated Genes",
-      "description": " "
-    },
-    {
-      "name": "Study View",
-      "description": " "
-    },
-    {
-      "name": "Variant Counts",
-      "description": " "
-    },
-    {
-      "name": "mRNA Percentile",
-      "description": " "
-    }
-  ],
-  "schemes": [
-    "http",
-    "https"
-  ],
-  "paths": {
-    "/clinical-data-bin-counts/fetch": {
-      "post": {
-        "tags": [
-          "Study View"
-        ],
-        "summary": "Fetch clinical data bin counts by study view filter",
-        "operationId": "fetchClinicalDataBinCountsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "dataBinMethod",
-            "in": "query",
-            "description": "Method for data binning",
-            "required": false,
-            "type": "string",
-            "default": "DYNAMIC",
-            "enum": [
-              "STATIC",
-              "DYNAMIC"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "clinicalDataBinCountFilter",
-            "description": "Clinical data bin count filter",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ClinicalDataBinCountFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/DataBin"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/clinical-data-counts/fetch": {
-      "post": {
-        "tags": [
-          "Study View"
-        ],
-        "summary": "Fetch clinical data counts by study view filter",
-        "operationId": "fetchClinicalDataCountsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "clinicalDataCountFilter",
-            "description": "Clinical data count filter",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ClinicalDataCountFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ClinicalDataCountItem"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/clinical-data-density-plot/fetch": {
-      "post": {
-        "tags": [
-          "Study View"
-        ],
-        "summary": "Fetch clinical data density plot bins by study view filter",
-        "operationId": "fetchClinicalDataDensityPlotUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "xAxisAttributeId",
-            "in": "query",
-            "description": "Clinical Attribute ID of the X axis",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "xAxisBinCount",
-            "in": "query",
-            "description": "Number of the bins in X axis",
-            "required": false,
-            "type": "integer",
-            "default": 50,
-            "format": "int32"
-          },
-          {
-            "name": "xAxisStart",
-            "in": "query",
-            "description": "Starting point of the X axis, if different than smallest value",
-            "required": false,
-            "type": "number"
-          },
-          {
-            "name": "xAxisEnd",
-            "in": "query",
-            "description": "Starting point of the X axis, if different than largest value",
-            "required": false,
-            "type": "number"
-          },
-          {
-            "name": "yAxisAttributeId",
-            "in": "query",
-            "description": "Clinical Attribute ID of the Y axis",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "yAxisBinCount",
-            "in": "query",
-            "description": "Number of the bins in Y axis",
-            "required": false,
-            "type": "integer",
-            "default": 50,
-            "format": "int32"
-          },
-          {
-            "name": "yAxisStart",
-            "in": "query",
-            "description": "Starting point of the Y axis, if different than smallest value",
-            "required": false,
-            "type": "number"
-          },
-          {
-            "name": "yAxisEnd",
-            "in": "query",
-            "description": "Starting point of the Y axis, if different than largest value",
-            "required": false,
-            "type": "number"
-          },
-          {
-            "name": "clinicalDataType",
-            "in": "query",
-            "description": "Clinical data type of both attributes",
-            "required": true,
-            "type": "string",
-            "enum": [
-              "SAMPLE",
-              "PATIENT"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "studyViewFilter",
-            "description": "Study view filter",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/StudyViewFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/DensityPlotBin"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/cna-genes/fetch": {
-      "post": {
-        "tags": [
-          "Study View"
-        ],
-        "summary": "Fetch CNA genes by study view filter",
-        "operationId": "fetchCNAGenesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "studyViewFilter",
-            "description": "Study view filter",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/StudyViewFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CopyNumberCountByGene"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/cosmic-counts/fetch": {
-      "post": {
-        "tags": [
-          "Cosmic Counts"
-        ],
-        "summary": "Get counts within the COSMIC database by keywords",
-        "operationId": "fetchCosmicCountsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "keywords",
-            "description": "List of keywords",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CosmicMutation"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/filtered-samples/fetch": {
-      "post": {
-        "tags": [
-          "Study View"
-        ],
-        "summary": "Fetch sample IDs by study view filter",
-        "operationId": "fetchFilteredSamplesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "negateFilters",
-            "in": "query",
-            "description": "Whether to negate the study view filters",
-            "required": false,
-            "type": "boolean",
-            "default": false
-          },
-          {
-            "in": "body",
-            "name": "studyViewFilter",
-            "description": "Study view filter",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/StudyViewFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Sample"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/geneset-hierarchy/fetch": {
-      "post": {
-        "tags": [
-          "Gene Set Hierarchy"
-        ],
-        "summary": "Get gene set hierarchical organization information. I.e. how different gene sets relate to other gene sets, in a hierarchy",
-        "operationId": "fetchGenesetHierarchyInfoUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "geneticProfileId",
-            "in": "query",
-            "description": "Genetic Profile ID e.g. gbm_tcga_gsva_scores. The final hierarchy  will only include gene sets scored in the specified profile.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "percentile",
-            "in": "query",
-            "description": "Percentile (for score calculation). Which percentile to use when determining the *representative score*",
-            "required": false,
-            "type": "integer",
-            "default": 75,
-            "maximum": 100,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "scoreThreshold",
-            "in": "query",
-            "description": "Gene set score threshold (for absolute score value). Filters out gene sets where the GSVA(like) *representative score* is under this threshold.",
-            "required": false,
-            "type": "number",
-            "default": 0.4,
-            "maximum": 1,
-            "exclusiveMaximum": false,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "double"
-          },
-          {
-            "name": "pvalueThreshold",
-            "in": "query",
-            "description": "p-value threshold. Filters out gene sets for which the score p-value is higher than this threshold.",
-            "required": false,
-            "type": "number",
-            "default": 0.05,
-            "maximum": 1,
-            "exclusiveMaximum": false,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "double"
-          },
-          {
-            "name": "sampleListId",
-            "in": "query",
-            "description": "Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "sampleIds",
-            "description": "Fill this one if you want to specify a subset of samples: sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenesetHierarchyInfo"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/genesets": {
-      "get": {
-        "tags": [
-          "Gene Sets"
-        ],
-        "summary": "Get all gene sets",
-        "operationId": "getAllGenesetsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 2147483647,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Geneset"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/genesets/fetch": {
-      "post": {
-        "tags": [
-          "Gene Sets"
-        ],
-        "summary": "Fetch gene sets by ID",
-        "operationId": "fetchGenesetsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "genesetIds",
-            "description": "List of Gene set IDs",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Geneset"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/genesets/{genesetId}": {
-      "get": {
-        "tags": [
-          "Gene Sets"
-        ],
-        "summary": "Get a gene set",
-        "operationId": "getGenesetUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "genesetId",
-            "in": "path",
-            "description": "Gene set ID e.g. GNF2_ZAP70",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/Geneset"
-            }
-          }
-        }
-      }
-    },
-    "/genesets/{genesetId}/expression-correlation/fetch": {
-      "post": {
-        "tags": [
-          "Gene Set Correlation"
-        ],
-        "summary": "Get the genes in a gene set that have expression correlated to the gene set scores (calculated using Spearman's correlation)",
-        "operationId": "fetchCorrelatedGenesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "genesetId",
-            "in": "path",
-            "description": "Gene set ID, e.g. HINATA_NFKB_MATRIX.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "geneticProfileId",
-            "in": "query",
-            "description": "Genetic Profile ID e.g. gbm_tcga_gsva_scores",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "correlationThreshold",
-            "in": "query",
-            "description": "Correlation threshold (for absolute correlation value, Spearman correlation)",
-            "required": false,
-            "type": "number",
-            "default": 0.3,
-            "maximum": 1,
-            "exclusiveMaximum": false,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "double"
-          },
-          {
-            "name": "sampleListId",
-            "in": "query",
-            "description": "Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "sampleIds",
-            "description": "Fill this one if you want to specify a subset of samples: sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenesetCorrelation"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/genetic-profiles/{geneticProfileId}/geneset-genetic-data/fetch": {
-      "post": {
-        "tags": [
-          "Gene Set Scores"
-        ],
-        "summary": "Fetch gene set \"genetic data\" items (gene set scores) by profile Id, gene set ids and sample ids",
-        "operationId": "fetchGeneticDataItemsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "geneticProfileId",
-            "in": "path",
-            "description": "Genetic profile ID, e.g. gbm_tcga_gsva_scores",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "genesetDataFilterCriteria",
-            "description": "Search criteria to return the values for a given set of samples and gene set items. genesetIds: The list of identifiers for the gene sets of interest, e.g. HINATA_NFKB_MATRIX. Use one of these if you want to specify a subset of samples:(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GenesetDataFilterCriteria"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenesetMolecularData"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/info": {
-      "get": {
-        "tags": [
-          "Info"
-        ],
-        "summary": "Get information about the running instance",
-        "operationId": "getInfoUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/Info"
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/co-expressions/fetch": {
-      "post": {
-        "tags": [
-          "Co-Expressions"
-        ],
-        "summary": "Fetch co-expressions in a molecular profile",
-        "operationId": "fetchCoExpressionsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "coExpressionFilter",
-            "description": "List of Sample IDs/Sample List ID",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CoExpressionFilter"
-            }
-          },
-          {
-            "name": "entrezGeneId",
-            "in": "query",
-            "description": "Entrez Gene ID",
-            "required": true,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "threshold",
-            "in": "query",
-            "description": "Threshold",
-            "required": false,
-            "type": "number",
-            "default": 0.3,
-            "format": "double"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/CoExpression"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/copy-number-enrichments/fetch": {
-      "post": {
-        "tags": [
-          "Copy Number Enrichments"
-        ],
-        "summary": "Fetch copy number enrichments in a molecular profile",
-        "operationId": "fetchCopyNumberEnrichmentsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "copyNumberEventType",
-            "in": "query",
-            "description": "Type of the copy number event",
-            "required": false,
-            "type": "string",
-            "default": "HOMDEL",
-            "enum": [
-              "HOMDEL",
-              "AMP"
-            ]
-          },
-          {
-            "name": "enrichmentType",
-            "in": "query",
-            "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
-            "required": false,
-            "type": "string",
-            "default": "SAMPLE",
-            "enum": [
-              "SAMPLE",
-              "PATIENT"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "enrichmentFilter",
-            "description": "List of altered and unaltered Sample/Patient IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/EnrichmentFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AlterationEnrichment"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/expression-enrichments/fetch": {
-      "post": {
-        "tags": [
-          "Expression Enrichments"
-        ],
-        "summary": "Fetch expression enrichments in a molecular profile",
-        "operationId": "fetchExpressionEnrichmentsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "enrichmentType",
-            "in": "query",
-            "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
-            "required": false,
-            "type": "string",
-            "default": "SAMPLE",
-            "enum": [
-              "SAMPLE",
-              "PATIENT"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "enrichmentFilter",
-            "description": "List of altered and unaltered Sample/Patient IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/EnrichmentFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ExpressionEnrichment"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/mrna-percentile/fetch": {
-      "post": {
-        "tags": [
-          "mRNA Percentile"
-        ],
-        "summary": "Get mRNA expression percentiles for list of genes for a sample",
-        "operationId": "fetchMrnaPercentileUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "sampleId",
-            "in": "query",
-            "description": "Sample ID e.g. TCGA-OR-A5J2-01",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "entrezGeneIds",
-            "description": "List of Entrez Gene IDs",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MrnaPercentile"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/mutation-enrichments/fetch": {
-      "post": {
-        "tags": [
-          "Mutation Enrichments"
-        ],
-        "summary": "Fetch mutation enrichments in a molecular profile",
-        "operationId": "fetchMutationEnrichmentsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "enrichmentType",
-            "in": "query",
-            "description": "Type of the enrichment e.g. SAMPLE or PATIENT",
-            "required": false,
-            "type": "string",
-            "default": "SAMPLE",
-            "enum": [
-              "SAMPLE",
-              "PATIENT"
-            ]
-          },
-          {
-            "in": "body",
-            "name": "enrichmentFilter",
-            "description": "List of altered and unaltered Sample/Patient IDs",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/EnrichmentFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AlterationEnrichment"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/mutation-spectrums/fetch": {
-      "post": {
-        "tags": [
-          "Mutation Spectrums"
-        ],
-        "summary": "Fetch mutation spectrums in a molecular profile",
-        "operationId": "fetchMutationSpectrumsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "mutationSpectrumFilter",
-            "description": "List of Sample IDs/Sample List ID",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MutationSpectrumFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MutationSpectrum"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/molecular-profiles/{molecularProfileId}/variant-counts/fetch": {
-      "post": {
-        "tags": [
-          "Variant Counts"
-        ],
-        "summary": "Get counts of specific variants within a mutation molecular profile",
-        "operationId": "fetchVariantCountsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "molecularProfileId",
-            "in": "path",
-            "description": "Molecular Profile ID e.g. acc_tcga_mutations",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "variantCountIdentifiers",
-            "description": "List of variant count identifiers",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/VariantCountIdentifier"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/VariantCount"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/mutated-genes/fetch": {
-      "post": {
-        "tags": [
-          "Study View"
-        ],
-        "summary": "Fetch mutated genes by study view filter",
-        "operationId": "fetchMutatedGenesUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "studyViewFilter",
-            "description": "Study view filter",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/StudyViewFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MutationCountByGene"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sample-counts/fetch": {
-      "post": {
-        "tags": [
-          "Study View"
-        ],
-        "summary": "Fetch sample counts by study view filter",
-        "operationId": "fetchMolecularProfileSampleCountsUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "studyViewFilter",
-            "description": "Study view filter",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/StudyViewFilter"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/MolecularProfileSampleCount"
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/significant-copy-number-regions": {
-      "get": {
-        "tags": [
-          "Significant Copy Number Regions"
-        ],
-        "summary": "Get significant copy number alteration regions in a study",
-        "operationId": "getSignificantCopyNumberRegionsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "chromosome",
-              "cytoband",
-              "widePeakStart",
-              "widePeakEnd",
-              "qValue",
-              "amp"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Gistic"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/studies/{studyId}/significantly-mutated-genes": {
-      "get": {
-        "tags": [
-          "Significantly Mutated Genes"
-        ],
-        "summary": "Get significantly mutated genes in a study",
-        "operationId": "getSignificantlyMutatedGenesUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "studyId",
-            "in": "path",
-            "description": "Study ID e.g. acc_tcga",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "projection",
-            "in": "query",
-            "description": "Level of detail of the response",
-            "required": false,
-            "type": "string",
-            "default": "SUMMARY",
-            "enum": [
-              "ID",
-              "SUMMARY",
-              "DETAILED",
-              "META"
-            ]
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Page size of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 10000000,
-            "maximum": 10000000,
-            "exclusiveMaximum": false,
-            "minimum": 1,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "description": "Page number of the result list",
-            "required": false,
-            "type": "integer",
-            "default": 0,
-            "minimum": 0,
-            "exclusiveMinimum": false,
-            "format": "int32"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Name of the property that the result list is sorted by",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "entrezGeneId",
-              "hugoGeneSymbol",
-              "rank",
-              "numberOfMutations",
-              "pValue",
-              "qValue"
-            ]
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Direction of the sort",
-            "required": false,
-            "type": "string",
-            "default": "ASC",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MutSig"
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "definitions": {
-    "AlterationEnrichment": {
-      "type": "object",
-      "required": [
-        "alteredCount",
-        "entrezGeneId",
-        "hugoGeneSymbol",
-        "logRatio",
-        "pValue",
-        "unalteredCount"
-      ],
-      "properties": {
-        "alteredCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "cytoband": {
-          "type": "string"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "logRatio": {
-          "type": "string"
-        },
-        "pValue": {
-          "type": "number"
-        },
-        "unalteredCount": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "AlterationEnrichment"
-    },
-    "ClinicalDataBinCountFilter": {
-      "type": "object",
-      "properties": {
-        "attributes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalDataBinFilter"
-          }
-        },
-        "studyViewFilter": {
-          "$ref": "#/definitions/StudyViewFilter"
-        }
-      },
-      "title": "ClinicalDataBinCountFilter"
-    },
-    "ClinicalDataBinFilter": {
-      "type": "object",
-      "properties": {
-        "attributeId": {
-          "type": "string"
-        },
-        "clinicalDataType": {
-          "type": "string",
-          "enum": [
-            "SAMPLE",
-            "PATIENT"
-          ]
-        },
-        "customBins": {
-          "type": "array",
-          "items": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "disableLogScale": {
-          "type": "boolean"
-        },
-        "end": {
-          "type": "number",
-          "format": "double"
-        },
-        "start": {
-          "type": "number",
-          "format": "double"
-        }
-      },
-      "title": "ClinicalDataBinFilter"
-    },
-    "ClinicalDataCount": {
-      "type": "object",
-      "properties": {
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalDataCount"
-    },
-    "ClinicalDataCountFilter": {
-      "type": "object",
-      "properties": {
-        "attributes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalDataFilter"
-          }
-        },
-        "studyViewFilter": {
-          "$ref": "#/definitions/StudyViewFilter"
-        }
-      },
-      "title": "ClinicalDataCountFilter"
-    },
-    "ClinicalDataCountItem": {
-      "type": "object",
-      "properties": {
-        "attributeId": {
-          "type": "string"
-        },
-        "clinicalDataType": {
-          "type": "string",
-          "enum": [
-            "SAMPLE",
-            "PATIENT"
-          ]
-        },
-        "counts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalDataCount"
-          }
-        }
-      },
-      "title": "ClinicalDataCountItem"
-    },
-    "ClinicalDataEqualityFilter": {
-      "type": "object",
-      "properties": {
-        "attributeId": {
-          "type": "string"
-        },
-        "clinicalDataType": {
-          "type": "string",
-          "enum": [
-            "SAMPLE",
-            "PATIENT"
-          ]
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "title": "ClinicalDataEqualityFilter"
-    },
-    "ClinicalDataFilter": {
-      "type": "object",
-      "properties": {
-        "attributeId": {
-          "type": "string"
-        },
-        "clinicalDataType": {
-          "type": "string",
-          "enum": [
-            "SAMPLE",
-            "PATIENT"
-          ]
-        }
-      },
-      "title": "ClinicalDataFilter"
-    },
-    "ClinicalDataIntervalFilter": {
-      "type": "object",
-      "properties": {
-        "attributeId": {
-          "type": "string"
-        },
-        "clinicalDataType": {
-          "type": "string",
-          "enum": [
-            "SAMPLE",
-            "PATIENT"
-          ]
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalDataIntervalFilterValue"
-          }
-        }
-      },
-      "title": "ClinicalDataIntervalFilter"
-    },
-    "ClinicalDataIntervalFilterValue": {
-      "type": "object",
-      "properties": {
-        "end": {
-          "type": "number",
-          "format": "double"
-        },
-        "start": {
-          "type": "number",
-          "format": "double"
-        },
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": "ClinicalDataIntervalFilterValue"
-    },
-    "CoExpression": {
-      "type": "object",
-      "required": [
-        "cytoband",
-        "entrezGeneId",
-        "hugoGeneSymbol",
-        "pValue",
-        "spearmansCorrelation"
-      ],
-      "properties": {
-        "cytoband": {
-          "type": "string"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "pValue": {
-          "type": "number"
-        },
-        "spearmansCorrelation": {
-          "type": "number"
-        }
-      },
-      "title": "CoExpression"
-    },
-    "CoExpressionFilter": {
-      "type": "object",
-      "properties": {
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "CoExpressionFilter"
-    },
-    "CopyNumberCountByGene": {
-      "type": "object",
-      "properties": {
-        "alteration": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "countByEntity": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "cytoband": {
-          "type": "string"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "frequency": {
-          "type": "number"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "qValue": {
-          "type": "number"
-        },
-        "totalCount": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "CopyNumberCountByGene"
-    },
-    "CopyNumberGeneFilter": {
-      "type": "object",
-      "properties": {
-        "alterations": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CopyNumberGeneFilterElement"
-          }
-        }
-      },
-      "title": "CopyNumberGeneFilter"
-    },
-    "CopyNumberGeneFilterElement": {
-      "type": "object",
-      "properties": {
-        "alteration": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "CopyNumberGeneFilterElement"
-    },
-    "CosmicMutation": {
-      "type": "object",
-      "required": [
-        "cosmicMutationId",
-        "count",
-        "proteinChange"
-      ],
-      "properties": {
-        "cosmicMutationId": {
-          "type": "string"
-        },
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "keyword": {
-          "type": "string"
-        },
-        "proteinChange": {
-          "type": "string"
-        }
-      },
-      "title": "CosmicMutation"
-    },
-    "DataBin": {
-      "type": "object",
-      "properties": {
-        "attributeId": {
-          "type": "string"
-        },
-        "clinicalDataType": {
-          "type": "string",
-          "enum": [
-            "SAMPLE",
-            "PATIENT"
-          ]
-        },
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "end": {
-          "type": "number",
-          "format": "double"
-        },
-        "specialValue": {
-          "type": "string"
-        },
-        "start": {
-          "type": "number",
-          "format": "double"
-        }
-      },
-      "title": "DataBin"
-    },
-    "DensityPlotBin": {
-      "type": "object",
-      "properties": {
-        "binX": {
-          "type": "number"
-        },
-        "binY": {
-          "type": "number"
-        },
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "maxX": {
-          "type": "number"
-        },
-        "maxY": {
-          "type": "number"
-        },
-        "minX": {
-          "type": "number"
-        },
-        "minY": {
-          "type": "number"
-        }
-      },
-      "title": "DensityPlotBin"
-    },
-    "EnrichmentFilter": {
-      "type": "object",
-      "required": [
-        "alteredIds",
-        "unalteredIds"
-      ],
-      "properties": {
-        "alteredIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "unalteredIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "title": "EnrichmentFilter"
-    },
-    "ExpressionEnrichment": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "hugoGeneSymbol",
-        "meanExpressionInAlteredGroup",
-        "meanExpressionInUnalteredGroup",
-        "pValue",
-        "standardDeviationInAlteredGroup",
-        "standardDeviationInUnalteredGroup"
-      ],
-      "properties": {
-        "cytoband": {
-          "type": "string"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "meanExpressionInAlteredGroup": {
-          "type": "number"
-        },
-        "meanExpressionInUnalteredGroup": {
-          "type": "number"
-        },
-        "pValue": {
-          "type": "number"
-        },
-        "standardDeviationInAlteredGroup": {
-          "type": "number"
-        },
-        "standardDeviationInUnalteredGroup": {
-          "type": "number"
-        }
-      },
-      "title": "ExpressionEnrichment"
-    },
-    "Geneset": {
-      "type": "object",
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "genesetId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "refLink": {
-          "type": "string"
-        },
-        "representativePvalue": {
-          "type": "number",
-          "format": "double"
-        },
-        "representativeScore": {
-          "type": "number",
-          "format": "double"
-        }
-      },
-      "title": "Geneset"
-    },
-    "GenesetCorrelation": {
-      "type": "object",
-      "properties": {
-        "correlationValue": {
-          "type": "number",
-          "format": "double"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "expressionGeneticProfileId": {
-          "type": "string"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "zScoreGeneticProfileId": {
-          "type": "string"
-        }
-      },
-      "title": "GenesetCorrelation"
-    },
-    "GenesetDataFilterCriteria": {
-      "type": "object",
-      "properties": {
-        "genesetIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "GenesetDataFilterCriteria"
-    },
-    "GenesetHierarchyInfo": {
-      "type": "object",
-      "properties": {
-        "genesets": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Geneset"
-          }
-        },
-        "nodeId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "nodeName": {
-          "type": "string"
-        },
-        "parentId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "parentNodeName": {
-          "type": "string"
-        }
-      },
-      "title": "GenesetHierarchyInfo"
-    },
-    "GenesetMolecularData": {
-      "type": "object",
-      "required": [
-        "geneticProfileId",
-        "patientId",
-        "sampleId",
-        "studyId",
-        "value"
-      ],
-      "properties": {
-        "genesetId": {
-          "type": "string"
-        },
-        "geneticProfileId": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": "GenesetMolecularData"
-    },
-    "Gistic": {
-      "type": "object",
-      "required": [
-        "amp",
-        "chromosome",
-        "cytoband",
-        "qValue",
-        "studyId",
-        "widePeakEnd",
-        "widePeakStart"
-      ],
-      "properties": {
-        "amp": {
-          "type": "boolean"
-        },
-        "chromosome": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "cytoband": {
-          "type": "string"
-        },
-        "genes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/GisticToGene"
-          }
-        },
-        "qValue": {
-          "type": "number"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "widePeakEnd": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "widePeakStart": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "Gistic"
-    },
-    "GisticToGene": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "hugoGeneSymbol"
-      ],
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        }
-      },
-      "title": "GisticToGene"
-    },
-    "Info": {
-      "type": "object",
-      "required": [
-        "dbVersion",
-        "gitBranch",
-        "gitCommitId",
-        "gitCommitIdAbbrev",
-        "gitCommitIdDescribe",
-        "gitCommitIdDescribeShort",
-        "gitCommitMessageFull",
-        "gitCommitMessageShort",
-        "gitCommitMessageUserEmail",
-        "gitCommitMessageUserName",
-        "gitDirty",
-        "portalVersion"
-      ],
-      "properties": {
-        "dbVersion": {
-          "type": "string"
-        },
-        "gitBranch": {
-          "type": "string"
-        },
-        "gitCommitId": {
-          "type": "string"
-        },
-        "gitCommitIdAbbrev": {
-          "type": "string"
-        },
-        "gitCommitIdDescribe": {
-          "type": "string"
-        },
-        "gitCommitIdDescribeShort": {
-          "type": "string"
-        },
-        "gitCommitMessageFull": {
-          "type": "string"
-        },
-        "gitCommitMessageShort": {
-          "type": "string"
-        },
-        "gitCommitMessageUserEmail": {
-          "type": "string"
-        },
-        "gitCommitMessageUserName": {
-          "type": "string"
-        },
-        "gitDirty": {
-          "type": "boolean"
-        },
-        "portalVersion": {
-          "type": "string"
-        }
-      },
-      "title": "Info"
-    },
-    "MolecularProfileSampleCount": {
-      "type": "object",
-      "properties": {
-        "numberOfCNAProfiledSamples": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfCNAUnprofiledSamples": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfCNSegmentSamples": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfMutationProfiledSamples": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfMutationUnprofiledSamples": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "MolecularProfileSampleCount"
-    },
-    "MrnaPercentile": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "molecularProfileId",
-        "patientId",
-        "percentile",
-        "sampleId",
-        "studyId",
-        "zScore"
-      ],
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "percentile": {
-          "type": "number"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        },
-        "zScore": {
-          "type": "number"
-        }
-      },
-      "title": "MrnaPercentile"
-    },
-    "MutSig": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "hugoGeneSymbol",
-        "numberOfMutations",
-        "pValue",
-        "qValue",
-        "rank",
-        "studyId"
-      ],
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "numberOfMutations": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "pValue": {
-          "type": "number"
-        },
-        "qValue": {
-          "type": "number"
-        },
-        "rank": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "MutSig"
-    },
-    "MutationCountByGene": {
-      "type": "object",
-      "properties": {
-        "countByEntity": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "frequency": {
-          "type": "number"
-        },
-        "hugoGeneSymbol": {
-          "type": "string"
-        },
-        "qValue": {
-          "type": "number"
-        },
-        "totalCount": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "MutationCountByGene"
-    },
-    "MutationGeneFilter": {
-      "type": "object",
-      "properties": {
-        "entrezGeneIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "title": "MutationGeneFilter"
-    },
-    "MutationSpectrum": {
-      "type": "object",
-      "required": [
-        "CtoA",
-        "CtoG",
-        "CtoT",
-        "TtoA",
-        "TtoC",
-        "TtoG",
-        "molecularProfileId",
-        "patientId",
-        "sampleId",
-        "studyId"
-      ],
-      "properties": {
-        "CtoA": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "CtoG": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "CtoT": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "TtoA": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "TtoC": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "TtoG": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "MutationSpectrum"
-    },
-    "MutationSpectrumFilter": {
-      "type": "object",
-      "properties": {
-        "sampleIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sampleListId": {
-          "type": "string"
-        }
-      },
-      "title": "MutationSpectrumFilter"
-    },
-    "RectangleBounds": {
-      "type": "object",
-      "properties": {
-        "xEnd": {
-          "type": "number"
-        },
-        "xStart": {
-          "type": "number"
-        },
-        "yEnd": {
-          "type": "number"
-        },
-        "yStart": {
-          "type": "number"
-        }
-      },
-      "title": "RectangleBounds"
-    },
-    "Sample": {
-      "type": "object",
-      "required": [
-        "patientId",
-        "sampleId",
-        "studyId"
-      ],
-      "properties": {
-        "copyNumberSegmentPresent": {
-          "type": "boolean"
-        },
-        "patientId": {
-          "type": "string"
-        },
-        "sampleId": {
-          "type": "string"
-        },
-        "sampleType": {
-          "type": "string",
-          "enum": [
-            "Primary Solid Tumor",
-            "Recurrent Solid Tumor",
-            "Primary Blood Tumor",
-            "Recurrent Blood Tumor",
-            "Metastatic",
-            "Blood Derived Normal",
-            "Solid Tissues Normal"
-          ]
-        },
-        "sequenced": {
-          "type": "boolean"
-        },
-        "studyId": {
-          "type": "string"
-        },
-        "uniquePatientKey": {
-          "type": "string"
-        },
-        "uniqueSampleKey": {
-          "type": "string"
-        }
-      },
-      "title": "Sample"
-    },
-    "SampleIdentifier": {
-      "type": "object",
-      "properties": {
-        "sampleId": {
-          "type": "string"
-        },
-        "studyId": {
-          "type": "string"
-        }
-      },
-      "title": "SampleIdentifier"
-    },
-    "StudyViewFilter": {
-      "type": "object",
-      "properties": {
-        "clinicalDataEqualityFilters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalDataEqualityFilter"
-          }
-        },
-        "clinicalDataIntervalFilters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalDataIntervalFilter"
-          }
-        },
-        "cnaGenes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CopyNumberGeneFilter"
-          }
-        },
-        "mutatedGenes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MutationGeneFilter"
-          }
-        },
-        "mutationCountVsCNASelection": {
-          "$ref": "#/definitions/RectangleBounds"
-        },
-        "sampleIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SampleIdentifier"
-          }
-        },
-        "studyIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "withCNAData": {
-          "type": "boolean"
-        },
-        "withMutationData": {
-          "type": "boolean"
-        }
-      },
-      "title": "StudyViewFilter"
-    },
-    "VariantCount": {
-      "type": "object",
-      "required": [
-        "entrezGeneId",
-        "molecularProfileId",
-        "numberOfSamples",
-        "numberOfSamplesWithKeyword",
-        "numberOfSamplesWithMutationInGene"
-      ],
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "keyword": {
-          "type": "string"
-        },
-        "molecularProfileId": {
-          "type": "string"
-        },
-        "numberOfSamples": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfSamplesWithKeyword": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numberOfSamplesWithMutationInGene": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "title": "VariantCount"
-    },
-    "VariantCountIdentifier": {
-      "type": "object",
-      "properties": {
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "keyword": {
-          "type": "string"
-        }
-      },
-      "title": "VariantCountIdentifier"
-    }
-  }
 }

--- a/src/shared/api/generated/CBioPortalAPIInternal.ts
+++ b/src/shared/api/generated/CBioPortalAPIInternal.ts
@@ -114,9 +114,9 @@ export type CopyNumberCountByGene = {
 
         'entrezGeneId': number
 
-        'frequency': number
-
         'hugoGeneSymbol': string
+
+        'numberOfSamplesProfiled': number
 
         'qValue': number
 
@@ -364,9 +364,9 @@ export type MutationCountByGene = {
 
         'entrezGeneId': number
 
-        'frequency': number
-
         'hugoGeneSymbol': string
+
+        'numberOfSamplesProfiled': number
 
         'qValue': number
 
@@ -491,7 +491,7 @@ export type VariantCountIdentifier = {
  */
 export default class CBioPortalAPIInternal {
 
-    private domain: string = "";
+    private domain: string = "http://localhost:8080/cbioportal/api";
     private errorHandlers: CallbackHandler[] = [];
 
     constructor(domain ? : string) {

--- a/src/shared/api/generated/CBioPortalAPIInternal.ts
+++ b/src/shared/api/generated/CBioPortalAPIInternal.ts
@@ -2,9 +2,7 @@ import * as request from "superagent";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type AlterationEnrichment = {
-    'alteredCount': number
-
-        'cytoband': string
+    'cytoband': string
 
         'entrezGeneId': number
 
@@ -14,7 +12,25 @@ export type AlterationEnrichment = {
 
         'pValue': number
 
-        'unalteredCount': number
+        'set1CountSummary': CountSummary
+
+        'set2CountSummary': CountSummary
+
+};
+export type ClinicalAttribute = {
+    'clinicalAttributeId': string
+
+        'datatype': string
+
+        'description': string
+
+        'displayName': string
+
+        'patientAttribute': boolean
+
+        'priority': string
+
+        'studyId': string
 
 };
 export type ClinicalDataBinCountFilter = {
@@ -57,6 +73,16 @@ export type ClinicalDataCountItem = {
         'counts': Array < ClinicalDataCount >
 
 };
+export type ClinicalDataEnrichment = {
+    'clinicalAttribute': ClinicalAttribute
+
+        'method': string
+
+        'pValue': number
+
+        'score': number
+
+};
 export type ClinicalDataEqualityFilter = {
     'attributeId': string
 
@@ -90,9 +116,11 @@ export type ClinicalDataIntervalFilterValue = {
 export type CoExpression = {
     'cytoband': string
 
-        'entrezGeneId': number
+        'geneticEntityId': string
 
-        'hugoGeneSymbol': string
+        'geneticEntityName': string
+
+        'geneticEntityType': "GENE" | "GENESET"
 
         'pValue': number
 
@@ -100,7 +128,11 @@ export type CoExpression = {
 
 };
 export type CoExpressionFilter = {
-    'sampleIds': Array < string >
+    'entrezGeneId': number
+
+        'genesetId': string
+
+        'sampleIds': Array < string >
 
         'sampleListId': string
 
@@ -108,13 +140,13 @@ export type CoExpressionFilter = {
 export type CopyNumberCountByGene = {
     'alteration': number
 
-        'countByEntity': number
-
         'cytoband': string
 
         'entrezGeneId': number
 
         'hugoGeneSymbol': string
+
+        'numberOfAlteredCases': number
 
         'numberOfSamplesProfiled': number
 
@@ -141,6 +173,12 @@ export type CosmicMutation = {
         'keyword': string
 
         'proteinChange': string
+
+};
+export type CountSummary = {
+    'alteredCount': number
+
+        'profiledCount': number
 
 };
 export type DataBin = {
@@ -244,13 +282,17 @@ export type GenesetHierarchyInfo = {
 
 };
 export type GenesetMolecularData = {
-    'genesetId': string
+    'geneset': Geneset
+
+        'genesetId': string
 
         'geneticProfileId': string
 
         'patientId': string
 
         'sampleId': string
+
+        'stableId': string
 
         'studyId': string
 
@@ -285,6 +327,16 @@ export type GisticToGene = {
         'hugoGeneSymbol': string
 
 };
+export type Group = {
+    'name': string
+
+        'sampleIdentifiers': Array < SampleIdentifier >
+
+};
+export type GroupFilter = {
+    'groups': Array < Group >
+
+};
 export type Info = {
     'dbVersion': string
 
@@ -309,6 +361,12 @@ export type Info = {
         'gitDirty': boolean
 
         'portalVersion': string
+
+};
+export type MolecularProfileCaseIdentifier = {
+    'caseId': string
+
+        'molecularProfileId': string
 
 };
 export type MolecularProfileSampleCount = {
@@ -343,6 +401,12 @@ export type MrnaPercentile = {
         'zScore': number
 
 };
+export type MultipleStudiesEnrichmentFilter = {
+    'molecularProfileCaseSet1': Array < MolecularProfileCaseIdentifier >
+
+        'molecularProfileCaseSet2': Array < MolecularProfileCaseIdentifier >
+
+};
 export type MutSig = {
     'entrezGeneId': number
 
@@ -360,11 +424,11 @@ export type MutSig = {
 
 };
 export type MutationCountByGene = {
-    'countByEntity': number
-
-        'entrezGeneId': number
+    'entrezGeneId': number
 
         'hugoGeneSymbol': string
+
+        'numberOfAlteredCases': number
 
         'numberOfSamplesProfiled': number
 
@@ -912,6 +976,83 @@ export default class CBioPortalAPIInternal {
                 return response.body;
             });
         };
+    fetchClinicalEnrichmentsUsingPOSTURL(parameters: {
+        'groupFilter': GroupFilter,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/clinical-data-enrichments/fetch';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Fetch clinical data enrichments for the sample groups
+     * @method
+     * @name CBioPortalAPIInternal#fetchClinicalEnrichmentsUsingPOST
+     * @param {} groupFilter - List of altered and unaltered Sample/Patient IDs
+     */
+    fetchClinicalEnrichmentsUsingPOSTWithHttpInfo(parameters: {
+        'groupFilter': GroupFilter,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/clinical-data-enrichments/fetch';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['groupFilter'] !== undefined) {
+                body = parameters['groupFilter'];
+            }
+
+            if (parameters['groupFilter'] === undefined) {
+                reject(new Error('Missing required  parameter: groupFilter'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Fetch clinical data enrichments for the sample groups
+     * @method
+     * @name CBioPortalAPIInternal#fetchClinicalEnrichmentsUsingPOST
+     * @param {} groupFilter - List of altered and unaltered Sample/Patient IDs
+     */
+    fetchClinicalEnrichmentsUsingPOST(parameters: {
+            'groupFilter': GroupFilter,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < ClinicalDataEnrichment >
+        > {
+            return this.fetchClinicalEnrichmentsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
     fetchCNAGenesUsingPOSTURL(parameters: {
         'studyViewFilter': StudyViewFilter,
         $queryParameters ? : any
@@ -986,6 +1127,108 @@ export default class CBioPortalAPIInternal {
         }): Promise < Array < CopyNumberCountByGene >
         > {
             return this.fetchCNAGenesUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+    fetchCopyNumberEnrichmentsUsingPOSTURL(parameters: {
+        'copyNumberEventType' ? : "HOMDEL" | "AMP",
+        'enrichmentType' ? : "SAMPLE" | "PATIENT",
+        'multipleStudiesEnrichmentFilter': MultipleStudiesEnrichmentFilter,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/copy-number-enrichments/fetch';
+        if (parameters['copyNumberEventType'] !== undefined) {
+            queryParameters['copyNumberEventType'] = parameters['copyNumberEventType'];
+        }
+
+        if (parameters['enrichmentType'] !== undefined) {
+            queryParameters['enrichmentType'] = parameters['enrichmentType'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Fetch copy number enrichments in a molecular profile
+     * @method
+     * @name CBioPortalAPIInternal#fetchCopyNumberEnrichmentsUsingPOST
+     * @param {string} copyNumberEventType - Type of the copy number event
+     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
+     * @param {} multipleStudiesEnrichmentFilter - List of entities
+     */
+    fetchCopyNumberEnrichmentsUsingPOSTWithHttpInfo(parameters: {
+        'copyNumberEventType' ? : "HOMDEL" | "AMP",
+        'enrichmentType' ? : "SAMPLE" | "PATIENT",
+        'multipleStudiesEnrichmentFilter': MultipleStudiesEnrichmentFilter,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/copy-number-enrichments/fetch';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['copyNumberEventType'] !== undefined) {
+                queryParameters['copyNumberEventType'] = parameters['copyNumberEventType'];
+            }
+
+            if (parameters['enrichmentType'] !== undefined) {
+                queryParameters['enrichmentType'] = parameters['enrichmentType'];
+            }
+
+            if (parameters['multipleStudiesEnrichmentFilter'] !== undefined) {
+                body = parameters['multipleStudiesEnrichmentFilter'];
+            }
+
+            if (parameters['multipleStudiesEnrichmentFilter'] === undefined) {
+                reject(new Error('Missing required  parameter: multipleStudiesEnrichmentFilter'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Fetch copy number enrichments in a molecular profile
+     * @method
+     * @name CBioPortalAPIInternal#fetchCopyNumberEnrichmentsUsingPOST
+     * @param {string} copyNumberEventType - Type of the copy number event
+     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
+     * @param {} multipleStudiesEnrichmentFilter - List of entities
+     */
+    fetchCopyNumberEnrichmentsUsingPOST(parameters: {
+            'copyNumberEventType' ? : "HOMDEL" | "AMP",
+            'enrichmentType' ? : "SAMPLE" | "PATIENT",
+            'multipleStudiesEnrichmentFilter': MultipleStudiesEnrichmentFilter,
+            $queryParameters ? : any,
+                $domain ? : string
+        }): Promise < Array < AlterationEnrichment >
+        > {
+            return this.fetchCopyNumberEnrichmentsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };
@@ -1830,19 +2073,20 @@ export default class CBioPortalAPIInternal {
         });
     };
     fetchCoExpressionsUsingPOSTURL(parameters: {
-        'molecularProfileId': string,
+        'molecularProfileIdA': string,
+        'molecularProfileIdB': string,
         'coExpressionFilter': CoExpressionFilter,
-        'entrezGeneId': number,
         'threshold' ? : number,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
-        let path = '/molecular-profiles/{molecularProfileId}/co-expressions/fetch';
+        let path = '/molecular-profiles/co-expressions/fetch';
+        if (parameters['molecularProfileIdA'] !== undefined) {
+            queryParameters['molecularProfileIdA'] = parameters['molecularProfileIdA'];
+        }
 
-        path = path.replace('{molecularProfileId}', parameters['molecularProfileId'] + '');
-
-        if (parameters['entrezGeneId'] !== undefined) {
-            queryParameters['entrezGeneId'] = parameters['entrezGeneId'];
+        if (parameters['molecularProfileIdB'] !== undefined) {
+            queryParameters['molecularProfileIdB'] = parameters['molecularProfileIdB'];
         }
 
         if (parameters['threshold'] !== undefined) {
@@ -1860,18 +2104,18 @@ export default class CBioPortalAPIInternal {
     };
 
     /**
-     * Fetch co-expressions in a molecular profile
+     * Calculates correlations between a genetic entity from a specific profile and another profile from the same study
      * @method
      * @name CBioPortalAPIInternal#fetchCoExpressionsUsingPOST
-     * @param {string} molecularProfileId - Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna
-     * @param {} coExpressionFilter - List of Sample IDs/Sample List ID
-     * @param {integer} entrezGeneId - Entrez Gene ID
+     * @param {string} molecularProfileIdA - Molecular Profile ID from the Genetic Entity referenced in the co-expression filter e.g. acc_tcga_rna_seq_v2_mrna
+     * @param {string} molecularProfileIdB - Molecular Profile ID (can be the same as molecularProfileIdA) e.g. acc_tcga_rna_seq_v2_mrna
+     * @param {} coExpressionFilter - List of Sample IDs/Sample List ID and Entrez Gene ID/Gene set ID
      * @param {number} threshold - Threshold
      */
     fetchCoExpressionsUsingPOSTWithHttpInfo(parameters: {
-        'molecularProfileId': string,
+        'molecularProfileIdA': string,
+        'molecularProfileIdB': string,
         'coExpressionFilter': CoExpressionFilter,
-        'entrezGeneId': number,
         'threshold' ? : number,
         $queryParameters ? : any,
         $domain ? : string
@@ -1879,7 +2123,7 @@ export default class CBioPortalAPIInternal {
         const domain = parameters.$domain ? parameters.$domain : this.domain;
         const errorHandlers = this.errorHandlers;
         const request = this.request;
-        let path = '/molecular-profiles/{molecularProfileId}/co-expressions/fetch';
+        let path = '/molecular-profiles/co-expressions/fetch';
         let body: any;
         let queryParameters: any = {};
         let headers: any = {};
@@ -1888,10 +2132,21 @@ export default class CBioPortalAPIInternal {
             headers['Accept'] = 'application/json';
             headers['Content-Type'] = 'application/json';
 
-            path = path.replace('{molecularProfileId}', parameters['molecularProfileId'] + '');
+            if (parameters['molecularProfileIdA'] !== undefined) {
+                queryParameters['molecularProfileIdA'] = parameters['molecularProfileIdA'];
+            }
 
-            if (parameters['molecularProfileId'] === undefined) {
-                reject(new Error('Missing required  parameter: molecularProfileId'));
+            if (parameters['molecularProfileIdA'] === undefined) {
+                reject(new Error('Missing required  parameter: molecularProfileIdA'));
+                return;
+            }
+
+            if (parameters['molecularProfileIdB'] !== undefined) {
+                queryParameters['molecularProfileIdB'] = parameters['molecularProfileIdB'];
+            }
+
+            if (parameters['molecularProfileIdB'] === undefined) {
+                reject(new Error('Missing required  parameter: molecularProfileIdB'));
                 return;
             }
 
@@ -1901,15 +2156,6 @@ export default class CBioPortalAPIInternal {
 
             if (parameters['coExpressionFilter'] === undefined) {
                 reject(new Error('Missing required  parameter: coExpressionFilter'));
-                return;
-            }
-
-            if (parameters['entrezGeneId'] !== undefined) {
-                queryParameters['entrezGeneId'] = parameters['entrezGeneId'];
-            }
-
-            if (parameters['entrezGeneId'] === undefined) {
-                reject(new Error('Missing required  parameter: entrezGeneId'));
                 return;
             }
 
@@ -1930,140 +2176,24 @@ export default class CBioPortalAPIInternal {
     };
 
     /**
-     * Fetch co-expressions in a molecular profile
+     * Calculates correlations between a genetic entity from a specific profile and another profile from the same study
      * @method
      * @name CBioPortalAPIInternal#fetchCoExpressionsUsingPOST
-     * @param {string} molecularProfileId - Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna
-     * @param {} coExpressionFilter - List of Sample IDs/Sample List ID
-     * @param {integer} entrezGeneId - Entrez Gene ID
+     * @param {string} molecularProfileIdA - Molecular Profile ID from the Genetic Entity referenced in the co-expression filter e.g. acc_tcga_rna_seq_v2_mrna
+     * @param {string} molecularProfileIdB - Molecular Profile ID (can be the same as molecularProfileIdA) e.g. acc_tcga_rna_seq_v2_mrna
+     * @param {} coExpressionFilter - List of Sample IDs/Sample List ID and Entrez Gene ID/Gene set ID
      * @param {number} threshold - Threshold
      */
     fetchCoExpressionsUsingPOST(parameters: {
-            'molecularProfileId': string,
+            'molecularProfileIdA': string,
+            'molecularProfileIdB': string,
             'coExpressionFilter': CoExpressionFilter,
-            'entrezGeneId': number,
             'threshold' ? : number,
             $queryParameters ? : any,
             $domain ? : string
         }): Promise < Array < CoExpression >
         > {
             return this.fetchCoExpressionsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-    fetchCopyNumberEnrichmentsUsingPOSTURL(parameters: {
-        'molecularProfileId': string,
-        'copyNumberEventType' ? : "HOMDEL" | "AMP",
-        'enrichmentType' ? : "SAMPLE" | "PATIENT",
-        'enrichmentFilter': EnrichmentFilter,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/molecular-profiles/{molecularProfileId}/copy-number-enrichments/fetch';
-
-        path = path.replace('{molecularProfileId}', parameters['molecularProfileId'] + '');
-        if (parameters['copyNumberEventType'] !== undefined) {
-            queryParameters['copyNumberEventType'] = parameters['copyNumberEventType'];
-        }
-
-        if (parameters['enrichmentType'] !== undefined) {
-            queryParameters['enrichmentType'] = parameters['enrichmentType'];
-        }
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Fetch copy number enrichments in a molecular profile
-     * @method
-     * @name CBioPortalAPIInternal#fetchCopyNumberEnrichmentsUsingPOST
-     * @param {string} molecularProfileId - Molecular Profile ID e.g. acc_tcga_mutations
-     * @param {string} copyNumberEventType - Type of the copy number event
-     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
-     * @param {} enrichmentFilter - List of altered and unaltered Sample/Patient IDs
-     */
-    fetchCopyNumberEnrichmentsUsingPOSTWithHttpInfo(parameters: {
-        'molecularProfileId': string,
-        'copyNumberEventType' ? : "HOMDEL" | "AMP",
-        'enrichmentType' ? : "SAMPLE" | "PATIENT",
-        'enrichmentFilter': EnrichmentFilter,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/molecular-profiles/{molecularProfileId}/copy-number-enrichments/fetch';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            path = path.replace('{molecularProfileId}', parameters['molecularProfileId'] + '');
-
-            if (parameters['molecularProfileId'] === undefined) {
-                reject(new Error('Missing required  parameter: molecularProfileId'));
-                return;
-            }
-
-            if (parameters['copyNumberEventType'] !== undefined) {
-                queryParameters['copyNumberEventType'] = parameters['copyNumberEventType'];
-            }
-
-            if (parameters['enrichmentType'] !== undefined) {
-                queryParameters['enrichmentType'] = parameters['enrichmentType'];
-            }
-
-            if (parameters['enrichmentFilter'] !== undefined) {
-                body = parameters['enrichmentFilter'];
-            }
-
-            if (parameters['enrichmentFilter'] === undefined) {
-                reject(new Error('Missing required  parameter: enrichmentFilter'));
-                return;
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Fetch copy number enrichments in a molecular profile
-     * @method
-     * @name CBioPortalAPIInternal#fetchCopyNumberEnrichmentsUsingPOST
-     * @param {string} molecularProfileId - Molecular Profile ID e.g. acc_tcga_mutations
-     * @param {string} copyNumberEventType - Type of the copy number event
-     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
-     * @param {} enrichmentFilter - List of altered and unaltered Sample/Patient IDs
-     */
-    fetchCopyNumberEnrichmentsUsingPOST(parameters: {
-            'molecularProfileId': string,
-            'copyNumberEventType' ? : "HOMDEL" | "AMP",
-            'enrichmentType' ? : "SAMPLE" | "PATIENT",
-            'enrichmentFilter': EnrichmentFilter,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < AlterationEnrichment >
-        > {
-            return this.fetchCopyNumberEnrichmentsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };
@@ -2275,109 +2405,6 @@ export default class CBioPortalAPIInternal {
         }): Promise < Array < MrnaPercentile >
         > {
             return this.fetchMrnaPercentileUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-    fetchMutationEnrichmentsUsingPOSTURL(parameters: {
-        'molecularProfileId': string,
-        'enrichmentType' ? : "SAMPLE" | "PATIENT",
-        'enrichmentFilter': EnrichmentFilter,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/molecular-profiles/{molecularProfileId}/mutation-enrichments/fetch';
-
-        path = path.replace('{molecularProfileId}', parameters['molecularProfileId'] + '');
-        if (parameters['enrichmentType'] !== undefined) {
-            queryParameters['enrichmentType'] = parameters['enrichmentType'];
-        }
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Fetch mutation enrichments in a molecular profile
-     * @method
-     * @name CBioPortalAPIInternal#fetchMutationEnrichmentsUsingPOST
-     * @param {string} molecularProfileId - Molecular Profile ID e.g. acc_tcga_mutations
-     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
-     * @param {} enrichmentFilter - List of altered and unaltered Sample/Patient IDs
-     */
-    fetchMutationEnrichmentsUsingPOSTWithHttpInfo(parameters: {
-        'molecularProfileId': string,
-        'enrichmentType' ? : "SAMPLE" | "PATIENT",
-        'enrichmentFilter': EnrichmentFilter,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/molecular-profiles/{molecularProfileId}/mutation-enrichments/fetch';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            path = path.replace('{molecularProfileId}', parameters['molecularProfileId'] + '');
-
-            if (parameters['molecularProfileId'] === undefined) {
-                reject(new Error('Missing required  parameter: molecularProfileId'));
-                return;
-            }
-
-            if (parameters['enrichmentType'] !== undefined) {
-                queryParameters['enrichmentType'] = parameters['enrichmentType'];
-            }
-
-            if (parameters['enrichmentFilter'] !== undefined) {
-                body = parameters['enrichmentFilter'];
-            }
-
-            if (parameters['enrichmentFilter'] === undefined) {
-                reject(new Error('Missing required  parameter: enrichmentFilter'));
-                return;
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Fetch mutation enrichments in a molecular profile
-     * @method
-     * @name CBioPortalAPIInternal#fetchMutationEnrichmentsUsingPOST
-     * @param {string} molecularProfileId - Molecular Profile ID e.g. acc_tcga_mutations
-     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
-     * @param {} enrichmentFilter - List of altered and unaltered Sample/Patient IDs
-     */
-    fetchMutationEnrichmentsUsingPOST(parameters: {
-            'molecularProfileId': string,
-            'enrichmentType' ? : "SAMPLE" | "PATIENT",
-            'enrichmentFilter': EnrichmentFilter,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < AlterationEnrichment >
-        > {
-            return this.fetchMutationEnrichmentsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };
@@ -2637,6 +2664,95 @@ export default class CBioPortalAPIInternal {
         }): Promise < Array < MutationCountByGene >
         > {
             return this.fetchMutatedGenesUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+    fetchMutationEnrichmentsUsingPOSTURL(parameters: {
+        'enrichmentType' ? : "SAMPLE" | "PATIENT",
+        'multipleStudiesEnrichmentFilter': MultipleStudiesEnrichmentFilter,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/mutation-enrichments/fetch';
+        if (parameters['enrichmentType'] !== undefined) {
+            queryParameters['enrichmentType'] = parameters['enrichmentType'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Fetch mutation enrichments in a molecular profile
+     * @method
+     * @name CBioPortalAPIInternal#fetchMutationEnrichmentsUsingPOST
+     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
+     * @param {} multipleStudiesEnrichmentFilter - List of entities
+     */
+    fetchMutationEnrichmentsUsingPOSTWithHttpInfo(parameters: {
+        'enrichmentType' ? : "SAMPLE" | "PATIENT",
+        'multipleStudiesEnrichmentFilter': MultipleStudiesEnrichmentFilter,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/mutation-enrichments/fetch';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['enrichmentType'] !== undefined) {
+                queryParameters['enrichmentType'] = parameters['enrichmentType'];
+            }
+
+            if (parameters['multipleStudiesEnrichmentFilter'] !== undefined) {
+                body = parameters['multipleStudiesEnrichmentFilter'];
+            }
+
+            if (parameters['multipleStudiesEnrichmentFilter'] === undefined) {
+                reject(new Error('Missing required  parameter: multipleStudiesEnrichmentFilter'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Fetch mutation enrichments in a molecular profile
+     * @method
+     * @name CBioPortalAPIInternal#fetchMutationEnrichmentsUsingPOST
+     * @param {string} enrichmentType - Type of the enrichment e.g. SAMPLE or PATIENT
+     * @param {} multipleStudiesEnrichmentFilter - List of entities
+     */
+    fetchMutationEnrichmentsUsingPOST(parameters: {
+            'enrichmentType' ? : "SAMPLE" | "PATIENT",
+            'multipleStudiesEnrichmentFilter': MultipleStudiesEnrichmentFilter,
+            $queryParameters ? : any,
+                $domain ? : string
+        }): Promise < Array < AlterationEnrichment >
+        > {
+            return this.fetchMutationEnrichmentsUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };


### PR DESCRIPTION
# What? Why?
Fix # .
Fix cBioPortal/cbioportal#5851

Changes proposed in this pull request:

    Adds a tooltip to the MutatedGenesTable and CNAGenesTable that shows the total number of genes profiled when the user hovers over them.
    Change the API to fetch the number of genes profiled instead of the frequency.
