### PR TITLE
Gene bar chart align left 15px to prevent overlap

### DIFF
--- a/src/pages/resultsView/enrichments/GeneBarPlot.tsx
+++ b/src/pages/resultsView/enrichments/GeneBarPlot.tsx
@@ -158,7 +158,7 @@ export default class GeneBarPlot extends React.Component<IGeneBarPlotProps, {}> 
     @computed get toolbar() {
         return (
             <React.Fragment>
-                <div style={{ zIndex: 10, position: "absolute", top: "10px", left: "90px" }}>
+                <div style={{ zIndex: 10, position: "absolute", top: "10px", left: "15px" }}>
                         <strong>{ this._label || this.defaultOption.label}</strong>
                 </div>
                 <div style={{ zIndex: 10, position: "absolute", top: "10px", right: "10px" }}>


### PR DESCRIPTION
Make gene bar chart left align 15px to prevent overlapping.