### PR TITLE
update mutex tab(exclude unprofiled samples)

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1018,9 +1018,9 @@ export class ResultsViewPageStore {
 
 
     readonly isSampleAlteredMap = remoteData({
-        await: () => [this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine, this.samples],
+        await: () => [this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine, this.samples, this.coverageInformation, this.selectedMolecularProfiles],
         invoke: async() => {
-            return getSampleAlteredMap(this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine.result!, this.samples.result, this.rvQuery.oqlQuery);
+            return getSampleAlteredMap(this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine.result!, this.samples.result, this.rvQuery.oqlQuery, this.coverageInformation.result, this.selectedMolecularProfiles.result!.map((profile) => profile.molecularProfileId));
         }
     });
 

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -26,6 +26,7 @@ import sessionServiceClient from "shared/api//sessionServiceInstance";
 import { VirtualStudy, VirtualStudyData } from "shared/model/VirtualStudy";
 import client from "shared/api/cbioportalClientInstance";
 import AccessorsForOqlFilter, {getSimplifiedMutationType} from "../../shared/lib/oql/AccessorsForOqlFilter";
+import { AlteredStatus } from "./mutualExclusivity/MutualExclusivityUtil";
 
 describe("ResultsViewPageStoreUtils", ()=>{
     describe("computeCustomDriverAnnotationReport", ()=>{
@@ -2277,44 +2278,44 @@ describe('getSampleAlteredMap', () => {
         const ret = getSampleAlteredMap(filteredAlterationData, samples, oqlQuery, coverageInformation, molecularProfileIds);
         const expectedResult = {
             "RAS": [
-                true,
-                false,
-                true,
-                false,
-                false,
-                true,
-                false,
-                false
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ],
             "SMAD4 / RAN": [
-                false,
-                true,
-                true,
-                false,
-                true,
-                true,
-                false,
-                false
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ],
             "SMAD4: MUT": [
-                false,
-                true,
-                true,
-                false,
-                true,
-                true,
-                false,
-                false
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ],
             "KRAS": [
-                true,
-                false,
-                true,
-                false,
-                false,
-                true,
-                false,
-                false
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ]
         };
         assert.deepEqual(ret["KRAS"], expectedResult["KRAS"], "single gene track");
@@ -2329,44 +2330,44 @@ describe('getSampleAlteredMap', () => {
         const ret = getSampleAlteredMap(filteredAlterationData, samples, oqlQuery, coverageInformationWithUnprofiledSamples, molecularProfileIds);
         const expectedResult = {
             "RAS": [
-                true,
-                false,
-                true,
-                false,
-                false,
-                true,
-                false,
-                false
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ],
             "SMAD4 / RAN": [
-                undefined,
-                true,
-                true,
-                false,
-                true,
-                true,
-                false,
-                false
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ],
             "SMAD4: MUT": [
-                false,
-                true,
-                true,
-                false,
-                true,
-                true,
-                false,
-                false
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ],
             "KRAS": [
-                undefined,
-                undefined,
-                true,
-                false,
-                false,
-                true,
-                false,
-                false
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.ALTERED,
+                AlteredStatus.UNALTERED,
+                AlteredStatus.UNALTERED
             ]
         };
         assert.deepEqual(ret["KRAS"], expectedResult["KRAS"], "single gene track with unprofiled samples");
@@ -2379,14 +2380,14 @@ describe('getSampleAlteredMap', () => {
         const ret = getSampleAlteredMap(filteredAlterationData, samples, oqlQuery, coverageInformationWithUnprofiledSamples, unprofiledMolecularProfileIds);
         const expectedResult = {
             "RAS": [
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED,
+                AlteredStatus.UNPROFILED
             ]
         };
         assert.deepEqual(ret["RAS"], expectedResult["RAS"], "should return an list contains only undefined value");

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -1264,7 +1264,7 @@ describe("ResultsViewPageStoreUtils", ()=>{
 
 describe('getSampleAlteredMap', () => {
 
-    const arg0 = [
+    const filteredAlterationData = [
         {
             "cases": {
                 "samples": {
@@ -1578,7 +1578,7 @@ describe('getSampleAlteredMap', () => {
         }
     ] as IQueriedMergedTrackCaseData[];
 
-    var arg1 = [
+    var samples = [
         {
             "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
             "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
@@ -1661,11 +1661,620 @@ describe('getSampleAlteredMap', () => {
         }
     ] as Sample[];
 
-    const arg2 = "[\"RAS\" KRAS NRAS]\n[SMAD4 RAN]\nSMAD4: MUT\nKRAS";
+    const oqlQuery = "[\"RAS\" KRAS NRAS]\n[SMAD4 RAN]\nSMAD4: MUT\nKRAS";
 
-    it('handles different type of gene tracks correctly', () => {
+    const coverageInformation = {
+        "samples": {
+            "QjA4NTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "B085",
+                        "patientId": "B085",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "QjA5OTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "QjA5OTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "QjA5OTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "B099",
+                        "patientId": "B099",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "UjEwNDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "R104",
+                        "patientId": "R104",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VDAyNjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "T026",
+                        "patientId": "T026",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VTA0NDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "U044",
+                        "patientId": "U044",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAxMjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W012",
+                        "patientId": "W012",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAzOTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W039",
+                        "patientId": "W039",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzA0MDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W040",
+                        "patientId": "W040",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            }
+        },
+        "patients": {
+            "QjA4NTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "B085",
+                        "patientId": "B085",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "QjA5OTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "QjA5OTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "QjA5OTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "B099",
+                        "patientId": "B099",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "UjEwNDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "R104",
+                        "patientId": "R104",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VDAyNjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "T026",
+                        "patientId": "T026",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VTA0NDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "U044",
+                        "patientId": "U044",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAxMjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W012",
+                        "patientId": "W012",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAzOTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W039",
+                        "patientId": "W039",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzA0MDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W040",
+                        "patientId": "W040",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            }
+        }
+    };
+
+    const coverageInformationWithUnprofiledSamples = {
+        "samples": {
+            "QjA4NTpjaG9sX251c18yMDEy": {
+                "byGene": {
+                    "NRAS": [
+                        {
+                            "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B085",
+                            "patientId": "B085",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ]
+                },
+                "allGenes": [],
+                "notProfiledByGene": {
+                    "KRAS": [
+                        {
+                            "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B085",
+                            "patientId": "B085",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ],
+                    "SMAD4": [
+                        {
+                            "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B085",
+                            "patientId": "B085",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ],
+                    "RAN": [
+                        {
+                            "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B085",
+                            "patientId": "B085",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ]
+                },
+                "notProfiledAllGenes": []
+            },
+            "QjA5OTpjaG9sX251c18yMDEy": {
+                "byGene": {
+                    "NRAS": [
+                        {
+                            "uniqueSampleKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B099",
+                            "patientId": "B099",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ],
+                    "SMAD4": [
+                        {
+                            "uniqueSampleKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B099",
+                            "patientId": "B099",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ],
+                    "RAN": [
+                        {
+                            "uniqueSampleKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B099",
+                            "patientId": "B099",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ]
+                },
+                "allGenes": [],
+                "notProfiledByGene": {
+                    "KRAS": [
+                        {
+                            "uniqueSampleKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "uniquePatientKey": "QjA5OTpjaG9sX251c18yMDEy",
+                            "molecularProfileId": "chol_nus_2012_mutations",
+                            "sampleId": "B099",
+                            "patientId": "B099",
+                            "genePanelId": "test",
+                            "studyId": "chol_nus_2012",
+                            "profiled": true
+                        }
+                    ]
+                },
+                "notProfiledAllGenes": []
+            },
+            "UjEwNDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "R104",
+                        "patientId": "R104",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VDAyNjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "T026",
+                        "patientId": "T026",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VTA0NDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "U044",
+                        "patientId": "U044",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAxMjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W012",
+                        "patientId": "W012",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAzOTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W039",
+                        "patientId": "W039",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzA0MDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W040",
+                        "patientId": "W040",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            }
+        },
+        "patients": {
+            "QjA4NTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "QjA4NTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "QjA4NTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "B085",
+                        "patientId": "B085",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "QjA5OTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "QjA5OTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "QjA5OTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "B099",
+                        "patientId": "B099",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "UjEwNDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "UjEwNDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "R104",
+                        "patientId": "R104",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VDAyNjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VDAyNjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "T026",
+                        "patientId": "T026",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VTA0NDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VTA0NDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "U044",
+                        "patientId": "U044",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAxMjpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAxMjpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W012",
+                        "patientId": "W012",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzAzOTpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzAzOTpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W039",
+                        "patientId": "W039",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            },
+            "VzA0MDpjaG9sX251c18yMDEy": {
+                "byGene": {},
+                "allGenes": [
+                    {
+                        "uniqueSampleKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "uniquePatientKey": "VzA0MDpjaG9sX251c18yMDEy",
+                        "molecularProfileId": "chol_nus_2012_mutations",
+                        "sampleId": "W040",
+                        "patientId": "W040",
+                        "studyId": "chol_nus_2012",
+                        "profiled": true
+                    }
+                ],
+                "notProfiledByGene": {},
+                "notProfiledAllGenes": []
+            }
+        }
+    };
+
+    const molecularProfileIds = ["chol_nus_2012_mutations"];
+    const unprofiledMolecularProfileIds = ["chol_nus_2012_mutations","chol_nus_2012_cna"];
+
+    it('should handle all profiled samples correctly', () => {
         
-        const ret = getSampleAlteredMap(arg0, arg1, arg2);
+        const ret = getSampleAlteredMap(filteredAlterationData, samples, oqlQuery, coverageInformation, molecularProfileIds);
         const expectedResult = {
             "RAS": [
                 true,
@@ -1713,6 +2322,74 @@ describe('getSampleAlteredMap', () => {
         assert.deepEqual(ret["SMAD4 / RAN"], expectedResult["SMAD4 / RAN"], "merged gene track");
         assert.deepEqual(ret["RAS"], expectedResult["RAS"], "merged gene track(with group name)");
 
+    });
+
+    it('should set undefined for the not profiled samples', () => {
+        
+        const ret = getSampleAlteredMap(filteredAlterationData, samples, oqlQuery, coverageInformationWithUnprofiledSamples, molecularProfileIds);
+        const expectedResult = {
+            "RAS": [
+                true,
+                false,
+                true,
+                false,
+                false,
+                true,
+                false,
+                false
+            ],
+            "SMAD4 / RAN": [
+                undefined,
+                true,
+                true,
+                false,
+                true,
+                true,
+                false,
+                false
+            ],
+            "SMAD4: MUT": [
+                false,
+                true,
+                true,
+                false,
+                true,
+                true,
+                false,
+                false
+            ],
+            "KRAS": [
+                undefined,
+                undefined,
+                true,
+                false,
+                false,
+                true,
+                false,
+                false
+            ]
+        };
+        assert.deepEqual(ret["KRAS"], expectedResult["KRAS"], "single gene track with unprofiled samples");
+        assert.deepEqual(ret["RAS"], expectedResult["RAS"], "merged gene track with unprofiled samples in one gene");
+        assert.deepEqual(ret["SMAD4 / RAN"], expectedResult["SMAD4 / RAN"], "merged gene track with unprofiled samples in all genes");
+    });
+
+    it('should search in all molecularProfile ids', () => {
+        
+        const ret = getSampleAlteredMap(filteredAlterationData, samples, oqlQuery, coverageInformationWithUnprofiledSamples, unprofiledMolecularProfileIds);
+        const expectedResult = {
+            "RAS": [
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            ]
+        };
+        assert.deepEqual(ret["RAS"], expectedResult["RAS"], "should return an list contains only undefined value");
     });
 });
 

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.ts
@@ -32,6 +32,7 @@ import {remoteData} from "../../shared/api/remoteData";
 import {calculateQValues} from "../../shared/lib/calculation/BenjaminiHochbergFDRCalculator";
 import {SpecialAttribute} from "../../shared/cache/ClinicalDataCache";
 import { isSampleProfiled } from "shared/lib/isSampleProfiled";
+import { AlteredStatus } from "./mutualExclusivity/MutualExclusivityUtil";
 
 type CustomDriverAnnotationReport = {
     hasBinary: boolean,
@@ -61,7 +62,7 @@ export type CoverageInformation = {
         {[uniquePatientKey:string]:CoverageInformationForCase};
 };
 
-export type SampleAlteredMap = {[trackOqlKey:string]:(boolean | undefined)[]};
+export type SampleAlteredMap = {[trackOqlKey:string]:AlteredStatus[]};
 
 export function computeCustomDriverAnnotationReport(mutations:Mutation[]):CustomDriverAnnotationReport {
     let hasBinary = false;
@@ -421,26 +422,29 @@ export function getSampleAlteredMap(filteredAlterationData: IQueriedMergedTrackC
         //1: is not group
         if (element.mergedTrackOqlList === undefined) {
             const notGroupedOql = element.oql as OQLLineFilterOutput<AnnotatedExtendedAlteration>;                    
-            const sampleKeys = _.map(notGroupedOql.data, (data) => data.uniqueSampleKey);
-            const unProfiledSampleKeys = samples.map((sample) => sample.uniqueSampleKey).filter((sampleKey) => {
+            const sampleKeysMap = _.keyBy(_.map(notGroupedOql.data, (data) => data.uniqueSampleKey));
+            const unProfiledSampleKeysMap = _.keyBy(samples.map((sample) => sample.uniqueSampleKey).filter((sampleKey) => {
                 // if not profiled in some genes molecular profile, then we think it is not profiled and will exclude this sample
                 return _.some(_.map(selectedMolecularProfileIds, (selectedMolecularProfileId) => {
                     return isSampleProfiled(sampleKey, selectedMolecularProfileId, notGroupedOql.gene, coverageInformation);
                 }) , (profiled) => profiled === false);
-            });
+            }));
             result[getSingleGeneResultKey(key, oqlQuery, notGroupedOql)] = samples.map((sample: Sample) => {
-                if (unProfiledSampleKeys.includes(sample.uniqueSampleKey)) {
-                    return undefined;
+                if (sample.uniqueSampleKey in unProfiledSampleKeysMap) {
+                    return AlteredStatus.UNPROFILED;
+                } else if (sample.uniqueSampleKey in sampleKeysMap) {
+                    return AlteredStatus.ALTERED;
+                } else {
+                    return AlteredStatus.UNALTERED;
                 }
-                return sampleKeys.includes(sample.uniqueSampleKey);
             });
         }
         //2: is group
         else {
             const groupedOql = element.oql as MergedTrackLineFilterOutput<AnnotatedExtendedAlteration>;
-            const sampleKeys = _.map(_.flatten(_.map(groupedOql.list, (list) => list.data)), (data) => data.uniqueSampleKey);
+            const sampleKeysMap = _.keyBy(_.map(_.flatten(_.map(groupedOql.list, (list) => list.data)), (data) => data.uniqueSampleKey));
             const groupGenes = _.map(groupedOql.list, (oql) => oql.gene);
-            const unProfiledSampleKeys = samples.map((sample) => sample.uniqueSampleKey).filter((sampleKey) => {
+            const unProfiledSampleKeysMap = _.keyBy(samples.map((sample) => sample.uniqueSampleKey).filter((sampleKey) => {
                 // if not profiled in some genes molecular profile, then we think it is not profiled and will exclude this sample
                 return _.some(_.map(selectedMolecularProfileIds, (selectedMolecularProfileId) => {
                     // if not profiled in every genes, then the sample is not profiled, or we think it is profiled
@@ -448,12 +452,15 @@ export function getSampleAlteredMap(filteredAlterationData: IQueriedMergedTrackC
                         return isSampleProfiled(sampleKey, selectedMolecularProfileId, gene, coverageInformation);
                     }), (profiled) => profiled === false);
                 }) , (notProfiled) => notProfiled === true);
-            });
+            }));
             result[getMultipleGeneResultKey(groupedOql)] = samples.map((sample: Sample) => {
-                if (unProfiledSampleKeys.includes(sample.uniqueSampleKey)) {
-                    return undefined;
+                if (sample.uniqueSampleKey in unProfiledSampleKeysMap) {
+                    return AlteredStatus.UNPROFILED;
+                } else if (sample.uniqueSampleKey in sampleKeysMap) {
+                    return AlteredStatus.ALTERED;
+                } else {
+                    return AlteredStatus.UNALTERED;
                 }
-                return sampleKeys.includes(sample.uniqueSampleKey);
             });
         }
     });

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.spec.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.spec.tsx
@@ -123,6 +123,19 @@ describe("MutualExclusivityUtil", () => {
         it("returns [2, 0, 0, 0] for [false, false] and [false, false]", () => {
             assert.deepEqual(countOccurences([false, false], [false, false]), [2, 0, 0, 0]);
         });
+
+        it("returns [1, 0, 1, 1] for [undefined, undefined, true, false] and [true, true, false, false]", () => {
+            assert.deepEqual(countOccurences([undefined, undefined, true, false], [true, true, false, false]), [1, 0, 1, 0]);
+        });
+
+        it("returns [0, 0, 0, 0] for [undefined, undefined, true, false] and [true, true, undefined, undefined]", () => {
+            assert.deepEqual(countOccurences([undefined, undefined, true, false], [true, true, undefined, undefined]), [0, 0, 0, 0]);
+        });
+        
+        it("returns [0, 0, 0, 0] for [undefined, undefined, undefined, undefined] and [true, true, false, false]", () => {
+            assert.deepEqual(countOccurences([undefined, undefined, undefined, undefined], [true, true, false, false]), [0, 0, 0, 0]);
+        });
+
     });
 
     describe("#calculatePValue()", () => {

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.spec.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import * as _ from 'lodash';
 import {
     calculateAssociation, countOccurences, calculatePValue, calculateLogOddsRatio, getMutuallyExclusiveCounts,
-    getTrackPairsCountText, getData, getFilteredData, formatPValue, formatQValueWithStyle, formatLogOddsRatio, calculateAdjustedPValue
+    getTrackPairsCountText, getData, getFilteredData, formatPValue, formatQValueWithStyle, formatLogOddsRatio, calculateAdjustedPValue, AlteredStatus
 } from "./MutualExclusivityUtil";
 import { MutualExclusivity } from "../../../shared/model/MutualExclusivity";
 import expect from 'expect';
@@ -90,10 +90,10 @@ const exampleData = [
 ];
 
 const isSampleAlteredMap: any = {
-    "EGFR": [true, false, true, true, false, false, true, true, false, false],
-    "KRAS": [false, true, false, false, true, true, false, false, true, true],
-    "TP53": [false, false, false, false, false, true, false, false, true, true],
-    "BRAF": [false, false, false, true, false, true, false, false, true, true]
+    "EGFR": [AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED],
+    "KRAS": [AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED],
+    "TP53": [AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED],
+    "BRAF": [AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED]
 };
 
 describe("MutualExclusivityUtil", () => {
@@ -112,28 +112,28 @@ describe("MutualExclusivityUtil", () => {
     });
 
     describe("#countOccurences()", () => {
-        it("returns [1, 0, 0, 1] for [false, true] and [false, true]", () => {
-            assert.deepEqual(countOccurences([false, true], [false, true]), [1, 0, 0, 1]);
+        it("returns [1, 0, 0, 1] for [AlteredStatus.UNALTERED, AlteredStatus.ALTERED] and [AlteredStatus.UNALTERED, AlteredStatus.ALTERED]", () => {
+            assert.deepEqual(countOccurences([AlteredStatus.UNALTERED, AlteredStatus.ALTERED], [AlteredStatus.UNALTERED, AlteredStatus.ALTERED]), [1, 0, 0, 1]);
         });
 
-        it("returns [1, 1, 1, 1] for [false, true, false, true] and [false, true, true, false]", () => {
-            assert.deepEqual(countOccurences([false, true, false, true], [false, true, true, false]), [1, 1, 1, 1]);
+        it("returns [1, 1, 1, 1] for [AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED] and [AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED]", () => {
+            assert.deepEqual(countOccurences([AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.ALTERED], [AlteredStatus.UNALTERED, AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED]), [1, 1, 1, 1]);
         });
 
-        it("returns [2, 0, 0, 0] for [false, false] and [false, false]", () => {
-            assert.deepEqual(countOccurences([false, false], [false, false]), [2, 0, 0, 0]);
+        it("returns [2, 0, 0, 0] for [AlteredStatus.UNALTERED, AlteredStatus.UNALTERED] and [AlteredStatus.UNALTERED, AlteredStatus.UNALTERED]", () => {
+            assert.deepEqual(countOccurences([AlteredStatus.UNALTERED, AlteredStatus.UNALTERED], [AlteredStatus.UNALTERED, AlteredStatus.UNALTERED]), [2, 0, 0, 0]);
         });
 
-        it("returns [1, 0, 1, 1] for [undefined, undefined, true, false] and [true, true, false, false]", () => {
-            assert.deepEqual(countOccurences([undefined, undefined, true, false], [true, true, false, false]), [1, 0, 1, 0]);
+        it("returns [1, 0, 1, 1] for [AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED] and [AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED]", () => {
+            assert.deepEqual(countOccurences([AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED], [AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED]), [1, 0, 1, 0]);
         });
 
-        it("returns [0, 0, 0, 0] for [undefined, undefined, true, false] and [true, true, undefined, undefined]", () => {
-            assert.deepEqual(countOccurences([undefined, undefined, true, false], [true, true, undefined, undefined]), [0, 0, 0, 0]);
+        it("returns [0, 0, 0, 0] for [AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED] and [AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED]", () => {
+            assert.deepEqual(countOccurences([AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED], [AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED]), [0, 0, 0, 0]);
         });
         
-        it("returns [0, 0, 0, 0] for [undefined, undefined, undefined, undefined] and [true, true, false, false]", () => {
-            assert.deepEqual(countOccurences([undefined, undefined, undefined, undefined], [true, true, false, false]), [0, 0, 0, 0]);
+        it("returns [0, 0, 0, 0] for [AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED] and [AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED]", () => {
+            assert.deepEqual(countOccurences([AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED, AlteredStatus.UNPROFILED], [AlteredStatus.ALTERED, AlteredStatus.ALTERED, AlteredStatus.UNALTERED, AlteredStatus.UNALTERED]), [0, 0, 0, 0]);
         });
 
     });
@@ -296,7 +296,7 @@ describe("MutualExclusivityUtil", () => {
 
     describe("#getFilteredData()", () => {
         it("returns the data correctly", () => {
-
+            
             const result = getFilteredData(exampleData, true, false, true);
             assert.deepEqual(result,
                 [

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.tsx
@@ -10,7 +10,7 @@ export function calculateAssociation(logOddsRatio: number): string {
     return logOddsRatio > 0 ? "Co-occurrence" : "Mutual exclusivity";
 }
 
-export function countOccurences(valuesA: boolean[], valuesB: boolean[]): [number, number, number, number] {
+export function countOccurences(valuesA: (boolean | undefined)[], valuesB: (boolean | undefined)[]): [number, number, number, number] {
 
     let neither = 0;
     let bNotA = 0;
@@ -18,7 +18,10 @@ export function countOccurences(valuesA: boolean[], valuesB: boolean[]): [number
     let both = 0;
 
     valuesA.forEach((valueA, index) => {
-
+        // jump over this comparison if there is undefined value(not profiled value)
+        if (valueA === undefined || valuesB[index] === undefined) {
+            return true;
+        }
         const valueB = valuesB[index];
         if (!valueA && !valueB) {
             neither++;
@@ -97,7 +100,7 @@ export function getCountsText(data: MutualExclusivity[]): JSX.Element {
             coOccurentCounts[1]}.</p>;
 }
 
-export function getData(isSampleAlteredMap: Dictionary<boolean[]>): MutualExclusivity[] {
+export function getData(isSampleAlteredMap: Dictionary<(boolean | undefined)[]>): MutualExclusivity[] {
 
     let data: MutualExclusivity[] = [];
     const combinations: string[][] = (Combinatorics as any).bigCombination(Object.keys(isSampleAlteredMap), 2).toArray();

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.tsx
@@ -5,6 +5,7 @@ import {calculateQValues} from "../../../shared/lib/calculation/BenjaminiHochber
 import Combinatorics from 'js-combinatorics';
 import Dictionary = _.Dictionary;
 import * as _ from 'lodash';
+import { SampleAlteredMap } from '../ResultsViewPageStoreUtils';
 
 export enum AlteredStatus {
     UNPROFILED = "unprofiled",
@@ -172,4 +173,16 @@ export function formatLogOddsRatio(logOddsRatio: number): string {
         return ">3";
     }
     return logOddsRatio.toFixed(3);
+}
+
+export function getSampleAlteredFilteredMap(isSampleAlteredMap: SampleAlteredMap): SampleAlteredMap {
+    const filteredMap : SampleAlteredMap = {};
+    _.forIn(isSampleAlteredMap, (alteredStatus, trackOql) => {
+        if (alteredStatus && alteredStatus.length > 0) {
+            if (alteredStatus.filter((status) => status != AlteredStatus.UNPROFILED).length > 0) {
+                filteredMap[trackOql] = alteredStatus;
+            }
+        }
+    });
+    return filteredMap;
 }

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityUtil.tsx
@@ -6,11 +6,17 @@ import Combinatorics from 'js-combinatorics';
 import Dictionary = _.Dictionary;
 import * as _ from 'lodash';
 
+export enum AlteredStatus {
+    UNPROFILED = "unprofiled",
+    ALTERED = "altered",
+    UNALTERED = "unaltered"
+}
+
 export function calculateAssociation(logOddsRatio: number): string {
     return logOddsRatio > 0 ? "Co-occurrence" : "Mutual exclusivity";
 }
 
-export function countOccurences(valuesA: (boolean | undefined)[], valuesB: (boolean | undefined)[]): [number, number, number, number] {
+export function countOccurences(valuesA: AlteredStatus[], valuesB: AlteredStatus[]): [number, number, number, number] {
 
     let neither = 0;
     let bNotA = 0;
@@ -18,16 +24,16 @@ export function countOccurences(valuesA: (boolean | undefined)[], valuesB: (bool
     let both = 0;
 
     valuesA.forEach((valueA, index) => {
-        // jump over this comparison if there is undefined value(not profiled value)
-        if (valueA === undefined || valuesB[index] === undefined) {
+        // jump over this comparison if there is a unprofiled value
+        if (valueA === AlteredStatus.UNPROFILED || valuesB[index] === AlteredStatus.UNPROFILED) {
             return true;
         }
         const valueB = valuesB[index];
-        if (!valueA && !valueB) {
+        if (valueA === AlteredStatus.UNALTERED && valueB === AlteredStatus.UNALTERED) {
             neither++;
-        } else if (!valueA && valueB) {
+        } else if (valueA === AlteredStatus.UNALTERED && valueB === AlteredStatus.ALTERED) {
             bNotA++;
-        } else if (valueA && !valueB) {
+        } else if (valueA === AlteredStatus.ALTERED && valueB === AlteredStatus.UNALTERED) {
             aNotB++;
         } else {
             both++;
@@ -100,7 +106,7 @@ export function getCountsText(data: MutualExclusivity[]): JSX.Element {
             coOccurentCounts[1]}.</p>;
 }
 
-export function getData(isSampleAlteredMap: Dictionary<(boolean | undefined)[]>): MutualExclusivity[] {
+export function getData(isSampleAlteredMap: Dictionary<AlteredStatus[]>): MutualExclusivity[] {
 
     let data: MutualExclusivity[] = [];
     const combinations: string[][] = (Combinatorics as any).bigCombination(Object.keys(isSampleAlteredMap), 2).toArray();

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
@@ -24,6 +24,7 @@ import {countMutations, mutationCountByPositionKey} from "../../../resultsView/m
 import {Mutation, MutationCountByPosition} from "../../../../shared/api/generated/CBioPortalAPI";
 import {SampleAlteredMap} from "../../../resultsView/ResultsViewPageStoreUtils";
 import {CancerGene} from "shared/api/generated/OncoKbAPI";
+import { AlteredStatus } from "pages/resultsView/mutualExclusivity/MutualExclusivityUtil";
 
 export type OncoprinterDriverAnnotationSettings = Pick<DriverAnnotationSettings, "ignoreUnknown" | "hotspots" | "cbioportalCount" | "cbioportalCountThreshold" | "oncoKb" | "driversAnnotated">;
 
@@ -290,9 +291,11 @@ export default class OncoprinterStore {
                 map[next.label] = this.sampleIds.map(sampleId=>{
                     const datum = sampleToDatum[sampleId];
                     if (!datum) {
-                        return false;
+                        return AlteredStatus.UNPROFILED;
+                    } else if (datum.data.length > 0) {
+                        return AlteredStatus.ALTERED;
                     } else {
-                        return datum.data.length > 0;
+                        return AlteredStatus.UNALTERED;
                     }
                 });
                 return map;


### PR DESCRIPTION
Update mutex tab(exclude unprofiled samples)
Fix # https://github.com/cbioportal/cbioportal/issues/6033.

Proposed changes:
a. exclude unprofiled oql track add a warning when oql is not profiled in all samples
![image](https://user-images.githubusercontent.com/15748980/59460745-ceee4c80-8ded-11e9-89b0-5aad301c66c2.png)

b. change alert when there are less than 2 available oql
![image](https://user-images.githubusercontent.com/15748980/59460837-ffce8180-8ded-11e9-8ba2-ea53fe6dfd01.png)

