### PR TITLE
Support urls in clinical data

### DIFF
--- a/src/pages/patientView/clinicalInformation/ClinicalInformationPatientTable.tsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationPatientTable.tsx
@@ -5,6 +5,7 @@ import LazyMobXTable from "shared/components/lazyMobXTable/LazyMobXTable";
 import styles from './style/patientTable.module.scss';
 import {SHOW_ALL_PAGE_SIZE} from "../../../shared/components/paginationControls/PaginationControls";
 import {sortByClinicalAttributePriorityThenName} from "../../../shared/lib/SortUtils";
+import { isUrl } from "public-lib";
 
 export interface IClinicalInformationPatientTableProps {
     data: ClinicalData[];
@@ -56,7 +57,12 @@ export default class ClinicalInformationPatientTable extends React.Component<ICl
                       },
                       {
                           name:'Value',
-                          render: (data)=><span>{this.getDisplayValue(data)}</span>,
+                          render: (data)=>{
+                              if(isUrl(data.value)){
+                                return <a href={data.value} target="_blank">{data.value}</a>
+                              }
+                              return <span>{this.getDisplayValue(data)}</span>
+                          },
                           download: (data) => this.getDisplayValue(data),
                           filter: (data:IPatientRow, filterString:string, filterStringUpper:string) =>
                             data.value.toString().toUpperCase().indexOf(filterStringUpper) > -1

--- a/src/pages/patientView/clinicalInformation/ClinicalInformationSamplesTable.tsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationSamplesTable.tsx
@@ -7,6 +7,7 @@ import {ClinicalAttribute} from "../../../shared/api/generated/CBioPortalAPI";
 import styles from './style/sampleTable.module.scss';
 import {SHOW_ALL_PAGE_SIZE} from "../../../shared/components/paginationControls/PaginationControls";
 import {sortByClinicalAttributePriorityThenName} from "../../../shared/lib/SortUtils";
+import { isUrl } from "public-lib";
 
 interface IClinicalInformationSamplesTableProps {
     samples?: ClinicalDataBySampleId[];
@@ -28,7 +29,12 @@ export default class ClinicalInformationSamplesTable extends React.Component<ICl
         const columns:Column<ISampleRow>[] = [{id: 'attribute'}, ...sampleInvertedData.columns].map((col) =>  (
             {
                 name: col.id,
-                render: (data:ISampleRow)=><span>{data[col.id]}</span>,
+                render: (data: ISampleRow) => {
+                    if (isUrl(data[col.id] as any)) {
+                        return <a href={data[col.id] as any} target="_blank">{data[col.id]}</a>
+                    }
+                    return <span>{data[col.id]}</span>
+                },
                 download: (data:ISampleRow) => `${data[col.id]}`,
                 filter: (data:ISampleRow, filterString:string, filterStringUpper:string) =>
                     (data[col.id].toString().toUpperCase().indexOf(filterStringUpper) > -1)

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -17,6 +17,7 @@ import {Else, If, Then} from 'react-if';
 import ProgressIndicator, {IProgressIndicatorItem} from "../../../shared/components/progressIndicator/ProgressIndicator";
 import autobind from 'autobind-decorator';
 import {WindowWidthBox} from "../../../shared/components/WindowWidthBox/WindowWidthBox";
+import { isUrl } from "public-lib";
 
 export interface IClinicalDataTabTable {
     store: StudyViewPageStore;
@@ -32,7 +33,12 @@ export class ClinicalDataTab extends React.Component<IClinicalDataTabTable, {}> 
         return {
             name: columnName || '',
             headerRender: (data: string) => <span data-test={data}>{data}</span>,
-            render: (data: { [id: string]: string }) => <span data-test={data[key]}>{data[key]}</span>,
+            render: (data: { [id: string]: string }) => {
+                if (isUrl(data[key])) {
+                    return <a href={data[key]} target="_blank">{data[key]}</a>
+                }
+                return <span data-test={data[key]}>{data[key]}</span>
+            },
             download: (data: { [id: string]: string }) => data[key] || '',
             sortBy: (data: { [id: string]: any }) => {
                 if (data[key]) {

--- a/src/public-lib/lib/StringUtils.spec.ts
+++ b/src/public-lib/lib/StringUtils.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import {
-    unescapeTabDelimited, longestCommonStartingSubstring, stringListToIndexSet, stringListToSet, unquote
+    unescapeTabDelimited, longestCommonStartingSubstring, stringListToIndexSet, stringListToSet, unquote, isUrl
 } from "./StringUtils";
 
 describe("longestCommonStartingSubstring", ()=>{
@@ -37,5 +37,17 @@ describe("unquote and decodeTabDelimited", () => {
     it("unquotes only wrapping quotes and replaces all \\t and \\n characters in a string", () => {
         assert.equal(unquote(unescapeTabDelimited("\"cBioPortal\\n'Redefining'\\t\"Data Analysis\"\"")),
             "cBioPortal\n\'Redefining\'\t\"Data Analysis\"");
+    });
+});
+
+
+describe("isUrl", () => {
+    it("gives correct result on various inputs", ()=>{
+        assert.isFalse(isUrl("example.com"))
+        assert.isFalse(isUrl("http"))
+        assert.isTrue(isUrl("http://example.com"))
+        assert.isTrue(isUrl("https://example.com"))
+        assert.isTrue(isUrl("http://www.example.com"))
+        assert.isTrue(isUrl("https://www.example.com"))
     });
 });

--- a/src/public-lib/lib/StringUtils.ts
+++ b/src/public-lib/lib/StringUtils.ts
@@ -66,3 +66,8 @@ export function capitalize(str:string) {
         return str[0].toLocaleUpperCase() + str.slice(1);
     }
 }
+
+export function isUrl(str:string) {
+    const pattern = /^http[s]?:\/\//;
+    return pattern.test(str);
+}


### PR DESCRIPTION
# What? Why?
Partial fix https://github.com/cBioPortal/cbioportal/issues/6383
Supports only links in clinical data in study view and patient view pages

Example

<img width="1289" alt="Screen Shot 2019-07-31 at 12 30 54 PM" src="https://user-images.githubusercontent.com/12956870/62230187-4886cd80-b38f-11e9-8346-6076d9a78f83.png">
<img width="767" alt="Screen Shot 2019-07-31 at 12 31 20 PM" src="https://user-images.githubusercontent.com/12956870/62230188-4886cd80-b38f-11e9-8f9f-bde090f9c12c.png">
