### PR TITLE
Remove obsolete treatment related elements from Query Page components

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -99,8 +99,7 @@ export type CancerStudyQueryParams = Pick<QueryStore,
     'caseIds' |
     'caseIdsMode' |
     'geneQuery' |
-    'genesetQuery' |
-	'treatmentQuery'>;
+    'genesetQuery'>;
 export const QueryParamsKeys: (keyof CancerStudyQueryParams)[] = [
     'searchText',
     'selectableSelectedStudyIds',
@@ -112,8 +111,7 @@ export const QueryParamsKeys: (keyof CancerStudyQueryParams)[] = [
     'caseIds',
     'caseIdsMode',
     'geneQuery',
-    'genesetQuery',
-	'treatmentQuery'
+    'genesetQuery'
 ];
 
 type GenesetId = string;
@@ -393,25 +391,12 @@ export class QueryStore {
         this._genesetQuery = value;
 	}
 
-	@observable _treatmentQuery = '';
-    get treatmentQuery()
-    {
-        return this._treatmentQuery;
-    }
-    set treatmentQuery(value:string)
-    {
-        // clear error when gene query is modified
-        this.treatmentQueryErrorDisplayStatus = 'unfocused';
-        this._treatmentQuery = value;
-    }
-
     ////////////////////////////////////////////////////////////////////////////////
     // VISUAL OPTIONS
     ////////////////////////////////////////////////////////////////////////////////
 
     @observable geneQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
     @observable genesetQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
-    @observable treatmentQueryErrorDisplayStatus: 'unfocused' | 'shouldFocus' | 'focused' = 'unfocused';
     @observable showMutSigPopup = false;
     @observable showGisticPopup = false;
     @observable showGenesetsHierarchyPopup = false;
@@ -1578,7 +1563,6 @@ export class QueryStore {
         this.caseIdsMode = 'sample'; // url always contains sample IDs
         this.geneQuery = normalizeQuery(decodeURIComponent(params.gene_list || ''));
         this.genesetQuery = normalizeQuery(decodeURIComponent(params[QueryParameter.GENESET_LIST] || ''));
-        this.treatmentQuery = decodeURIComponent(params[QueryParameter.TREATMENT_LIST] || ''); // pvannierop: removed the conversion to uppercase
         this.forDownloadTab = params.tab_index === 'tab_download';
         this.initiallySelected.profileIds = true;
         this.initiallySelected.sampleListId = true;

--- a/src/shared/components/query/QueryStoreUtils.ts
+++ b/src/shared/components/query/QueryStoreUtils.ts
@@ -6,7 +6,7 @@ import { VirtualStudy } from "shared/model/VirtualStudy";
 
 export type NonMolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
     'cancer_study_id' | 'cancer_study_list' | 'Z_SCORE_THRESHOLD' | 'RPPA_SCORE_THRESHOLD' | 'data_priority' |
-    'case_set_id' | 'case_ids' | 'gene_list' | 'geneset_list' | 'treatment_list' | 'tab_index' | 'transpose_matrix' | 'Action'>;
+    'case_set_id' | 'case_ids' | 'gene_list' | 'geneset_list' | 'tab_index' | 'transpose_matrix' | 'Action'>;
 
 export type MolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
     'genetic_profile_ids_PROFILE_MUTATION_EXTENDED' | 'genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION' |
@@ -53,7 +53,6 @@ export function nonMolecularProfileParams(store:QueryStore, whitespace_separated
         case_ids,
         gene_list: encodeURIComponent(normalizeQuery(store.geneQuery) || ' '), // empty string won't work
         geneset_list: normalizeQuery(store.genesetQuery) || ' ', //empty string won't work
-        treatment_list: normalizeQuery(store.treatmentQuery) || ' ', //empty string won't work
         tab_index: store.forDownloadTab ? 'tab_download' : 'tab_visualize' as any,
         transpose_matrix: store.transposeDataMatrix ? 'on' : undefined,
         Action: 'Submit',


### PR DESCRIPTION
# Problem
There where elements added to the Query page as part of the treatment reponse feature. Handling of treatments is not mediated by the Query page.

# Fix
I have removed unneeded sections.