### PR TITLE
Enrichments: fix maxWidth calculation on bar chart

### DIFF
--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
@@ -251,7 +251,7 @@ export default class AlterationEnrichmentContainer extends React.Component<IAlte
 
         return (
             <div className={styles.Container}>
-                <div className={styles.ChartsPanel} style={{maxWidth:WindowStore.size.width-20}}>
+                <div className={styles.ChartsPanel} style={{maxWidth:WindowStore.size.width-60}}>
                     {this.isTwoGroupAnalysis && <MiniScatterChart data={getAlterationScatterData(this.data, this.props.store ? this.props.store.hugoGeneSymbols : [])}
                         xAxisLeftLabel={this.volcanoPlotLabels[0]} xAxisRightLabel={this.volcanoPlotLabels[1]} xAxisDomain={15}
                         xAxisTickValues={[-10, 0, 10]}

--- a/src/pages/resultsView/enrichments/GeneBarPlot.tsx
+++ b/src/pages/resultsView/enrichments/GeneBarPlot.tsx
@@ -29,6 +29,8 @@ const SVG_ID = "GroupComparisonGeneFrequencyPlot";
 
 const DEFAULT_GENES_COUNT = 10;
 
+const CHART_BAR_WIDTH = 10;
+
 @observer
 export default class GeneBarPlot extends React.Component<IGeneBarPlotProps, {}> {
 
@@ -180,15 +182,24 @@ export default class GeneBarPlot extends React.Component<IGeneBarPlotProps, {}> 
         return this.props.containerType === AlterationContainerType.MUTATION ? 'Mutation frequency' : 'Copy-number alteration frequency';
     }
 
+    // figure out maxwidth of chart based on data
+    // note: placement of chart inside constained parents may result in scrolling
+    @computed private get maxWidth(){
+        const geneCount = this.barPlotData[0].counts.length;
+        const groupCount = this.barPlotData.length;
+        return ((groupCount + 1) * geneCount * CHART_BAR_WIDTH) + 350;
+    }
+
     public render() {
+
         return (
-            <div data-test="ClinicalTabPlotDiv" className="borderedChart" style={{ overflow: 'auto', overflowY: 'hidden', flexGrow: 1 }}>
+            <div data-test="ClinicalTabPlotDiv" className="borderedChart" style={{ overflow: 'auto', overflowY: 'hidden', flexGrow: 1, maxWidth:this.maxWidth }}>
                 {this.toolbar}
                 <div style={{ position: this.props.isTwoGroupAnalysis ? 'absolute' : 'static' }}>
                     <MultipleCategoryBarPlot
                         svgId={SVG_ID}
-                        barWidth={this.props.isTwoGroupAnalysis ? 10 : 20}
-                        domainPadding={this.props.isTwoGroupAnalysis ? 10 : 20}
+                        barWidth={CHART_BAR_WIDTH}
+                        domainPadding={CHART_BAR_WIDTH}
                         chartBase={300}
                         legendLocationWidthThreshold={800}
                         ticksCount={6}


### PR DESCRIPTION
Calculation was resulting in too great max-width, causing page level horizontal scrolling.