### PR TITLE
Fix e2e-localdb tests not running for nightly master and rc builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,14 +223,14 @@ E2e-testing against a local database removes dependence on data provided by publ
 Requirement for setting the BACKEND variable depends on the context of the job:
 | **context**             | **BACKEND var** | **comments** |
 |------------------------ | ----------------- | ------------ |
-| _Local_                   | required        ||
-| _CircleCI_                | required        | |
+| _Local_                   | mandatory        | |
+| _CircleCI_                | mandatory for feature branches  | not for `master` or `rc` builds |
 | _CircleCI+PR_   | optional        | 1. When specified, GitHub PR must be of 'draft' state.<br>2. When not-specified, backend branch will mirror frontend branch (rc frontend vs. rc backend) |
 
 The value of the `BACKEND` variable must be formatted as `<BACKEND_GITHUB_USER>:<BACKEND_BRANCH>`. For example, when the /env/custom.sh file contains `export BACKEND=thehyve:uwe7872A` this is interpreted as a requirement for the commit `uwe7872A` of the _github.com/thehyve/cbioportal_ repository.
 
 #### BACKEND environmental variable in _CircleCI+PR_ context
-Using the `BACKEND` variable e2e-localdb tests can be conducted against any backend version. This poses a risk when testing in the context of a pull request, i.e., tests show up as succesful but should have failed against the backend version that compatible with the target cbioportal-frontend branch. To guard against this and prevent merging of incompatible branches into cbioportal-frontend the e2e-localdb tests enforce the use of _draft_ pull requests (see [here](https://help.github.com/en/articles/creating-a-pull-request) for more info). When a cBioPortal backend version is specified (i.e., may require a not yet merged backend branch) and the branch is part of a pull request, the pull request must be in state _draft_. Only when the `BACKEND` variable is not defined a (non-_draft_) e2e-localdb tests will be conducted on branches that are part of pull requests. Needles to say, pull request should for this and other reasons only be merged when the e2e-localdb tests succeed!
+Using the `BACKEND` variable e2e-localdb tests can be conducted against any backend version. This poses a risk when testing in _CircleCI+PR_ context, i.e., tests show up as succesful but should have failed against the backend version that compatible with the target cbioportal-frontend branch. To guard against this and prevent merging of incompatible branches into cbioportal-frontend the e2e-localdb tests enforce the use of _draft_ pull requests (see [here](https://help.github.com/en/articles/creating-a-pull-request) for more info). When a cBioPortal backend version is specified (i.e., may require a not yet merged backend branch) and the branch is part of a pull request, the pull request must be in state _draft_. Only when the `BACKEND` variable is not defined a (non-_draft_) e2e-localdb tests will be conducted on branches that are part of pull requests. Needles to say, pull request should for this and other reasons only be merged when the e2e-localdb tests succeed!
 
 When the `BACKEND` variable is not set, the backend version will be set to the target branch of the pull request, i.e. a pull request to 'rc' branch will be tested against the 'rc' branch of the backend.
 

--- a/end-to-end-test/local/runtime-config/setup_environment.sh
+++ b/end-to-end-test/local/runtime-config/setup_environment.sh
@@ -58,10 +58,18 @@ if [[ "$CIRCLECI" = true ]]; then
     fi
 
     # Check whether custom BACKEND environmental var is defined (required when running outside context of a pull request on CircleCI)
+    # When the current branch is master or rc continue using corresponding master or rc backend, respectively. 
     if [[ -z $BACKEND ]]; then
         if [[ -z $CIRCLE_PULL_REQUEST ]]; then
-            echo Error: BACKEND environmental variable not set in /env/custom.sh. This is required when running outside context of a pull request on CircleCI.
-            exit 1
+            if [[ "$CIRCLE_BRANCH" = "master" ]] || [[ "$CIRCLE_BRANCH" = "rc" ]]; then
+                BACKEND_PROJECT_USERNAME="cbioportal"
+                echo "export BACKEND_PROJECT_USERNAME=$BACKEND_PROJECT_USERNAME"
+                BACKEND_BRANCH="$CIRCLE_BRANCH"
+                echo "export BACKEND_BRANCH=$BACKEND_BRANCH"
+            else
+                echo Error: BACKEND environmental variable not set in /env/custom.sh for this feature branch. This is required when running outside context of a pull request on CircleCI.
+                exit 1
+            fi
         fi
     else
         parse_custom_backend_var


### PR DESCRIPTION
# What? Why?
The recently merged e2e-localdb feature does not run for nightly master and rc builds. This PR hotfix will correct this.