### PR TITLE
Download links in network tab should not allow opening in new window

### DIFF
--- a/src/pages/resultsView/network/network.htm
+++ b/src/pages/resultsView/network/network.htm
@@ -126,6 +126,9 @@
     // calls to network do must now include all case ids
     // so we need to hijack click and form submit
     $(document).ready(function(){
+
+
+
         $("body").on("click","#netmsg a",function(e){
             e.preventDefault();
 
@@ -167,6 +170,15 @@
     body {
         background:transparent !important;
     }
+
+    #netmsg a {
+        color:#1974b8;
+        cursor:pointer;
+    }
+    #netmsg a:hover {
+        text-decoration:underline;
+    }
+
 </style>
 
 </head>
@@ -202,6 +214,11 @@
                                 $(divNetMsg).append(msgs.replace(/\n/g, "<br/>\n"));
                             }
                         }
+
+                        // these download links should not open in a new tab
+                        // text is stored in backend so this is a cloodge
+                        $("#netmsg a:lt(2)").removeAttr("href");
+
                     }
 
                     function showXDebug(graphml) {


### PR DESCRIPTION
Downloading GraphML of network tab wasn't working when right clicking and choosing open in new tab. Without href on the GraphML links you can't open it anymore like that. Always need to download with left click