### PR TITLE
Max 20 groups in a comparison session

### DIFF
--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -298,7 +298,6 @@ export default class GroupComparisonStore {
             const sortOrder = stringListToIndexSet(this._originalGroups.result!.map(g=>g.uid));
             let groupsInSortOrder = getOverlapFilteredGroups(groups, { overlappingSamplesSet, overlappingPatientsSet }).concat(_.values(removedGroups));
             groupsInSortOrder = _.sortBy(groupsInSortOrder, g=>sortOrder[g.uid]);
-            console.log(groupsInSortOrder.map(g=>g.nameWithOrdinal));
             return Promise.resolve({
                 groups:groupsInSortOrder,
                 overlappingSamples,

--- a/src/pages/groupComparison/GroupComparisonUtils.tsx
+++ b/src/pages/groupComparison/GroupComparisonUtils.tsx
@@ -58,6 +58,8 @@ export function defaultGroupOrder<T extends Pick<ComparisonGroup, "name">>(group
     return _.sortBy(isNA[1], g=>g.name.toLowerCase()).concat(isNA[0]);
 }
 
+export const MAX_GROUPS_IN_SESSION = 20;
+
 const alphabet = "-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 export function getOrdinals(num:number, base:number) {

--- a/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManager.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManager.tsx
@@ -7,7 +7,7 @@ import autobind from "autobind-decorator";
 import {
     DUPLICATE_GROUP_NAME_MSG,
     getDefaultGroupName,
-    getSampleIdentifiers,
+    getSampleIdentifiers, MAX_GROUPS_IN_SESSION,
     StudyViewComparisonGroup
 } from "../GroupComparisonUtils";
 import {getComparisonLoadingUrl, redirectToComparisonPage} from "../../../shared/api/urls";
@@ -253,11 +253,24 @@ export default class ComparisonGroupManager extends React.Component<IComparisonG
     private get compareButton() {
         if (this.props.store.comparisonGroups.isComplete) {
             // only show if there are enough groups to possibly compare (i.e. 2)
-            const tooltipText = this.props.store.comparisonGroups.result.length >=2 ? "Open a comparison session with selected groups" : "Create at least two groups to open a comparison session";
+            const numSelectedGroups = getSelectedGroups(this.props.store.comparisonGroups.result, this.props.store).length;
+            const wrongNumberOfGroups = numSelectedGroups > MAX_GROUPS_IN_SESSION || numSelectedGroups < 2;
+
+            let tooltipText = "";
+            if (this.props.store.comparisonGroups.result.length >=2) {
+                if (wrongNumberOfGroups) {
+                    tooltipText = `Select between 2 and ${MAX_GROUPS_IN_SESSION} groups to enable comparison.`;
+                } else {
+                    tooltipText = "Open a comparison session with selected groups";
+                }
+            } else {
+                tooltipText = "Create at least two groups to open a comparison session";
+            }
+
             return (
                 <DefaultTooltip overlay={tooltipText}>
                     <button className="btn btn-sm btn-primary"
-                            disabled={getSelectedGroups(this.props.store.comparisonGroups.result, this.props.store).length < 2}
+                            disabled={wrongNumberOfGroups}
                             onClick={async()=>{
                                 // open window before the first `await` call - this makes it a synchronous window.open,
                                 //  which doesnt trigger pop-up blockers. We'll send it to the correct url once we get the result

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -201,6 +201,7 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
                     this.showCustomSelectTooltip = false;
                 }
             }}>
+                {this.store.comparisonConfirmationModal}
                 {this.store.unknownQueriedIds.isComplete &&
                 this.store.unknownQueriedIds.result.length > 0 && (
                     <Alert bsStyle="danger">

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -261,7 +261,6 @@ export class StudyViewPageStore {
     @action
     public setComparisonConfirmationModal(getModal:((hideModal:()=>void)=>JSX.Element)) {
         this._comparisonConfirmationModal = getModal(()=>{this._comparisonConfirmationModal = null; });
-        console.log(this.comparisonConfirmationModal);
     }
 
     // <comparison groups code>

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -253,6 +253,17 @@ export class StudyViewPageStore {
         }
     }
 
+    @observable.ref private _comparisonConfirmationModal:JSX.Element|null = null;
+    public get comparisonConfirmationModal() {
+        return this._comparisonConfirmationModal;
+    }
+    @autobind
+    @action
+    public setComparisonConfirmationModal(getModal:((hideModal:()=>void)=>JSX.Element)) {
+        this._comparisonConfirmationModal = getModal(()=>{this._comparisonConfirmationModal = null; });
+        console.log(this.comparisonConfirmationModal);
+    }
+
     // <comparison groups code>
     private _selectedComparisonGroups = observable.shallowMap<boolean>();
     private _comparisonGroupsMarkedForDeletion = observable.shallowMap<boolean>();

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -216,12 +216,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                 case ChartTypeEnum.TABLE:
                     this.props.openComparisonPage({
                         chartMeta: this.props.chartMeta,
-                        clinicalAttributeValues:(this.props.promise.result! as ClinicalDataCountWithColor[]).map(d=>{
-                            return {
-                                value: d.value,
-                                color: d.color
-                            }
-                        }),
+                        clinicalAttributeValues:(this.props.promise.result! as ClinicalDataCountWithColor[]),
                     });
                     break;
                 case ChartTypeEnum.BAR_CHART:

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -35,6 +35,7 @@ import {ChartTypeEnum, STUDY_VIEW_CONFIG} from "../StudyViewConfig";
 import LoadingIndicator from "../../../shared/components/loadingIndicator/LoadingIndicator";
 import {getComparisonUrl} from "../../../shared/api/urls";
 import {DownloadControlsButton} from "../../../shared/components/downloadControls/DownloadControls";
+import {MAX_GROUPS_IN_SESSION} from "../../groupComparison/GroupComparisonUtils";
 
 export interface AbstractChart {
     toSVGDOMNode: () => Element;
@@ -214,10 +215,17 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
             switch (this.props.chartMeta.chartType) {
                 case ChartTypeEnum.PIE_CHART:
                 case ChartTypeEnum.TABLE:
-                    this.props.openComparisonPage({
-                        chartMeta: this.props.chartMeta,
-                        clinicalAttributeValues:(this.props.promise.result! as ClinicalDataCountWithColor[]),
-                    });
+                    const values = (this.props.promise.result! as ClinicalDataCountWithColor[]);
+                    let openSession = true;
+                    if (values.length > MAX_GROUPS_IN_SESSION) {
+                        openSession = confirm(`Group comparisons are limited to ${MAX_GROUPS_IN_SESSION}. Click OK to create a comparison of the 20 largest groups. Or, you can click to select fewer groups in this chart to compare.`);
+                    }
+                    if (openSession) {
+                        this.props.openComparisonPage({
+                            chartMeta: this.props.chartMeta,
+                            clinicalAttributeValues:(this.props.promise.result! as ClinicalDataCountWithColor[]),
+                        });
+                    }
                     break;
                 case ChartTypeEnum.BAR_CHART:
                     this.props.openComparisonPage({

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -126,7 +126,8 @@ export class StudySummaryTab extends React.Component<IStudySummaryTabProps, {}> 
             onDeleteChart: this.handlers.onDeleteChart,
             isNewlyAdded: this.handlers.isNewlyAdded,
             studyViewFilters: this.store.filters,
-            analysisGroupsSettings: this.store.analysisGroupsSettings
+            analysisGroupsSettings: this.store.analysisGroupsSettings,
+            setComparisonConfirmationModal: this.store.setComparisonConfirmationModal
         };
 
         switch (chartMeta.chartType) {


### PR DESCRIPTION
(1) Prevent more than 20 groups creating a session from the groups dropdown
(2) When creating a session from a large chart, make session only out of the top 20 biggest groups, and confirm with user first

![image](https://user-images.githubusercontent.com/636232/58840400-8ab3bd00-8633-11e9-9b29-e5b23813be00.png)

