### PR TITLE
Support multi-study expression tab for rna seq v1 profiles

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -343,9 +343,7 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
                                 expressionProfiles={store.expressionProfiles}
                                 numericGeneMolecularDataCache={store.numericGeneMolecularDataCache}
                                 mutations={store.filteredAndAnnotatedMutations.result!}
-                                RNASeqVersion={store.expressionTabSeqVersion}
                                 coverageInformation={store.coverageInformation.result}
-                                onRNASeqVersionChange={(version:number)=>store.expressionTabSeqVersion=version}
                             />)
                         }
                     </MSKTab>

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -465,8 +465,6 @@ export class ResultsViewPageStore {
 
     @observable public sessionIdURL = '';
 
-    @observable expressionTabSeqVersion: number = 2;
-
     @observable queryFormVisible: boolean = false;
 
     @observable public modifyQueryParams: ModifyQueryParams | undefined = undefined;
@@ -3327,55 +3325,10 @@ export class ResultsViewPageStore {
         ],
         invoke:()=>{
             return Promise.resolve(this.molecularProfilesInStudies.result.filter(
-                (profile:MolecularProfile)=>isRNASeqProfile(profile.molecularProfileId, this.expressionTabSeqVersion)
+                (profile:MolecularProfile)=>isRNASeqProfile(profile.molecularProfileId)
             ));
         }
     },[]);
-
-    readonly rnaSeqMolecularData = remoteData<{[hugoGeneSymbol:string]:NumericGeneMolecularData[][]}>({
-       await:()=>[
-           this.expressionProfiles,
-           this.genes,
-           this.geneMolecularDataCache
-       ],
-       invoke: async ()=>{
-
-           const rnaSeqProfiles = this.expressionProfiles.result!;
-
-           const queries = _.flatMap(this.genes.result,(gene:Gene)=>{
-               return rnaSeqProfiles.map((profile:MolecularProfile)=> {
-                   return ({
-                       entrezGeneId: gene.entrezGeneId,
-                       molecularProfileId: profile.molecularProfileId,
-                       hugoGeneSymbol:gene.hugoGeneSymbol
-                   })
-               });
-           });
-
-           const data = await this.geneMolecularDataCache.result!.getPromise(queries,true);
-
-           // group cache objects by entrez geneId
-           const groupedByGene = _.groupBy(data,
-               (cacheItem:CacheData<NumericGeneMolecularData[], { entrezGeneId:number, molecularProfileId:string; }>)=>
-                   (cacheItem.meta) ? cacheItem.meta!.entrezGeneId : undefined
-           );
-
-           // now convert key from entrez to hugeGeneSymbol
-           const keyedByHugoSymbol = _.mapKeys(groupedByGene,(val, entrezGeneId:string)=>{
-               // look up huge gene symbol on gene with matching entrez
-               return _.find(this.genes.result,(gene:Gene)=>gene.entrezGeneId.toString()===entrezGeneId)!.hugoGeneSymbol;
-           });
-
-           const unwrapCacheObjects:{[hugeGeneSymbol:string]:NumericGeneMolecularData[][]} =
-               _.mapValues(keyedByHugoSymbol,(val:AugmentedData<NumericGeneMolecularData[], GeneMolecularDataCache>)=>{
-                    return _.map(val,(item:AugmentedData<NumericGeneMolecularData[], GeneMolecularDataCache>)=>item.data);
-                }) as any; // there's an error with typing for _.mapValues
-
-           return Promise.resolve(unwrapCacheObjects);
-
-       }
-
-    });
 
     @memoize sortRnaSeqMolecularDataByStudy(seqData:{[profileId:string]:NumericGeneMolecularData[]}){
         return _.keyBy(seqData,(data:NumericGeneMolecularData[])=>{

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -1216,14 +1216,11 @@ describe("ResultsViewPageStoreUtils", ()=>{
     describe('getRNASeqProfiles',()=>{
 
         it('properly recognizes expression profile based on patterns in id',()=>{
-            assert.isFalse(isRNASeqProfile("",1), "blank is false");
-            assert.isTrue(isRNASeqProfile("acc_tcga_rna_seq_v2_mrna",2),"matches seq v2 id");
-            assert.isFalse(isRNASeqProfile("acc_tcga_rna_seq_v2_mrna",1),"fails if versions is wrong");
-            assert.isTrue(isRNASeqProfile("chol_tcga_pan_can_atlas_2018_rna_seq_v2_mrna_median",2),'matches pan can v2');
-            assert.isFalse(isRNASeqProfile("chol_tcga_pan_can_atlas_2018_rna_seq_v2_mrna_median",1),'matches pan can v2');
-            assert.isFalse(isRNASeqProfile("laml_tcga_rna_seq_mrna",2));
-            assert.isTrue(isRNASeqProfile("laml_tcga_rna_seq_mrna",1));
-            assert.isFalse(isRNASeqProfile("chol_tcga_pan_can_atlas_2018_rna_seq_v2_mrna_median_Zscores",2), 'doesn\'t match zscores profils');
+            assert.isFalse(isRNASeqProfile(""), "blank is false");
+            assert.isTrue(isRNASeqProfile("acc_tcga_rna_seq_v2_mrna"),"matches seq v2 id");
+            assert.isTrue(isRNASeqProfile("chol_tcga_pan_can_atlas_2018_rna_seq_v2_mrna_median"),'matches pan can v2');
+            assert.isTrue(isRNASeqProfile("laml_tcga_rna_seq_mrna"));
+            assert.isFalse(isRNASeqProfile("chol_tcga_pan_can_atlas_2018_rna_seq_v2_mrna_median_Zscores"), 'doesn\'t match zscores profils');
         });
 
     });

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.ts
@@ -380,10 +380,8 @@ export function filterSubQueryData(
 }
 
 
-export function isRNASeqProfile(profileId:string, version:number): boolean {
-    const ver = (version === 2) ? 'v2_' : '';
-    // note that pan can only has v2 expression data, so don't worry about v1
-    return RegExp(`rna_seq_${ver}mrna$|pan_can_atlas_2018_rna_seq_${ver}mrna_median$`).test(profileId);
+export function isRNASeqProfile(profileId:string): boolean {
+    return RegExp(`rna_seq_mrna$|rna_seq_v2_mrna$|pan_can_atlas_2018_rna_seq_mrna_median$|pan_can_atlas_2018_rna_seq_v2_mrna_median$`).test(profileId);
 }
 
 export function isTCGAPubStudy(studyId:string){

--- a/src/pages/resultsView/expression/expressionHelpers.spec.ts
+++ b/src/pages/resultsView/expression/expressionHelpers.spec.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {getMolecularDataBuckets, prioritizeMutations} from "./expressionHelpers";
+import {getMolecularDataBuckets, prioritizeMutations, getPossibleRNASeqVersions} from "./expressionHelpers";
 import {CoverageInformation} from "../ResultsViewPageStoreUtils";
 import {studyData as sampleStudyData, mutationsKeyedBySampleId, coverageInformation} from './expressionHelpers.sample.js';
 import {Mutation, NumericGeneMolecularData} from "../../../shared/api/generated/CBioPortalAPI";
@@ -1571,6 +1571,11 @@ describe('prioritizeMutations',()=>{
 
 });
 
-
-
-
+describe('getPossibleRNASeqVersions', () => {
+    it('return appropriate RNA seq version options', () => {
+        assert.deepEqual(getPossibleRNASeqVersions([{ "molecularProfileId": "" }]), [])
+        assert.deepEqual(getPossibleRNASeqVersions([{ "molecularProfileId": "acc_tcga_rna_seq_v2_mrna" }]), [{"label":"RNA Seq V2","value":"rna_seq_v2_mrna"}])
+        assert.deepEqual(getPossibleRNASeqVersions([{ "molecularProfileId": "laml_tcga_rna_seq_mrna" }]), [{"label":"RNA Seq","value":"rna_seq_mrna"}])
+        assert.deepEqual(getPossibleRNASeqVersions([{ "molecularProfileId": "acc_tcga_rna_seq_v2_mrna" }, { "molecularProfileId": "laml_tcga_rna_seq_mrna" }]), [{"label":"RNA Seq V2","value":"rna_seq_v2_mrna"},{"label":"RNA Seq","value":"rna_seq_mrna"}])
+    });
+});

--- a/src/pages/resultsView/expression/expressionHelpers.tsx
+++ b/src/pages/resultsView/expression/expressionHelpers.tsx
@@ -1,7 +1,8 @@
 import * as _ from 'lodash';
 import {
     CancerStudy, GenePanelData, Mutation,
-    NumericGeneMolecularData
+    NumericGeneMolecularData,
+    MolecularProfile
 } from "../../../shared/api/generated/CBioPortalAPI";
 import {CoverageInformation} from "../ResultsViewPageStoreUtils";
 import {isSampleProfiled} from "../../../shared/lib/isSampleProfiled";
@@ -119,6 +120,14 @@ export const ExpressionStyleSheet: { [mutationType:string]:ExpressionStyle } = {
 
 };
 
+export const RNASeqOptions = [{
+    label: 'RNA Seq V2',
+    value: 'rna_seq_v2_mrna'
+}, {
+    label: 'RNA Seq',
+    value: 'rna_seq_mrna'
+}];
+
 export function getExpressionStyle(mutationType: string){
     return ExpressionStyleSheet[mutationType];
 }
@@ -204,4 +213,18 @@ export function expressionTooltip(d:IBoxScatterPlotPoint, studyIdToStudy:{[study
             )}
         </div>
     );
+}
+
+export function getPossibleRNASeqVersions(expressionProfiles: Pick<MolecularProfile, "molecularProfileId">[]) {
+    const possibleRNASeqVersions: { [id: string]: boolean } = {
+        'rna_seq_mrna': false,
+        'rna_seq_v2_mrna': false
+    };
+
+    possibleRNASeqVersions.rna_seq_mrna = _.some(expressionProfiles, expressionProfile =>
+        RegExp(`rna_seq_mrna$|pan_can_atlas_2018_rna_seq_mrna_median$`).test(expressionProfile.molecularProfileId));
+    possibleRNASeqVersions.rna_seq_v2_mrna = _.some(expressionProfiles, expressionProfile =>
+        RegExp(`rna_seq_v2_mrna$|pan_can_atlas_2018_rna_seq_v2_mrna_median$`).test(expressionProfile.molecularProfileId));
+
+    return RNASeqOptions.filter(option => possibleRNASeqVersions[option.value]);
 }


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/6541

Example
Expression tab is not show for this query 
https://www.cbioportal.org/results/oncoprint?Action=Submit&cancer_study_list=pcpg_tcga_pub%2Clusc_tcga_pub&case_set_id=all&clinicallist=CANCER_STUDY%2CNUM_SAMPLES_PER_PATIENT%2CPROFILED_IN_COPY_NUMBER_ALTERATION&data_priority=0&gene_list=TP53%0ALRP1B%0AKMT2D&show_samples=false&tab_index=tab_visualize

With these changes Expression tab is visible even when only rna seq v1 data is present
https://cbioportal-frontend-pr-2655.herokuapp.com/results/expression?Action=Submit&cancer_study_list=pcpg_tcga_pub%2Clusc_tcga_pub&case_set_id=all&clinicallist=CANCER_STUDY%2CNUM_SAMPLES_PER_PATIENT%2CPROFILED_IN_COPY_NUMBER_ALTERATION&data_priority=0&gene_list=TP53%0ALRP1B%0AKMT2D&show_samples=false&tab_index=tab_visualize