### PR TITLE
Add uscs.build to e2e-test portal.properties.

### DIFF
--- a/end-to-end-test/local/runtime-config/portal.properties
+++ b/end-to-end-test/local/runtime-config/portal.properties
@@ -3,3 +3,4 @@ db.password=cbio_pass
 db.portal_db_name=endtoend_local_cbiodb
 db.connection_string=jdbc:mysql://cbiodb-endtoend:3306/
 db.host=cbiodb-endtoend
+ucsc.build=hg19


### PR DESCRIPTION
# What? Why?
Update of cbioportal backend reference genome handling broke e2e-locadb tests.

# Fix
Update portal.properties used in docker environment.