### PR TITLE
GC - fix venn to always show circle borders

### DIFF
--- a/src/pages/groupComparison/VennSimple.tsx
+++ b/src/pages/groupComparison/VennSimple.tsx
@@ -192,20 +192,7 @@ export default class VennSimple extends React.Component<IVennSimpleProps, {}> {
             }
 
             return [hoverArea];
-        }).concat(_.sortBy(this.regions.filter(r=>r.combination.length === 1), r=>-r.vennJsSize).map(r=>{
-            // draw the outlines of the circles
-            const uid = this.props.groups[r.combination[0]].uid;
-            return (
-                <circle
-                    cx={this.circleCenters[uid].x}
-                    cy={this.circleCenters[uid].y}
-                    r={this.circleRadii[uid]}
-                    fill="none"
-                    stroke={r.color}
-                    strokeWidth={2}
-                />
-            );
-        }))).concat(_.flattenDeep<any>(this.regions.map(region=>{
+        })).concat(_.flattenDeep<any>(this.regions.map(region=>{
             if (region.numCases === 0) {
                 return [];
             }
@@ -246,6 +233,21 @@ export default class VennSimple extends React.Component<IVennSimpleProps, {}> {
             ];
         })));
 
+        const circleOutlines = _.sortBy(this.regions.filter(r=>r.combination.length === 1), r=>-r.vennJsSize).map(r=>{
+            // draw the outlines of the circles
+            const uid = this.props.groups[r.combination[0]].uid;
+            return (
+                <circle
+                    cx={this.circleCenters[uid].x}
+                    cy={this.circleCenters[uid].y}
+                    r={this.circleRadii[uid]}
+                    fill="none"
+                    stroke={r.color}
+                    strokeWidth={2}
+                />
+            );
+        });
+
         return (
             <>
                 <filter id="whiteFilter">
@@ -273,6 +275,9 @@ export default class VennSimple extends React.Component<IVennSimpleProps, {}> {
                 {clipPaths}
                 <g mask={`url(#${nonZeroClipPathId})`}>
                     {elements}
+                </g>
+                <g>
+                    {circleOutlines}
                 </g>
             </>
         );


### PR DESCRIPTION
BEFORE:
![image](https://camo.githubusercontent.com/935c20821bd67810af426f71f7e4a126884847ca/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3539343938393333353161613263333035373832343730652f61303631303031622d373739642d343530322d616232312d323731623336363438663335)

AFTER:
![image](https://user-images.githubusercontent.com/636232/60140331-699c4300-977f-11e9-93fc-6b7ccfd26ef8.png)

https://www.cbioportal.org/comparison/overlap?sessionId=5d127ba7e4b0ab41378778e1