### PR TITLE
Fix alteration enrichemnts when case of all groups are altered

### DIFF
--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
@@ -267,6 +267,21 @@ export default class AlterationEnrichmentContainer extends React.Component<IAlte
         }, {} as { [id: string]: string });
     }
 
+    @computed private get alterationFrequencyScatterData() {
+        if (this.isTwoGroupAnalysis) {
+            return getAlterationFrequencyScatterData(this.data, this.props.store ? this.props.store.hugoGeneSymbols : [], this.group1.name, this.group2.name);
+        }
+        return [];
+
+    }
+
+    @computed private get alterationScatterData() {
+        if (this.isTwoGroupAnalysis) {
+            return getAlterationScatterData(this.data, this.props.store ? this.props.store.hugoGeneSymbols : []);
+        }
+        return [];
+    }
+
     public render() {
 
         if (this.props.data.length === 0) {
@@ -276,9 +291,9 @@ export default class AlterationEnrichmentContainer extends React.Component<IAlte
         return (
             <div className={styles.Container}>
                 <div className={styles.ChartsPanel} style={{maxWidth:WindowStore.size.width-60}}>
-                    {this.isTwoGroupAnalysis &&
+                    {this.alterationScatterData.length > 0 && 
                         <MiniScatterChart
-                            data={getAlterationScatterData(this.data, this.props.store ? this.props.store.hugoGeneSymbols : [])}
+                            data={this.alterationScatterData}
                             xAxisLeftLabel={this.group2.nameOfEnrichmentDirection || this.group2.name}
                             xAxisRightLabel={this.group1.nameOfEnrichmentDirection || this.group1.name}
                             xAxisDomain={15}
@@ -290,9 +305,9 @@ export default class AlterationEnrichmentContainer extends React.Component<IAlte
                         />
                     }
 
-                    {this.isTwoGroupAnalysis &&
+                    {this.alterationFrequencyScatterData.length > 0 && 
                         <MiniFrequencyScatterChart
-                            data={getAlterationFrequencyScatterData(this.data, this.props.store ? this.props.store.hugoGeneSymbols : [], this.group1.name, this.group2.name)}
+                            data={this.alterationFrequencyScatterData}
                             xGroupName={this.group1.name}
                             yGroupName={this.group2.name}
                             onGeneNameClick={this.onGeneNameClick}
@@ -339,11 +354,14 @@ export default class AlterationEnrichmentContainer extends React.Component<IAlte
                             />Significant only
                         </label>
                     </div>
-                    <AlterationEnrichmentTable data={this.filteredData} onCheckGene={this.props.store ? this.onCheckGene : undefined}
-                                               checkedGenes={this.props.store ? this.checkedGenes : undefined}
-                                               dataStore={this.dataStore}
-                                               visibleOrderedColumnNames={this.visibleOrderedColumnNames}
-                                               customColumns={_.keyBy(this.customColumns,column=>column.name)}
+                    <AlterationEnrichmentTable
+                        data={this.filteredData}
+                        onCheckGene={this.props.store ? this.onCheckGene : undefined}
+                        checkedGenes={this.props.store ? this.checkedGenes : undefined}
+                        dataStore={this.dataStore}
+                        visibleOrderedColumnNames={this.visibleOrderedColumnNames}
+                        customColumns={_.keyBy(this.customColumns, column => column.name)}
+                        groupsCount={this.props.groups.length}
                     />
                 </div>
             </div>

--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsTable.tsx
@@ -22,6 +22,7 @@ export interface IAlterationEnrichmentTableProps {
     onCheckGene?: (hugoGeneSymbol: string) => void;
     onGeneNameClick?: (hugoGeneSymbol: string) => void;
     checkedGenes?:string[];
+    groupsCount:number
 }
 
 export enum AlterationEnrichmentTableColumnType {
@@ -120,17 +121,25 @@ export default class AlterationEnrichmentTable extends React.Component<IAlterati
 
         columns[AlterationEnrichmentTableColumnType.P_VALUE] = {
             name: "p-Value",
-            render: (d: AlterationEnrichmentRow) => <span style={{whiteSpace: 'nowrap'}}>{toConditionalPrecision(d.pValue, 3, 0.01)}</span>,
-            tooltip: <span>Derived from Fisher's exact test</span>,
-            sortBy: (d: AlterationEnrichmentRow) => d.pValue,
+            render: (d: AlterationEnrichmentRow) => {
+                const pValue = d.pValue == undefined ? 'NA' : toConditionalPrecision(d.pValue, 3, 0.01);
+                return <span style={{ whiteSpace: 'nowrap' }}>{pValue}</span>;
+            },
+            tooltip: <span>Derived from {this.props.groupsCount > 2 ? "Chi-Square" : "Fisher's exact"} test</span>,
+            // set to 0 when p-value is undefined. this happens when all the cases in all groups are altered
+            sortBy: (d: AlterationEnrichmentRow) => d.pValue || 0,
             download: (d: AlterationEnrichmentRow) => toConditionalPrecision(d.pValue, 3, 0.01)
         };
 
         columns[AlterationEnrichmentTableColumnType.Q_VALUE] = {
             name: "q-Value",
-            render: (d: AlterationEnrichmentRow) => <span style={{whiteSpace: 'nowrap'}}>{formatSignificanceValueWithStyle(d.qValue)}</span>,
+            render: (d: AlterationEnrichmentRow) => {
+                const qValue = d.qValue == undefined ? 'NA' : formatSignificanceValueWithStyle(d.qValue);
+                return <span style={{ whiteSpace: 'nowrap' }}>{qValue}</span>
+            },
             tooltip: <span>Derived from Benjamini-Hochberg procedure</span>,
-            sortBy: (d: AlterationEnrichmentRow) => d.qValue,
+            // set to 0 when q-value is undefined. this happens when all the cases in all groups are altered
+            sortBy: (d: AlterationEnrichmentRow) => d.qValue || 0,
             download: (d: AlterationEnrichmentRow) => toConditionalPrecision(d.qValue, 3, 0.01)
         };
 

--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
@@ -87,30 +87,37 @@ function volcanoPlotYCoord(pValue:number) {
 
 export function getAlterationScatterData(alterationEnrichments: AlterationEnrichmentRow[], queryGenes: string[]): any[] {
 
-    return alterationEnrichments.filter(a => !queryGenes.includes(a.hugoGeneSymbol)).map((alterationEnrichment) => {
-        return {
-            x: roundLogRatio(Number(alterationEnrichment.logRatio), 10),
-            y: volcanoPlotYCoord(alterationEnrichment.pValue),
-            hugoGeneSymbol: alterationEnrichment.hugoGeneSymbol,
-            pValue: alterationEnrichment.pValue,
-            qValue: alterationEnrichment.qValue,
-            logRatio: alterationEnrichment.logRatio,
-            hovered: false
-        };
-    });
+    // filter alterationEnrichments where all cases are altered i.e, p-value is undefined
+    return alterationEnrichments
+        .filter(a => a.pValue !== undefined && !queryGenes.includes(a.hugoGeneSymbol))
+        .map((alterationEnrichment) => {
+            return {
+                x: roundLogRatio(Number(alterationEnrichment.logRatio), 10),
+                y: volcanoPlotYCoord(alterationEnrichment.pValue),
+                hugoGeneSymbol: alterationEnrichment.hugoGeneSymbol,
+                pValue: alterationEnrichment.pValue,
+                qValue: alterationEnrichment.qValue,
+                logRatio: alterationEnrichment.logRatio,
+                hovered: false
+            };
+        });
 }
 
 export function getAlterationFrequencyScatterData(alterationEnrichments: AlterationEnrichmentRow[], queryGenes: string[], group1:string, group2:string): IMiniFrequencyScatterChartData[] {
-    return alterationEnrichments.filter(a => !queryGenes.includes(a.hugoGeneSymbol)).map((alterationEnrichment) => {
-        return {
-            x: alterationEnrichment.groupsSet[group1].alteredPercentage,
-            y: alterationEnrichment.groupsSet[group2].alteredPercentage,
-            hugoGeneSymbol: alterationEnrichment.hugoGeneSymbol,
-            pValue: alterationEnrichment.pValue,
-            qValue: alterationEnrichment.qValue,
-            logRatio: alterationEnrichment.logRatio!
-        };
-    });
+    
+    // filter alterationEnrichments where all cases are altered i.e, p-value is undefined
+    return alterationEnrichments
+        .filter(a => a.pValue !== undefined && !queryGenes.includes(a.hugoGeneSymbol))
+        .map((alterationEnrichment) => {
+            return {
+                x: alterationEnrichment.groupsSet[group1].alteredPercentage,
+                y: alterationEnrichment.groupsSet[group2].alteredPercentage,
+                hugoGeneSymbol: alterationEnrichment.hugoGeneSymbol,
+                pValue: alterationEnrichment.pValue,
+                qValue: alterationEnrichment.qValue,
+                logRatio: alterationEnrichment.logRatio!
+            };
+        });
 }
 
 export function getExpressionScatterData(expressionEnrichments: ExpressionEnrichmentRow[], queryGenes: string[]): any[] {
@@ -538,7 +545,8 @@ export function getGeneListOptions(data: AlterationEnrichmentRow[], includeAlter
     });
 
     let dataSortedBypValue = _.clone(dataWithOptionName).sort(function (kv1, kv2) {
-        return kv1.pValue - kv2.pValue;
+        // set to 0 when p-value is undefined. this happens when all the cases in all groups are altered
+        return (kv1.pValue || 0) - (kv2.pValue || 0);
     });
 
     return [

--- a/src/pages/resultsView/enrichments/GeneBarPlot.tsx
+++ b/src/pages/resultsView/enrichments/GeneBarPlot.tsx
@@ -150,8 +150,8 @@ export default class GeneBarPlot extends React.Component<IGeneBarPlotProps, {}> 
                 </tbody>
 
             </table>
-            <strong>p-Value</strong>: {toConditionalPrecision(geneData.pValue, 3, 0.01)}<br />
-            <strong>q-Value</strong>: {toConditionalPrecision(geneData.qValue, 3, 0.01)}
+            <strong>p-Value</strong>: {geneData.pValue == undefined ? 'NA' : toConditionalPrecision(geneData.pValue, 3, 0.01)}<br />
+            <strong>q-Value</strong>: {geneData.qValue == undefined ? 'NA' : toConditionalPrecision(geneData.qValue, 3, 0.01)}
         </div>)
     }
 


### PR DESCRIPTION
# What? Why?
Frontend changes for https://github.com/cBioPortal/cbioportal/issues/6395

Backend enrichments api wont be sending p-value when cases of all groups(>2) are altered. In this case p-value and q-value is are shown as `NA` in the table.