### PR TITLE
Wrap contents of oncoprint tooltip to contents.

### DIFF
--- a/src/shared/components/oncoprint/styles.scss
+++ b/src/shared/components/oncoprint/styles.scss
@@ -1,9 +1,14 @@
 .oncoprintjs__tooltip {
   padding: 5px;
   margin-top: -10px; // to compensate position for padding, since tooltip is positioned above (if positioned at center, wouldnt be problem)
-  width:250px;
+  max-width: none;
+}
+
+.oncoprint__tooltip {
+  min-width: 160px;
+  max-width: none;
 }
 
 .oncoprint-hidden {
   opacity: 0;
-}
+} 


### PR DESCRIPTION
# What? Why?
Long sample names would overflow the boundaries of the oncoprint tooltip (see screenshots).

# Fix
The css properties of oncoprint tooltip were overridden so that the tooltip scales with the length of the sample names.

# Before
![Screenshot from 2019-08-26 16-54-49](https://user-images.githubusercontent.com/745885/63700361-097b5900-c823-11e9-8ac0-102bb9c6fa47.png)
![Screenshot from 2019-08-26 16-55-04](https://user-images.githubusercontent.com/745885/63700370-0c764980-c823-11e9-9e6b-def0c47577c6.png)

# After
![Screenshot from 2019-08-26 16-51-39](https://user-images.githubusercontent.com/745885/63700373-1009d080-c823-11e9-9c8b-9a161b727ef2.png)
![Screenshot from 2019-08-26 16-56-37](https://user-images.githubusercontent.com/745885/63700381-15ffb180-c823-11e9-8c9e-d125d9f241ea.png)