### PR TITLE
fix query page error when there is no study selected

### DIFF
--- a/src/shared/components/query/QueryContainer.tsx
+++ b/src/shared/components/query/QueryContainer.tsx
@@ -58,9 +58,9 @@ export default class QueryContainer extends React.Component<QueryContainerProps,
 		}
 	}
 
-	// indicates we have loaded the study data necessary to show default selected studies (e.g. modify query scenario)
+	// indicates we have loaded the study data necessary to show default selected studies (e.g. modify query scenario), studiesHaveChangedSinceInitialization indicates all data is ready and we don't need to consider other conditions anymore.
 	@computed get studiesDataReady() : boolean {
-		return this.store.selectableSelectedStudyIds.length > 0 && this.store.initiallySelected.profileIds && this.store.cancerTypes.isComplete && this.store.cancerStudies.isComplete && this.store.profiledSamplesCount.isComplete;
+		return this.store.studiesHaveChangedSinceInitialization || this.store.selectableSelectedStudyIds.length > 0 && this.store.initiallySelected.profileIds && this.store.cancerTypes.isComplete && this.store.cancerStudies.isComplete && this.store.profiledSamplesCount.isComplete;
 	}
 	
     render():JSX.Element


### PR DESCRIPTION
fix query page error when there is no study selected
Fix issue introduced in https://github.com/cBioPortal/cbioportal-frontend/pull/2215.