### PR TITLE
First updates to germline filtering in results view

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -333,7 +333,7 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
                     >
                         {
                             (store.studyIdToStudy.isComplete
-                                && store.putativeDriverAnnotatedMutations.isComplete
+                                && store.filteredAndAnnotatedMutations.isComplete
                                 && store.genes.isComplete
                                 && store.coverageInformation.isComplete) &&
                             (<ExpressionWrapper store={store}
@@ -341,7 +341,7 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
                                 genes={store.genes.result}
                                 expressionProfiles={store.expressionProfiles}
                                 numericGeneMolecularDataCache={store.numericGeneMolecularDataCache}
-                                mutations={store.putativeDriverAnnotatedMutations.result!}
+                                mutations={store.filteredAndAnnotatedMutations.result!}
                                 RNASeqVersion={store.expressionTabSeqVersion}
                                 coverageInformation={store.coverageInformation.result}
                                 onRNASeqVersionChange={(version:number)=>store.expressionTabSeqVersion=version}

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -103,7 +103,7 @@ import {
     annotateMolecularDatum,
     computeCustomDriverAnnotationReport,
     computeGenePanelInformation,
-    computePutativeDriverAnnotatedMutations,
+    filterAndAnnotateMutations,
     CoverageInformation,
     fetchQueriedStudies,
     filterSubQueryData,
@@ -347,7 +347,7 @@ export function extendSamplesWithCancerType(samples:Sample[], clinicalDataForSam
 }
 
 export type DriverAnnotationSettings = {
-    ignoreUnknown: boolean;
+    excludeVUS: boolean;
     cbioportalCount:boolean;
     cbioportalCountThreshold:number;
     cosmicCount:boolean;
@@ -385,7 +385,7 @@ export class ResultsViewPageStore {
             _customBinary: undefined,
             _hotspots:false,
             _oncoKb:false,
-            _ignoreUnknown: false,
+            _excludeVUS: false,
 
             set hotspots(val:boolean) {
                 this._hotspots = val;
@@ -399,11 +399,11 @@ export class ResultsViewPageStore {
             get oncoKb() {
                 return AppConfig.serverConfig.show_oncokb && this._oncoKb && !store.didOncoKbFailInOncoprint;
             },
-            set ignoreUnknown(val:boolean) {
-                this._ignoreUnknown = val;
+            set excludeVUS(val:boolean) {
+                this._excludeVUS = val;
             },
-            get ignoreUnknown() {
-                return this._ignoreUnknown && this.driversAnnotated;
+            get excludeVUS() {
+                return this._excludeVUS && this.driversAnnotated;
             },
             get driversAnnotated() {
                 const anySelected = this.oncoKb ||
@@ -453,6 +453,7 @@ export class ResultsViewPageStore {
     @observable expressionTabSeqVersion: number = 2;
 
     public driverAnnotationSettings:DriverAnnotationSettings;
+    @observable public excludeGermlineMutations = false;
 
     @observable.ref public _selectedEnrichmentMutationProfile: MolecularProfile;
     @observable.ref public _selectedEnrichmentCopyNumberProfile: MolecularProfile;
@@ -519,7 +520,7 @@ export class ResultsViewPageStore {
         this.driverAnnotationSettings.driverTiers = observable.map<boolean>();
         (this.driverAnnotationSettings as any)._oncoKb = !!AppConfig.serverConfig.oncoprint_oncokb_default;
         this.driverAnnotationSettings.hotspots = !!AppConfig.serverConfig.oncoprint_hotspots_default;
-        (this.driverAnnotationSettings as any)._ignoreUnknown = !!AppConfig.serverConfig.oncoprint_hide_vus_default;
+        (this.driverAnnotationSettings as any)._excludeVUS = !!AppConfig.serverConfig.oncoprint_hide_vus_default;
     }
 
     private getURL() {
@@ -939,8 +940,8 @@ export class ResultsViewPageStore {
 
     readonly nonOqlFilteredAlterations = remoteData<ExtendedAlteration[]>({
         await: ()=>[
-            this.putativeDriverAnnotatedMutations,
-            this.annotatedMolecularData,
+            this.filteredAndAnnotatedMutations,
+            this.filteredAndAnnotatedMolecularData,
             this.selectedMolecularProfiles,
             this.entrezGeneIdToGene
         ],
@@ -948,8 +949,8 @@ export class ResultsViewPageStore {
             const accessors = new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!);
             const entrezGeneIdToGene = this.entrezGeneIdToGene.result!;
             let result:(AnnotatedMutation|AnnotatedNumericGeneMolecularData)[] = [];
-            result = result.concat(this.putativeDriverAnnotatedMutations.result!);
-            result = result.concat(this.annotatedMolecularData.result!);
+            result = result.concat(this.filteredAndAnnotatedMutations.result!);
+            result = result.concat(this.filteredAndAnnotatedMolecularData.result!);
             return Promise.resolve(result.map(d=>{
                 const extendedD:ExtendedAlteration = annotateAlterationTypes(d, accessors);
                 extendedD.hugoGeneSymbol = entrezGeneIdToGene[d.entrezGeneId].hugoGeneSymbol;
@@ -961,16 +962,16 @@ export class ResultsViewPageStore {
 
     readonly oqlFilteredAlterations = remoteData<ExtendedAlteration[]>({
         await:()=>[
-            this.putativeDriverAnnotatedMutations,
-            this.annotatedMolecularData,
+            this.filteredAndAnnotatedMutations,
+            this.filteredAndAnnotatedMolecularData,
             this.selectedMolecularProfiles,
             this.defaultOQLQuery
         ],
         invoke:()=>{
             if (this.rvQuery.oqlQuery.trim() != "") {
                 let data:(AnnotatedMutation|AnnotatedNumericGeneMolecularData)[] = [];
-                data = data.concat(this.putativeDriverAnnotatedMutations.result!);
-                data = data.concat(this.annotatedMolecularData.result!);
+                data = data.concat(this.filteredAndAnnotatedMutations.result!);
+                data = data.concat(this.filteredAndAnnotatedMolecularData.result!);
                 return Promise.resolve(
                         filterCBioPortalWebServiceData(this.rvQuery.oqlQuery, data, (new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!)), this.defaultOQLQuery.result!)
                 );
@@ -1016,15 +1017,15 @@ export class ResultsViewPageStore {
         IQueriedMergedTrackCaseData[]
     >({
         await: () => [
-            this.putativeDriverAnnotatedMutations,
-            this.annotatedMolecularData,
+            this.filteredAndAnnotatedMutations,
+            this.filteredAndAnnotatedMolecularData,
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
             this.samples,
             this.patients
         ],
         invoke: () => {
-            const data = [...(this.putativeDriverAnnotatedMutations.result!), ...(this.annotatedMolecularData.result!)];
+            const data = [...(this.filteredAndAnnotatedMutations.result!), ...(this.filteredAndAnnotatedMolecularData.result!)];
             const accessorsInstance = new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!);
             const defaultOQLQuery = this.defaultOQLQuery.result!;
             const samples = this.samples.result!;
@@ -1067,8 +1068,8 @@ export class ResultsViewPageStore {
 
     readonly oqlFilteredCaseAggregatedDataByOQLLine = remoteData<IQueriedCaseData<AnnotatedExtendedAlteration>[]>({
         await:()=>[
-            this.putativeDriverAnnotatedMutations,
-            this.annotatedMolecularData,
+            this.filteredAndAnnotatedMutations,
+            this.filteredAndAnnotatedMolecularData,
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
             this.samples,
@@ -1080,7 +1081,7 @@ export class ResultsViewPageStore {
             } else {
                 const filteredAlterationsByOQLLine:OQLLineFilterOutput<AnnotatedExtendedAlteration>[] = filterCBioPortalWebServiceDataByOQLLine(
                     this.rvQuery.oqlQuery,
-                    [...(this.putativeDriverAnnotatedMutations.result!), ...(this.annotatedMolecularData.result!)],
+                    [...(this.filteredAndAnnotatedMutations.result!), ...(this.filteredAndAnnotatedMolecularData.result!)],
                     (new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!)),
                     this.defaultOQLQuery.result!
                 );
@@ -1661,7 +1662,7 @@ export class ResultsViewPageStore {
             // use oql filtering in mutations tab only if query contains mutation oql
             mutations = (this.oqlFilteredAlterations.result || []).filter(a=>isMutation(a));
         } else {
-            mutations = this.putativeDriverAnnotatedMutations.result || [];
+            mutations = this.filteredAndAnnotatedMutations.result || [];
         }
         return _.groupBy(mutations,(mutation:Mutation)=>mutation.gene.hugoGeneSymbol);
     }
@@ -2305,18 +2306,22 @@ export class ResultsViewPageStore {
         }
     });
 
-    readonly putativeDriverAnnotatedMutations = remoteData<AnnotatedMutation[]>({
+    readonly filteredAndAnnotatedMutations = remoteData<AnnotatedMutation[]>({
         await:()=>[
             this.mutations,
             this.getPutativeDriverInfo,
             this.entrezGeneIdToGene
         ],
         invoke:()=>{
-            return Promise.resolve(computePutativeDriverAnnotatedMutations(this.mutations.result!, this.getPutativeDriverInfo.result!, this.entrezGeneIdToGene.result!, !!this.driverAnnotationSettings.ignoreUnknown));
+            return Promise.resolve(filterAndAnnotateMutations(
+                this.mutations.result!, this.getPutativeDriverInfo.result!,
+                this.entrezGeneIdToGene.result!, !!this.driverAnnotationSettings.excludeVUS,
+                this.excludeGermlineMutations
+            ));
         }
     });
 
-    public putativeDriverAnnotatedMutationCache =
+    public filteredAndAnnotatedMutationCache =
         new MobxPromiseCache<{entrezGeneId:number}, AnnotatedMutation[]>(
             q=>({
                 await: ()=>[
@@ -2325,12 +2330,16 @@ export class ResultsViewPageStore {
                     this.entrezGeneIdToGene
                 ],
                 invoke: ()=>{
-                    return Promise.resolve(computePutativeDriverAnnotatedMutations(this.mutationCache.get(q).result!, this.getPutativeDriverInfo.result!, this.entrezGeneIdToGene.result!, !!this.driverAnnotationSettings.ignoreUnknown));
+                    return Promise.resolve(filterAndAnnotateMutations(
+                        this.mutationCache.get(q).result!, this.getPutativeDriverInfo.result!,
+                        this.entrezGeneIdToGene.result!, !!this.driverAnnotationSettings.excludeVUS,
+                        this.excludeGermlineMutations
+                    ));
                 }
             })
         );
 
-    readonly annotatedMolecularData = remoteData<AnnotatedNumericGeneMolecularData[]>({
+    readonly filteredAndAnnotatedMolecularData = remoteData<AnnotatedNumericGeneMolecularData[]>({
         await: ()=>[
             this.molecularData,
             this.entrezGeneIdToGene,
@@ -2346,7 +2355,7 @@ export class ResultsViewPageStore {
                 getOncoKbAnnotation = this.getOncoKbCnaAnnotationForOncoprint.result! as typeof getOncoKbAnnotation;
             }
             const profileIdToProfile = this.molecularProfileIdToMolecularProfile.result!;
-            const ignoreUnknown = !!this.driverAnnotationSettings.ignoreUnknown;
+            const excludeVUS = !!this.driverAnnotationSettings.excludeVUS;
             return Promise.resolve(this.molecularData.result!.reduce((acc:AnnotatedNumericGeneMolecularData[], next)=>{
                     const d = annotateMolecularDatum(
                         next,
@@ -2354,8 +2363,8 @@ export class ResultsViewPageStore {
                         profileIdToProfile,
                         entrezGeneIdToGene
                     );
-                    if (!ignoreUnknown || d.oncoKbOncogenic) { // truthy check - empty string means not driver
-                        // add data if we don't need to filter it out for ignoreUnknown
+                    if (!excludeVUS || d.oncoKbOncogenic) { // truthy check - empty string means not driver
+                        // add data if we don't need to filter it out for excludeVUS
                         acc.push(d);
                     }
                     return acc;

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -6,7 +6,7 @@ import {
 import {
     annotateMolecularDatum,
     annotateMutationPutativeDriver,
-    computeCustomDriverAnnotationReport, computeGenePanelInformation, computePutativeDriverAnnotatedMutations,
+    computeCustomDriverAnnotationReport, computeGenePanelInformation, filterAndAnnotateMutations,
     filterSubQueryData,
     getOncoKbOncogenic,
     initializeCustomDriverAnnotationSettings,
@@ -526,17 +526,18 @@ describe("ResultsViewPageStoreUtils", ()=>{
         });
     });
 
-    describe("computePutativeDriverAnnotatedMutations", ()=>{
+    describe("filterAndAnnotateMutations", ()=>{
         it("returns empty list for empty input", ()=>{
-            assert.deepEqual(computePutativeDriverAnnotatedMutations([], ()=>({}) as any, {}, false), []);
+            assert.deepEqual(filterAndAnnotateMutations([], ()=>({}) as any, {}, false, false), []);
         });
         it("annotates a single mutation", ()=>{
             assert.deepEqual(
-                computePutativeDriverAnnotatedMutations(
+                filterAndAnnotateMutations(
                     [{mutationType:"missense", entrezGeneId:1} as Mutation],
                     ()=>({oncoKb:"", hotspots:true, cbioportalCount:false, cosmicCount:true, customDriverBinary:false}),
                     {1:{ hugoGeneSymbol:"mygene"} as Gene},
-                    true
+                    true,
+                    false
                 ) as Partial<AnnotatedMutation>[],
                 [{
                     mutationType:"missense",
@@ -551,11 +552,12 @@ describe("ResultsViewPageStoreUtils", ()=>{
         });
         it("annotates a few mutations", ()=>{
             assert.deepEqual(
-                computePutativeDriverAnnotatedMutations(
+                filterAndAnnotateMutations(
                     [{mutationType:"missense", entrezGeneId:1} as Mutation, {mutationType:"in_frame_del", entrezGeneId:1} as Mutation, {mutationType:"asdf", entrezGeneId:134} as Mutation],
                     ()=>({oncoKb:"", hotspots:true, cbioportalCount:false, cosmicCount:true, customDriverBinary:false}),
                     {1:{hugoGeneSymbol:"gene1hello"} as Gene, 134:{hugoGeneSymbol:"gene3hello"} as Gene},
-                    true
+                    true,
+                    false
                 ) as Partial<AnnotatedMutation>[],
                 [{
                     mutationType:"missense",
@@ -586,24 +588,61 @@ describe("ResultsViewPageStoreUtils", ()=>{
         });
         it("excludes a single non-annotated mutation", ()=>{
             assert.deepEqual(
-                computePutativeDriverAnnotatedMutations(
+                filterAndAnnotateMutations(
                     [{mutationType:"missense", entrezGeneId:1} as Mutation],
                     ()=>({oncoKb:"", hotspots:false, cbioportalCount:false, cosmicCount:false, customDriverBinary:false}),
                     {1:{hugoGeneSymbol:"gene1hello"} as Gene, 134:{hugoGeneSymbol:"gene3hello"} as Gene},
-                    true
+                    true,
+                    false
                 ),
                 []
             );
         });
         it("excludes non-annotated mutations from a list of a few", ()=>{
             assert.deepEqual(
-                computePutativeDriverAnnotatedMutations(
+                filterAndAnnotateMutations(
                     [{mutationType:"missense", entrezGeneId:1} as Mutation, {mutationType:"in_frame_del", entrezGeneId:1} as Mutation, {mutationType:"asdf", entrezGeneId:134} as Mutation],
                     (m)=>(m.mutationType === "in_frame_del" ?
                         {oncoKb:"", hotspots:false, cbioportalCount:false, cosmicCount:false, customDriverBinary:true}:
                         {oncoKb:"", hotspots:false, cbioportalCount:false, cosmicCount:false, customDriverBinary:false}
                     ),
                     {1:{hugoGeneSymbol:"gene1hello"} as Gene, 134:{hugoGeneSymbol:"gene3hello"} as Gene},
+                    true,
+                    false
+                ) as Partial<AnnotatedMutation>[],
+                [{
+                    mutationType:"in_frame_del",
+                    hugoGeneSymbol:"gene1hello",
+                    entrezGeneId:1,
+                    simplifiedMutationType: getSimplifiedMutationType("in_frame_del"),
+                    isHotspot: false,
+                    oncoKbOncogenic: "",
+                    putativeDriver: true
+                }]
+            );
+        });
+        it("excludes a single germline mutation", ()=>{
+            assert.deepEqual(
+                filterAndAnnotateMutations(
+                    [{mutationType:"missense", entrezGeneId:1, mutationStatus:"germline"} as Mutation],
+                    ()=>({oncoKb:"", hotspots:false, cbioportalCount:false, cosmicCount:false, customDriverBinary:false}),
+                    {1:{hugoGeneSymbol:"gene1hello"} as Gene, 134:{hugoGeneSymbol:"gene3hello"} as Gene},
+                    false,
+                    true
+                ),
+                []
+            );
+        });
+        it("excludes germline mutations from a list of a few", ()=>{
+            assert.deepEqual(
+                filterAndAnnotateMutations(
+                    [{mutationType:"missense", entrezGeneId:1, mutationStatus:"germline"} as Mutation, {mutationType:"in_frame_del", entrezGeneId:1} as Mutation, {mutationType:"asdf", entrezGeneId:134, mutationStatus:"germline"} as Mutation],
+                    (m)=>(m.mutationType === "in_frame_del" ?
+                            {oncoKb:"", hotspots:false, cbioportalCount:false, cosmicCount:false, customDriverBinary:true}:
+                            {oncoKb:"", hotspots:false, cbioportalCount:false, cosmicCount:false, customDriverBinary:false}
+                    ),
+                    {1:{hugoGeneSymbol:"gene1hello"} as Gene, 134:{hugoGeneSymbol:"gene3hello"} as Gene},
+                    false,
                     true
                 ) as Partial<AnnotatedMutation>[],
                 [{

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -799,11 +799,11 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
     }
 
     readonly mutationPromise = remoteData({
-        await:()=>this.props.store.putativeDriverAnnotatedMutationCache.getAll(
+        await:()=>this.props.store.filteredAndAnnotatedMutationCache.getAll(
             getMutationQueries(this.horzSelection, this.vertSelection)
         ),
         invoke: ()=>{
-            return Promise.resolve(_.flatten(this.props.store.putativeDriverAnnotatedMutationCache.getAll(
+            return Promise.resolve(_.flatten(this.props.store.filteredAndAnnotatedMutationCache.getAll(
                 getMutationQueries(this.horzSelection, this.vertSelection)
             ).map(p=>p.result!)).filter(x=>!!x));
         }

--- a/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
+++ b/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
@@ -89,7 +89,7 @@ export default class Oncoprinter extends React.Component<IOncoprinterProps, {}> 
                 return self.props.store.driverAnnotationSettings.cbioportalCount;
             },
             get hidePutativePassengers() {
-                return self.props.store.driverAnnotationSettings.ignoreUnknown;
+                return self.props.store.driverAnnotationSettings.excludeVUS;
             },
             get annotateCBioPortalInputValue() {
                 return self.props.store.driverAnnotationSettings.cbioportalCountThreshold + "";
@@ -142,7 +142,7 @@ export default class Oncoprinter extends React.Component<IOncoprinterProps, {}> 
                 if (!s) {
                     this.props.store.driverAnnotationSettings.oncoKb = false;
                     this.props.store.driverAnnotationSettings.cbioportalCount = false;
-                    this.props.store.driverAnnotationSettings.ignoreUnknown = false;
+                    this.props.store.driverAnnotationSettings.excludeVUS = false;
                 } else {
                     if (!this.controlsState.annotateDriversOncoKbDisabled && !this.controlsState.annotateDriversOncoKbError)
                         this.props.store.driverAnnotationSettings.oncoKb = true;
@@ -164,7 +164,7 @@ export default class Oncoprinter extends React.Component<IOncoprinterProps, {}> 
                 this.controlsHandlers.onSelectAnnotateCBioPortal && this.controlsHandlers.onSelectAnnotateCBioPortal(true);
             }),
             onSelectHidePutativePassengers:(s:boolean)=>{
-                this.props.store.driverAnnotationSettings.ignoreUnknown = s;
+                this.props.store.driverAnnotationSettings.excludeVUS = s;
             },
             onSelectSortByMutationType:(s:boolean)=>{this.sortByMutationType = s;},
             onSelectSortByDrivers:(sort:boolean)=>{this.sortByDrivers=sort;},

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
@@ -26,7 +26,7 @@ import {SampleAlteredMap} from "../../../resultsView/ResultsViewPageStoreUtils";
 import {CancerGene} from "shared/api/generated/OncoKbAPI";
 import { AlteredStatus } from "pages/resultsView/mutualExclusivity/MutualExclusivityUtil";
 
-export type OncoprinterDriverAnnotationSettings = Pick<DriverAnnotationSettings, "ignoreUnknown" | "hotspots" | "cbioportalCount" | "cbioportalCountThreshold" | "oncoKb" | "driversAnnotated">;
+export type OncoprinterDriverAnnotationSettings = Pick<DriverAnnotationSettings, "excludeVUS" | "hotspots" | "cbioportalCount" | "cbioportalCountThreshold" | "oncoKb" | "driversAnnotated">;
 
 /* Leaving commented only for reference, this will be replaced by unified input strategy
 function genomeNexusKey(l:OncoprinterInputLineType3_Incomplete){
@@ -352,7 +352,7 @@ export default class OncoprinterStore {
             this.nonAnnotatedGeneticTrackData.result!,
             this.annotationData.promisesMap,
             this.annotationData.params,
-            this.driverAnnotationSettings.ignoreUnknown
+            this.driverAnnotationSettings.excludeVUS
         )
     });
 

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterUtils.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterUtils.ts
@@ -76,7 +76,7 @@ export function initDriverAnnotationSettings(store:OncoprinterStore) {
         cbioportalCount: false,
         cbioportalCountThreshold: 0,
         _oncoKb:true,
-        _ignoreUnknown: false,
+        _excludeVUS: false,
         hotspots: false, // for now
 
         set oncoKb(val:boolean) {
@@ -85,11 +85,11 @@ export function initDriverAnnotationSettings(store:OncoprinterStore) {
         get oncoKb() {
             return AppConfig.serverConfig.show_oncokb && this._oncoKb && !store.didOncoKbFail;
         },
-        set ignoreUnknown(val:boolean) {
-            this._ignoreUnknown = val;
+        set excludeVUS(val:boolean) {
+            this._excludeVUS = val;
         },
-        get ignoreUnknown() {
-            return this._ignoreUnknown && this.driversAnnotated;
+        get excludeVUS() {
+            return this._excludeVUS && this.driversAnnotated;
         },
         get driversAnnotated() {
             const anySelected = this.oncoKb ||
@@ -428,7 +428,7 @@ export function annotateGeneticTrackData(
         cbioportalCountThreshold?:number;
         useHotspots:boolean;
     },
-    ignoreUnknown:boolean
+    excludeVUS:boolean
 ) {
     // build annotater functions
     let getOncoKbCnaAnnotation = (d:OncoprinterGeneticTrackDatum_Data)=>"";
@@ -502,7 +502,7 @@ export function annotateGeneticTrackData(
                 if (d.molecularProfileAlterationType === AlterationTypeConstants.MUTATION_EXTENDED) {
                     // tag mutations as putative driver, and filter them
                     d.putativeDriver = !!(d.oncoKbOncogenic || (params.useHotspots && d.isHotspot) || getCBioAnnotation(d));
-                    return (!ignoreUnknown || d.putativeDriver);
+                    return (!excludeVUS || d.putativeDriver);
                 } else {
                     return true;
                 }

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -179,7 +179,6 @@ export function makeGeneticTrackData(
     samples:Sample[],
     genePanelInformation:CoverageInformation,
     selectedMolecularProfiles:MolecularProfile[],
-    hideGermlineMutations?:boolean
 ):GeneticTrackDatum[];
 
 export function makeGeneticTrackData(
@@ -188,7 +187,6 @@ export function makeGeneticTrackData(
     patients:Patient[],
     genePanelInformation:CoverageInformation,
     selectedMolecularProfiles:MolecularProfile[],
-    hideGermlineMutations?:boolean
 ):GeneticTrackDatum[];
 
 export function makeGeneticTrackData(
@@ -197,7 +195,6 @@ export function makeGeneticTrackData(
     cases:Sample[]|Patient[],
     genePanelInformation:CoverageInformation,
     selectedMolecularProfiles:MolecularProfile[],
-    hideGermlineMutations?:boolean
 ):GeneticTrackDatum[] {
     if (!cases.length) {
         return [];
@@ -230,9 +227,6 @@ export function makeGeneticTrackData(
             newDatum.not_profiled_in = newDatum.not_profiled_in.concat(sampleSequencingInfo.notProfiledAllGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
 
             let sampleData = caseAggregatedAlterationData[sample.uniqueSampleKey];
-            if (hideGermlineMutations) {
-                sampleData = sampleData.filter(isNotGermlineMutation);
-            }
             ret.push(fillGeneticTrackDatum(
                 newDatum,
                 geneSymbolArray.join(' / '),
@@ -263,9 +257,6 @@ export function makeGeneticTrackData(
             newDatum.not_profiled_in = newDatum.not_profiled_in.concat(patientSequencingInfo.notProfiledAllGenes).filter(p=>!!_selectedMolecularProfiles[p.molecularProfileId]); // filter out coverage information about non-selected profiles
 
             let patientData = caseAggregatedAlterationData[patient.uniquePatientKey];
-            if (hideGermlineMutations) {
-                patientData = patientData.filter(isNotGermlineMutation);
-            }
             ret.push(fillGeneticTrackDatum(
                 newDatum,
                 geneSymbolArray.join(' / '),

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -337,7 +337,6 @@ interface IGeneticTrackAppState {
     sampleMode: boolean;
     samples: Pick<Sample, 'sampleId'|'studyId'|'uniqueSampleKey'>[];
     patients: Pick<Patient, 'patientId'|'studyId'|'uniquePatientKey'>[];
-    hideGermlineMutations:boolean;
     coverageInformation: CoverageInformation;
     sequencedSampleKeysByGene: any;
     sequencedPatientKeysByGene: any;
@@ -370,7 +369,6 @@ export function makeGeneticTrackWith({
     sampleMode,
     samples,
     patients,
-    hideGermlineMutations,
     coverageInformation,
     sequencedSampleKeysByGene,
     sequencedPatientKeysByGene,
@@ -389,8 +387,8 @@ export function makeGeneticTrackWith({
         );
         const dataByCase = caseData.cases;
         const data = (sampleMode
-            ? makeGeneticTrackData(dataByCase.samples, geneSymbolArray, samples as Sample[], coverageInformation, selectedMolecularProfiles, hideGermlineMutations)
-            : makeGeneticTrackData(dataByCase.patients, geneSymbolArray, patients as Patient[], coverageInformation, selectedMolecularProfiles, hideGermlineMutations)
+            ? makeGeneticTrackData(dataByCase.samples, geneSymbolArray, samples as Sample[], coverageInformation, selectedMolecularProfiles)
+            : makeGeneticTrackData(dataByCase.patients, geneSymbolArray, patients as Patient[], coverageInformation, selectedMolecularProfiles)
         );
         const alterationInfo = alterationInfoForOncoprintTrackData(
             sampleMode,
@@ -467,7 +465,6 @@ export function makeGeneticTracksMobxPromise(oncoprint:ResultsViewOncoprint, sam
                 sampleMode,
                 samples: oncoprint.props.store.samples.result!,
                 patients: oncoprint.props.store.patients.result!,
-                hideGermlineMutations: oncoprint.hideGermlineMutations,
                 coverageInformation: oncoprint.props.store.coverageInformation.result!,
                 sequencedSampleKeysByGene: oncoprint.props.store.sequencedSampleKeysByGene.result!,
                 sequencedPatientKeysByGene: oncoprint.props.store.sequencedPatientKeysByGene.result!,

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -86,7 +86,6 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
     @observable sortMode:SortMode = {type:"data"};
 
     @observable distinguishGermlineMutations:boolean = true;
-    @observable hideGermlineMutations:boolean = false;
     @observable distinguishMutationType:boolean = true;
     @observable sortByMutationType:boolean = true;
     @observable sortByDrivers:boolean = true;
@@ -272,10 +271,10 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                 return self.props.store.driverAnnotationSettings.cosmicCount;
             },
             get hidePutativePassengers() {
-                return self.props.store.driverAnnotationSettings.ignoreUnknown;
+                return self.props.store.driverAnnotationSettings.excludeVUS;
             },
             get hideGermlineMutations() {
-                return self.hideGermlineMutations;
+                return self.props.store.excludeGermlineMutations;
             },
             get annotateCBioPortalInputValue() {
                 return self.props.store.driverAnnotationSettings.cbioportalCountThreshold + "";
@@ -417,7 +416,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                     this.props.store.driverAnnotationSettings.driverTiers.forEach((value, key)=>{
                         this.props.store.driverAnnotationSettings.driverTiers.set(key, false);
                     });
-                    this.props.store.driverAnnotationSettings.ignoreUnknown = false;
+                    this.props.store.driverAnnotationSettings.excludeVUS = false;
                 } else {
                     if (!this.controlsState.annotateDriversOncoKbDisabled && !this.controlsState.annotateDriversOncoKbError)
                         this.props.store.driverAnnotationSettings.oncoKb = true;
@@ -461,10 +460,10 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                 this.props.store.driverAnnotationSettings.driverTiers.set(value, checked);
             }),
             onSelectHidePutativePassengers:(s:boolean)=>{
-                this.props.store.driverAnnotationSettings.ignoreUnknown = s;
+                this.props.store.driverAnnotationSettings.excludeVUS = s;
             },
             onSelectHideGermlineMutations:(s:boolean)=>{
-                this.hideGermlineMutations = s;
+                this.props.store.excludeGermlineMutations = s;
             },
             onSelectSortByMutationType:(s:boolean)=>{this.sortByMutationType = s;},
             onClickSortAlphabetical:()=>{
@@ -993,7 +992,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
         const usingHotspot = this.props.store.driverAnnotationSettings.hotspots;
         ret.push({
             label: getAnnotatingProgressMessage(usingOncokb, usingHotspot),
-            promises:[this.props.store.annotatedMolecularData, this.props.store.putativeDriverAnnotatedMutations]
+            promises:[this.props.store.filteredAndAnnotatedMolecularData, this.props.store.filteredAndAnnotatedMutations]
         });
 
         ret.push({

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -748,19 +748,19 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
                                 data-test="HideVUS"
                                 type="checkbox"
                                 value={EVENT_KEY.hidePutativePassengers}
-                                checked={!this.props.state.hidePutativePassengers}
+                                checked={this.props.state.hidePutativePassengers}
                                 onClick={this.onInputClick}
                                 disabled={!this.props.state.distinguishDrivers}
-                            /> Show VUS (variants of unknown significance)
+                            /> Hide VUS (variants of unknown significance)
                         </label></div>
                         <div className="checkbox"><label>
                             <input
                                 data-test="HideGermline"
                                 type="checkbox"
                                 value={EVENT_KEY.hideGermlineMutations}
-                                checked={!this.props.state.hideGermlineMutations}
+                                checked={this.props.state.hideGermlineMutations}
                                 onClick={this.onInputClick}
-                            /> Show germline mutations
+                            /> Hide germline mutations
                         </label></div>
                     </div>
                 </div>


### PR DESCRIPTION
Addresses a few issues from this comment:https://github.com/cBioPortal/cbioportal/issues/6133#issuecomment-503652330

(1) Flip "sign" of checkboxes in oncoprint filter settings
(2) Germline filtering now propagates to all tabs