### PR TITLE
Optimize group combinations calculation for Upset

### DIFF
--- a/src/pages/groupComparison/GroupComparisonUtils.spec.ts
+++ b/src/pages/groupComparison/GroupComparisonUtils.spec.ts
@@ -2,107 +2,39 @@ import chai, {assert, expect} from 'chai';
 import {
     caseCounts,
     caseCountsInParens,
-    ComparisonGroup, convertPatientsStudiesAttrToSamples, excludePatients, excludeSamples,
+    ComparisonGroup,
+    convertPatientsStudiesAttrToSamples,
+    excludePatients,
+    excludeSamples,
     finalizeStudiesAttr,
-    getCombinations, getNumPatients,
+    getNumPatients,
     getNumSamples,
     getOverlapFilteredGroups,
     getOverlappingPatients,
-    getOverlappingSamples, getPatientIdentifiers,
+    getOverlappingSamples,
+    getPatientIdentifiers,
     getSampleIdentifiers,
     getStackedBarData,
     getStudyIds,
-    getVennPlotData, intersectPatients, intersectSamples, isGroupEmpty,
-    OverlapFilteredComparisonGroup, sortDataIntoQuartiles, unionPatients, unionSamples
+    getVennPlotData,
+    intersectPatients,
+    intersectSamples,
+    isGroupEmpty,
+    OverlapFilteredComparisonGroup,
+    sortDataIntoQuartiles,
+    unionPatients,
+    unionSamples
 } from './GroupComparisonUtils';
 import deepEqualInAnyOrder from "deep-equal-in-any-order";
 import ComplexKeySet from "../../shared/lib/complexKeyDataStructures/ComplexKeySet";
-import ListIndexedMap from "../../shared/lib/ListIndexedMap";
 import {Sample} from "../../shared/api/generated/CBioPortalAPI";
 import ComplexKeyMap from "../../shared/lib/complexKeyDataStructures/ComplexKeyMap";
 import {assertDeepEqualInAnyOrder} from "../../shared/lib/SpecUtils";
-import _ from "lodash";
 import ComplexKeyGroupsMap from "../../shared/lib/complexKeyDataStructures/ComplexKeyGroupsMap";
 
 chai.use(deepEqualInAnyOrder);
 
 describe('GroupComparisonUtils', () => {
-
-    describe('getCombinations', () => {
-        it('when empty groups', () => {
-            assert.deepEqual(getCombinations([]), [])
-        });
-
-        it('when there are no overlapping groups', () => {
-            assert.deepEqual(
-                getCombinations([{
-                    uid: '1',
-                    cases: ['1-1', '1-2']
-                }, {
-                    uid: '2',
-                    cases: ['2-1']
-                }]), [
-                    { groups: ['1'], cases: ['1-1', '1-2'] },
-                    { groups: ['1', '2'], cases: [] },
-                    { groups: ['2'], cases: ['2-1'] }
-                ]);
-        });
-
-        it('when there are one or more overlapping groups', () => {
-            assert.deepEqual(
-                getCombinations([{
-                    uid: '1',
-                    cases: ['1-1', '1-2']
-                }, {
-                    uid: '2',
-                    cases: ['1-1']
-                }]), [
-                    { groups: ['1'], cases: ['1-1', '1-2'] },
-                    { groups: ['1', '2'], cases: ['1-1'] },
-                    { groups: ['2'], cases: ['1-1'] }
-                ]);
-
-            assert.deepEqual(
-                getCombinations([{
-                    uid: '1',
-                    cases: ['1-1', '1-2']
-                }, {
-                    uid: '2',
-                    cases: ['1-1', '1-3']
-                }, {
-                    uid: '3',
-                    cases: ['1-1', '1-2', '1-3']
-                }]), [
-                    { groups: ['1'], cases: ['1-1', '1-2'] },
-                    { groups: ['1', '2'], cases: ['1-1'] },
-                    { groups: ['1', '2', '3'], cases: ['1-1'] },
-                    { groups: ['1', '3'], cases: ['1-1', '1-2'] },
-                    { groups: ['2'], cases: ['1-1', '1-3'] },
-                    { groups: ['2', '3'], cases: ['1-1', '1-3'] },
-                    { groups: ['3'], cases: ['1-1', '1-2', '1-3'] }
-                ]);
-
-            assert.deepEqual(
-                getCombinations([{
-                    uid: '1',
-                    cases: ['1-1', '1-2']
-                }, {
-                    uid: '2',
-                    cases: ['1-2', '1-3']
-                }, {
-                    uid: '3',
-                    cases: ['1-3', '1-1']
-                }]), [
-                    { groups: ['1'], cases: ['1-1', '1-2'] },
-                    { groups: ['1', '2'], cases: ['1-2'] },
-                    { groups: ['1', '2', '3'], cases: [] },
-                    { groups: ['1', '3'], cases: ['1-1'] },
-                    { groups: ['2'], cases: ['1-2', '1-3'] },
-                    { groups: ['2', '3'], cases: ['1-3'] },
-                    { groups: ['3'], cases: ['1-3', '1-1'] }
-                ]);
-        });
-    });
 
     describe('getStackedBarData', () => {
         const uidToGroup = {

--- a/src/pages/groupComparison/GroupComparisonUtils.tsx
+++ b/src/pages/groupComparison/GroupComparisonUtils.tsx
@@ -1,9 +1,8 @@
 import {MobxPromise} from 'mobxpromise/dist/src/MobxPromise';
-import {ClinicalAttribute, PatientIdentifier, Sample, SampleIdentifier} from "../../shared/api/generated/CBioPortalAPI";
+import {PatientIdentifier, Sample, SampleIdentifier} from "../../shared/api/generated/CBioPortalAPI";
 import _ from "lodash";
 import {
     ClinicalDataEnrichment,
-    ClinicalDataIntervalFilterValue,
     CopyNumberGeneFilterElement,
     StudyViewFilter
 } from "../../shared/api/generated/CBioPortalAPIInternal";
@@ -54,25 +53,6 @@ export type OverlapFilteredComparisonGroup = ComparisonGroup & {
 export type ClinicalDataEnrichmentWithQ = ClinicalDataEnrichment & { qValue:number };
 
 export type CopyNumberEnrichment = AlterationEnrichmentWithQ & { value:number };
-
-export function getCombinations(groups: { uid: string, cases: string[] }[]) {
-    let combinations: { groups: string[], cases: string[] }[] = [];
-
-    let f = function (res: { groups: string[], cases: string[] }, groups: { uid: string, cases: string[] }[]) {
-        for (let i = 0; i < groups.length; i++) {
-            let currentSet = groups[i];
-            let commonCases = res.groups.length === 0 ? currentSet.cases : _.intersection(res.cases, currentSet.cases)
-            let newSet = {
-                groups: [...res.groups, currentSet.uid],
-                cases: commonCases
-            }
-            combinations.push(newSet);
-            f(newSet, groups.slice(i + 1));
-        }
-    }
-    f({ groups: [], cases: [] }, groups);
-    return combinations;
-}
 
 export const OVERLAP_GROUP_COLOR = "#CCCCCC";
 

--- a/src/pages/groupComparison/Overlap.tsx
+++ b/src/pages/groupComparison/Overlap.tsx
@@ -1,22 +1,16 @@
 import * as React from 'react';
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
-import { observer, Observer } from "mobx-react";
+import {observer} from "mobx-react";
 import GroupComparisonStore from './GroupComparisonStore';
-import { computed, observable } from 'mobx';
+import {observable} from 'mobx';
 import Venn from './OverlapVenn';
 import _ from "lodash";
-import OverlapStackedBar from './OverlapStackedBar';
 import autobind from 'autobind-decorator';
 import DownloadControls from 'shared/components/downloadControls/DownloadControls';
 import {MakeMobxView} from "../../shared/components/MobxView";
 import Loader from "../../shared/components/loadingIndicator/LoadingIndicator";
 import ErrorMessage from "../../shared/components/ErrorMessage";
-import {
-    ENRICHMENTS_NOT_2_GROUPS_MSG,
-    getCombinations,
-    getSampleIdentifiers,
-    OVERLAP_NOT_ENOUGH_GROUPS_MSG
-} from "./GroupComparisonUtils";
+import {getSampleIdentifiers, OVERLAP_NOT_ENOUGH_GROUPS_MSG} from "./GroupComparisonUtils";
 import {remoteData} from "../../shared/api/remoteData";
 import UpSet from './UpSet';
 
@@ -34,9 +28,6 @@ enum PlotType {
 @observer
 export default class Overlap extends React.Component<IOverlapProps, {}> {
 
-    constructor(props: IOverlapProps, context: any) {
-        super(props, context);
-    }
     @observable plotExists = false;
 
     componentDidUpdate() {

--- a/src/pages/groupComparison/OverlapUtils.spec.tsx
+++ b/src/pages/groupComparison/OverlapUtils.spec.tsx
@@ -4,6 +4,8 @@ import expectJSX from 'expect-jsx';
 import * as React from "react";
 expect.extend(expectJSX);
 import {
+    getAllCombinationsOfKey,
+    getCombinations,
     getExcludedIndexes,
     getStudiesAttrForPatientOverlapGroup,
     getStudiesAttrForSampleOverlapGroup,
@@ -16,6 +18,95 @@ import {Sample} from "../../shared/api/generated/CBioPortalAPI";
 import _ from "lodash";
 
 describe("OverlapUtils", () => {
+    describe("getAllCombinationsOfKey", ()=>{
+        it("one", ()=>{
+            assertDeepEqualInAnyOrder(getAllCombinationsOfKey({ a:true}), [{a:true}]);
+        });
+        it("two", ()=>{
+            assertDeepEqualInAnyOrder(getAllCombinationsOfKey({ a:true, b:true}), [
+                {a:true}, {b:true}, {a:true, b:true}
+            ]);
+        });
+        it("three", ()=>{
+            assertDeepEqualInAnyOrder(getAllCombinationsOfKey({ a:true, b:true, c:true}), [
+                {a:true}, {b:true}, {a:true, b:true}, {c:true},
+                {a:true, c:true}, {b:true, c:true}, {a:true, b:true, c:true}
+            ]);
+        });
+    });
+    describe('getCombinations', () => {
+        it('when empty groups', () => {
+            assert.deepEqual(getCombinations([]), [])
+        });
+
+        it('when there are no overlapping groups', () => {
+            assertDeepEqualInAnyOrder(
+                getCombinations([{
+                    uid: '1',
+                    cases: ['1-1', '1-2']
+                }, {
+                    uid: '2',
+                    cases: ['2-1']
+                }]), [
+                    { groups: ['1'], cases: ['1-1', '1-2'] },
+                    { groups: ['2'], cases: ['2-1'] }
+                ]);
+        });
+
+        it('when there are one or more overlapping groups', () => {
+            assertDeepEqualInAnyOrder(
+                getCombinations([{
+                    uid: '1',
+                    cases: ['1-1', '1-2']
+                }, {
+                    uid: '2',
+                    cases: ['1-1']
+                }]), [
+                    { groups: ['1'], cases: ['1-1', '1-2'] },
+                    { groups: ['1', '2'], cases: ['1-1'] },
+                    { groups: ['2'], cases: ['1-1'] }
+                ]);
+
+            assertDeepEqualInAnyOrder(
+                getCombinations([{
+                    uid: '1',
+                    cases: ['1-1', '1-2']
+                }, {
+                    uid: '2',
+                    cases: ['1-1', '1-3']
+                }, {
+                    uid: '3',
+                    cases: ['1-1', '1-2', '1-3']
+                }]), [
+                    { groups: ['1'], cases: ['1-1', '1-2'] },
+                    { groups: ['1', '2'], cases: ['1-1'] },
+                    { groups: ['1', '2', '3'], cases: ['1-1'] },
+                    { groups: ['1', '3'], cases: ['1-1', '1-2'] },
+                    { groups: ['2'], cases: ['1-1', '1-3'] },
+                    { groups: ['2', '3'], cases: ['1-1', '1-3'] },
+                    { groups: ['3'], cases: ['1-1', '1-2', '1-3'] }
+                ]);
+
+            assertDeepEqualInAnyOrder(
+                getCombinations([{
+                    uid: '1',
+                    cases: ['1-1', '1-2']
+                }, {
+                    uid: '2',
+                    cases: ['1-2', '1-3']
+                }, {
+                    uid: '3',
+                    cases: ['1-3', '1-1']
+                }]), [
+                    { groups: ['1'], cases: ['1-1', '1-2'] },
+                    { groups: ['1', '2'], cases: ['1-2'] },
+                    { groups: ['1', '3'], cases: ['1-1'] },
+                    { groups: ['2'], cases: ['1-2', '1-3'] },
+                    { groups: ['2', '3'], cases: ['1-3'] },
+                    { groups: ['3'], cases: ['1-3', '1-1'] }
+                ]);
+        });
+    });
     describe("getExcludedIndexes", ()=>{
         it("empty input", ()=>{
             assert.deepEqual(

--- a/src/pages/groupComparison/UpSet.tsx
+++ b/src/pages/groupComparison/UpSet.tsx
@@ -1,22 +1,21 @@
 import * as React from 'react';
-import { observer, Observer } from "mobx-react";
-import { VictoryChart, VictoryAxis, VictoryBar, VictoryScatter, VictoryLine, VictoryLabel } from 'victory';
-import { computed, observable } from 'mobx';
+import {observer, Observer} from "mobx-react";
+import {VictoryAxis, VictoryBar, VictoryChart, VictoryLabel, VictoryLine, VictoryScatter} from 'victory';
+import {computed, observable} from 'mobx';
 import * as _ from 'lodash';
-import CBIOPORTAL_VICTORY_THEME, { axisTickLabelStyles } from 'shared/theme/cBioPoralTheme';
+import CBIOPORTAL_VICTORY_THEME, {axisTickLabelStyles} from 'shared/theme/cBioPoralTheme';
 import autobind from 'autobind-decorator';
-import { getCombinations, ComparisonGroup } from './GroupComparisonUtils';
+import {ComparisonGroup} from './GroupComparisonUtils';
 import {getTextWidth, truncateWithEllipsis} from 'shared/lib/wrapText';
-import { tickFormatNumeral } from 'shared/components/plots/TickUtils';
-import Timer = NodeJS.Timer;
-import ScatterPlotTooltip from 'shared/components/plots/ScatterPlotTooltip';
-import { joinNames, blendColors } from './OverlapUtils';
-import { pluralize } from 'shared/lib/StringUtils';
-import { getPlotDomain } from './UpSetUtils';
+import {tickFormatNumeral} from 'shared/components/plots/TickUtils';
+import {blendColors, getCombinations, joinNames} from './OverlapUtils';
+import {pluralize} from 'shared/lib/StringUtils';
+import {getPlotDomain} from './UpSetUtils';
 import * as ReactDOM from "react-dom";
 import {Popover} from "react-bootstrap";
 import classnames from "classnames";
 import styles from "../resultsView/survival/styles.module.scss";
+import Timer = NodeJS.Timer;
 
 export interface IUpSetrProps {
     groups: {


### PR DESCRIPTION
Improves the exponential factor of running time from 2^(number of groups) to 2^(maximum number of groups that share a sample), which hopefully most of the time will not be very big, and in particular in queries that come out of a large pie chart it is always =1 for the mutually exclusive groups.