### PR TITLE
Remove dimension/chartType from ChartMeta

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -81,7 +81,7 @@ import {
     showOriginStudiesInSummaryDescription,
     SPECIAL_CHARTS,
     StudyWithSamples,
-    submitToPage,
+    submitToPage, ChartMetaWithDimensionAndChartType,
     UniqueKey
 } from './StudyViewUtils';
 import MobxPromise from 'mobxpromise';
@@ -236,21 +236,21 @@ export class StudyViewPageStore {
         }));
 
         // Include special charts into custom charts list
-       SPECIAL_CHARTS.forEach(chartMeta => {
+       SPECIAL_CHARTS.forEach((chartMeta:ChartMetaWithDimensionAndChartType) => {
            const uniqueKey = chartMeta.uniqueKey;
-           const chartType = this.chartsType.get(uniqueKey) || chartMeta.chartType;
+           const chartType = chartMeta.chartType;
            if (chartType !== undefined) {
                this._customCharts.set(uniqueKey, {
                    displayName: chartMeta.displayName,
                    uniqueKey: uniqueKey,
-                   chartType: chartType,
                    dataType: getChartMetaDataType(uniqueKey),
                    patientAttribute: chartMeta.patientAttribute,
                    description: chartMeta.description,
                    renderWhenDataChange: false,
-                   dimension: this.chartsDimension[uniqueKey] || chartMeta.dimension,
                    priority: STUDY_VIEW_CONFIG.priority[uniqueKey] || chartMeta.priority
                });
+               this.chartsType.set(uniqueKey, chartMeta.chartType);
+               this.chartsDimension.set(uniqueKey, chartMeta.dimension);
 
                if (uniqueKey === UniqueKey.CANCER_STUDIES) {
                    this.customChartsPromises[uniqueKey] = this.cancerStudiesData;
@@ -581,7 +581,7 @@ export class StudyViewPageStore {
                 statusCallback
             );
         } else {
-            switch (params.chartMeta.chartType) {
+            switch (this.chartsType.get(params.chartMeta.uniqueKey)) {
                 case ChartTypeEnum.PIE_CHART:
                 case ChartTypeEnum.TABLE:
                     sessionId =
@@ -638,9 +638,9 @@ export class StudyViewPageStore {
 
     private geneMapCache:{[entrezGeneId:number]:string} = {};
 
-    @observable private chartsDimension: { [uniqueKey: string]: ChartDimension } = {};
+    @observable public chartsDimension = observable.map<ChartDimension>();
 
-    @observable private chartsType = observable.map<ChartType>();
+    @observable public chartsType = observable.map<ChartType>();
 
     private newlyAddedCharts = observable.array<string>();
 
@@ -815,7 +815,7 @@ export class StudyViewPageStore {
             cols: cols,
             grid: STUDY_VIEW_CONFIG.layout.grid,
             gridMargin: STUDY_VIEW_CONFIG.layout.gridMargin,
-            layout: calculateLayout(this.visibleAttributes, cols, this.currentGridLayout, this.currentFocusedChartByUser),
+            layout: calculateLayout(this.visibleAttributes, cols, this.chartsDimension.toJS(), this.currentGridLayout, this.currentFocusedChartByUser, this.currentFocusedChartByUserDimension),
             dimensions: STUDY_VIEW_CONFIG.layout.dimensions
         };
     }
@@ -827,6 +827,7 @@ export class StudyViewPageStore {
 
     private currentGridLayout: ReactGridLayout.Layout[] | undefined = undefined;
     private currentFocusedChartByUser: ChartMeta | undefined = undefined;
+    private currentFocusedChartByUserDimension: ChartDimension | undefined = undefined;
 
     public clinicalDataBinPromises: { [id: string]: MobxPromise<DataBin[]> } = {};
     public clinicalDataCountPromises: { [id: string]: MobxPromise<ClinicalDataCountWithColor[]> } = {};
@@ -1229,7 +1230,7 @@ export class StudyViewPageStore {
     @action
     resetFilterAndChangeChartVisibility(chartMeta: ChartMeta, visible: boolean) {
         if (!visible) {
-            switch (chartMeta.chartType) {
+            switch (this.chartsType.get(chartMeta.uniqueKey)) {
                 case ChartTypeEnum.MUTATED_GENES_TABLE:
                     this.resetGeneFilter();
                     break;
@@ -2124,17 +2125,12 @@ export class StudyViewPageStore {
     @action addCustomChart(newChart:NewChart) {
         const uniqueKey = this.newCustomChartUniqueKey();
         const newChartName = newChart.name ? newChart.name : this.getDefaultCustomChartName();
-        let chartMeta = {
+        let chartMeta:ChartMeta = {
             uniqueKey: uniqueKey,
             displayName: newChartName,
             description: newChartName,
-            chartType: ChartTypeEnum.PIE_CHART,
             dataType: getChartMetaDataType(uniqueKey),
             patientAttribute: false,
-            dimension: {
-                w: 1,
-                h: 1
-            },
             renderWhenDataChange: false,
             priority: 1
         };
@@ -2157,6 +2153,8 @@ export class StudyViewPageStore {
         this._customCharts.set(uniqueKey, chartMeta);
         this._chartVisibility.set(uniqueKey, true);
         this._customChartsSelectedCases.set(uniqueKey, allCases);
+        this.chartsType.set(uniqueKey, ChartTypeEnum.PIE_CHART);
+        this.chartsDimension.set(uniqueKey, {w: 1, h: 1});
 
         // Autoselect the groups
         this.setCustomChartFilters(chartMeta, newChart.groups.map(group=>group.name));
@@ -2182,7 +2180,6 @@ export class StudyViewPageStore {
 
     @computed
     get chartMetaSet(): { [id: string]: ChartMeta } {
-
         let _chartMetaSet: { [id: string]: ChartMeta } = _.reduce(this._customCharts.values(), (acc: { [id: string]: ChartMeta }, chartMeta:ChartMeta) => {
             acc[chartMeta.uniqueKey] = toJS(chartMeta);
             return acc
@@ -2192,21 +2189,16 @@ export class StudyViewPageStore {
         // Convert to a Set for easy access and to update attribute meta information(would be useful while adding new features)
         _.reduce(this.clinicalAttributes.result, (acc: { [id: string]: ChartMeta }, attribute) => {
             const uniqueKey = getClinicalAttributeUniqueKey(attribute);
-            const chartType = this.chartsType.get(uniqueKey);
-            if (chartType !== undefined) {
-                acc[uniqueKey] = {
-                    displayName: attribute.displayName,
-                    uniqueKey: uniqueKey,
-                    chartType: chartType,
-                    dataType: getChartMetaDataType(uniqueKey),
-                    patientAttribute:attribute.patientAttribute,
-                    description: attribute.description,
-                    dimension: this.chartsDimension[uniqueKey]!,
-                    priority: getPriorityByClinicalAttribute(attribute),
-                    renderWhenDataChange: chartType === ChartTypeEnum.TABLE,
-                    clinicalAttribute: attribute
-                };
-            }
+            acc[uniqueKey] = {
+                displayName: attribute.displayName,
+                uniqueKey: uniqueKey,
+                dataType: getChartMetaDataType(uniqueKey),
+                patientAttribute:attribute.patientAttribute,
+                description: attribute.description,
+                priority: getPriorityByClinicalAttribute(attribute),
+                renderWhenDataChange: false,
+                clinicalAttribute: attribute
+            };
             return acc
         }, _chartMetaSet);
 
@@ -2215,8 +2207,6 @@ export class StudyViewPageStore {
                 uniqueKey: UniqueKey.MUTATED_GENES_TABLE,
                 dataType: getChartMetaDataType(UniqueKey.MUTATED_GENES_TABLE),
                 patientAttribute:false,
-                chartType: this.chartsType.get(UniqueKey.MUTATED_GENES_TABLE)!,
-                dimension: this.chartsDimension[UniqueKey.MUTATED_GENES_TABLE]!,
                 displayName: 'Mutated Genes',
                 priority: getDefaultPriorityByUniqueKey(UniqueKey.MUTATED_GENES_TABLE),
                 renderWhenDataChange: false,
@@ -2229,8 +2219,6 @@ export class StudyViewPageStore {
                 uniqueKey: UniqueKey.CNA_GENES_TABLE,
                 dataType: getChartMetaDataType(UniqueKey.CNA_GENES_TABLE),
                 patientAttribute:false,
-                chartType: this.chartsType.get(UniqueKey.CNA_GENES_TABLE)!,
-                dimension: this.chartsDimension[UniqueKey.CNA_GENES_TABLE]!,
                 displayName: 'CNA Genes',
                 renderWhenDataChange: false,
                 priority: getDefaultPriorityByUniqueKey(UniqueKey.CNA_GENES_TABLE),
@@ -2253,10 +2241,8 @@ export class StudyViewPageStore {
                 dataType: getChartMetaDataType(UniqueKey.MUTATION_COUNT_CNA_FRACTION),
                 patientAttribute:false,
                 uniqueKey: UniqueKey.MUTATION_COUNT_CNA_FRACTION,
-                chartType: ChartTypeEnum.SCATTER,
                 displayName: 'Mutation Count vs Fraction of Genome Altered',
                 priority: getDefaultPriorityByUniqueKey(UniqueKey.MUTATION_COUNT_CNA_FRACTION),
-                dimension: STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.SCATTER],
                 renderWhenDataChange: false,
                 description: ''
             };
@@ -2269,16 +2255,6 @@ export class StudyViewPageStore {
         return _.reduce(this._chartVisibility.entries(), (acc, [chartUniqueKey, visible]) => {
             if (visible && this.chartMetaSet[chartUniqueKey]) {
                 let chartMeta = this.chartMetaSet[chartUniqueKey];
-                let dimension = this.chartsDimension[chartUniqueKey];
-                if (dimension !== undefined) {
-                    chartMeta.dimension = dimension;
-                } else {
-                    chartMeta.dimension = STUDY_VIEW_CONFIG.layout.dimensions[chartMeta.chartType] || {w: 1, h: 1};
-                }
-                const chartType = this.chartsType.get(chartUniqueKey);
-                if (chartType !== undefined) {
-                    chartMeta.chartType = chartType;
-                }
                 acc.push(chartMeta);
             }
             return acc;
@@ -2310,7 +2286,7 @@ export class StudyViewPageStore {
                 this.changeChartVisibility(UniqueKey.MUTATED_GENES_TABLE, true);
             }
             this.chartsType.set(UniqueKey.MUTATED_GENES_TABLE, ChartTypeEnum.MUTATED_GENES_TABLE);
-            this.chartsDimension[UniqueKey.MUTATED_GENES_TABLE] = STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.MUTATED_GENES_TABLE];
+            this.chartsDimension.set(UniqueKey.MUTATED_GENES_TABLE, STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.MUTATED_GENES_TABLE]);
         }
         if (!_.isEmpty(this.cnaProfiles.result)) {
             const cnaGeneMeta = _.find(this.chartMetaSet, chartMeta => chartMeta.uniqueKey === UniqueKey.CNA_GENES_TABLE);
@@ -2318,7 +2294,7 @@ export class StudyViewPageStore {
                 this.changeChartVisibility(UniqueKey.CNA_GENES_TABLE, true);
             }
             this.chartsType.set(UniqueKey.CNA_GENES_TABLE, ChartTypeEnum.CNA_GENES_TABLE);
-            this.chartsDimension[UniqueKey.CNA_GENES_TABLE] = STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.CNA_GENES_TABLE];
+            this.chartsDimension.set(UniqueKey.CNA_GENES_TABLE, STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.CNA_GENES_TABLE]);
         }
 
         this.initializeClinicalDataCountCharts();
@@ -2354,17 +2330,17 @@ export class StudyViewPageStore {
 
             if (obj.datatype === 'NUMBER') {
                 this.chartsType.set(uniqueKey, ChartTypeEnum.BAR_CHART);
-                this.chartsDimension[uniqueKey] =STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.BAR_CHART];
+                this.chartsDimension.set(uniqueKey, STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.BAR_CHART]);
             } else {
                 this.chartsType.set(uniqueKey, ChartTypeEnum.PIE_CHART);
-                this.chartsDimension[uniqueKey] = STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.PIE_CHART];
+                this.chartsDimension.set(uniqueKey, STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.PIE_CHART]);
             }
         });
 
         const cancerTypeIds = _.uniq(this.queriedPhysicalStudies.result.map(study => study.cancerTypeId));
 
         this.chartsType.set(UniqueKey.MUTATION_COUNT_CNA_FRACTION, ChartTypeEnum.SCATTER);
-        this.chartsDimension[UniqueKey.MUTATION_COUNT_CNA_FRACTION] = STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.SCATTER];
+        this.chartsDimension.set(UniqueKey.MUTATION_COUNT_CNA_FRACTION, STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.SCATTER]);
         if (mutationCountFlag && fractionGenomeAlteredFlag && getDefaultPriorityByUniqueKey(UniqueKey.MUTATION_COUNT_CNA_FRACTION)!== 0) {
             this.changeChartVisibility(UniqueKey.MUTATION_COUNT_CNA_FRACTION, true);
         }
@@ -2404,15 +2380,15 @@ export class StudyViewPageStore {
                 data = this.getClinicalDataCount(attr);
             }
             if (data !== undefined) {
-                this.chartsDimension[attr.uniqueKey] = this.getTableDimensionByNumberOfRecords(data.result!.length);
+                this.chartsDimension.set(attr.uniqueKey, this.getTableDimensionByNumberOfRecords(data.result!.length));
             }
             this.chartsType.set(attr.uniqueKey, ChartTypeEnum.TABLE);
         } else {
-            this.chartsDimension[attr.uniqueKey] = STUDY_VIEW_CONFIG.layout.dimensions[newChartType];
+            this.chartsDimension.set(attr.uniqueKey, STUDY_VIEW_CONFIG.layout.dimensions[newChartType]);
             this.chartsType.set(attr.uniqueKey, newChartType);
         }
         this.currentFocusedChartByUser = _.clone(attr);
-        this.currentFocusedChartByUser.dimension = this.chartsDimension[attr.uniqueKey];
+        this.currentFocusedChartByUserDimension = this.chartsDimension.get(attr.uniqueKey);
     }
 
     readonly defaultVisibleAttributes = remoteData({
@@ -2508,7 +2484,7 @@ export class StudyViewPageStore {
                 this._chartVisibility.set(uniqueKey, true);
             }
             this.chartsType.set(uniqueKey, ChartTypeEnum.BAR_CHART);
-            this.chartsDimension[uniqueKey] = STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.BAR_CHART];
+            this.chartsDimension.set(uniqueKey, STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.BAR_CHART]);
         });
     }
 
@@ -3504,10 +3480,10 @@ export class StudyViewPageStore {
 
             if (dataSize > STUDY_VIEW_CONFIG.thresholds.pieToTable || _.includes(STUDY_VIEW_CONFIG.tableAttrs, uniqueKey)) {
                 this.chartsType.set(uniqueKey, ChartTypeEnum.TABLE);
-                this.chartsDimension[uniqueKey] = this.getTableDimensionByNumberOfRecords(dataSize);
+                this.chartsDimension.set(uniqueKey, this.getTableDimensionByNumberOfRecords(dataSize));
             }else {
                 this.chartsType.set(uniqueKey, ChartTypeEnum.PIE_CHART);
-                this.chartsDimension[uniqueKey] = STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.PIE_CHART];
+                this.chartsDimension.set(uniqueKey, STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.PIE_CHART]);
             }
         }
     }

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -73,12 +73,14 @@ export type ChartMeta = {
     uniqueKey: string,
     displayName: string,
     description: string,
-    dimension: ChartDimension,
     priority: number,
     dataType: ChartMetaDataType,
     patientAttribute: boolean,
-    chartType: ChartType,
     renderWhenDataChange: boolean
+}
+export type ChartMetaWithDimensionAndChartType = ChartMeta & {
+    dimension: ChartDimension,
+    chartType: ChartType,
 }
 export type ClinicalDataCountSet = { [attrId: string]: number };
 export type StudyWithSamples = CancerStudy & {
@@ -94,7 +96,7 @@ export enum Datalabel {
     NA = "NA"
 }
 
-export const SPECIAL_CHARTS: ChartMeta[] = [{
+export const SPECIAL_CHARTS: ChartMetaWithDimensionAndChartType[] = [{
     uniqueKey: UniqueKey.CANCER_STUDIES,
     displayName: 'Cancer Studies',
     description: 'Cancer Studies',
@@ -1072,17 +1074,21 @@ export function isOccupied(matrix: string[][], position: Position, chartDimensio
     return occupied;
 }
 
-export function calculateLayout(visibleAttributes: ChartMeta[], cols: number, currentGridLayout?: Layout[], currentFocusedChartByUser?: ChartMeta): Layout[] {
+export function getDefaultChartDimension(): ChartDimension {
+    return {w: 1, h: 1};
+}
+
+export function calculateLayout(visibleAttributes: ChartMeta[], cols: number, chartsDimension:{[uniqueId:string]:ChartDimension}, currentGridLayout?: Layout[], currentFocusedChartByUser?: ChartMeta, currentFocusedChartByUserDimension?: ChartDimension): Layout[] {
     let layout: Layout[] = [];
     let matrix = [new Array(cols).fill('')] as string[][];
     // sort the visibleAttributes by priority
     visibleAttributes.sort(chartMetaComparator);
 
     // look if we need to put the chart to a fixed position and add the position to the matrix
-    if (currentGridLayout && currentGridLayout.length > 0 && currentFocusedChartByUser) {
+    if (currentGridLayout && currentGridLayout.length > 0 && currentFocusedChartByUser && currentFocusedChartByUserDimension) {
         const currentChartLayout = currentGridLayout.find((layout) => layout.i === currentFocusedChartByUser.uniqueKey)!;
         if (currentChartLayout) {
-            const newChartLayout = calculateNewLayoutForFocusedChart(currentChartLayout, currentFocusedChartByUser, cols);
+            const newChartLayout = calculateNewLayoutForFocusedChart(currentChartLayout, currentFocusedChartByUser, cols, currentFocusedChartByUserDimension);
             layout.push(newChartLayout);
             matrix = generateMatrixByLayout(newChartLayout, cols);
         }
@@ -1093,20 +1099,21 @@ export function calculateLayout(visibleAttributes: ChartMeta[], cols: number, cu
 
     // filter out the fixed position chart then calculate layout
     _.forEach(_.filter(visibleAttributes, (chart: ChartMeta) => currentFocusedChartByUser ? chart.uniqueKey !== currentFocusedChartByUser.uniqueKey : true), (chart: ChartMeta) => {
-        const position = findSpot(matrix, chart.dimension);
-        while ((position.y + chart.dimension.h) >= matrix.length) {
+        const dimension = chartsDimension[chart.uniqueKey] || getDefaultChartDimension();
+        const position = findSpot(matrix, dimension);
+        while ((position.y + dimension.h) >= matrix.length) {
             matrix.push(new Array(cols).fill(''));
         }
         layout.push({
             i: chart.uniqueKey,
             x: position.x,
             y: position.y,
-            w: chart.dimension.w,
-            h: chart.dimension.h,
+            w: dimension.w,
+            h: dimension.h,
             isResizable: false
         });
-        const xMax = position.x + chart.dimension.w;
-        const yMax = position.y + chart.dimension.h;
+        const xMax = position.x + dimension.w;
+        const yMax = position.y + dimension.h;
         for (let i = position.y; i < yMax; i++) {
             for (let j = position.x; j < xMax; j++) {
                 matrix[i][j] = chart.uniqueKey;
@@ -1116,14 +1123,14 @@ export function calculateLayout(visibleAttributes: ChartMeta[], cols: number, cu
     return layout;
 }
 
-export function calculateNewLayoutForFocusedChart(previousLayout: Layout, currentFocusedChartByUser: ChartMeta, cols: number): Layout {
+export function calculateNewLayoutForFocusedChart(previousLayout: Layout, currentFocusedChartByUser: ChartMeta, cols: number, currentFocusedChartByUserDimension:ChartDimension): Layout {
     const initialX = previousLayout.x;
     const initialY = previousLayout.y;
-    const dimensionWidth = currentFocusedChartByUser.dimension.w;
+    const dimensionWidth = currentFocusedChartByUserDimension.w;
     let x = initialX;
     let y = initialY;
 
-    if (isFocusedChartShrunk({w: previousLayout.w, h: previousLayout.h}, currentFocusedChartByUser.dimension)) {
+    if (isFocusedChartShrunk({w: previousLayout.w, h: previousLayout.h}, currentFocusedChartByUserDimension)) {
         x = initialX + previousLayout.w - dimensionWidth;
     }
     else if (initialX + dimensionWidth >= cols && initialX - dimensionWidth >= 0) {
@@ -1134,8 +1141,8 @@ export function calculateNewLayoutForFocusedChart(previousLayout: Layout, curren
         i: currentFocusedChartByUser.uniqueKey,
         x,
         y,
-        w: currentFocusedChartByUser.dimension.w,
-        h: currentFocusedChartByUser.dimension.h,
+        w: currentFocusedChartByUserDimension.w,
+        h: currentFocusedChartByUserDimension.h,
         isResizable: false
     };
 }
@@ -1266,13 +1273,13 @@ export function calculateClinicalDataCountFrequency(data: ClinicalDataCountSet, 
 }
 
 
-export function getOptionsByChartMetaDataType(type: ChartMetaDataType, allCharts: { [id: string]: ChartMeta }, selectedAttrs: string[]) {
+export function getOptionsByChartMetaDataType(type: ChartMetaDataType, allCharts: { [id: string]: ChartMeta }, selectedAttrs: string[], allChartTypes:{[id:string]:ChartType}) {
     return _.filter(allCharts, chartMeta => chartMeta.dataType === type)
         .map(chartMeta => {
             return {
                 label: chartMeta.displayName,
                 key: chartMeta.uniqueKey,
-                chartType: chartMeta.chartType,
+                chartType: allChartTypes[chartMeta.uniqueKey],
                 disabled: false,
                 selected: selectedAttrs.includes(chartMeta.uniqueKey),
                 freq: 100

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -128,7 +128,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
 
     @computed
     get genomicDataOptions(): ChartOption[] {
-        const genomicDataOptions = getOptionsByChartMetaDataType(ChartMetaDataTypeEnum.GENOMIC, this.props.store.chartMetaSet, this.selectedAttrs);
+        const genomicDataOptions = getOptionsByChartMetaDataType(ChartMetaDataTypeEnum.GENOMIC, this.props.store.chartMetaSet, this.selectedAttrs, this.props.store.chartsType.toJS());
         if (this.props.currentTab === StudyViewPageTabKeyEnum.CLINICAL_DATA) {
             return genomicDataOptions.filter(option => option.chartType === ChartTypeEnum.BAR_CHART || option.chartType === ChartTypeEnum.PIE_CHART);
         } else {
@@ -138,7 +138,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
 
     @computed
     get clinicalDataOptions(): ChartOption[] {
-        return getOptionsByChartMetaDataType(ChartMetaDataTypeEnum.CLINICAL, this.props.store.chartMetaSet, this.selectedAttrs);
+        return getOptionsByChartMetaDataType(ChartMetaDataTypeEnum.CLINICAL, this.props.store.chartMetaSet, this.selectedAttrs, this.props.store.chartsType.toJS());
     }
 
     @computed

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -31,7 +31,7 @@ import {
 import {ClinicalAttribute, ClinicalData} from "../../../shared/api/generated/CBioPortalAPI";
 import {makeSurvivalChartData} from "./survival/StudyViewSurvivalUtils";
 import StudyViewDensityScatterPlot from "./scatterPlot/StudyViewDensityScatterPlot";
-import {ChartTypeEnum, STUDY_VIEW_CONFIG} from "../StudyViewConfig";
+import {ChartDimension, ChartTypeEnum, STUDY_VIEW_CONFIG} from "../StudyViewConfig";
 import LoadingIndicator from "../../../shared/components/loadingIndicator/LoadingIndicator";
 import {getComparisonUrl} from "../../../shared/api/urls";
 import {DownloadControlsButton} from "../../../public-lib/components/downloadControls/DownloadControls";
@@ -53,6 +53,8 @@ const COMPARISON_CHART_TYPES:ChartType[] = [ChartTypeEnum.PIE_CHART, ChartTypeEn
 
 export interface IChartContainerProps {
     chartMeta: ChartMeta;
+    chartType: ChartType;
+    dimension: ChartDimension;
     title: string;
     promise: MobxPromise<any>;
     filters: any;
@@ -101,7 +103,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
     constructor(props: IChartContainerProps) {
         super(props);
 
-        this.chartType = this.props.chartMeta.chartType;
+        this.chartType = this.props.chartType;
 
         this.handlers = {
             ref: (plot: AbstractChart) => {
@@ -203,7 +205,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
         return validChart &&
             this.props.promise.isComplete &&
                 this.props.promise.result!.length > 1 &&
-                (COMPARISON_CHART_TYPES.indexOf(this.props.chartMeta.chartType) > -1);
+                (COMPARISON_CHART_TYPES.indexOf(this.props.chartType) > -1);
     }
 
     @autobind
@@ -216,7 +218,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
     @action
     openComparisonPage() {
         if (this.comparisonPagePossible) {
-            switch (this.props.chartMeta.chartType) {
+            switch (this.props.chartType) {
                 case ChartTypeEnum.PIE_CHART:
                 case ChartTypeEnum.TABLE:
                     const openComparison = ()=>this.props.openComparisonPage({
@@ -292,8 +294,8 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
         switch (this.chartType) {
             case ChartTypeEnum.PIE_CHART: {
                 return ()=>(<PieChart
-                    width={getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth)}
-                    height={getHeightByDimension(this.props.chartMeta.dimension, this.chartHeaderHeight)}
+                    width={getWidthByDimension(this.props.dimension, this.borderWidth)}
+                    height={getHeightByDimension(this.props.dimension, this.chartHeaderHeight)}
                     ref={this.handlers.ref}
                     onUserSelection={this.handlers.onValueSelection}
                     filters={this.props.filters}
@@ -307,8 +309,8 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
             case ChartTypeEnum.BAR_CHART: {
                 return ()=>(
                     <BarChart
-                        width={getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth)}
-                        height={getHeightByDimension(this.props.chartMeta.dimension, this.chartHeaderHeight)}
+                        width={getWidthByDimension(this.props.dimension, this.borderWidth)}
+                        height={getHeightByDimension(this.props.dimension, this.chartHeaderHeight)}
                         ref={this.handlers.ref}
                         onUserSelection={this.handlers.onDataBinSelection}
                         filters={this.props.filters}
@@ -319,8 +321,8 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
             case ChartTypeEnum.TABLE: {
                 return ()=>(<ClinicalTable
                     data={this.props.promise.result}
-                    width={getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth)}
-                    height={getTableHeightByDimension(this.props.chartMeta.dimension, this.chartHeaderHeight)}
+                    width={getWidthByDimension(this.props.dimension, this.borderWidth)}
+                    height={getTableHeightByDimension(this.props.dimension, this.chartHeaderHeight)}
                     filters={this.props.filters}
                     onUserSelection={this.handlers.onValueSelection}
                     labelDescription={this.props.chartMeta.description}
@@ -332,8 +334,8 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                 return ()=>(
                     <MutatedGenesTable
                         promise={this.props.promise}
-                        width={getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth)}
-                        height={getTableHeightByDimension(this.props.chartMeta.dimension, this.chartHeaderHeight)}
+                        width={getWidthByDimension(this.props.dimension, this.borderWidth)}
+                        height={getTableHeightByDimension(this.props.dimension, this.chartHeaderHeight)}
                         numOfSelectedSamples={100}
                         filters={this.props.filters}
                         onUserSelection={this.handlers.updateGeneFilters}
@@ -347,8 +349,8 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                 return ()=>(
                     <CNAGenesTable
                         promise={this.props.promise}
-                        width={getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth)}
-                        height={getTableHeightByDimension(this.props.chartMeta.dimension, this.chartHeaderHeight)}
+                        width={getWidthByDimension(this.props.dimension, this.borderWidth)}
+                        height={getTableHeightByDimension(this.props.dimension, this.chartHeaderHeight)}
                         numOfSelectedSamples={100}
                         filters={this.props.filters}
                         onUserSelection={this.handlers.updateCNAGeneFilters}
@@ -383,12 +385,12 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                                        disableZoom={true}
                                        showTable={false}
                                        styleOpts={{
-                                           width: getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth),
-                                           height: getHeightByDimension(this.props.chartMeta.dimension, this.chartHeaderHeight),
+                                           width: getWidthByDimension(this.props.dimension, this.borderWidth),
+                                           height: getHeightByDimension(this.props.dimension, this.chartHeaderHeight),
                                            tooltipXOffset:10,
                                            tooltipYOffset:-58,
                                            pValue: {
-                                               x:getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth)-10,
+                                               x:getWidthByDimension(this.props.dimension, this.borderWidth)-10,
                                                y:30,
                                                textAnchor:"end"
                                            },
@@ -409,14 +411,14 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
             }
             case ChartTypeEnum.SCATTER: {
                 return ()=>(
-                    <div style={{overflow:"hidden", height:getHeightByDimension(this.props.chartMeta.dimension, this.chartHeaderHeight)}}>
+                    <div style={{overflow:"hidden", height:getHeightByDimension(this.props.dimension, this.chartHeaderHeight)}}>
                         {/* have to do all this weird positioning to decrease gap btwn chart and title, bc I cant do it from within Victory */}
                         {/* overflow: "hidden" because otherwise the large SVG (I have to make it larger to make the plot large enough to
                             decrease the gap) will cover the header controls and make them unclickable */}
                         <div style={{marginTop:-33}}>
                             <StudyViewDensityScatterPlot
                                 ref={this.handlers.ref}
-                                width={getWidthByDimension(this.props.chartMeta.dimension, this.borderWidth)}
+                                width={getWidthByDimension(this.props.dimension, this.borderWidth)}
                                 height={this.getScatterPlotHeight()}
                                 yBinsMin={MutationCountVsCnaYBinsMin}
                                 onSelection={this.props.onValueSelection}
@@ -457,8 +459,8 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
     }
 
     componentWillReceiveProps(nextProps: Readonly<IChartContainerProps>, nextContext: any): void {
-        if (nextProps.chartMeta.chartType !== this.chartType) {
-            this.chartType = nextProps.chartMeta.chartType;
+        if (nextProps.chartType !== this.chartType) {
+            this.chartType = nextProps.chartType;
         }
     }
 

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -120,6 +120,8 @@ export class StudySummaryTab extends React.Component<IStudySummaryTabProps, {}> 
     renderAttributeChart = (chartMeta: ChartMeta) => {
         const props:Partial<IChartContainerProps> = {
             chartMeta: chartMeta,
+            chartType: this.store.chartsType.get(chartMeta.uniqueKey),
+            dimension: this.store.chartsDimension.get(chartMeta.uniqueKey),
             openComparisonPage: this.store.openComparisonPage,
             title: chartMeta.displayName,
             filters: [],
@@ -131,7 +133,7 @@ export class StudySummaryTab extends React.Component<IStudySummaryTabProps, {}> 
             setComparisonConfirmationModal: this.store.setComparisonConfirmationModal
         };
 
-        switch (chartMeta.chartType) {
+        switch (this.store.chartsType.get(chartMeta.uniqueKey)) {
             case ChartTypeEnum.PIE_CHART: {
 
                 //if the chart is one of the custom charts then get the appropriate promise


### PR DESCRIPTION
Move dimension and chartType out of ChartMeta to prevent unnecessary computing.
dimension and chartType are frequently updated and should not be associated with any promise if not related.

# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/5549


