### PR TITLE
Wrap contents of oncoprint tooltip to contents

### DIFF
--- a/src/shared/components/oncoprint/styles.scss
+++ b/src/shared/components/oncoprint/styles.scss
@@ -1,9 +1,14 @@
 .oncoprintjs__tooltip {
   padding: 5px;
   margin-top: -10px; // to compensate position for padding, since tooltip is positioned above (if positioned at center, wouldnt be problem)
-  width:250px;
+  max-width: none;
+}
+
+.oncoprint__tooltip {
+  min-width: 160px;
+  max-width: none;
 }
 
 .oncoprint-hidden {
   opacity: 0;
-}
+} 

--- a/src/shared/components/oncoprint/styles.scss
+++ b/src/shared/components/oncoprint/styles.scss
@@ -1,12 +1,8 @@
 .oncoprintjs__tooltip {
   padding: 5px;
   margin-top: -10px; // to compensate position for padding, since tooltip is positioned above (if positioned at center, wouldnt be problem)
-  max-width: none;
-}
-
-.oncoprint__tooltip {
-  min-width: 160px;
-  max-width: none;
+  width: 250px;
+  word-break: break-all;
 }
 
 .oncoprint-hidden {


### PR DESCRIPTION
Note: this is a duplicate of [PR #2633](https://github.com/cBioPortal/cbioportal-frontend/pull/2633) from other remote (problems with triggering CircleCI jobs).

# What? Why?
Long sample names would overflow the boundaries of the oncoprint tooltip (see screenshots).

# Fix
The css properties of oncoprint tooltip were overridden so that the tooltip scales with the length of the sample names.

# Before
![Screenshot from 2019-08-26 16-54-49](https://user-images.githubusercontent.com/745885/63700361-097b5900-c823-11e9-8ac0-102bb9c6fa47.png)
![Screenshot from 2019-08-26 16-55-04](https://user-images.githubusercontent.com/745885/63700370-0c764980-c823-11e9-9e6b-def0c47577c6.png)

# After
![image](https://user-images.githubusercontent.com/745885/64321594-23563200-cfc1-11e9-9042-92ee46cf7780.png)
![image](https://user-images.githubusercontent.com/745885/64321669-4bde2c00-cfc1-11e9-857b-f06514a124a8.png)

