### PR TITLE
Update webpack style-loader to fix hot-reload of css modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "seedrandom": "^2.4.3",
     "shallowequal": "^1.1.0",
     "source-map-loader": "^0.1.6",
-    "style-loader": "^0.13.1",
+    "style-loader": "^0.23.1",
     "styled-components": "^4.2.1",
     "superagent": "^3.8.3",
     "superagent-cache": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15192,12 +15192,20 @@ strongly-connected-components@^1.0.1:
   resolved "https://registry.yarnpkg.com/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz#0920e2b4df67c8eaee96c6b6234fe29e873dba99"
   integrity sha1-CSDitN9nyOrulsa2I0/inoc9upk=
 
-style-loader@^0.13.0, style-loader@^0.13.1:
+style-loader@^0.13.0:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.2.tgz#74533384cf698c7104c7951150b49717adc2f3bb"
   integrity sha1-dFMzhM9pjHEEx5URULSXF63C87s=
   dependencies:
     loader-utils "^1.0.2"
+
+style-loader@^0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
+  integrity sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^1.0.0"
 
 styled-components@^4.2.1:
   version "4.2.1"


### PR DESCRIPTION
Css module hot reload has been broken since upgrade to webpack 4.  This fixes it.