### PR TITLE
Fix CircleCI caching e2e+unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ run_e2e_and_save_artifacts: &run_e2e_and_save_artifacts
           sudo npm install --global yarn@1.13.0
     - attach_workspace:
         at: /tmp/
+    - checkout
     - run:
         name: "Spin up frontend over ssl if necessary and run end to end tests"
         command: |
@@ -126,6 +127,7 @@ jobs:
             sudo npm install --global yarn@1.13.0
       - attach_workspace:
           at: /tmp/
+      - checkout
       # run tests!
       - run:
           command: "yarn run test"

--- a/end-to-end-tests/specs/specUtils.js
+++ b/end-to-end-tests/specs/specUtils.js
@@ -1,4 +1,5 @@
 const clipboardy = require('clipboardy');
+afasfdsa
 
 function waitForOncoprint(timeout) {
     browser.pause(100); // give oncoprint time to disappear


### PR DESCRIPTION
the e2e and unit tests were also cached based on the source code changes instead of just the compiled artifacts