### PR TITLE
molecular files download

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -475,8 +475,6 @@ export class ResultsViewPageStore {
 
     @observable queryFormVisible: boolean = false;
 
-    @observable public selectedMolecularProfileNameForDownload: string | undefined = undefined;
-
     @computed get doNonSelectedMolecularProfilesExist() {
         return this.nonSelectedMolecularProfilesGroupByName.result && _.keys(this.nonSelectedMolecularProfilesGroupByName.result).length > 0;
     }

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -19,7 +19,6 @@ import {
 import styles from "./styles.module.scss";
 import classNames from 'classnames';
 import OqlStatusBanner from "../../../shared/components/banners/OqlStatusBanner";
-import WindowStore from "../../../shared/components/window/WindowStore";
 import {WindowWidthBox} from "../../../shared/components/WindowWidthBox/WindowWidthBox";
 import {remoteData} from "../../../public-lib/api/remoteData";
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
@@ -30,15 +29,10 @@ import ErrorMessage from "../../../shared/components/ErrorMessage";
 import AlterationFilterWarning from "../../../shared/components/banners/AlterationFilterWarning";
 import sessionServiceClient from "shared/api//sessionServiceInstance";
 import { buildCBioPortalPageUrl } from 'shared/api/urls';
-import { MakeMobxView } from 'shared/components/MobxView';
 import { CUSTOM_CASE_LIST_ID } from 'shared/components/query/QueryStore';
 import { IVirtualStudyProps } from 'pages/studyView/virtualStudy/VirtualStudy';
 import { Alteration } from 'shared/lib/oql/oql-parser';
 import ReactSelect from "react-select";
-import Select from "react-select1";
-import { Dropdown, Checkbox } from 'react-bootstrap';
-import { DropdownToggleProps } from 'react-bootstrap/lib/DropdownToggle';
-import { DropdownMenuProps } from 'react-bootstrap/lib/DropdownMenu';
 import autobind from 'autobind-decorator';
 import DefaultTooltip from 'public-lib/components/defaultTooltip/DefaultTooltip';
 import FontAwesome from 'react-fontawesome';
@@ -739,27 +733,5 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         }
         this.props.store.modifyQueryParams = modifyQueryParams;
         this.props.store.queryFormVisible = true;
-    }
-
-    @action
-    private async handleVirtualStudyButtonClick(alterations: ICaseAlteration[]) {
-        let studies = _.reduce(_.groupBy(alterations, "studyId"), (acc: { id: string; samples: string[] }[], alteration, studyId) => {
-            acc.push({
-                id: studyId,
-                samples: alterations.map(alteration => alteration.sampleId)
-            })
-            return acc;
-        }, []);
-
-        let parameters = {
-            name: "virtual study",
-            description: "virtual study",
-            origin: studies.map(study => study.id),
-            studies: studies
-        }
-        const saveStudyResult = await sessionServiceClient.saveVirtualStudy(parameters, false);
-        if (saveStudyResult && saveStudyResult.id) {
-            window.open(buildCBioPortalPageUrl({pathname:'study', query: {id: saveStudyResult.id}}), "_blank");
-        }
     }
 }

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import {computed, observable, action} from "mobx";
 import {observer} from 'mobx-react';
 import fileDownload from 'react-file-download';
-import {AnnotatedExtendedAlteration, ExtendedAlteration, ResultsViewPageStore, ModifyQueryParams} from "../ResultsViewPageStore";
+import {AnnotatedExtendedAlteration, ExtendedAlteration, ResultsViewPageStore, ModifyQueryParams, CaseAggregatedData, AlterationTypeConstants} from "../ResultsViewPageStore";
 import {CoverageInformation, getSingleGeneResultKey, getMultipleGeneResultKey} from "../ResultsViewPageStoreUtils";
 import {OQLLineFilterOutput, UnflattenedOQLLineFilterOutput, MergedTrackLineFilterOutput} from "shared/lib/oql/oqlfilter";
 import FeatureTitle from "shared/components/featureTitle/FeatureTitle";
@@ -13,7 +13,7 @@ import {default as CaseAlterationTable, ICaseAlteration} from "./CaseAlterationT
 import {
     generateCaseAlterationData, generateCnaData, generateDownloadData, generateGeneAlterationData, generateMrnaData,
     generateMutationData, generateMutationDownloadData,
-    generateProteinData, hasValidData, hasValidMutationData, stringify2DArray
+    generateProteinData, hasValidData, hasValidMutationData, stringify2DArray, generateOtherMolecularProfileData, generateOtherMolecularProfileDownloadData
 } from "./DownloadUtils";
 
 import styles from "./styles.module.scss";
@@ -24,7 +24,7 @@ import {WindowWidthBox} from "../../../shared/components/WindowWidthBox/WindowWi
 import {remoteData} from "../../../public-lib/api/remoteData";
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
 import onMobxPromise from "shared/lib/onMobxPromise";
-import {MolecularProfile, Sample} from "shared/api/generated/CBioPortalAPI";
+import {MolecularProfile, Sample, CancerStudy} from "shared/api/generated/CBioPortalAPI";
 import {getMobxPromiseGroupStatus} from "../../../shared/lib/getMobxPromiseGroupStatus";
 import ErrorMessage from "../../../shared/components/ErrorMessage";
 import AlterationFilterWarning from "../../../shared/components/banners/AlterationFilterWarning";
@@ -34,6 +34,14 @@ import { MakeMobxView } from 'shared/components/MobxView';
 import { CUSTOM_CASE_LIST_ID } from 'shared/components/query/QueryStore';
 import { IVirtualStudyProps } from 'pages/studyView/virtualStudy/VirtualStudy';
 import { Alteration } from 'shared/lib/oql/oql-parser';
+import ReactSelect from "react-select";
+import Select from "react-select1";
+import { Dropdown, Checkbox } from 'react-bootstrap';
+import { DropdownToggleProps } from 'react-bootstrap/lib/DropdownToggle';
+import { DropdownMenuProps } from 'react-bootstrap/lib/DropdownMenu';
+import autobind from 'autobind-decorator';
+import DefaultTooltip from 'public-lib/components/defaultTooltip/DefaultTooltip';
+import FontAwesome from 'react-fontawesome';
 
 export interface IDownloadTabProps {
     store: ResultsViewPageStore;
@@ -96,7 +104,9 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
 
     readonly mutationData = remoteData<{[key: string]: ExtendedAlteration[]}>({
         await:()=>[this.props.store.nonOqlFilteredCaseAggregatedData],
-        invoke:()=>Promise.resolve(generateMutationData(this.props.store.nonOqlFilteredCaseAggregatedData.result!))
+        invoke:()=>{
+            return Promise.resolve(generateMutationData(this.props.store.nonOqlFilteredCaseAggregatedData.result!));
+        }
     });
 
     readonly mutationDownloadData = remoteData<string[][]>({
@@ -119,6 +129,45 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
     readonly transposedMutationDataText = remoteData<string>({
         await:()=>[this.transposedMutationDownloadData],
         invoke:()=>Promise.resolve(stringify2DArray(this.transposedMutationDownloadData.result!))
+    });
+
+    readonly otherMolecularProfileData = remoteData<{[key: string]: ExtendedAlteration[]}>({
+        await:()=>[this.props.store.nonQueriedMolecularData, this.props.store.nonSelectedMolecularProfilesGroupByName],
+        invoke:()=>{
+            const profileNames = _.keys(this.props.store.nonSelectedMolecularProfilesGroupByName.result);
+            const selectedProfileName = this.props.store.selectedMolecularProfileNameForDownload ? this.props.store.selectedMolecularProfileNameForDownload : profileNames[0];
+            if (this.props.store.doNonSelectedMolecularProfilesExist) {
+                const data = {
+                    "samples": _.groupBy(this.props.store.nonQueriedMolecularData.result!, (data) => data.uniqueSampleKey)
+                } as CaseAggregatedData<ExtendedAlteration>
+                return Promise.resolve(generateOtherMolecularProfileData(this.props.store.nonSelectedMolecularProfilesGroupByName.result[selectedProfileName].map(profile => profile.molecularProfileId), data))
+            }
+            return Promise.resolve({});
+        }
+    });
+
+    readonly otherMolecularProfileDownloadData = remoteData<string[][]>({
+        await:()=>[this.otherMolecularProfileData, this.props.store.samples, this.props.store.genes],
+        invoke:()=>Promise.resolve(generateOtherMolecularProfileDownloadData(
+            this.otherMolecularProfileData.result!, this.props.store.samples.result!, this.props.store.genes.result!
+        ))
+    });
+
+    readonly transposedOtherMolecularProfileDownloadData = remoteData<string[][]>({
+        await:()=>[this.otherMolecularProfileDownloadData],
+        invoke:()=>Promise.resolve(_.unzip(this.otherMolecularProfileDownloadData.result!))
+    });
+
+    readonly otherMolecularProfileDataText = remoteData<string>({
+        await:()=>[this.otherMolecularProfileDownloadData],
+        invoke:()=>Promise.resolve(stringify2DArray(this.otherMolecularProfileDownloadData.result!))
+    });
+
+    readonly transposedOtherMolecularProfileDataText = remoteData<string>({
+        await:()=>[this.transposedOtherMolecularProfileDownloadData],
+        invoke:()=>{
+            return Promise.resolve(stringify2DArray(this.transposedOtherMolecularProfileDownloadData.result!))
+        }
     });
 
     readonly mrnaData = remoteData<{[key: string]: ExtendedAlteration[]}>({
@@ -334,7 +383,8 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
 
     public render() {
         const status = getMobxPromiseGroupStatus(this.geneAlterationData, this.caseAlterationData, this.oqls, this.trackLabels, this.trackAlterationTypesMap, this.geneAlterationMap, this.cnaData, this.mutationData, 
-            this.mrnaData, this.proteinData, this.unalteredCaseAlterationData, this.alteredCaseAlterationData, this.props.store.virtualStudyParams, this.sampleMatrixText);
+            this.mrnaData, this.proteinData, this.unalteredCaseAlterationData, this.alteredCaseAlterationData, this.props.store.virtualStudyParams, this.sampleMatrixText, this.props.store.nonSelectedMolecularProfilesGroupByName,
+            this.props.store.studies, this.props.store.selectedMolecularProfiles);
 
         switch (status) {
             case "pending":
@@ -359,11 +409,12 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
                                 <tbody>
                                     {hasValidData(this.cnaData.result!) && this.cnaDownloadControls()}
                                     {hasValidMutationData(this.mutationData.result!) && this.mutationDownloadControls()}
-                                    {hasValidData(this.mrnaData.result!) && this.mrnaExprDownloadControls()}
-                                    {hasValidData(this.proteinData.result!) && this.proteinExprDownloadControls()}
+                                    {hasValidData(this.mrnaData.result!) && this.mrnaExprDownloadControls(this.props.store.selectedMolecularProfiles.result!.find((profile) => profile.molecularAlterationType === AlterationTypeConstants.MRNA_EXPRESSION)!.name)}
+                                    {hasValidData(this.proteinData.result!) && this.proteinExprDownloadControls(this.props.store.selectedMolecularProfiles.result!.find((profile) => profile.molecularAlterationType === AlterationTypeConstants.PROTEIN_LEVEL)!.name)}
                                     {this.alteredSamplesDownloadControls(this.alteredCaseAlterationData.result!, this.props.store.virtualStudyParams.result!)}
                                     {this.unalteredSamplesDownloadControls(this.unalteredCaseAlterationData.result!, this.props.store.virtualStudyParams.result!)}
                                     {this.sampleMatrixDownloadControls(this.sampleMatrixText.result!)}
+                                    {(this.props.store.doNonSelectedMolecularProfilesExist) && this.nonSelectedProfileDownloadRow(this.props.store.nonSelectedMolecularProfilesGroupByName.result!)}
                                 </tbody>
                             </table>
                         </div>
@@ -412,38 +463,126 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
                                         this.handleTransposedMutationDownload);
     }
 
-    private mrnaExprDownloadControls(): JSX.Element
+    private mrnaExprDownloadControls(profileName: string): JSX.Element
     {
-        return this.downloadControlsRow("mRNA Expression",
+        return this.downloadControlsRow(profileName,
                                         this.handleMrnaDownload,
                                         this.handleTransposedMrnaDownload);
     }
 
-    private proteinExprDownloadControls(): JSX.Element
+    private proteinExprDownloadControls(profileName: string): JSX.Element
     {
-        return this.downloadControlsRow("Protein Expression",
+        return this.downloadControlsRow(profileName,
                                         this.handleProteinDownload,
                                         this.handleTransposedProteinDownload);
     }
 
-    private downloadControlsRow(title:string,
-                                handleTabDelimitedDownload: () => void,
-                                handleTransposedMatrixDownload: () => void)
+    private downloadControlsRow(profileName:string,
+                                handleTabDelimitedDownload: (name: string) => void,
+                                handleTransposedMatrixDownload: (name: string) => void)
     {
         return (
             <tr>
-                <td style={{width: 500}}>{title}</td>
+                <td style={{width: 500}}>{profileName}</td>
                 <td>
-                    <a onClick={handleTabDelimitedDownload}>
+                    <a onClick={(event) => handleTabDelimitedDownload(profileName)}>
                         <i className='fa fa-cloud-download' style={{marginRight: 5}}/>Tab Delimited Format
                     </a>
                     <span style={{margin:'0px 10px'}}>|</span>
-                    <a onClick={handleTransposedMatrixDownload}>
+                    <a onClick={(event) => handleTransposedMatrixDownload(profileName)}>
                         <i className='fa fa-cloud-download' style={{marginRight: 5}}/>Transposed Matrix
                     </a>
                 </td>
             </tr>
         );
+    }
+
+    private nonSelectedProfileDownloadRow(nonSelectedMolecularProfilesGroupByName:_.Dictionary<MolecularProfile[]>)
+    {
+        const profileOptions = _.keys(nonSelectedMolecularProfilesGroupByName).map((name) => {
+            if (this.props.store.studies.result!.length === 1) {
+                const singleStudyProfile = nonSelectedMolecularProfilesGroupByName[name][0];
+                return {
+                    "value": name,
+                    "label": name,
+                    "description": singleStudyProfile.description
+                }
+            }
+            return {"value": name, "label": name}
+        });
+
+        const selectedOption = profileOptions.find((option) => {
+            if (this.props.store.selectedMolecularProfileNameForDownload && _.keys(nonSelectedMolecularProfilesGroupByName).includes(this.props.store.selectedMolecularProfileNameForDownload)) {
+                return option.value === this.props.store.selectedMolecularProfileNameForDownload;
+            }
+            return option.value === _.keys(nonSelectedMolecularProfilesGroupByName)[0];
+        });
+        const selectedProfileName = selectedOption!.value;
+        
+        return (
+            <tr>
+                <td style={{width: 500}}>
+                    <div style={{display: "flex", alignItems:"center"}}>
+                        {"Other profiles"}
+                        <div className={styles["other-profiles-select"]}>
+                            <ReactSelect
+                                    value={selectedOption}
+                                    onChange={this.handleSelect}
+                                    options={profileOptions}
+                                    formatOptionLabel={this.formatOptionLabel}
+                                    clearable={false}
+                                    autosize={false}
+                            />
+                        </div>
+                    </div>
+                </td>
+                <td>
+                    {
+                        (this.props.store.doNonSelectedMolecularProfilesExist) && (
+                            <div>
+                                <a onClick={(event) => this.handleOtherMolecularProfileDownload(event, selectedProfileName)}>
+                                <i className='fa fa-cloud-download' style={{marginRight: 5}}/>Tab Delimited Format
+                                </a>
+                                <span style={{margin:'0px 10px'}}>|</span>
+                                <a onClick={(event) => this.handleTransposedOtherMolecularProfileDownload(event, selectedProfileName)}>
+                                    <i className='fa fa-cloud-download' style={{marginRight: 5}}/>Transposed Matrix
+                                </a>
+                            </div>
+                        )
+                    }
+
+
+                </td>
+            </tr>
+        );
+    }
+
+    @autobind
+    @action
+    private formatOptionLabel(props: any) {
+        return (
+            <div style={{ display: "flex" }}>
+                <div>{props.label}</div>
+                {
+                    (props.description) && (
+                        <DefaultTooltip
+                            mouseEnterDelay={0}
+                            placement="right"
+                            overlay={<div className={styles.tooltip}>{props.description}</div>}
+                        >
+                            <FontAwesome className={styles.infoIcon} name='question-circle'/>
+                        </DefaultTooltip>
+                    )
+                }
+            </div>
+        )
+    };
+
+    @autobind
+    private handleSelect(option: any) {
+        if (option && option.value) {
+            this.props.store.selectedMolecularProfileNameForDownload = option.value;
+        }
     }
 
     private copyDownloadControlsRow(title:string,
@@ -549,24 +688,36 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         onMobxPromise(this.transposedMutationDataText, text=>fileDownload(text, "mutations_transposed.txt"));
     }
 
-    private handleMrnaDownload()
+    @autobind
+    private handleOtherMolecularProfileDownload(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>, profileName: string)
     {
-        onMobxPromise(this.mrnaDataText, text=>fileDownload(text, "mRNA_exp.txt"));
+        onMobxPromise(this.otherMolecularProfileDataText, text=>fileDownload(text, `${profileName}.txt`));
     }
 
-    private handleTransposedMrnaDownload()
+    @autobind
+    private handleTransposedOtherMolecularProfileDownload(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>, profileName: string)
     {
-        onMobxPromise(this.transposedMrnaDataText, text=>fileDownload(text, "mRNA_exp_transposed.txt"));
+        onMobxPromise(this.transposedOtherMolecularProfileDataText, text=>fileDownload(text, `${profileName}.txt`));
     }
 
-    private handleProteinDownload()
+    private handleMrnaDownload(profileName: string)
     {
-        onMobxPromise(this.proteinDataText, text=>fileDownload(text, "protein_exp.txt"));
+        onMobxPromise(this.mrnaDataText, text=>fileDownload(text, `${profileName}.txt`));
     }
 
-    private handleTransposedProteinDownload()
+    private handleTransposedMrnaDownload(profileName: string)
     {
-        onMobxPromise(this.transposedProteinDataText, text=>fileDownload(text, "protein_exp_transposed.txt"));
+        onMobxPromise(this.transposedMrnaDataText, text=>fileDownload(text, `${profileName}.txt`));
+    }
+
+    private handleProteinDownload(profileName: string)
+    {
+        onMobxPromise(this.proteinDataText, text=>fileDownload(text, `${profileName}.txt`));
+    }
+
+    private handleTransposedProteinDownload(profileName: string)
+    {
+        onMobxPromise(this.transposedProteinDataText, text=>fileDownload(text, `${profileName}.txt`));
     }
 
     private handleCnaDownload()

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -112,21 +112,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         ))
     });
 
-    readonly transposedMutationDownloadData = remoteData<string[][]>({
-        await:()=>[this.mutationDownloadData],
-        invoke:()=>Promise.resolve(_.unzip(this.mutationDownloadData.result!))
-    });
-
-    readonly mutationDataText = remoteData<string>({
-        await:()=>[this.mutationDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.mutationDownloadData.result!))
-    });
-
-    readonly transposedMutationDataText = remoteData<string>({
-        await:()=>[this.transposedMutationDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.transposedMutationDownloadData.result!))
-    });
-
     readonly allOtherMolecularProfileDataGroupByProfileName = remoteData<{[profileName: string]: {[key: string]: ExtendedAlteration[]}}>({
         await:()=>[this.props.store.nonQueriedMolecularData, this.props.store.nonSelectedMolecularProfilesGroupByName],
         invoke:()=>{
@@ -168,21 +153,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         ))
     });
 
-    readonly transposedMrnaDownloadData = remoteData<string[][]>({
-        await:()=>[this.mrnaDownloadData],
-        invoke:()=>Promise.resolve(_.unzip(this.mrnaDownloadData.result!))
-    });
-
-    readonly mrnaDataText = remoteData<string>({
-        await:()=>[this.mrnaDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.mrnaDownloadData.result!))
-    });
-
-    readonly transposedMrnaDataText = remoteData<string>({
-        await:()=>[this.transposedMrnaDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.transposedMrnaDownloadData.result!))
-    });
-
     readonly proteinData = remoteData<{[key: string]: ExtendedAlteration[]}>({
         await:()=>[this.props.store.nonOqlFilteredCaseAggregatedData],
         invoke:()=>Promise.resolve(generateProteinData(this.props.store.nonOqlFilteredCaseAggregatedData.result!))
@@ -195,21 +165,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         ))
     });
 
-    readonly transposedProteinDownloadData = remoteData<string[][]>({
-        await:()=>[this.proteinDownloadData],
-        invoke:()=>Promise.resolve(_.unzip(this.proteinDownloadData.result!))
-    });
-
-    readonly proteinDataText = remoteData<string>({
-        await:()=>[this.proteinDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.proteinDownloadData.result!))
-    });
-
-    readonly transposedProteinDataText = remoteData<string>({
-        await:()=>[this.transposedProteinDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.transposedProteinDownloadData.result!))
-    });
-
     readonly cnaData = remoteData<{[key: string]: ExtendedAlteration[]}>({
         await:()=>[this.props.store.nonOqlFilteredCaseAggregatedData],
         invoke:()=>Promise.resolve(generateCnaData(this.props.store.nonOqlFilteredCaseAggregatedData.result!))
@@ -220,21 +175,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         invoke:()=>Promise.resolve(generateDownloadData(
             this.cnaData.result!, this.props.store.samples.result!, this.props.store.genes.result!
         ))
-    });
-
-    readonly transposedCnaDownloadData = remoteData<string[][]>({
-        await:()=>[this.cnaDownloadData],
-        invoke:()=>Promise.resolve(_.unzip(this.cnaDownloadData.result!))
-    });
-
-    readonly cnaDataText = remoteData<string>({
-        await:()=>[this.cnaDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.cnaDownloadData.result!))
-    });
-
-    readonly transposedCnaDataText = remoteData<string>({
-        await:()=>[this.transposedCnaDownloadData],
-        invoke:()=>Promise.resolve(stringify2DArray(this.transposedCnaDownloadData.result!))
     });
 
     readonly alteredCaseAlterationData = remoteData<ICaseAlteration[]>({
@@ -645,12 +585,66 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
 
     private handleMutationDownload()
     {
-        onMobxPromise(this.mutationDataText, text=>fileDownload(text, "mutations.txt"));
+        onMobxPromise(this.mutationDownloadData, data=>{
+            const text = this.downloadDataText(data);
+            fileDownload(text, "mutations.txt")
+        });
     }
 
     private handleTransposedMutationDownload()
     {
-        onMobxPromise(this.transposedMutationDataText, text=>fileDownload(text, "mutations_transposed.txt"));
+        onMobxPromise(this.mutationDownloadData, data=>{
+            const text = this.downloadDataText(this.unzipDownloadData(data));
+            fileDownload(text, "mutations_transposed.txt")
+        });
+    }
+
+    private handleMrnaDownload(profileName: string)
+    {
+        onMobxPromise(this.mrnaDownloadData, data=>{
+            const text = this.downloadDataText(data);
+            fileDownload(text, `${profileName}.txt`)
+        });
+    }
+
+    private handleTransposedMrnaDownload(profileName: string)
+    {
+        onMobxPromise(this.mrnaDownloadData, data=>{
+            const text = this.downloadDataText(this.unzipDownloadData(data));
+            fileDownload(text, `${profileName}.txt`)
+        });
+    }
+
+    private handleProteinDownload(profileName: string)
+    {
+        onMobxPromise(this.proteinDownloadData, data=>{
+            const text = this.downloadDataText(data);
+            fileDownload(text, `${profileName}.txt`)
+        });
+    }
+
+    private handleTransposedProteinDownload(profileName: string)
+    {
+        onMobxPromise(this.proteinDownloadData, data=>{
+            const text = this.downloadDataText(this.unzipDownloadData(data));
+            fileDownload(text, `${profileName}.txt`)
+        });
+    }
+
+    private handleCnaDownload()
+    {
+        onMobxPromise(this.cnaDownloadData, data=>{
+            const text = this.downloadDataText(data);
+            fileDownload(text, "cna.txt")
+        });
+    }
+
+    private handleTransposedCnaDownload()
+    {
+        onMobxPromise(this.cnaDownloadData, data=>{
+            const text = this.downloadDataText(this.unzipDownloadData(data));
+            fileDownload(text, "cna_transposed.txt")
+        });
     }
 
     @autobind
@@ -669,36 +663,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
             const transposedTextMap = this.downloadDataTextGroupByProfileName(this.unzipDownloadDataGroupByProfileName(downloadDataGroupByProfileName));
             fileDownload(transposedTextMap[profileName], `${profileName}.txt`)
         });
-    }
-
-    private handleMrnaDownload(profileName: string)
-    {
-        onMobxPromise(this.mrnaDataText, text=>fileDownload(text, `${profileName}.txt`));
-    }
-
-    private handleTransposedMrnaDownload(profileName: string)
-    {
-        onMobxPromise(this.transposedMrnaDataText, text=>fileDownload(text, `${profileName}.txt`));
-    }
-
-    private handleProteinDownload(profileName: string)
-    {
-        onMobxPromise(this.proteinDataText, text=>fileDownload(text, `${profileName}.txt`));
-    }
-
-    private handleTransposedProteinDownload(profileName: string)
-    {
-        onMobxPromise(this.transposedProteinDataText, text=>fileDownload(text, `${profileName}.txt`));
-    }
-
-    private handleCnaDownload()
-    {
-        onMobxPromise(this.cnaDataText, text=>fileDownload(text, "cna.txt"));
-    }
-
-    private handleTransposedCnaDownload()
-    {
-        onMobxPromise(this.transposedCnaDataText, text=>fileDownload(text, "cna_transposed.txt"));
     }
 
     @action
@@ -722,5 +686,13 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         return _.mapValues(downloadDataGroupByProfileName, (downloadData) => {
             return stringify2DArray(downloadData);
         })
+    }
+
+    private unzipDownloadData(downloadData: string[][]): string[][] {
+        return _.unzip(downloadData);
+    }
+
+    private downloadDataText(downloadData: string[][]): string {
+        return stringify2DArray(downloadData);
     }
 }

--- a/src/pages/resultsView/download/DownloadUtils.spec.ts
+++ b/src/pages/resultsView/download/DownloadUtils.spec.ts
@@ -3,7 +3,7 @@ import {assert} from 'chai';
 import {GeneticTrackDatum} from "shared/components/oncoprint/Oncoprint";
 import {GenePanelData, MolecularProfile, Sample} from "shared/api/generated/CBioPortalAPI";
 import {
-    generateCaseAlterationData, generateDownloadData, generateGeneAlterationData, generateMutationDownloadData, generateOqlData, updateOqlData
+    generateCaseAlterationData, generateDownloadData, generateGeneAlterationData, generateMutationDownloadData, generateOqlData, updateOqlData, decideMolecularProfileSortingOrder
 } from "./DownloadUtils";
 import {
     AnnotatedMutation, ExtendedAlteration
@@ -903,6 +903,30 @@ describe('DownloadUtils', () => {
                 "mutation is not profiled for the two not profiled GeneticTrackDatum");
             assert.equal(oqlData2.isProteinLevelNotProfiled, true,
                 "protein level is profiled for the two not profiled GeneticTrackDatum");
+        });
+    });
+
+    describe.only('molecularProfileSortingOrder', () => {
+        it('should return specific number for 7 specific molecular profile types', () => {
+            assert.equal(decideMolecularProfileSortingOrder("MUTATION_EXTENDED"), 1,
+                "MUTATION_EXTENDED should be the 1st type");
+            assert.equal(decideMolecularProfileSortingOrder("COPY_NUMBER_ALTERATION"), 2,
+                "COPY_NUMBER_ALTERATION should be the 2nd type");
+            assert.equal(decideMolecularProfileSortingOrder("GENESET_SCORE"), 3,
+                "GENESET_SCORE should be the 3rd type");
+            assert.equal(decideMolecularProfileSortingOrder("MRNA_EXPRESSION"), 4,
+                "MRNA_EXPRESSION should be the 4th type");
+            assert.equal(decideMolecularProfileSortingOrder("METHYLATION"), 5,
+                "METHYLATION should be the 5th type");
+            assert.equal(decideMolecularProfileSortingOrder("METHYLATION_BINARY"), 6,
+                "METHYLATION_BINARY should be the 6th type");
+            assert.equal(decideMolecularProfileSortingOrder("PROTEIN_LEVEL"), 7,
+                "PROTEIN_LEVEL should be the 7th type");
+        });
+
+        it('should return maximum number for the other types', () => {
+            assert.equal(decideMolecularProfileSortingOrder("FUSION"), Number.MAX_VALUE,
+                "FUSION should be put to the end");
         });
     });
 });

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -231,6 +231,25 @@ export function generateCnaData(unfilteredCaseAggregatedData?: CaseAggregatedDat
         generateSampleAlterationDataByGene(unfilteredCaseAggregatedData, sampleFilter) : {};
 }
 
+export function generateOtherMolecularProfileData(molecularProfileId:string[], unfilteredCaseAggregatedData?: CaseAggregatedData<ExtendedAlteration>):
+    {[key: string]: ExtendedAlteration[]}
+{
+    const sampleFilter = (alteration: ExtendedAlteration) => {
+        return molecularProfileId.includes(alteration.molecularProfileId);
+    };
+
+    return unfilteredCaseAggregatedData ?
+        generateSampleAlterationDataByGene(unfilteredCaseAggregatedData, sampleFilter) : {};
+}
+
+export function generateOtherMolecularProfileDownloadData(sampleAlterationDataByGene: {[key: string]: ExtendedAlteration[]},
+                                             samples: Sample[] = [],
+                                             genes: Gene[] = []): string[][]
+{
+    return sampleAlterationDataByGene ?
+        generateDownloadData(sampleAlterationDataByGene, samples, genes) : [];
+}
+
 export function generateSampleAlterationDataByGene(unfilteredCaseAggregatedData: CaseAggregatedData<ExtendedAlteration>,
                                                    sampleFilter?: (alteration: ExtendedAlteration) => boolean): {[key: string]: ExtendedAlteration[]}
 {
@@ -249,7 +268,6 @@ export function generateSampleAlterationDataByGene(unfilteredCaseAggregatedData:
             }
         });
     });
-
     return sampleDataByGene;
 }
 
@@ -458,4 +476,25 @@ export function hasValidMutationData(sampleAlterationDataByGene: {[key: string]:
 function extractMutationValue(alteration: ExtendedAlteration)
 {
     return alteration.proteinChange;
+}
+
+export function decideMolecularProfileSortingOrder(profileType: MolecularProfile['molecularAlterationType']) {
+    switch (profileType) {
+        case "MUTATION_EXTENDED":
+            return 1;
+        case "COPY_NUMBER_ALTERATION":
+            return 2;
+        case "GENESET_SCORE":
+            return 3;
+        case "MRNA_EXPRESSION":
+            return 4;
+        case "METHYLATION":
+            return 5;
+        case "METHYLATION_BINARY":
+            return 6;
+        case "PROTEIN_LEVEL":
+            return 7;
+        default:
+            return Number.MAX_VALUE;
+    }
 }

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -22,6 +22,8 @@ export interface IDownloadFileRow {
     alterationData: {[gene: string]: string[]};
 }
 
+export const DOWNLOAD_TABLE_DEFAULT_ROW_LIMIT = 7;
+
 export function generateOqlData(datum: GeneticTrackDatum,
                                 geneAlterationDataByGene?: {[gene: string]: IGeneAlteration},
                                 molecularProfileIdToMolecularProfile?: {[molecularProfileId:string]:MolecularProfile}): IOqlData

--- a/src/pages/resultsView/download/styles.module.scss
+++ b/src/pages/resultsView/download/styles.module.scss
@@ -23,3 +23,19 @@
     white-space: nowrap;
     font-weight: bold;
 }
+
+.other-profiles-select {
+  flex: 1;
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.tooltip {
+  max-width: 300px;
+}
+
+.infoIcon {
+  margin-left: 4px;
+  margin-top: 4px;
+  color: #555;
+}

--- a/src/pages/resultsView/download/styles.module.scss
+++ b/src/pages/resultsView/download/styles.module.scss
@@ -24,10 +24,14 @@
     font-weight: bold;
 }
 
-.other-profiles-select {
-  flex: 1;
-  margin-left: 10px;
-  margin-right: 10px;
+.showMoreButtonContainer {
+  display: flex;
+  justify-content: center;
+}
+
+.showMoreButton {
+  // margin-left: 10px !important;
+  width: 200px;
 }
 
 .tooltip {
@@ -36,6 +40,5 @@
 
 .infoIcon {
   margin-left: 4px;
-  margin-top: 4px;
   color: #555;
 }

--- a/src/shared/components/query/QueryContainer.tsx
+++ b/src/shared/components/query/QueryContainer.tsx
@@ -167,6 +167,11 @@ export default class QueryContainer extends React.Component<QueryContainerProps,
                 }
 
                 {
+                    this.store.forDownloadTab && 
+                    <div className={"alert alert-danger"} role="alert">The Download interface has been removed. Enhanced download functionality is now available through the Query interface. Run a query with your gene(s) of interest and use the Download tab to download all available data types.</div>
+                }
+
+                {   !this.store.forDownloadTab &&
                     <If condition={this.store.defaultSelectedIds.size === 0 || this.studiesDataReady}>
                         <Then>
                             <If condition={this.props.forkedMode && this.showQueryControls}>


### PR DESCRIPTION
move data download from Query to ResultView.
Fix # https://github.com/cBioPortal/cbioportal/issues/5189.

Changes proposed in this pull request:
- add one row to download data from other profiles (select the first option by default)
multiple studies:
![image](https://user-images.githubusercontent.com/15748980/66236155-b917d680-e6bf-11e9-8d71-c5836c9f29c1.png)
single study(with tooltip):
![image](https://user-images.githubusercontent.com/15748980/66236112-9daccb80-e6bf-11e9-8c44-1689f301614c.png)

- add a warning on the download tab (query page)
![image](https://user-images.githubusercontent.com/15748980/66074632-a074b880-e527-11e9-94b5-7460875a4825.png)

- sort the profiles by type, unit tests included (DownloadUtils.ts)

