### PR TITLE
hide plots tab tooltips in e2e

### DIFF
--- a/src/globalStyles/e2etest.scss
+++ b/src/globalStyles/e2etest.scss
@@ -17,4 +17,8 @@
     display:none !important;
   }
 
+  .plotsTab .cbioTooltip.popover {
+    opacity:0 !important;
+  }
+
 }


### PR DESCRIPTION
These tooltips are often causing e2e to fail 