### PR TITLE
Rename `Tumors` column to `Samples` in mutation and CNA tables

### DIFF
--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.spec.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.spec.tsx
@@ -30,9 +30,9 @@ describe("CopyNumberTableWrapper", ()=>{
         assert(!hasColumn(getTable(["sampleA", "sampleB"], "id"), "mRNA Expr."), "Doesn't have with 2 samples and id");
     });
 
-    it("shows tumors column iff theres more than one sample", ()=>{
-        assert(!hasColumn(getTable(["sampleA"]), "Tumors"), "Doesnt have with one sample");
-        assert(!hasColumn(getTable(["sampleA"]), "Tumors"), "Doesnt have with zero samples");
-        assert(hasColumn(getTable(["sampleA", "sampleB"]), "Tumors"), "Has with two samples");
+    it("shows samples column iff theres more than one sample", ()=>{
+        assert(!hasColumn(getTable(["sampleA"]), "Samples"), "Doesnt have with one sample");
+        assert(!hasColumn(getTable(["sampleA"]), "Samples"), "Doesnt have with zero samples");
+        assert(hasColumn(getTable(["sampleA", "sampleB"]), "Samples"), "Has with two samples");
     });
 });

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -77,7 +77,7 @@ export default class CopyNumberTableWrapper extends React.Component<ICopyNumberT
 
         if (numSamples >= 2) {
             columns.push({
-                name: "Tumors",
+                name: "Samples",
                 render:(d:DiscreteCopyNumberData[])=>TumorColumnFormatter.renderFunction(d, this.props.sampleManager),
                 sortBy:(d:DiscreteCopyNumberData[])=>TumorColumnFormatter.getSortValue(d, this.props.sampleManager),
                 download: (d:DiscreteCopyNumberData[])=>TumorColumnFormatter.getSample(d),

--- a/src/pages/patientView/mutation/PatientViewMutationTable.spec.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.spec.tsx
@@ -18,7 +18,7 @@ function getTable(samples:string[], mrnaId?:string, cnaId?:string):ReactWrapper<
         discreteCNAMolecularProfileId={cnaId}
         columns={[MutationTableColumnType.GENE,
                     MutationTableColumnType.MRNA_EXPR,
-                    MutationTableColumnType.TUMORS,
+                    MutationTableColumnType.SAMPLES,
                     MutationTableColumnType.COPY_NUM]}
         data={[]}
         />);
@@ -47,13 +47,13 @@ describe("PatientViewMutationTable", ()=>{
         assert.isFalse(hasColumn(getTable(["sampleA","sampleB"], undefined, "cnaId"), "Copy #"));
     });
 
-    it("hides the tumors column if theres less than two samples", ()=>{
-        assert(!hasColumn(getTable([]), "Tumors"), "Hides with no samples (this shouldnt happen though)");
-        assert(!hasColumn(getTable(["sampleA"]), "Tumors"), "Hides with one sample");
+    it("hides the samples column if theres less than two samples", ()=>{
+        assert(!hasColumn(getTable([]), "Samples"), "Hides with no samples (this shouldnt happen though)");
+        assert(!hasColumn(getTable(["sampleA"]), "Samples"), "Hides with one sample");
     });
 
-    it("shows the tumors column if theres more than one sample", ()=>{
-        assert(hasColumn(getTable(["sampleA", "sampleB"]), "Tumors"));
+    it("shows the samples column if theres more than one sample", ()=>{
+        assert(hasColumn(getTable(["sampleA", "sampleB"]), "Samples"));
     });
 
     it("hides the copy number column if theres no discrete cna profile", ()=>{

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -53,7 +53,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             MutationTableColumnType.FUNCTIONAL_IMPACT,
             MutationTableColumnType.COSMIC,
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
-            MutationTableColumnType.TUMORS,
+            MutationTableColumnType.SAMPLES,
             MutationTableColumnType.EXON,
             MutationTableColumnType.HGVSC,
             MutationTableColumnType.GNOMAD,
@@ -84,8 +84,8 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
                 this.props.dataStore ? this.props.dataStore.allData : this.props.data)
         };
 
-        this._columns[MutationTableColumnType.TUMORS] = {
-            name: "Tumors",
+        this._columns[MutationTableColumnType.SAMPLES] = {
+            name: "Samples",
             render:(d:Mutation[])=>TumorColumnFormatter.renderFunction(d, this.props.sampleManager),
             sortBy:(d:Mutation[])=>TumorColumnFormatter.getSortValue(d, this.props.sampleManager),
             download: (d:Mutation[])=>TumorColumnFormatter.getSample(d),
@@ -119,7 +119,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             (d:Mutation[]) => (ExonColumnFormatter.renderFunction(d, this.props.genomeNexusCache, true));
         
         // order columns
-        this._columns[MutationTableColumnType.TUMORS].order = 5;
+        this._columns[MutationTableColumnType.SAMPLES].order = 5;
         this._columns[MutationTableColumnType.GENE].order = 20;
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].order = 30;
         this._columns[MutationTableColumnType.ANNOTATION].order = 35;
@@ -155,7 +155,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         // only hide tumor column if there is one sample and no uncalled
         // mutations (there is no information added in that case by the sample
         // label)
-        this._columns[MutationTableColumnType.TUMORS].shouldExclude = ()=>{
+        this._columns[MutationTableColumnType.SAMPLES].shouldExclude = ()=>{
             return this.getSamples().length < 2 && !this.hasUncalledMutations;
         };
         this._columns[MutationTableColumnType.COPY_NUM].shouldExclude = ()=>{

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -100,7 +100,7 @@ export interface IMutationTableProps {
 export enum MutationTableColumnType {
     STUDY,
     SAMPLE_ID,
-    TUMORS,
+    SAMPLES,
     GENE,
     PROTEIN_CHANGE,
     CHROMOSOME,


### PR DESCRIPTION
# What? Why?
In Mutation table and CNA table columns that represent samples is named `Tumors`. As part of RFC45 the column will be renamed to `Samples`.

# Fix
This PR will rename the `Tumors` column in mutation and CNA tables to `Samples`. Unit tests and screenshot tests were updated accordingly.

