### PR TITLE
Remove skin.blurb (homepage text) default in frontend

### DIFF
--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -68,13 +68,6 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     default_cross_cancer_study_list_name: "TCGA PanCancer Atlas studies",
     skin_title:"cBioPortal for Cancer Genomics",
 
-    skin_blurb:`The cBioPortal for Cancer Genomics provides 
-        <b>visualization</b>, <b>analysis</b> and <b>download</b> of large-scale cancer genomics data sets.
-        <p><b>Please cite</b> <a href=\"http://www.ncbi.nlm.nih.gov/pubmed/23550210\">Gao 
-        et al. <i>Sci. Signal.</i> 2013</a> &amp; 
-        <a href=\"http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract\">
-        Cerami et al. <i>Cancer Discov.</i> 2012</a> when publishing results based on cBioPortal.</p>`,
-
     skin_data_sets_footer:`Data sets of TCGA studies were downloaded from Broad 
             Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the 
             TCGA working groups directly.`,


### PR DESCRIPTION
Citation text is now in another property (with separate default).   