### PR TITLE
Sort mode of oncoprint set via URL parameter

### DIFF
--- a/env/rc.sh
+++ b/env/rc.sh
@@ -1,2 +1,2 @@
-export CBIOPORTAL_URL="http://test.cbioportal.org/rc"
+export CBIOPORTAL_URL="https://rc.cbioportal.org"
 export GENOME_NEXUS_URL="https://www.genomenexus.org"

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.spec.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.spec.tsx
@@ -1,0 +1,85 @@
+import {assert} from "chai";
+import ResultsViewOncoprint from "./ResultsViewOncoprint";
+import { ResultsViewPageStore } from "pages/resultsView/ResultsViewPageStore";
+import { Sample, Patient } from "shared/api/generated/CBioPortalAPI";
+import getBrowserWindow from "shared/lib/getBrowserWindow";
+import ExtendedRouterStore from "shared/lib/ExtendedRouterStore";
+import sinon from "sinon";
+import { isOccupied } from "pages/studyView/StudyViewUtils";
+import { SortByUrlParamValue } from 'shared/components/oncoprint/ResultsViewOncoprint';
+
+describe('Oncoprint sortBy URL parameter', () => {
+
+    const samples = [
+        {sampleId: "Sample1", uniqueSampleKey: "Sample1_key"},
+        {sampleId: "Sample2", uniqueSampleKey: "Sample2_key"},
+        {sampleId: "Sample3", uniqueSampleKey: "Sample3_key"}
+    ] as Sample[];
+
+    const patients = [
+        {patientId: "Patient1", uniquePatientKey: "Patient1_key"},
+        {patientId: "Patient2", uniquePatientKey: "Patient2_key"},
+        {patientId: "Patient3", uniquePatientKey: "Patient3_key"}
+    ] as Patient[];
+
+    const caseList = [
+        {sampleId: "Sample2", uniqueSampleKey: "Sample2_key", uniquePatientKey: "Patient2_key"},
+        {sampleId: "Sample3", uniqueSampleKey: "Sample3_key", uniquePatientKey: "Patient3_key"},
+        {sampleId: "Sample1", uniqueSampleKey: "Sample1_key", uniquePatientKey: "Patient1_key"}
+    ] as Sample[];
+
+    const storeMock = {
+        samples: {isComplete: true, result: samples},
+        patients: {isComplete: true, result: patients},
+        givenSampleOrder: {isComplete: true, result: caseList}
+    } as any as ResultsViewPageStore;
+
+    it('`case_id` provides sorted sample config to oncoprint', () => {
+        const oncoprintView = initResultsViewWithSortByParam({sortByParam:SortByUrlParamValue.CASE_ID, columnMode: 'sample'});
+        assert.deepEqual( oncoprintView.sortConfig.order, ["Sample1_key","Sample2_key","Sample3_key"]);
+    });
+
+    it('`case_id` provides sorted patient config to oncoprint', () => {
+        const oncoprintView = initResultsViewWithSortByParam({sortByParam:SortByUrlParamValue.CASE_ID, columnMode:'patient'});
+        assert.deepEqual( oncoprintView.sortConfig.order, ["Patient1_key","Patient2_key","Patient3_key"]);
+    });
+
+    it('`case_list` provides sorted sample config to oncoprint when case list is available', () => {
+        const oncoprintView = initResultsViewWithSortByParam({sortByParam:SortByUrlParamValue.CASE_LIST, columnMode: 'sample', caselistEnabled: true});
+        assert.deepEqual(oncoprintView.sortConfig.order,  ["Sample2_key","Sample3_key","Sample1_key"]);
+    });
+
+    it('`case_list` provides sorted patient config to oncoprint when case list is available', () => {
+        const oncoprintView = initResultsViewWithSortByParam({sortByParam:SortByUrlParamValue.CASE_LIST, columnMode: 'patient', caselistEnabled: true});
+        assert.deepEqual(oncoprintView.sortConfig.order,  ["Patient2_key","Patient3_key","Patient1_key"]);
+    });
+
+    it('`case_list` provides no sort config to oncoprint when case list is unavailable', () => {
+        const oncoprintView = initResultsViewWithSortByParam({sortByParam:SortByUrlParamValue.CASE_LIST, columnMode: 'patient', caselistEnabled: false});
+        assert.isUndefined(oncoprintView.sortConfig.order);
+    });
+
+    interface IHelperFunction {
+        sortByParam:SortByUrlParamValue;
+        columnMode?:"sample"|"patient" ;
+        caselistEnabled?:boolean;
+    }
+
+    const initResultsViewWithSortByParam = (params:IHelperFunction) => {
+        // mock the url params by mocking the ExtendedRouterStore class
+        const routingStub = sinon.createStubInstance(ExtendedRouterStore);
+        routingStub.location = { query: {oncoprint_sortby: params.sortByParam}};
+        getBrowserWindow().globalStores = {routing: routingStub };
+        if (params.caselistEnabled !== undefined) {
+            storeMock.givenSampleOrder.isComplete = params.caselistEnabled;
+        }
+        const oncoprintView = new ResultsViewOncoprint(
+            {divId: "", store: storeMock, routing: ""}
+        );
+        if (params.columnMode !== undefined) {
+            oncoprintView.columnMode = params.columnMode;
+        }
+        return oncoprintView;
+    };
+
+});


### PR DESCRIPTION
# What? Why?
Oncoprint samples can be sorted based on different properties such as case identifier, mutation types, etc. The property that controls sort order (a.k.a. _sort mode_) is controlled by the user via UI events in the `Sort` menu of the OncoprintControls component. In the current implementation oncoprint view cannot be opened with a predetermined sort mode that requires no UI actions by the user.

# Changes by this PR
For integration with tools external to cBioPortal we have created a new feature that allows to open oncoprint view with a specified sort mode via the URL. This PR will implement a new URL parameter `oncoprint_sortby` for oncoprint. This parameter can have 6 different values that control the different sort modes:

| param value  | sort mode |
|  :--- |  :--- |
| `case_id` | sort by sample/patient identifier |
| `case_list` | sort by sample/patient case list |
| `data` | sort by data |
| `data_mut` | sort by data and mutation type |
|`data_dri` | sort by data and driver/passenger mutation |
| `data_mut_dri` | sort by data, mutation type and driver/passenger mutation |

When the sort mode is updated by the user via an UI event, the URL is updated (w/o page refresh) to reflect this change so that the URL can used to open the same view.

The PR includes unit tests for the URL param processing by the ResultsViewOncoprint component.

# Notes
- Sort order by heatmap is not not covered by this PR.