### PR TITLE
Fix oncoprint sort for treatment profiles

### DIFF
--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -1389,7 +1389,7 @@ describe("DataUtils", ()=>{
             {value:NaN},
             {value:NaN}
            ];
-           const partialTrackDatum = {};
+           const partialTrackDatum = {} as ITreatmentHeatmapTrackDatum;
            fillHeatmapTrackDatum<ITreatmentHeatmapTrackDatum, "treatment_id">(
             partialTrackDatum,
             "treatment_id",
@@ -1397,8 +1397,8 @@ describe("DataUtils", ()=>{
             {patientId:"patient", studyId:"study"} as Sample,
             data,
             "DESC"
-           )
-           assert.isTrue(partialTrackDatum.na)
+           );
+           assert.isTrue(partialTrackDatum.na);
        });
 
        it('Prefers largest non-threshold absolute value when no sort order provided', () => {

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -1194,6 +1194,22 @@ describe("DataUtils", ()=>{
                {hugo_gene_symbol:"gene", study_id:"study", profile_data:3}
            );
        });
+       it("removes data points with NaN value", ()=>{
+            const data:any[] = [
+                {value:3},
+                {value:NaN},
+            ];
+            assert.deepEqual(
+                fillHeatmapTrackDatum<IGeneHeatmapTrackDatum, "hugo_gene_symbol">(
+                    {},
+                    "hugo_gene_symbol",
+                    "gene",
+                    {sampleId:"sample", studyId:"study"} as Sample,
+                    data
+                ),
+                {hugo_gene_symbol:"gene", study_id:"study", profile_data:3}
+            );
+      });
        it("throws exception if more than one data given for sample",()=>{
            const data:any[] = [
                {value:3},
@@ -1382,10 +1398,7 @@ describe("DataUtils", ()=>{
             data,
             "DESC"
            )
-           assert.deepEqual(
-            partialTrackDatum,
-            {treatment_id: "TREATMENT_ID_1", study_id:"study", profile_data:NaN}
-           );
+           assert.isTrue(partialTrackDatum.na)
        });
 
        it('Prefers largest non-threshold absolute value when no sort order provided', () => {

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -283,16 +283,17 @@ export function fillHeatmapTrackDatum<T extends IBaseHeatmapTrackDatum, K extend
 ) {
     trackDatum[featureKey] = featureId;
     trackDatum.study_id = case_.studyId;
-    if (data) {
-        _.remove(data, (d) => isNaN(d.value)); // remove data with non-available values
-    }
-    if (!data || !data.length) {
+
+    // remove data points of which `value` is NaN
+    const dataWithValue =  _.filter(data, (d) => isNaN(d.value));
+
+    if (!dataWithValue || !dataWithValue.length) {
         trackDatum.profile_data = null;
         trackDatum.na = true;
-    } else if (data.length === 1) {
-        trackDatum.profile_data = data[0].value;
-        if (data[0].thresholdType) {
-            trackDatum.thresholdType = data[0].thresholdType;
+    } else if (dataWithValue.length === 1) {
+        trackDatum.profile_data = dataWithValue[0].value;
+        if (dataWithValue[0].thresholdType) {
+            trackDatum.thresholdType = dataWithValue[0].thresholdType;
             trackDatum.category = trackDatum.profile_data && trackDatum.thresholdType? `${trackDatum.thresholdType}${trackDatum.profile_data.toFixed(2)}` : undefined;
         }
     } else {
@@ -307,16 +308,16 @@ export function fillHeatmapTrackDatum<T extends IBaseHeatmapTrackDatum, K extend
             let representingDatum;
             switch (sortOrder) {
                 case "ASC":
-                    let bestValue = _(data).map((d:HeatmapCaseDatum)=>d.value).min();
-                    representingDatum = selectRepresentingDataPoint(bestValue!, data, false);
+                    let bestValue = _(dataWithValue).map((d:HeatmapCaseDatum)=>d.value).min();
+                    representingDatum = selectRepresentingDataPoint(bestValue!, dataWithValue, false);
                     break;
                 case "DESC":
-                    bestValue = _(data).map((d:HeatmapCaseDatum)=>d.value).max();
-                    representingDatum = selectRepresentingDataPoint(bestValue!, data, false);
+                    bestValue = _(dataWithValue).map((d:HeatmapCaseDatum)=>d.value).max();
+                    representingDatum = selectRepresentingDataPoint(bestValue!, dataWithValue, false);
                     break;
                 default:
-                    bestValue = _.maxBy(data,(d:HeatmapCaseDatum) => Math.abs(d.value))!.value;
-                    representingDatum = selectRepresentingDataPoint(bestValue, data, true);
+                    bestValue = _.maxBy(dataWithValue,(d:HeatmapCaseDatum) => Math.abs(d.value))!.value;
+                    representingDatum = selectRepresentingDataPoint(bestValue, dataWithValue, true);
                     break;
             }
             
@@ -324,7 +325,7 @@ export function fillHeatmapTrackDatum<T extends IBaseHeatmapTrackDatum, K extend
             // this is detected by `representingDatum` to be undefined
             // in that case select the first element as representing datum
             if (representingDatum === undefined) {
-                representingDatum = data[0];
+                representingDatum = dataWithValue[0];
             }
 
             trackDatum.profile_data = representingDatum!.value;

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -285,7 +285,7 @@ export function fillHeatmapTrackDatum<T extends IBaseHeatmapTrackDatum, K extend
     trackDatum.study_id = case_.studyId;
 
     // remove data points of which `value` is NaN
-    const dataWithValue =  _.filter(data, (d) => isNaN(d.value));
+    const dataWithValue =  _.filter(data, (d) => !isNaN(d.value));
 
     if (!dataWithValue || !dataWithValue.length) {
         trackDatum.profile_data = null;

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -283,6 +283,9 @@ export function fillHeatmapTrackDatum<T extends IBaseHeatmapTrackDatum, K extend
 ) {
     trackDatum[featureKey] = featureId;
     trackDatum.study_id = case_.studyId;
+    if (data) {
+        _.remove(data, (d) => isNaN(d.value)); // remove data with non-available values
+    }
     if (!data || !data.length) {
         trackDatum.profile_data = null;
         trackDatum.na = true;


### PR DESCRIPTION
Note: this is a duplicate of [PR #2637](https://github.com/cBioPortal/cbioportal-frontend/pull/2637) from other remote (problems with triggering CircleCI jobs).

# What? Why?
Oncoprint does not handle sorting of treatment profile heatmap tracks correctly (see screenshot below)
![63562317-2cf48a00-c52b-11e9-9cd9-d34e46a36c61](https://user-images.githubusercontent.com/745885/63754894-f1084e80-c8b5-11e9-8f49-752082434359.png)

# Fix
The cause of this is that the sorting comparator function does not handle profile values that are `NaN` (value allowed for profile data). Problem was removed by filtering out NaN values in oncoprint.
![fixed_oncoprint_sort](https://user-images.githubusercontent.com/745885/63755179-670cb580-c8b6-11e9-8eda-25b6deba8c93.png)