### PR TITLE
change case set options for virtual study

### DIFF
--- a/src/shared/components/query/CaseSetSelector.tsx
+++ b/src/shared/components/query/CaseSetSelector.tsx
@@ -50,9 +50,10 @@ export default class CaseSetSelector extends QueryStoreComponent<{modifyQueryPar
 				textLabel:sampleList.name
 			};
 		});
-
+		
 		let filteredcustomCaseSets = getFilteredCustomCaseSets(
-			this.store.isVirtualStudyQuery,
+			this.store.isVirtualStudySelected,
+			this.store.isMultipleNonVirtualStudiesSelected,
 			this.store.profiledSamplesCount.result);
 
 		let customCaseSets = filteredcustomCaseSets.map(s => {

--- a/src/shared/components/query/CaseSetSelectorUtils.spec.ts
+++ b/src/shared/components/query/CaseSetSelectorUtils.spec.ts
@@ -4,21 +4,33 @@ import { getFilteredCustomCaseSets, CustomCaseSets } from 'shared/components/que
 
 describe('CaseSetSelectorUtils', () => {
     describe('filterCustomCaseSets', () => {
-        it("returns only custom case set if there is one physical study selected ", () => {
-            assert.deepEqual(getFilteredCustomCaseSets(false, {} as any), [CustomCaseSets[4]]);
-            assert.deepEqual(getFilteredCustomCaseSets(false, {} as any), [CustomCaseSets[4]]);
-            assert.deepEqual(getFilteredCustomCaseSets(false, { w_mut: 100, w_cna: 100, w_mut_cna: 100, all:100 }), [CustomCaseSets[4]]);
+
+
+        it("returns only custom case set if profiledSamplesCount is empty", () => {
+            assert.deepEqual(getFilteredCustomCaseSets(true, false, {} as any), [CustomCaseSets[4]]);
+            assert.deepEqual(getFilteredCustomCaseSets(true, true, {} as any), [CustomCaseSets[4]]);
+            assert.deepEqual(getFilteredCustomCaseSets(false, false, {} as any), [CustomCaseSets[4]]);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, {} as any), [CustomCaseSets[4]]);
         });
 
-        it("returns correct filtered case sets depending on the samples when mutli/virtual studies selected", () => {
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 50, w_cna: 50, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna', 'w_mut', 'w_mut_cna']);
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 0, w_cna: 50, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna', 'w_mut_cna']);
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 50, w_cna: 0, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_mut', 'w_mut_cna']);
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 50, w_cna: 50, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna', 'w_mut']);
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 50, w_cna: 0, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_mut']);
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 0, w_cna: 50, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna']);
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 0, w_cna: 0, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_mut_cna']);
-            assert.deepEqual(getFilteredCustomCaseSets(true, { w_mut: 0, w_cna: 0, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all']);
+        it("returns all case set and custom case set if there is at least one virtual study selected", () => {
+            assert.deepEqual(getFilteredCustomCaseSets(true, false, { w_mut: 100, w_cna: 100, w_mut_cna: 100, all:100 }).map(obj => obj.value).sort(), ['-1', 'all']);
+            assert.deepEqual(getFilteredCustomCaseSets(true, true, { w_mut: 100, w_cna: 100, w_mut_cna: 100, all:100 }).map(obj => obj.value).sort(), ['-1', 'all']);
+        });
+
+        it("returns only custom case set if there is one physical study selected", () => {
+            assert.deepEqual(getFilteredCustomCaseSets(false, false, { w_mut: 100, w_cna: 100, w_mut_cna: 100, all:100 }), [CustomCaseSets[4]]);
+        });
+
+        it("returns correct filtered case sets depending on the samples when mutliple studies selected", () => {
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 50, w_cna: 50, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna', 'w_mut', 'w_mut_cna']);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 0, w_cna: 50, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna', 'w_mut_cna']);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 50, w_cna: 0, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_mut', 'w_mut_cna']);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 50, w_cna: 50, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna', 'w_mut']);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 50, w_cna: 0, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_mut']);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 0, w_cna: 50, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_cna']);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 0, w_cna: 0, w_mut_cna: 50, all:100 }).map(obj => obj.value).sort(), ['-1', 'all', 'w_mut_cna']);
+            assert.deepEqual(getFilteredCustomCaseSets(false, true, { w_mut: 0, w_cna: 0, w_mut_cna: 0, all:100 }).map(obj => obj.value).sort(), ['-1', 'all']);
         });
 
     })

--- a/src/shared/components/query/CaseSetSelectorUtils.ts
+++ b/src/shared/components/query/CaseSetSelectorUtils.ts
@@ -23,17 +23,25 @@ export const CustomCaseSets: CustomCaseSet[] = [
 	{name: 'User-defined Case List', description: 'Specify your own case list', value: CaseSetId.custom, isdefault : true}
 ]
 
-export function getFilteredCustomCaseSets(isVirtualStudy:boolean, profiledSamplesCount: { w_mut: number; w_cna: number; w_mut_cna: number; all: number}) {
-    return _.reduce(CustomCaseSets, (acc: CustomCaseSet[], next) => {
-        if (next.isdefault) {
-            acc.push(next)
-        } else if (isVirtualStudy) {
-            let count =  profiledSamplesCount[next.value as 'w_mut_cna'|'w_mut'|'w_cna'|'all'];
-            //add profile only if it has samples
-            if (count > 0) {
-                acc.push(Object.assign({}, next, { name: `${next.name} (${count})` }))
-            }
-        }
-        return acc;
-    }, []);
+export function getFilteredCustomCaseSets(isVirtualStudy:boolean, isMultipleNonVirtualStudies: boolean, profiledSamplesCount: { w_mut: number; w_cna: number; w_mut_cna: number; all: number}) {
+	return _.reduce(CustomCaseSets, (acc: CustomCaseSet[], next) => {
+		if (next.isdefault) {
+			acc.push(next)
+		} else if (isMultipleNonVirtualStudies && !isVirtualStudy) {
+			// add all non-zero CustomCaseSets options for multiple studies without virtual study
+			let count =  profiledSamplesCount[next.value as 'w_mut_cna'|'w_mut'|'w_cna'|'all'];
+			//add profile only if it has samples
+			if (count > 0) {
+				acc.push(Object.assign({}, next, { name: `${next.name} (${count})` }))
+			}
+		} else if (isVirtualStudy && next.value === CaseSetId.all) {
+			// only add 'all' option for virtual study
+			let count =  profiledSamplesCount[next.value as 'w_mut_cna'|'w_mut'|'w_cna'|'all'];
+			//add profile only if it has samples
+			if (count > 0) {
+				acc.push(Object.assign({}, next, { name: `${next.name} (${count})` }))
+			}
+		}
+		return acc;
+	}, []);
 }

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1082,6 +1082,11 @@ export class QueryStore {
     }
 
     @computed
+    public get isMultipleNonVirtualStudiesSelected() {
+        return this.selectableSelectedStudyIds.filter((id) => !this.isVirtualStudy(id)).length > 1;
+    }
+
+    @computed
     public get getOverlappingStudiesMap() {
         const overlappingStudyGroups = getOverlappingStudies(this.selectableSelectedStudies);
         return _.chain(overlappingStudyGroups)


### PR DESCRIPTION
fix virtual study cannot select other molecular profiles
Fix # https://github.com/cbioportal/cbioportal/issues/6491.

proposed change:
a. when the selection contains a virtual study (show `all` and `custom` options):
![image](https://user-images.githubusercontent.com/15748980/65282475-fe0a0d80-db02-11e9-8002-e87a607b2104.png)
b. when a single physical study selected (show default options and `custom` option):
![image](https://user-images.githubusercontent.com/15748980/65282631-58a36980-db03-11e9-95d6-5e4dce500a31.png)
c. when multiple physical studies selected (show non-zero caseset options and `custom` option):
![image](https://user-images.githubusercontent.com/15748980/65282687-7ec90980-db03-11e9-8496-94ea6ed39b41.png)

