### PR TITLE
Add study tags in the frontend

### DIFF
--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -24,7 +24,8 @@
 import * as React from 'react';
 import DefaultTooltip from '../defaultTooltip/DefaultTooltip';
 import { observer } from 'mobx-react';
-import { observable, computed } from "mobx";
+import { observable } from "mobx";
+import { JsonToTable } from 'react-json-to-table';
 import './StudyTagsTooltip.scss';
 import { remoteData } from '../../api/remoteData';
 import client from "shared/api/cbioportalClientInstance";
@@ -67,8 +68,7 @@ default class BuildOverlay extends React.Component<BuildOverlayTooltipProps, {}>
         else if (this.studyMetadata.isComplete) {
             const resultKeyLength = Object.keys(this.studyMetadata.result).length;
             const description = <div dangerouslySetInnerHTML={this.addHTMLDescription(this.props.studyDescription)}/>;
-            overlay = description; //resultKeyLength > 0 ? ([description, <br/>,
-                //<div className="studyTagsTooltip"> <JsonToTable json={this.studyMetadata.result}/></div>]) : description;
+            overlay = resultKeyLength > 0 ? ([description, <br/>, <div className="studyTagsTooltip"> <JsonToTable json={this.studyMetadata.result}/></div>]) : description;
         }
         else if (this.studyMetadata.isError) {
             overlay = 'error';


### PR DESCRIPTION
This PR introduces the tags feature, removed by mistake after being approved and merged in #1962 by @alisman.

For testing:
- Load the most recent version of `study_es_0`.
- Check that the tags are working by hovering over the info icon in the query page:
![Captura de pantalla 2019-06-07 a les 17 01 07](https://user-images.githubusercontent.com/20278013/59113714-dfae4680-8945-11e9-8805-85bb27a8d530.png)
