### PR TITLE
Fix gnomad test

### DIFF
--- a/end-to-end-tests/specs/core/mutationTable.spec.js
+++ b/end-to-end-tests/specs/core/mutationTable.spec.js
@@ -83,8 +83,11 @@ describe('Mutation Table', function() {
         });
 
         it('should show the gnomad table after mouse over the frequency in gnomad column', ()=>{
-
-            browser.waitForText('//*[text()="LUAD-B00416-Tumor"]',60000);
+            // filter the table
+            var textArea = browser.$('[class*=tableSearchInput]');
+            // only show LUAD-B00416-Tumor in table
+            textArea.setValue('LUAD-B00416-Tumor');
+            browser.waitForVisible("tr:nth-child(1) [data-test=oncogenic-icon-image]",60000);
             // show the gnomad column
             browser.scroll(1000, 0);
             // click on column button


### PR DESCRIPTION
fix test `should show the gnomad table after mouse over the frequency in gnomad column` in rc

https://www.cbioportal.org/results/mutations?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=nsclc_tcga_broad_2016&case_set_id=nsclc_tcga_broad_2016_cnaseq&data_priority=0&gene_list=TP53&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=nsclc_tcga_broad_2016_cna&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=nsclc_tcga_broad_2016_mutations&tab_index=tab_visualize


https://rc.cbioportal.org/results/mutations?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=nsclc_tcga_broad_2016&case_set_id=nsclc_tcga_broad_2016_cnaseq&data_priority=0&gene_list=TP53&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=nsclc_tcga_broad_2016_cna&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=nsclc_tcga_broad_2016_mutations&tab_index=tab_visualize

the default soring in master and rc are different. so filter the table first and do the test.