### PR TITLE
Fix compilation issue with igv library (needs babelification)

### DIFF
--- a/src/shared/components/igv/IntegrativeGenomicsViewer.tsx
+++ b/src/shared/components/igv/IntegrativeGenomicsViewer.tsx
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 import * as React from "react";
 import $ from "jquery";
-import igv from 'igv/dist/igv.esm.js';
+import igv from 'igv/dist/igv.min.js';
 import autobind from "autobind-decorator";
 
 import onNextRenderFrame from "shared/lib/onNextRenderFrame";

--- a/typings/missing.d.ts
+++ b/typings/missing.d.ts
@@ -38,7 +38,7 @@ declare module 'contrast';
 declare module 'react-spinkit';
 declare module 'react-portal';
 declare module 'little-loader';
-declare module 'igv/dist/igv.esm.js';
+declare module 'igv/dist/igv.min.js';
 declare module 'react-mfb';
 declare module 'regression';
 declare module 'react-select2';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,7 +136,7 @@ var config = {
 
     plugins: [
         new webpack.DefinePlugin({
-            'VERSION': version, 
+            'VERSION': version,
             'COMMIT': commit,
             'IS_DEV_MODE': isDev,
             'ENV_CBIOPORTAL_URL': isDev && process.env.CBIOPORTAL_URL? JSON.stringify(cleanAndValidateUrl(process.env.CBIOPORTAL_URL)) : '"replace_me_env_cbioportal_url"',
@@ -189,7 +189,10 @@ var config = {
                         "presets": ["@babel/preset-env", "@babel/preset-react"]
                     }
                 }],
-                exclude: /node_modules/
+                exclude: function(modulePath) {
+                    return /node_modules/.test(modulePath) &&
+                        !/igv\.min/.test(modulePath);
+                }
             },
             {
                 test: /\.otf(\?\S*)?$/,
@@ -285,7 +288,6 @@ var config = {
                     {loader: 'imports-loader?define=>false'}
                     ]
             },
-
             {
                 test: /\.js$/,
                 enforce:"pre",
@@ -293,8 +295,8 @@ var config = {
                     loader: "source-map-loader",
                 }],
                 exclude: [
-                    /node_modules\/igv\//g,
-                    /node_modules\/svg2pdf.js\//g
+                    /igv\.min/,
+                    /node_modules\/svg2pdf.js\//
                 ]
             }
 


### PR DESCRIPTION
For some reason even supposedly es5 compatible version of lib needs to be run through babel to work in ie11.  Not sure why webpack 4 brought this to surface, but it did