### PR TITLE
override Arial with FreeSans when download pdf

### DIFF
--- a/src/shared/lib/svgToPdfDownload.ts
+++ b/src/shared/lib/svgToPdfDownload.ts
@@ -22,11 +22,11 @@ export default function svgToPdfDownload(fileName: string, svg: any) {
     if (height > width) {
         direction = 'p';
     }
-
     const pdf = new jsPDF(direction, 'pt', [width, height]);
 
+    // override Arial with FreeSans to display special charactors
     pdf.addFileToVFS("FreeSans-normal.ttf", font.FreeSans);
-    pdf.addFont("FreeSans-normal.ttf", "FreeSans", "normal");
+    pdf.addFont("FreeSans-normal.ttf", "Arial", "normal");
 
     // render the svg element
     svg2pdf(svg, pdf, {
@@ -34,35 +34,6 @@ export default function svgToPdfDownload(fileName: string, svg: any) {
         yOffset: 0,
         scale: 1
     });
-    pdf.save(fileName);
-}
-
-export function svgToPdfData(svg: Element) : string{
-    const width = svg.scrollWidth || parseInt((svg.attributes.getNamedItem('width') as Attr).nodeValue!), height = svg.scrollHeight || parseInt((svg.attributes.getNamedItem('height') as Attr).nodeValue!);
-    // create a new jsPDF instance
     
-    let direction = 'l';
-    if (height > width) {
-        direction = 'p';
-    }
-
-    const pdf = new jsPDF(direction, 'pt', [width, height]);
-
-    // render the svg element
-    svg2pdf(svg, pdf, {
-        xOffset: 0,
-        yOffset: 0,
-        scale: 1
-    });
-    // return the svg data, we don't need the header
-    pdf.save("");
-    return pdf.output('dataurlstring');
-}
-
-export async function svgToPdfPromise(svg:Element) {
-    const res = await svgToPdfData(svg);
-
-    if(res) {
-        return "";
-    }
+    pdf.save(fileName);
 }

--- a/src/shared/theme/cBioPoralTheme.ts
+++ b/src/shared/theme/cBioPoralTheme.ts
@@ -41,7 +41,7 @@ const baseProps = {
 // * Labels
 // *
 export const baseLabelStyles = {
-    fontFamily: `FreeSans, ${sansSerif}`,
+    fontFamily: sansSerif,
     fontSize,
     letterSpacing,
     padding,
@@ -233,7 +233,7 @@ const CBIOPORTAL_VICTORY_THEME = {
                 strokeWidth:1,
                 stroke:"black"
             },
-            labels: assign({}, baseLabelStyles, { fontFamily: sansSerif }),
+            labels: baseLabelStyles,
             title: assign({}, baseLabelStyles, { padding: 5 })
         }
     }


### PR DESCRIPTION
Change the label style back to the original style and override Arial with FreeSans when downloading pdf.
Fix # https://github.com/cbioportal/cbioportal/issues/3225.