### PR TITLE
Fix comparison session

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -97,7 +97,9 @@ export function getComparisonUrl(params:Partial<GroupComparisonURLQuery>){
 }
 
 export function redirectToComparisonPage(win:Window, params:Partial<GroupComparisonURLQuery>) {
-    (win as any).routingStore.updateRoute(params, "comparison", true);
+    (win as any).location.href = getComparisonUrl(params);
+
+    //(win as any).routingStore.updateRoute(params, "comparison", true);
 }
 
 export function getComparisonLoadingUrl(params?:Partial<GroupComparisonLoadingParams>) {


### PR DESCRIPTION
Instead of using router and inviting strange timing issues, study view should open comparison window to loading state and then set it's location new url when session is determined