### PR TITLE
Rename 'Add to Heatmap'-button in oncoprint for treatment response profiles.

### DIFF
--- a/end-to-end-test/local/specs/treatment.screenshot.spec.js
+++ b/end-to-end-test/local/specs/treatment.screenshot.spec.js
@@ -24,7 +24,7 @@ describe('treatment feature', () => {
             selectReactSelectOption( $('.oncoprint__controls__heatmap_menu'), 'IC50 values of compounds on cellular phenotype readout');
             $('.oncoprint__controls__heatmap_menu textarea').setValue('17-AAG');
             $('div.icon-area div.icon').waitForExist();
-            $('button=Add Treatments to Heatmap').click();
+            $('button=Add Treatment Response to Heatmap').click();
             openHeatmapMenu();
             waitForOncoprint();
             var res = browser.checkElement('[id=oncoprintDiv]');

--- a/end-to-end-test/local/specs/treatment.spec.js
+++ b/end-to-end-test/local/specs/treatment.spec.js
@@ -112,7 +112,7 @@ describe('treatment feature', function() {
                 selectReactSelectOption( $('.oncoprint__controls__heatmap_menu'), 'IC50 values of compounds on cellular phenotype readout');
                 $('.oncoprint__controls__heatmap_menu textarea').setValue('17-AAG');
                 $('div.icon-area div.icon').waitForExist();
-                $('button=Add Treatments to Heatmap').click();
+                $('button=Add Treatment Response to Heatmap').click();
                 waitForOncoprint();
                 var url = browser.url().value;
                 var regex = /treatment_list=17-AAG/;

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -574,7 +574,7 @@ export default class OncoprintControls extends React.Component<IOncoprintControl
                                 className="btn btn-sm btn-default"
                                 name={EVENT_KEY.addTreatmentsToHeatmap}
                                 onClick={this.onButtonClick}
-                            >Add Treatments to Heatmap</button>
+                            >Add Treatment Response to Heatmap</button>
                             ]
                         }
 


### PR DESCRIPTION
# What? Why?
The button was named `Add Treatments to Heatmap`. This is incorrect since response data is added.

# Fix
Button was renamed to `Add Treatment Response to Heatmap`.

# Before
![Screenshot from 2019-09-05 08-47-21](https://user-images.githubusercontent.com/745885/64318219-d9b61900-cfb9-11e9-8914-3f1b4dcc2b04.png)

# After
![image](https://user-images.githubusercontent.com/745885/64318242-e9356200-cfb9-11e9-8f99-ef2be7d2527c.png)
