### PR TITLE
Do not retrieve tags for virtual studies

### DIFF
--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -325,6 +325,7 @@ export default class StudyList extends QueryStoreComponent<IStudyListProps, {}> 
                                     key={i}
                                     studyDescription={this.store.isVirtualStudy(study.studyId) ? study.description.replace(/\r?\n/g, '<br />') : study.description}
                                     studyId={study.studyId}
+                                    isVirtualStudy={this.store.isVirtualStudy(study.studyId)}
                                     mouseEnterDelay={0}
                                     placement="top"
                                 >

--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -34,6 +34,7 @@ import Loader from '../loadingIndicator/LoadingIndicator';
 export type StudyTagsTooltipProps = {
     studyDescription: string;
     studyId: string;
+    isVirtualStudy: boolean;
     key: number;
     mouseEnterDelay: number;
     placement: string;
@@ -43,12 +44,16 @@ export type StudyTagsTooltipProps = {
 export type BuildOverlayTooltipProps = {
     studyDescription: string;
     studyId: string;
+    isVirtualStudy: boolean;
 };
 
 @observer
 default class BuildOverlay extends React.Component<BuildOverlayTooltipProps, {}> {
     @observable readonly studyMetadata = remoteData({
         invoke: async () => {
+            if (this.props.isVirtualStudy) {
+                return '';
+            }
             return client.getTagsUsingGET({studyId: this.props.studyId});
         },
         onError: (error) => {
@@ -88,6 +93,7 @@ export default class StudyTagsTooltip extends React.Component<StudyTagsTooltipPr
             overlay={<BuildOverlay
                         studyDescription={this.props.studyDescription}
                         studyId={this.props.studyId}
+                        isVirtualStudy={this.props.isVirtualStudy}
                     />}
             children={this.props.children}
         />);


### PR DESCRIPTION
# What? Why?
Fix for cbioportal/cbioportal#6285. There is a bug when using virtual studies and hovering the info icon in the query page: the endpoint `/studies/{studyId}/tags` returns an error after attempting to retrieve the tags given the virtual study ID (instead of an expected non-virtual study ID). Since virtual studies can be made of multiple studies, I think the best way to deal with the error is not to retrieve tags for virtual studies. Feel free to comment if you think there is a better solution to deal with the issue.