### PR TITLE
Support samples filter in study page url

### DIFF
--- a/src/pages/resultsView/querySummary/QuerySummaryUtils.spec.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummaryUtils.spec.tsx
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {getAlterationSummary, getGeneSummary} from "./QuerySummaryUtils";
+import {getAlterationSummary, getGeneSummary, getStudyViewFilterHash} from "./QuerySummaryUtils";
 import * as React from "react";
 import expect from 'expect';
 import expectJSX from 'expect-jsx';
@@ -31,6 +31,35 @@ describe("QuerySummaryUtils", () => {
             expect(getAlterationSummary(8, 8, 0, 0, 1)).toEqualJSX(<strong><span>
                 Queried gene is altered in 0 (0%) of queried patients/samples
             </span></strong>, "none altered, same number samples and patients");
+        });
+    });
+    describe("getStudyViewFilterHash", () => {
+        it("gives correct summary for various inputs", () => {
+            assert.equal(getStudyViewFilterHash([], false), undefined);
+            assert.equal(getStudyViewFilterHash([], false, []), undefined);
+            assert.equal(getStudyViewFilterHash([], true), undefined);
+
+            assert.equal(getStudyViewFilterHash([{
+                studyId: "studyId1",
+                sampleId: "sampleId1"
+            }], false, [{ category: "all_cases_in_study" }]), undefined);
+
+            assert.equal(getStudyViewFilterHash([{
+                studyId: "studyId1",
+                sampleId: "sampleId1"
+            }], false), 'filters={"sampleIdentifiers":[{"sampleId":"sampleId1","studyId":"studyId1"}]}');
+
+            assert.equal(getStudyViewFilterHash([{
+                studyId: "studyId1",
+                sampleId: "sampleId1"
+            }], true), 'filters={"sampleIdentifiers":[{"sampleId":"sampleId1","studyId":"studyId1"}]}');
+
+            assert.equal(getStudyViewFilterHash([{
+                studyId: "studyId1",
+                sampleId: "sampleId1"
+            }], true, [{ category: "all_cases_in_study" }]), 'filters={"sampleIdentifiers":[{"sampleId":"sampleId1","studyId":"studyId1"}]}');
+
+
         });
     });
 });

--- a/src/pages/resultsView/querySummary/QuerySummaryUtils.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummaryUtils.tsx
@@ -1,5 +1,8 @@
 import {getPercentage} from "../../../shared/lib/FormatUtils";
 import * as React from "react";
+import { SampleList, Sample } from "shared/api/generated/CBioPortalAPI";
+import _ from "lodash";
+import { VirtualStudy } from "shared/model/VirtualStudy";
 
 export function getPatientSampleSummary(
     samples:any[],
@@ -59,4 +62,20 @@ export function getAlterationSummary(
             </strong>
         );
     }
+}
+
+export function getStudyViewFilterHash(
+    samples: Pick<Sample, "sampleId" | "studyId">[],
+    hasVirtualStudies: boolean,
+    sampleLists?: Pick<SampleList, "category">[]) {
+    const hasAllCaseLists = _.some(sampleLists, sampleList => sampleList.category === 'all_cases_in_study');
+    let studyViewFilterHash: string | undefined;
+    if (samples.length > 0 && (hasVirtualStudies || !hasAllCaseLists)) {
+        const sampleIdentifiers = samples.map(sample => ({
+            sampleId: sample.sampleId,
+            studyId: sample.studyId
+        }));
+        studyViewFilterHash = `filterJson=${JSON.stringify({ sampleIdentifiers })}`;
+    }
+    return studyViewFilterHash;
 }

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -83,16 +83,22 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
         this.store = new StudyViewPageStore();
 
         this.queryReaction = reaction(
-            () => props.routing.location.query,
-            query => {
+            () => [props.routing.location.query, props.routing.location.hash],
+            ([query,hash]) => {
 
                 if (!getBrowserWindow().globalStores.routing.location.pathname.includes("/study")) {
                     return;
                 }
 
                 this.store.updateCurrentTab(getStudyViewTabId(getBrowserWindow().globalStores.routing.location.pathname));
-                const newStudyViewFilter:StudyViewURLQuery = _.pick(props.routing.location.query, ['id', 'studyId', 'cancer_study_id', 'filters', 'filterAttributeId', 'filterValues']);
+                const newStudyViewFilter:StudyViewURLQuery = _.pick(query, ['id', 'studyId', 'cancer_study_id', 'filters', 'filterAttributeId', 'filterValues']);
 
+                if(hash) {
+                    const filters = hash.match(/filterJson=([^&]*)/);
+                    if (filters && filters.length > 1) {
+                        newStudyViewFilter.filters = filters[1];
+                    }
+                }
                 if (!_.isEqual(newStudyViewFilter, this.studyViewQueryFilter)) {
                     this.store.updateStoreFromURL(newStudyViewFilter);
                     this.studyViewQueryFilter = newStudyViewFilter;


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/6403

Example https://www.cbioportal.org/study/summary#filters={%22sampleIdentifiers%22:[{%22sampleId%22:%22TCGA-OR-A5L2-01%22,%22studyId%22:%22acc_tcga%22},{%22sampleId%22:%22TCGA-DQ-5625-01%22,%22studyId%22:%22hnsc_tcga%22},{%22sampleId%22:%22TCGA-CV-7252-01%22,%22studyId%22:%22hnsc_tcga%22},{%22sampleId%22:%22TCGA-CV-A463-01%22,%22studyId%22:%22hnsc_tcga%22},{%22sampleId%22:%22TCGA-QK-A6VC-01%22,%22studyId%22:%22hnsc_tcga%22}]}