### PR TITLE
Update warning message for treatment profile selection in PlotsTab

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -2075,7 +2075,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
             return (
                 <div>
                     <i className="fa fa-exclamation-triangle text-danger" />&nbsp;
-                    <span>You attempt to visualize treatment profile data, but did not select any treatments for visualization. Please add treatment profile heatmap tracks in OncoPrint tab to analyze treatments in the Plots tab.</span>
+                    <span>To visualize treatment response data, you must first visit the OncoPrint tab and use the "Heatmap" menu to add treatment response tracks to the OncoPrint. Any treatments added to the OncoPrint will then be available on this tab for visualization.</span>
                 </div>
             )
         }


### PR DESCRIPTION
# What? Why?
A warning is shown in plots tab when the user attempts to plot treatment response data, but no treatments were selected for visualization in OncoPrint. The message provided instruction to the user on what to do. This message could be more clear.

# Fix
Message was updated to:

>To visualize treatment response data, you must first visit the OncoPrint tab and use the "Heatmap" menu to add treatment response tracks to the OncoPrint. Any treatments added to the OncoPrint will then be available on this tab for visualization.