### PR TITLE
add tooltip for Co-occurrence Pattern column

### DIFF
--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
@@ -183,7 +183,18 @@ export default class AlterationEnrichmentContainer extends React.Component<IAlte
                           />
                       </div>
                   </DefaultTooltip>;
-              },
+            },
+            tooltip:
+                <table>
+                    <tr>
+                        <td>Upper row</td>
+                        <td>: Samples colored according to group.</td>
+                    </tr>
+                    <tr>
+                        <td>Lower row</td>
+                        <td>: Samples with {this.props.showCNAInTable ? 'the listed alteration' : 'a mutation'} in the listed gene are highlighted.</td>
+                    </tr>
+                </table>,
           });
         }
 


### PR DESCRIPTION
add tooltip for Co-occurrence Pattern column
Fix # https://github.com/cBioPortal/cbioportal/issues/6251.

Changes proposed in this pull request:
- a: mutation tab
![image](https://user-images.githubusercontent.com/15748980/59228719-8e50c200-8ba6-11e9-9ea0-10e12fe792a2.png)

- b: cna tab
![image](https://user-images.githubusercontent.com/15748980/59228730-93157600-8ba6-11e9-87bb-72c4449a8ff7.png)
