### PR TITLE
redirect /tutorials.jsp

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -125,6 +125,7 @@ export const makeRoutes = (routing) => {
                 <Redirect from={"/data_sets.jsp"} to={"/datasets"}/>
                 <Redirect from={"/oncoprinter.jsp"} to={"/oncoprinter"}/>
                 <Redirect from={"/onco_query_lang_desc.jsp"} to={"/oql"}/>
+                <Redirect from={"/tutorials.jsp"} to={"/tutorials"}/>
 
 
 


### PR DESCRIPTION
redirect `/tutorials.jsp` to `/tutorials`
Fix # https://github.com/cbioportal/cbioportal/issues/5912.