### PR TITLE
Optimize logging output in webpack build for netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,8 @@
   NODE_VERSION = "8.12.0"
   YARN_VERSION = "1.13.0"
   YARN_FLAGS = "--frozen-lockfile"
+  BABEL_CACHE_FOLDER = "/opt/build/cache/"
+  BUILD_REPORT_ERRORS_ONLY = "true"
 
 [[headers]]
 for = "/*.otf"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && cross-env NODE_ENV=development webpack-dev-server",
     "startSSL": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && cross-env NODE_ENV=development webpack-dev-server --https",
     "clean": "rimraf dist tsDist common-dist",
-    "build": "yarn run clean && yarn run compileOqlParser && yarn run buildDLL:prod && cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 webpack --progress --colors",
+    "build": "yarn run clean && yarn run compileOqlParser && yarn run buildDLL:prod && cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 webpack",
     "buildDLL:prod": "yarn run clean && cross-env NODE_ENV=production webpack --config vendor-bundles.webpack.config.js",
     "buildDLL:dev": "yarn run clean && cross-env NODE_ENV=development webpack --config vendor-bundles.webpack.config.js",
     "build:size": "yarn run clean && yarn run buildDLL:prod && cross-env NODE_ENV=production webpack --json > stats.json",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,10 @@ loader:'sass-resources-loader',
 
 var config = {
 
+    stats: {
+        colors:true
+    },
+
     entry: [
         `babel-polyfill`,
         `${path.join(src, 'appBootstrapper.jsx')}`
@@ -121,7 +125,7 @@ var config = {
 
     plugins: [
         new webpack.DefinePlugin({
-            'VERSION': version, 
+            'VERSION': version,
             'COMMIT': commit,
             'IS_DEV_MODE': isDev,
             'ENV_CBIOPORTAL_URL': isDev && process.env.CBIOPORTAL_URL? JSON.stringify(cleanAndValidateUrl(process.env.CBIOPORTAL_URL)) : '"replace_me_env_cbioportal_url"',
@@ -500,6 +504,12 @@ if (isDev || isTest) {
 
 }
 
+// reduce logging to optize netlify build
+if (process.env.BUILD_REPORT_ERRORS_ONLY === "true") {
+    config.stats = 'errors-only'
+};
+
+
 //config.entry.push('bootstrap-loader');
 // END BOOTSTRAP LOADER
 
@@ -526,5 +536,8 @@ if (isTest) {
     config.resolve.alias.sinon = 'sinon/pkg/sinon';
 }
 // End Testing
+
+
+
 
 module.exports = config;


### PR DESCRIPTION
Netlify told us that verbose logging causes builds to be sluggish and timeout on their platform.  