### PR TITLE
Network tab: sif and graphml download should not include comments

### DIFF
--- a/src/pages/resultsView/network/network.htm
+++ b/src/pages/resultsView/network/network.htm
@@ -135,11 +135,11 @@
             switch(this.innerText) {
                 case "GraphML":
                     e.preventDefault();
-                    formSubmit(apiHost + "network.do?download=on", networkParams, "_self", "post");
+                    formSubmit(apiHost + "network.do?download=on&msgoff=t", networkParams, "_self", "post");
                     break;
                 case "SIF":
                     e.preventDefault();
-                    formSubmit(apiHost + "network.do?download=on&format=sif", networkParams, "_self", "post");
+                    formSubmit(apiHost + "network.do?download=on&format=sif&msgoff=t", networkParams, "_self", "post");
                     break;
             }
 


### PR DESCRIPTION
Cytoscape does not ignore comments embedded in sif file.  Users complain that they cannot open files.