### PR TITLE
Fix waterfall plot log-scale for 0 values

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -1500,6 +1500,10 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
         return showMessage;
     }
 
+    isDisabledAxisLogCheckbox(vertical:boolean):boolean {
+        return vertical ? this.vertAxisDataHasNegativeNumbers : this.horzAxisDataHasNegativeNumbers;
+    }
+
     private getAxisMenu(
         vertical:boolean,
         dataTypeOptions:{value:string, label:string}[],
@@ -1622,8 +1626,8 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                                     type="checkbox"
                                     name={vertical ? "vert_logScale" : "vert_logScale"}
                                     value={vertical ? EventKey.vert_logScale : EventKey.horz_logScale}
-                                    checked={axisSelection.logScale}
-                                    disabled={vertical ? this.vertAxisDataHasNegativeNumbers : this.horzAxisDataHasNegativeNumbers }
+                                    checked={axisSelection.logScale && ! this.isDisabledAxisLogCheckbox(vertical)}
+                                    disabled={this.isDisabledAxisLogCheckbox(vertical)}
                                     onClick={this.onInputClick}
                                 />
                                 Log Scale
@@ -2159,7 +2163,6 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                     case PlotType.WaterfallPlot:
                         if (this.waterfallPlotData.isComplete) {
                             const horizontal = this.isHorizontalWaterfallPlot;
-                            const useLogScale = horizontal ? this.horzSelection.logScale : this.vertSelection.logScale;
                             plotElt = (
                                 <PlotsTabWaterfallPlot
                                     svgId={SVG_ID}

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -2016,7 +2016,7 @@ export function makeAxisLogScaleFunction(axisSelection:AxisMenuSelection):IAxisL
         return undefined;
     }
 
-    let label;          // suffix that will appear in the axis label
+    let label;         // suffix that will appear in the axis label
     let fLogScale;     // function for (log-)transforming a value
     let fInvLogScale;  // function for back-transforming a value transformed with fLogScale
 
@@ -2035,6 +2035,10 @@ export function makeAxisLogScaleFunction(axisSelection:AxisMenuSelection):IAxisL
             // this is done by pre-application of a externally provided offset.
             if (!offset) {
                 offset = 0;
+            }
+            if (x+offset === 0) {
+                // 0 cannot be log-transformed, return 0 when input is 0
+                return 0;
             }
             return Math.log10(x+offset);
         };


### PR DESCRIPTION
Note: this is a duplicate of [PR #2631](https://github.com/cBioPortal/cbioportal-frontend/pull/2631) from other remote (problems with triggering CircleCI jobs).

# What? Why?
- The log-scaling of values in the waterfall plot for treatment response data did not correctly handle offset values of 0.
- The log-scale checkbox is disabled when a profile is selected that contains neg.values. In the current situation the box was not deselected after disabling.

# Fix
Both issues have been saved by slightly adusting the code.