### PR TITLE
Implement gene panel API calls in PatientViewStore

### DIFF
--- a/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
+++ b/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
@@ -8,9 +8,9 @@ DIR=$PWD
 
 cd $TEST_HOME/local/docker
 ./build_portal_image.sh
-MD5_ES_0=$(docker run --rm $BACKEND_PROJECT_USERNAME/cbioportal:$BACKEND_BRANCH sh -c 'find /cbioportal/core/src/test/scripts/test_data/study_es_0/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//"')
+MD5_ES_0=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'find /cbioportal/core/src/test/scripts/test_data/study_es_0/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//"')
 MD5_TEST_STUDIES=$(find $TEST_HOME/local/studies/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//")
-MD5_MIGRATION_SQL=$(docker run --rm $BACKEND_PROJECT_USERNAME/cbioportal:$BACKEND_BRANCH sh -c 'md5sum /cbioportal/db-scripts/src/main/resources/migration.sql | sed "s/\s.*$//"')
+MD5_MIGRATION_SQL=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'md5sum /cbioportal/db-scripts/src/main/resources/migration.sql | sed "s/\s.*$//"')
 
 cd $DIR
 

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import {ClinicalDataBySampleId} from "../../../shared/api/api-types-extended";
 import {
     ClinicalData, MolecularProfile, Sample, Mutation, DiscreteCopyNumberFilter, DiscreteCopyNumberData, MutationFilter,
-    CopyNumberCount, ClinicalDataMultiStudyFilter, ReferenceGenomeGene
+    CopyNumberCount, ClinicalDataMultiStudyFilter, ReferenceGenomeGene, GenePanelData, GenePanel
 } from "../../../shared/api/generated/CBioPortalAPI";
 import client from "../../../shared/api/cbioportalClientInstance";
 import internalClient from "../../../shared/api/cbioportalInternalClientInstance";
@@ -69,7 +69,10 @@ import {
     concatMutationData,
     fetchOncoKbCancerGenes,
     fetchVariantAnnotationsIndexedByGenomicLocation,
-    fetchReferenceGenomeGenes
+    fetchReferenceGenomeGenes,
+    fetchGenePanelData,
+    fetchGenePanel,
+    noGenePanelUsed
 } from "shared/lib/StoreUtils";
 import {fetchHotspotsData} from "shared/lib/CancerHotspotsUtils";
 import {stringListToSet} from "../../../public-lib/lib/StringUtils";
@@ -145,6 +148,7 @@ function transformClinicalInformationToStoreShape(patientId: string, studyId: st
 }
 
 export class PatientViewPageStore {
+
     constructor() {
         labelMobxPromises(this);
         this.internalClient = internalClient;
@@ -762,6 +766,74 @@ export class PatientViewPageStore {
         ],
         invoke: ()=>Promise.resolve(indexHotspotsData(this.hotspotData))
     });
+
+    readonly sampleToMutationGenePanelData = remoteData<{[sampleId: string]: GenePanelData}>({
+        await:()=>[
+            this.mutationMolecularProfileId
+        ],
+        invoke: async() => {
+            if (this.mutationMolecularProfileId.result) {
+                return fetchGenePanelData(this.mutationMolecularProfileId.result, this.sampleIds);
+            }
+            return {};
+        }
+    }, {});
+
+    readonly sampleToMutationGenePanelId = remoteData<{[sampleId: string]: string}>({
+        await:()=>[
+            this.sampleToMutationGenePanelData
+        ],
+        invoke: async() => {
+            return _.mapValues(this.sampleToMutationGenePanelData.result, (genePanelData) => genePanelData.genePanelId);
+        }
+    }, {});
+
+    readonly sampleToDiscreteGenePanelData = remoteData<{[sampleId: string]: GenePanelData}>({
+        await:()=>[
+            this.molecularProfileIdDiscrete
+        ],
+        invoke: async() => {
+            if (this.molecularProfileIdDiscrete.result) {
+                return fetchGenePanelData(this.molecularProfileIdDiscrete.result, this.sampleIds);
+            }
+            return {};
+        }
+    }, {});
+
+    readonly sampleToDiscreteGenePanelId = remoteData<{[sampleId: string]: string}>({
+        await:()=>[
+            this.sampleToDiscreteGenePanelData
+        ],
+        invoke: async() => {
+            return _.mapValues(this.sampleToDiscreteGenePanelData.result, (genePanelData) => genePanelData.genePanelId);
+        }
+    }, {});
+
+    readonly genePanelIdToPanel = remoteData<{[genePanelId: string]: GenePanel}>({
+        await:()=>[
+            this.sampleToMutationGenePanelData,
+            this.sampleToDiscreteGenePanelData
+        ],
+        invoke: async() => {
+            const sampleGenePanelInfo = _.concat(_.values(this.sampleToMutationGenePanelData.result), _.values(this.sampleToDiscreteGenePanelData.result));
+            const panelIds = _(sampleGenePanelInfo)
+                .map((genePanelData) => genePanelData.genePanelId)
+                .filter((genePanelId) => !noGenePanelUsed(genePanelId))
+                .value();
+            return fetchGenePanel(panelIds);
+        }
+    }, {});
+
+    readonly genePanelIdToEntrezGeneIds = remoteData<{[genePanelId: string]: number[]}>({
+        await:()=>[
+            this.genePanelIdToPanel
+        ],
+        invoke: async() => {
+            return _(this.genePanelIdToPanel.result)
+            .mapValues((genePanel) => _.map(genePanel.genes, (genePanelToGene) => genePanelToGene.entrezGeneId))
+            .value();
+        }
+    }, {});
 
     @computed get mergedMutationData(): Mutation[][] {
         return mergeMutations(this.mutationData);

--- a/src/shared/api/generated/CBioPortalAPIInternal-docs.json
+++ b/src/shared/api/generated/CBioPortalAPIInternal-docs.json
@@ -1808,8 +1808,7 @@
       "required": [
         "counts",
         "entrezGeneId",
-        "hugoGeneSymbol",
-        "pValue"
+        "hugoGeneSymbol"
       ],
       "properties": {
         "counts": {


### PR DESCRIPTION
# What? Why?
As defined in RFC45 information on gene panels will be integrated in the PatientView component. This component does not yet retrieve information on gene panels for the patient samples from the backend.

#  Fix
This PR adds API calls to:
1. get the gene panels associated with each sample.
2. get genes associated with the gene panels retrieved in 1.

Note: at present the backend returns no gene panel id for a sample when a samples was analyzed with a whole genome approach. The implementation already accommodates an alternative strategy proposed by @n1zea144 involving `WES` and `WGS` tags for whole exome sequencing and whole genome sequencing profiles.