### PR TITLE
Make radio buttons of utilities menu in waterfall plot not de-selectable.

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -564,21 +564,25 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
                 this.vertSelection.logScale = !this.vertSelection.logScale;
                 break;
             case EventKey.utilities_viewCopyNumber:
-                this.viewCopyNumber = !this.viewCopyNumber;
                 // Styling by mutation type and CNA for waterfall plot
                 // is mutually exclusive. When selected the viewMutationType
                 // option is deselected when currently selected.
-                if (plotType === PlotType.WaterfallPlot && this.viewCopyNumber && this.viewMutationType) {
+                if (plotType === PlotType.WaterfallPlot) {
+                    this.viewCopyNumber = true;
                     this.viewMutationType = false;
+                } else {
+                    this.viewCopyNumber = !this.viewCopyNumber;
                 }
                 break;
             case EventKey.utilities_viewMutationType:
-                this.viewMutationType = !this.viewMutationType;
                 // Styling by mutation type and CNA for waterfall plot
                 // is mutually exclusive. When selected the viewCopyNumber
                 // option is deselected when currently selected.
-                if (plotType === PlotType.WaterfallPlot && this.viewMutationType && this.viewCopyNumber) {
+                if (plotType === PlotType.WaterfallPlot) {
                     this.viewCopyNumber = false;
+                    this.viewMutationType = true;
+                } else {
+                    this.viewMutationType = !this.viewMutationType;
                 }
                 break;
             case EventKey.utilities_showRegressionLine:


### PR DESCRIPTION
# What? Why?
Utilities menu radio buttons for the waterfall plot to style samples based on mutations or CNA's can be all deselected by again clicking on the currently selected option. This is not expected behavior of a radio button (one option should remain selected at all times).

# Fix
Code was updated to disallow deselection of the option.