### PR TITLE
Adjust y-dimension of waterfall plot to fit on small (13') screen.

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -177,6 +177,7 @@ export const NONE_SELECTED_OPTION_LABEL = "Ordered samples";
 export const ALL_SELECTED_OPTION_NUMERICAL_VALUE = -3;
 export const SAME_SELECTED_OPTION_STRING_VALUE = "same";
 export const SAME_SELECTED_OPTION_NUMERICAL_VALUE = -2;
+const LEGEND_TO_BOTTOM_WIDTH_THRESHOLD = 900; // when plot is wider than this value, the legend moves from right to bottom of screen
 
 const mutationCountByOptions = [
     { value: MutationCountBy.MutationType, label: "Mutation Type" },
@@ -2186,7 +2187,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                                     labelVisibility={this.waterfallPlotLimitValueSymbolVisibility}
                                     zIndexSortBy={this.zIndexSortBy}
                                     useLogSpaceTicks={true}
-                                    legendLocationWidthThreshold={550}
+                                    legendLocationWidthThreshold={LEGEND_TO_BOTTOM_WIDTH_THRESHOLD}
                                     sortOrder={this.waterfallPlotSortOrder}
                                     pivotThreshold={this.waterfallPlotPivotThreshold}
                                     legendData={scatterPlotLegendData(

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -82,8 +82,8 @@ export function sortMolecularProfilesForDisplay(profiles:MolecularProfile[]) {
 }
 
 export const CNA_STROKE_WIDTH = 1.8;
-export const PLOT_SIDELENGTH = 650;
-export const WATERFALLPLOT_BASE_SIDELENGTH = 500;
+export const PLOT_SIDELENGTH = 550;
+export const WATERFALLPLOT_BASE_SIDELENGTH = 480;
 export const WATERFALLPLOT_SIDELENGTH_SAMPLE_MULTIPLICATION_FACTOR = 1.6;
 
 export interface IAxisData {

--- a/src/shared/components/plots/WaterfallPlot.tsx
+++ b/src/shared/components/plots/WaterfallPlot.tsx
@@ -60,7 +60,7 @@ const DEFAULT_FONT_FAMILY = "Verdana,Arial,sans-serif";
 export const LEGEND_Y = 30
 const RIGHT_PADDING = 120; // room for correlation info and legend
 const NUM_AXIS_TICKS = 8;
-const PLOT_DATA_PADDING_PIXELS = 50;
+const PLOT_DATA_PADDING_PIXELS = {y: 3, x: [30, 30]};
 const LEFT_PADDING = 25;
 const LEGEND_ITEMS_PER_ROW = 4;
 const LABEL_OFFSET_FRACTION = .02;
@@ -200,8 +200,8 @@ export default class WaterfallPlot<D extends IBaseWaterfallPlotData> extends Rea
                     itemsPerRow={this.legendLocation === "right" ? undefined : LEGEND_ITEMS_PER_ROW}
                     rowGutter={this.legendLocation === "right" ? undefined : -5}
                     data={legendData}
-                    x={this.legendLocation === "right" ? this.legendX : 0}
-                    y={this.legendLocation === "right" ? 100 : this.svgHeight-this.bottomLegendHeight}
+                    x={this.legendLocation === "right" ? this.legendX : 50}
+                    y={this.legendLocation === "right" ? 100 : this.svgHeight-this.bottomLegendHeight+5}
                 />
             );
         } else {


### PR DESCRIPTION
# What? Why?
The waterfall plot did not dimension properly in the y-dimension (see screenshots below). This is a problem on devices with a small (1440x900) screen.

# Fix
Y-dimension properties of the waterfall plot were updated (see screenshots below).

# Before
![old_waterfall_layout](https://user-images.githubusercontent.com/745885/63696509-30359180-c81b-11e9-8b5b-3ffe57976706.png)

# After
![new_waterfall_layout](https://user-images.githubusercontent.com/745885/63696516-3461af00-c81b-11e9-91b1-f0181bd3b404.png)


 