### PR TITLE
Fix layout of select/deselect links on group comparison page

### DIFF
--- a/src/pages/groupComparison/GroupSelector.tsx
+++ b/src/pages/groupComparison/GroupSelector.tsx
@@ -32,7 +32,6 @@ export default class GroupSelector extends React.Component<IGroupSelectorProps,{
                 return (
                     <div style={{
                         display:"flex",
-                        flexDirection:"row",
                         alignItems:"center"
                     }}>
                         <strong style={{marginRight:5}}>Groups: </strong>
@@ -84,7 +83,7 @@ export default class GroupSelector extends React.Component<IGroupSelectorProps,{
                                 );
                             })}
                         </div>
-                        <div className="btn-group" style={{marginLeft:15}}>
+                        <div style={{marginLeft:15, display:'flex', whiteSpace:'nowrap'}} >
                             <a onClick={this.props.store.selectAllGroups}
                             >Select all
                             </a>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/186521/56429603-86089480-6291-11e9-84d9-336c0f2b5621.png)
becomes:
![image](https://user-images.githubusercontent.com/186521/56429616-928ced00-6291-11e9-88ad-4e768785d6ac.png)
