### PR TITLE
Change treatmentCache from @cached getter to readonly variable

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -3493,9 +3493,7 @@ export class ResultsViewPageStore {
         return new GenesetCache();
     }
 
-    @cached get treatmentCache() {
-        return new TreatmentCache();
-    }
+    readonly treatmentCache = new TreatmentCache();
 
     public numericGeneMolecularDataCache = new MobxPromiseCache<{entrezGeneId:number, molecularProfileId:string}, NumericGeneMolecularData[]>(
         q=>({

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -3485,14 +3485,8 @@ export class ResultsViewPageStore {
         )
     });
 
-    @cached get geneCache() {
-        return new GeneCache();
-    }
-
-    @cached get genesetCache() {
-        return new GenesetCache();
-    }
-
+    readonly geneCache = new GeneCache();
+    readonly genesetCache = new GenesetCache();
     readonly treatmentCache = new TreatmentCache();
 
     public numericGeneMolecularDataCache = new MobxPromiseCache<{entrezGeneId:number, molecularProfileId:string}, NumericGeneMolecularData[]>(


### PR DESCRIPTION
# Problem
When treatment response profiles are the only type of molecular profile in a study, heatmap tracks do not show for these profiles in oncoprint.

# Fix
The @cached annotation of the treatmentCache caused this behaviour. After consultation with @adamabeshouse  the @cached annotation was replaced with a readonly variable. This solves the problem, but leaves open why the @cached annotation caused problems.