### PR TITLE
changing warning message for overlapping studies

### DIFF
--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -171,7 +171,7 @@ export default class StudyList extends QueryStoreComponent<IStudyListProps, {}>
             <DefaultTooltip
                 mouseEnterDelay={0}
                 placement="top"
-                overlay={<div>This study may share samples with another selected study.</div>}
+                overlay={<div>This study has overlapping data with another selected study.</div>}
             >
                 <i className="fa fa-exclamation-triangle"></i>
             </DefaultTooltip>


### PR DESCRIPTION
changing warning message for overlapping studies
Fix # https://github.com/cBioPortal/cbioportal/issues/6103.

Changes proposed in this pull request:
- Change to "This study may share samples with another selected study" to "This study has overlapping data with another selected study."
![image](https://user-images.githubusercontent.com/15748980/57726309-1ea9ee80-765d-11e9-8891-fa231d131b54.png)
