### PR TITLE
Added components property to CheckedSelect for better customization

### DIFF
--- a/src/public-lib/components/checkedSelect/CheckedSelect.tsx
+++ b/src/public-lib/components/checkedSelect/CheckedSelect.tsx
@@ -19,6 +19,7 @@ type CheckedSelectProps = {
     value: {value: string}[];
     options: Option[];
     placeholder?: string | JSX.Element;
+    reactSelectComponents?: {[componentType: string]: (props: any) => JSX.Element};
     isClearable?: boolean;
     isDisabled?: boolean;
     onAddAll?: () => void;
@@ -62,6 +63,16 @@ export default class CheckedSelect extends React.Component<CheckedSelectProps, {
         else {
             return "Clear";
         }
+    }
+
+    @computed
+    get components() {
+        return this.props.showControls ?
+            {
+                GroupHeading: this.buttonsSection,
+                ...this.props.reactSelectComponents
+            }:
+            this.props.reactSelectComponents;
     }
 
     @autobind
@@ -164,7 +175,7 @@ export default class CheckedSelect extends React.Component<CheckedSelectProps, {
                             primary: theme.colors.primary50
                         },
                     })}
-                    components={this.props.showControls ? {GroupHeading: this.buttonsSection } : undefined}
+                    components={this.components}
                     name={this.props.name}
                     isMulti={true}
                     isClearable={this.props.isClearable}


### PR DESCRIPTION
- Exposed `components` property of the `react-select` library.
- This is required to better customize the `CheckedSelect` component

An example customization from `msk-insight`:

![checked_select_option_count](https://user-images.githubusercontent.com/3604198/63460142-ef590980-c423-11e9-91fb-ad2e69fa7ee6.png)

# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)