### PR TITLE
group comparison adjustments

### DIFF
--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -758,14 +758,14 @@ export default class GroupComparisonStore {
 
     public readonly patientsVennPartition = remoteData({
         await:()=>[
-            this._originalGroups,
+            this._activeGroupsNotOverlapRemoved,
             this.patientToSamplesSet,
             this.patientKeys
         ],
         invoke:()=>{
             const partitionMap = new ComplexKeyGroupsMap<string>();
             const patientToSamplesSet = this.patientToSamplesSet.result!;
-            const groupToPatientKeys = this._originalGroups.result!.reduce((map, group)=>{
+            const groupToPatientKeys = this._activeGroupsNotOverlapRemoved.result!.reduce((map, group)=>{
                 map[group.uid] = _.keyBy(getPatientIdentifiers([group]).map(id=>{
                     return patientToSamplesSet.get({ studyId: id.studyId, patientId: id.patientId })![0].uniquePatientKey;
                 }));
@@ -774,7 +774,7 @@ export default class GroupComparisonStore {
 
             for (const patientKey of this.patientKeys.result!) {
                 const key:any = {};
-                for (const group of this._originalGroups.result!) {
+                for (const group of this._activeGroupsNotOverlapRemoved.result!) {
                     key[group.uid] = patientKey in groupToPatientKeys[group.uid];
                 }
                 partitionMap.add(key, patientKey);

--- a/src/pages/groupComparison/GroupComparisonUtils.tsx
+++ b/src/pages/groupComparison/GroupComparisonUtils.tsx
@@ -373,7 +373,7 @@ export function MakeEnrichmentsTabUI(
                 return <span>{ENRICHMENTS_TOO_MANY_STUDIES_MSG("protein")}</span>;
             } else {
                 const content:any = [];
-                content.push(<OverlapExclusionIndicator store={store}/>);
+                content.push(<OverlapExclusionIndicator store={store} only="sample"/>);
                 content.push(getEnrichmentsUI().component);
                 return content;
             }

--- a/src/pages/groupComparison/OverlapExclusionIndicator.tsx
+++ b/src/pages/groupComparison/OverlapExclusionIndicator.tsx
@@ -5,6 +5,7 @@ import {caseCounts} from "./GroupComparisonUtils";
 
 export interface IOverlapExclusionIndicatorProps {
     store:GroupComparisonStore;
+    only?:"sample"|"patient"
 }
 
 @observer
@@ -14,14 +15,32 @@ export default class OverlapExclusionIndicator extends React.Component<IOverlapE
             return null;
         } else {
             const selectionInfo = this.props.store._selectionInfo.result!;
-            if (selectionInfo.overlappingSamples.length === 0 && selectionInfo.overlappingPatients.length === 0) {
+            if ((selectionInfo.overlappingPatients.length === 0 && selectionInfo.overlappingSamples.length === 0) ||
+                (this.props.only === "sample" && selectionInfo.overlappingSamples.length === 0) ||
+                (this.props.only === "patient" && selectionInfo.overlappingPatients.length === 0)) {
                 return null;
             }
 
             let iconClass;
             let alertClass;
             let message;
-            const caseCountsSummary = caseCounts(selectionInfo.overlappingSamples.length, selectionInfo.overlappingPatients.length, " and ");
+            let caseCountsSummary = "";
+            switch (this.props.only) {
+                case "sample":
+                case "patient":
+                    let count = 0;
+                    if (this.props.only === "sample") {
+                        count = selectionInfo.overlappingSamples.length;
+                    } else {
+                        count = selectionInfo.overlappingPatients.length;
+                    }
+                    const plural = (count !== 1);
+                    caseCountsSummary = `${count} ${this.props.only}${plural ? "s" : ""}`;
+                    break;
+                default:
+                    caseCountsSummary = caseCounts(selectionInfo.overlappingSamples.length, selectionInfo.overlappingPatients.length, " and ");
+                    break;
+            }
             switch (this.props.store.overlapStrategy) {
                 case OverlapStrategy.INCLUDE:
                     iconClass = "fa-exclamation-triangle";

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -63,7 +63,7 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                 // dont bother loading data for and computing UI if its not valid situation for it
                 return [this.props.store._activeGroupsNotOverlapRemoved];
             } else {
-                return [this.props.store._activeGroupsNotOverlapRemoved, this.survivalUI];
+                return [this.props.store._activeGroupsNotOverlapRemoved, this.survivalUI, this.props.store._selectionInfo];
             }
         },
         render:()=>{
@@ -73,21 +73,24 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                 let content: any = [];
                 switch (this.props.store.overlapStrategy) {
                     case OverlapStrategy.EXCLUDE:
-                        content.push(<OverlapExclusionIndicator store={this.props.store}/>);
+                        content.push(<OverlapExclusionIndicator store={this.props.store} only="patient"/>);
                         break;
                     case OverlapStrategy.INCLUDE:
-                        content.push(
-                            <div className={`alert alert-info`}>
-                                <i
-                                    className={`fa fa-md fa-info-circle`}
-                                    style={{
-                                        color: "#000000",
-                                        marginRight:5
-                                    }}
-                                />
-                                Overlapping samples and patients are graphed in multiple-group curves below.
-                            </div>
-                        );
+                        const selectionInfo = this.props.store._selectionInfo.result!;
+                        if (selectionInfo.overlappingPatients.length > 0) {
+                            content.push(
+                                <div className={`alert alert-info`}>
+                                    <i
+                                        className={`fa fa-md fa-info-circle`}
+                                        style={{
+                                            color: "#000000",
+                                            marginRight:5
+                                        }}
+                                    />
+                                    Overlapping patients are graphed in multiple-group curves below.
+                                </div>
+                            );
+                        }
                         break;
                 }
                 content.push(this.survivalUI.component)


### PR DESCRIPTION
(1) survival tab should only use selected groups for multiple-group curves
(2) tab overlap warnings specify precisely whats filtered out - samples, patients, or both
