### PR TITLE
Changed quicksearch route to cancerTypesSummary

### DIFF
--- a/src/shared/components/query/quickSearch/QuickSearch.tsx
+++ b/src/shared/components/query/quickSearch/QuickSearch.tsx
@@ -226,7 +226,7 @@ export default class QuickSearch extends React.Component {
                 gene_list: newOption.hugoGeneSymbol,
                 cancer_study_list: studyList,
             };
-            route = "results/mutations";
+            route = "results/cancerTypesSummary";
             this.trackClick("gene", this.inputValue);
         } else if (newOption.type === OptionType.PATIENT) {
             parameters = {studyId: newOption.studyId, caseId: newOption.patientId};


### PR DESCRIPTION
# What? Why?
Fixed https://github.com/cBioPortal/cbioportal/issues/5958

Changes proposed in this pull request:
- Changed the default root of quick search to cancerTypesSummary (if available)

# GIFs
![fixed](https://user-images.githubusercontent.com/35633575/56075891-3f292380-5de7-11e9-9292-f04b5bcdd322.gif)

# Notify reviewers
@jjgao @alisman @adamabeshouse @dippindots 
@cBioPortal/frontend