### PR TITLE
Hide the utilities menu when clinical/treatment selected in PlotsTab

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -300,8 +300,8 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
             return PotentialViewType.MutationSummary;
         }
         // one axis molecular profile
-        if (this.horzSelection.dataType !== CLIN_ATTR_DATA_TYPE ||
-            this.vertSelection.dataType !== CLIN_ATTR_DATA_TYPE) {
+        if ((this.horzSelection.dataType !== CLIN_ATTR_DATA_TYPE && this.horzSelection.dataType !== AlterationTypeConstants.GENERIC_ASSAY)
+            || (this.vertSelection.dataType !== CLIN_ATTR_DATA_TYPE &&  this.vertSelection.dataType !== AlterationTypeConstants.GENERIC_ASSAY)) {
             //  establish whether data may contain limit values
             // (for now only supported for treatment data)
             if (this.limitValuesCanBeShown) {
@@ -309,7 +309,6 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
             }
             return PotentialViewType.MutationTypeAndCopyNumber;
         }
-
 
         //  establish whether data may contain limit values
         // (for now only supported for treatment data)


### PR DESCRIPTION
# What? Why?
When a combination of clinical data and treatment data was selected in the plotstab. The utilities menu for mutation and CNA styling options was shown, where it should be hidded.

# Fix
Utilities menu is not hidden when clinical data and treatment data are selected in the plotstab.

# Before
![image](https://user-images.githubusercontent.com/745885/64354045-ffb1dc80-cffe-11e9-8ef6-ecdd0dfa48e4.png)

# After
![image](https://user-images.githubusercontent.com/745885/64353986-e6109500-cffe-11e9-85e5-0691a5826cfd.png)
