### PR TITLE
Fix #4090 tooltip display in segment tracks

### DIFF
--- a/src/pages/patientView/genomicOverview/tracksHelper.ts
+++ b/src/pages/patientView/genomicOverview/tracksHelper.ts
@@ -256,10 +256,10 @@ function addToolTip(node: any, tip: any,showDelay: any, position: any) {
         style: { classes: 'qtip-light qtip-rounded' },
         position: {
             my: "bottom right",
-            at: "top left"
+            at: "top left",
+            viewport: $("body")
         }
-        //position: {viewport: $(window)}
-    }; //TODO: viewport causes jquery exception
+    };
     // if (showDelay)
     //     param['show'] = { delay: showDelay };
     // if (position)


### PR DESCRIPTION
# Fix
Fix [#4090](https://github.com/cBioPortal/cbioportal/issues/4090) Part of tooltip in segment tracks outside browser window.

Changes proposed in this pull request:
- Added "viewport: $('body')" to qtip's position object. N.B. "viewport" only throws exception if the selected element is not connected to the document (Please refer [here](https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnoffset-requires-an-element-connected-to-a-document))

# Screenshots

### Before
<img width="588" alt="38618613-75ea69e2-3d9a-11e8-8395-dc67d59a4f64" src="https://user-images.githubusercontent.com/31291004/64356058-86b48400-d002-11e9-84af-ad4e8c6465c7.png">

### After
![#4090](https://user-images.githubusercontent.com/31291004/64356237-cda27980-d002-11e9-84fd-4eb958e497ed.png)
