### PR TITLE
add clinvar column to mutation table

### DIFF
--- a/end-to-end-tests/specs/core/mutationTable.spec.js
+++ b/end-to-end-tests/specs/core/mutationTable.spec.js
@@ -114,4 +114,29 @@ describe('Mutation Table', function() {
 
     });
 
+    describe('try getting ClinVar id from genome nexus', ()=>{
+        before(()=>{
+            var url = `${CBIOPORTAL_URL}/results/mutations?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=brca_broad&case_set_id=brca_broad_sequenced&data_priority=0&gene_list=TP53&geneset_list=%20&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=brca_broad_mutations&tab_index=tab_visualize`;
+
+            goToUrlAndSetLocalStorage(url);
+            // mutations table should be visiable after oncokb icon shows up,
+            // also need to wait for mutations to be sorted properly
+            browser.waitForVisible("tr:nth-child(1) [data-test=oncogenic-icon-image]",30000);
+        });
+
+        it('should show the ClinVar id after adding the ClinVar column', ()=>{
+            // click on column button
+            browser.click("button*=Columns");
+            // scroll down to activated "ClinVar" selection
+            browser.scroll(1000, 1000);
+            // click "clinvar"
+            browser.click('//*[text()="ClinVar ID"]');
+            let res;
+            browser.waitUntil(() => {
+                res =  executeInBrowser( ()=>$('[data-test="clinvar-data"]').length);
+                return res == 25
+            }, 60000, `Failed: There's 25 clinvar rows in table (${res} found)`);
+        });
+    });
+
 });

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -51,7 +51,8 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
             MutationTableColumnType.NUM_MUTATIONS,
             MutationTableColumnType.EXON,
             MutationTableColumnType.HGVSC,
-            MutationTableColumnType.GNOMAD
+            MutationTableColumnType.GNOMAD,
+            MutationTableColumnType.CLINVAR
         ]
     };
 
@@ -97,6 +98,7 @@ export default class ResultsViewMutationTable extends MutationTable<IResultsView
         this._columns[MutationTableColumnType.EXON].order = 230;
         this._columns[MutationTableColumnType.HGVSC].order = 240;
         this._columns[MutationTableColumnType.GNOMAD].order = 260;
+        this._columns[MutationTableColumnType.CLINVAR].order = 270;
 
         // exclude
         this._columns[MutationTableColumnType.CANCER_TYPE].shouldExclude = ()=>{

--- a/src/shared/api/generated/GenomeNexusAPI-docs.json
+++ b/src/shared/api/generated/GenomeNexusAPI-docs.json
@@ -1198,6 +1198,17 @@
         "hgvs": {
           "description": "hgvs",
           "$ref": "#/definitions/Hgvs"
+        },
+        "rcv": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rcv"
+          }
+        },
+        "variantId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "variant_id"
         }
       }
     },
@@ -2010,6 +2021,7 @@
       "type": "object",
       "properties": {
         "clinVar": {
+          "description": "clinvar",
           "$ref": "#/definitions/ClinVar"
         },
         "cosmic": {
@@ -2188,6 +2200,27 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "Rcv": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "accession"
+        },
+        "clinicalSignificance": {
+          "type": "string",
+          "description": "clinical_significance"
+        },
+        "origin": {
+          "type": "string",
+          "description": "origin"
+        },
+        "preferredName": {
+          "type": "string",
+          "description": "preferred_name"
         }
       }
     },

--- a/src/shared/api/generated/GenomeNexusAPI.ts
+++ b/src/shared/api/generated/GenomeNexusAPI.ts
@@ -84,6 +84,10 @@ export type ClinVar = {
 
         'hgvs': Hgvs
 
+        'rcv': Array < Rcv >
+
+        'variantId': number
+
 };
 export type ColocatedVariant = {
     'dbSnpId': string
@@ -491,6 +495,16 @@ export type PtmAnnotation = {
 };
 export type PtmFilter = {
     'transcriptIds': Array < string >
+
+};
+export type Rcv = {
+    'accession': string
+
+        'clinicalSignificance': string
+
+        'origin': string
+
+        'preferredName': string
 
 };
 export type Snpeff = {

--- a/src/shared/api/generated/GenomeNexusAPIInternal-docs.json
+++ b/src/shared/api/generated/GenomeNexusAPIInternal-docs.json
@@ -981,6 +981,17 @@
         "hgvs": {
           "description": "hgvs",
           "$ref": "#/definitions/Hgvs"
+        },
+        "rcv": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rcv"
+          }
+        },
+        "variantId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "variant_id"
         }
       }
     },
@@ -1551,6 +1562,7 @@
       "type": "object",
       "properties": {
         "clinVar": {
+          "description": "clinvar",
           "$ref": "#/definitions/ClinVar"
         },
         "cosmic": {
@@ -1617,6 +1629,27 @@
         "mutationType": {
           "type": "string",
           "description": "Mutation Type e.g. Missense_Mutation"
+        }
+      }
+    },
+    "Rcv": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "accession"
+        },
+        "clinicalSignificance": {
+          "type": "string",
+          "description": "clinical_significance"
+        },
+        "origin": {
+          "type": "string",
+          "description": "origin"
+        },
+        "preferredName": {
+          "type": "string",
+          "description": "preferred_name"
         }
       }
     },

--- a/src/shared/api/generated/GenomeNexusAPIInternal.ts
+++ b/src/shared/api/generated/GenomeNexusAPIInternal.ts
@@ -96,6 +96,10 @@ export type ClinVar = {
 
         'hgvs': Hgvs
 
+        'rcv': Array < Rcv >
+
+        'variantId': number
+
 };
 export type Cosmic = {
     '_license': string
@@ -369,6 +373,16 @@ export type ProteinLocation = {
         'end': number
 
         'mutationType': string
+
+};
+export type Rcv = {
+    'accession': string
+
+        'clinicalSignificance': string
+
+        'origin': string
+
+        'preferredName': string
 
 };
 export type Snpeff = {

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -49,6 +49,7 @@ import { VariantAnnotation } from "shared/api/generated/GenomeNexusAPI";
 import HgvscColumnFormatter from "./column/HgvscColumnFormatter";
 import {CancerGene} from "shared/api/generated/OncoKbAPI";
 import GnomadColumnFormatter from "./column/GnomadColumnFormatter";
+import ClinVarColumnFormatter from "./column/ClinVarColumnFormatter";
 
 export interface IMutationTableProps {
     studyIdToStudy?: {[studyId:string]:CancerStudy};
@@ -125,7 +126,8 @@ export enum MutationTableColumnType {
     NUM_MUTATIONS,
     EXON,
     HGVSC,
-    GNOMAD
+    GNOMAD,
+    CLINVAR
 }
 
 type MutationTableColumn = Column<Mutation[]>&{order?:number, shouldExclude?:()=>boolean};
@@ -544,6 +546,18 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
             download: (d:Mutation[]) => GnomadColumnFormatter.download(d, this.props.genomeNexusMyVariantInfoCache as GenomeNexusMyVariantInfoCache),
             tooltip: (<span><a href="https://gnomad.broadinstitute.org/">gnomAD</a> population allele frequencies. 
             Overall population allele frequency is shown. Hover over a frequency to see the frequency for each specific population.</span>),
+            defaultSortDirection: "desc",
+            visible: false,
+            align: "right"
+        };
+
+        this._columns[MutationTableColumnType.CLINVAR] = {
+            name: "ClinVar ID",
+            render: (d:Mutation[]) => ClinVarColumnFormatter.renderFunction(d, this.props.genomeNexusMyVariantInfoCache as GenomeNexusMyVariantInfoCache),
+            sortBy: (d:Mutation[]) => ClinVarColumnFormatter.getSortValue(d, this.props.genomeNexusMyVariantInfoCache as GenomeNexusMyVariantInfoCache),
+            download: (d:Mutation[]) => ClinVarColumnFormatter.download(d, this.props.genomeNexusMyVariantInfoCache as GenomeNexusMyVariantInfoCache),
+            tooltip: (<span><a href="https://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">ClinVar</a>
+            &nbsp;aggregates information about genomic variation and its relationship to human health.</span>),
             defaultSortDirection: "desc",
             visible: false,
             align: "right"

--- a/src/shared/components/mutationTable/column/ClinVarColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ClinVarColumnFormatter.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import {Circle} from "better-react-spinkit";
+import 'rc-tooltip/assets/bootstrap_white.css';
+import {Mutation} from "shared/api/generated/CBioPortalAPI";
+import {default as TableCellStatusIndicator, TableCellStatus} from "shared/components/TableCellStatus";
+import {MyVariantInfoAnnotation} from 'shared/api/generated/GenomeNexusAPI';
+import GenomeNexusMyVariantInfoCache, { GenomeNexusCacheDataType } from "shared/cache/GenomeNexusMyVariantInfoCache";
+import DefaultTooltip from 'shared/components/defaultTooltip/DefaultTooltip';
+
+export default class ClinVarColumnFormatter {
+    
+    public static renderFunction(data:Mutation[],
+                                genomeNexusMyVariantInfoCache: GenomeNexusMyVariantInfoCache | undefined) {
+        const genomeNexusCacheData = ClinVarColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusMyVariantInfoCache);
+        return (
+            <div data-test="clinvar-data">
+                {ClinVarColumnFormatter.getClinVarDataViz(genomeNexusCacheData)}
+            </div>
+        );
+    }
+
+    private static getGenomeNexusDataFromCache(data:Mutation[], cache:GenomeNexusMyVariantInfoCache | undefined): GenomeNexusCacheDataType | null {
+        if (data.length === 0 || !cache) {
+            return null;
+        }
+        return cache.get(data[0]);
+    }
+
+    private static getClinVarDataViz(genomeNexusCacheData:GenomeNexusCacheDataType | null) {
+        let status:TableCellStatus | null = null;
+
+        if (genomeNexusCacheData === null) {
+            status = TableCellStatus.LOADING;
+        } else if (genomeNexusCacheData.status === "error") {
+            status = TableCellStatus.ERROR;
+        } else if (genomeNexusCacheData.data === null) {
+            status = TableCellStatus.NA;
+        } else {
+            let clinVarId = ClinVarColumnFormatter.getData(genomeNexusCacheData.data.my_variant_info);
+            if (clinVarId == null) {
+                return (
+                    <DefaultTooltip
+                        placement="topRight"
+                        overlay={(<span>Variant has no ClinVar data.</span>)}
+                    >
+                        <span style={{height: '100%', width: '100%', display: 'block', overflow: 'hidden'}}>&nbsp;</span>
+                    </DefaultTooltip>
+                );
+            }
+            else {
+                let clinVarLink = "https://www.ncbi.nlm.nih.gov/clinvar/variation/" + clinVarId + "/";
+                return (
+                    <DefaultTooltip
+                        placement="top"
+                        overlay={(<span>Click to see variant on ClinVar website.</span>)}
+                    >
+                        <span style={{textAlign:"right", float:"right"}}>
+                            <a href={clinVarLink} target="_blank">{clinVarId}</a>
+                        </span>
+                    </DefaultTooltip>
+                );
+            }
+        }
+
+        if (status !== null) {
+            // show loading circle
+            if (status === TableCellStatus.LOADING) {
+                return <Circle size={18} scaleEnd={0.5} scaleStart={0.2} color="#aaa" className="pull-right"/>;
+            } 
+            else {
+                return <TableCellStatusIndicator status={status}/>;
+            }
+        }
+    }
+
+    public static getData(genomeNexusData:  MyVariantInfoAnnotation | null): string | null {
+        if (genomeNexusData && genomeNexusData.annotation && genomeNexusData.annotation.clinVar && genomeNexusData.annotation.clinVar.variantId)
+        {
+            return genomeNexusData.annotation.clinVar.variantId.toString();
+        }
+        else {
+            return null;
+        }
+    }
+
+    public static download(data: Mutation[], genomeNexusMyVariantInfoCache: GenomeNexusMyVariantInfoCache): string {
+        const genomeNexusCacheData = ClinVarColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusMyVariantInfoCache);
+        if (genomeNexusCacheData && genomeNexusCacheData.data) {
+            let clinVarId = ClinVarColumnFormatter.getData(genomeNexusCacheData.data.my_variant_info);   
+            if (clinVarId) {
+                return clinVarId;
+            }
+        }
+        return "";
+    }
+
+    public static getSortValue(data:Mutation[], genomeNexusCache:GenomeNexusMyVariantInfoCache): number | null {
+        const genomeNexusCacheData = ClinVarColumnFormatter.getGenomeNexusDataFromCache(data, genomeNexusCache);
+        if (genomeNexusCacheData && genomeNexusCacheData.data && genomeNexusCacheData.data.my_variant_info) {
+            let clinVarId = ClinVarColumnFormatter.getData(genomeNexusCacheData.data.my_variant_info);
+            if (clinVarId !== null) {
+                return parseInt(clinVarId);
+            }
+        }
+        return null; 
+    }
+}


### PR DESCRIPTION
Add clinvar column to mutation table.

1. shows clinvar id in the column
![image](https://user-images.githubusercontent.com/16869603/60288342-feb74d00-98e1-11e9-88dc-3b79fd01d6ce.png)


2. tootip for each clinVar id (the clinVar id links to https://www.ncbi.nlm.nih.gov/clinvar/variation/43594/
)
![image](https://user-images.githubusercontent.com/16869603/60288349-037c0100-98e2-11e9-9834-d6eb473134d2.png)


3. tooltip when no available data

![image](https://user-images.githubusercontent.com/16869603/60129459-13210b80-9763-11e9-9dd7-4d38625c3656.png)

