### PR TITLE
show first column header when show table in the tooltip

### DIFF
--- a/src/pages/studyView/charts/pieChart/PieChart.tsx
+++ b/src/pages/studyView/charts/pieChart/PieChart.tsx
@@ -249,6 +249,7 @@ export default class PieChart extends React.Component<IPieChartProps, {}> implem
                         width={300}
                         height={150}
                         data={this.props.data}
+                        label={this.props.label}
                         labelDescription={this.props.labelDescription}
                         patientAttribute={this.props.patientAttribute}
                         showAddRemoveAllButtons={true}


### PR DESCRIPTION
show first column header when show table in the tooltip
Fix # https://github.com/cBioPortal/cbioportal/issues/6255.

Changes proposed in this pull request:
- a: show header
![image](https://user-images.githubusercontent.com/15748980/59382455-c3d2e800-8d2b-11e9-80b9-253ad76def1e.png)
