### PR TITLE
redirect tutorial.jsp

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -126,6 +126,7 @@ export const makeRoutes = (routing) => {
                 <Redirect from={"/oncoprinter.jsp"} to={"/oncoprinter"}/>
                 <Redirect from={"/onco_query_lang_desc.jsp"} to={"/oql"}/>
                 <Redirect from={"/tutorials.jsp"} to={"/tutorials"}/>
+                <Redirect from={"/tutorial.jsp"} to={"/tutorials"}/>
                 <Redirect from={"/cgds_r.jsp"} to={"/rmatlab"}/>
 
 


### PR DESCRIPTION
some papers list `tutorial.jsp` instead of `tutorials.jsp`