### PR TITLE
Allow customization of SVG axis label padding

### DIFF
--- a/commons.webpack.config.js
+++ b/commons.webpack.config.js
@@ -7,7 +7,7 @@ var GeneratePackageJsonPlugin =require('generate-package-json-webpack-plugin');
 var TerserPlugin = require('terser-webpack-plugin');
 
 var commit = 'unknown';
-var version = '0.0.20';
+var version = '0.0.21';
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 

--- a/src/public-lib/components/SVGAxis.tsx
+++ b/src/public-lib/components/SVGAxis.tsx
@@ -17,9 +17,19 @@ type SVGAxisProps = {
     reverse?:boolean;
     invertTicks?:boolean;
     label?:string;
+    verticalLabelPadding?:number;
+    horizontalLabelPadding?:number;
+    tickLabelPadding?:number;
 };
 
-export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
+export default class SVGAxis extends React.Component<SVGAxisProps, {}>
+{
+    public static defaultProps: Partial<SVGAxisProps> = {
+        verticalLabelPadding: 30,
+        horizontalLabelPadding: 5,
+        tickLabelPadding: 3
+    };
+
     private positionToAxisPosition(position: number) {
         const pos = this.props.reverse ? this.props.rangeUpper - position : position;
         return (pos / (this.props.rangeUpper - this.props.rangeLower)) * this.props.length;
@@ -33,7 +43,7 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
             const y1 = this.props.vertical ? (this.props.y + this.props.length - axisPosition) : this.props.y;
             const x2 = this.props.vertical ? (this.props.x - tickLength) : (this.props.x + axisPosition);
             const y2 = this.props.vertical ? (this.props.y + this.props.length - axisPosition) : (this.props.y + tickLength);
-            const labelPadding = 3;
+            const labelPadding = this.props.tickLabelPadding!;
 
             let label = null;
             if (tick.label) {
@@ -89,16 +99,18 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
     private get label() {
         if (this.props.label) {
             const tickLength = this.props.invertTicks ? -this.props.tickLength : this.props.tickLength;
+            const verticalPadding = this.props.verticalLabelPadding!;
+            const horizontalPadding = this.props.horizontalLabelPadding!;
             let x:number;
             let y:number;
             let transform:string;
             if (this.props.vertical) {
-                x = this.props.x - tickLength + (this.props.invertTicks ? 30 : -30);
+                x = this.props.x - tickLength + (this.props.invertTicks ? verticalPadding : -verticalPadding);
                 y = this.props.y + (this.props.length / 2);
                 transform = `rotate(270,${x},${y})`;
             } else {
                 x = this.props.x + (this.props.length / 2);
-                y = this.props.y + tickLength + (this.props.invertTicks ? -5 : 5) ;
+                y = this.props.y + tickLength + (this.props.invertTicks ? -horizontalPadding : horizontalPadding) ;
                 transform = "";
             }
             return (


### PR DESCRIPTION
Before:
![y-axis-padding_before](https://user-images.githubusercontent.com/3604198/64805937-27092c00-d560-11e9-9a6b-96f7fc13d90c.png)

After:
![y-axis-padding_after](https://user-images.githubusercontent.com/3604198/64805973-39836580-d560-11e9-9530-b37ffe1498ea.png)


# Checks
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)