### PR TITLE
Make first action button and related text render early in study view

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -47,7 +47,8 @@ export interface IStudyViewPageProps {
     appStore: AppStore;
 }
 
-export class StudyResultsSummary extends React.Component<{ store:StudyViewPageStore, appStore:AppStore },{}> {
+@observer
+export class StudyResultsSummary extends React.Component<{ store:StudyViewPageStore, appStore:AppStore, loadingComplete: boolean },{}> {
 
     render(){
         return (
@@ -57,7 +58,7 @@ export class StudyResultsSummary extends React.Component<{ store:StudyViewPageSt
                      <strong data-test="selected-patients">{this.props.store.selectedPatients.length.toLocaleString()}</strong>&nbsp;<strong>patients</strong>&nbsp;|&nbsp;
                      <strong data-test="selected-samples">{this.props.store.selectedSamples.result.length.toLocaleString()}</strong>&nbsp;<strong>samples</strong>
                 </div>
-                <ActionButtons store={this.props.store} appStore={this.props.appStore}/>
+                <ActionButtons store={this.props.store} appStore={this.props.appStore} loadingComplete={this.props.loadingComplete}/>
             </div>
         )
     }
@@ -270,19 +271,20 @@ export default class StudyViewPage extends React.Component<IStudyViewPageProps, 
                                     <Observer>
                                         {
                                             () => {
+                                                // create element here to get correct mobx subscriber list
+                                                const summary  = <StudyResultsSummary
+                                                    store={this.store}
+                                                    appStore={this.props.appStore}
+                                                    loadingComplete={this.chartDataPromises.isComplete}
+                                                />;
                                                 return (
-                                                        <If condition={this.chartDataPromises.isComplete}>
-                                                            <Then>
-                                                                <CSSTransition classNames="studyFilterResult" in={true}
-                                                                               appear timeout={{enter: 200}}>
-                                                                    {() => <StudyResultsSummary store={this.store} appStore={this.props.appStore}/>
-                                                                    }
-                                                                </CSSTransition>
-                                                            </Then>
-                                                            <Else>
-                                                                <LoadingIndicator isLoading={true} size={"small"} className={styles.selectedInfoLoadingIndicator}/>
-                                                            </Else>
-                                                        </If>
+                                                    <CSSTransition
+                                                        classNames="studyFilterResult"
+                                                        in={true}
+                                                        appear timeout={{enter: 200}}
+                                                    >
+                                                        {() =>  { return summary; }}
+                                                    </CSSTransition>
                                                 )
                                             }
                                         }

--- a/src/pages/studyView/studyPageHeader/ActionButtons.tsx
+++ b/src/pages/studyView/studyPageHeader/ActionButtons.tsx
@@ -15,6 +15,7 @@ import {AppStore} from "../../../AppStore";
 import {serializeEvent} from "../../../shared/lib/tracking";
 
 export interface ActionButtonsProps {
+    loadingComplete: boolean;
     store: StudyViewPageStore;
     appStore: AppStore;
 }
@@ -64,8 +65,23 @@ export default class ActionButtons extends React.Component<ActionButtonsProps, {
         return 'Download clinical data for the selected cases';
     }
 
+    @computed
+    get virtualStudy(): JSX.Element | null {
+        if (this.props.loadingComplete) {
+            return <VirtualStudy
+                user={this.props.appStore.userName}
+                name={this.props.store.isSingleVirtualStudyPageWithoutFilter ? this.props.store.filteredVirtualStudies.result[0].data.name : undefined}
+                description={this.props.store.isSingleVirtualStudyPageWithoutFilter ? this.props.store.filteredVirtualStudies.result[0].data.description : undefined}
+                studyWithSamples={this.props.store.studyWithSamples.result}
+                selectedSamples={this.props.store.selectedSamples.result}
+                filter={this.props.store.userSelections}
+                attributesMetaSet={this.props.store.chartMetaSet}
+            />
+        }
+        return null;
+    }
 
-    render() {
+    render() {       
         return (
             <div className={classNames(styles.actionButtons, "btn-group")}>
 
@@ -74,9 +90,10 @@ export default class ActionButtons extends React.Component<ActionButtonsProps, {
                     placement={"top"}
                     overlay={<span>View selected cases</span>}
                 >
-                    <button className="btn btn-default btn-sm"
-                            onClick={this.openCases}
-                            data-event={serializeEvent({category:"studyPage", action:"viewPatientCohort", label:this.props.store.queriedPhysicalStudyIds.result})}
+                    <button
+                        className="btn btn-default btn-sm"
+                        onClick={this.openCases}
+                        data-event={serializeEvent({category:"studyPage", action:"viewPatientCohort", label:this.props.store.queriedPhysicalStudyIds.result})}
                     >
                         <i className="fa fa-user-circle-o"></i>
                     </button>
@@ -85,17 +102,7 @@ export default class ActionButtons extends React.Component<ActionButtonsProps, {
                 <DefaultTooltip
                     trigger={['click']}
                     destroyTooltipOnHide={true}
-                    overlay={
-                        <VirtualStudy
-                            user={this.props.appStore.userName}
-                            name={this.props.store.isSingleVirtualStudyPageWithoutFilter ? this.props.store.filteredVirtualStudies.result[0].data.name : undefined}
-                            description={this.props.store.isSingleVirtualStudyPageWithoutFilter ? this.props.store.filteredVirtualStudies.result[0].data.description : undefined}
-                            studyWithSamples={this.props.store.studyWithSamples.result}
-                            selectedSamples={this.props.store.selectedSamples.result}
-                            filter={this.props.store.userSelections}
-                            attributesMetaSet={this.props.store.chartMetaSet}
-                        />
-                    }
+                    overlay={this.virtualStudy}
                     placement="bottom"
                 >
                     <DefaultTooltip
@@ -105,6 +112,7 @@ export default class ActionButtons extends React.Component<ActionButtonsProps, {
                     >
                         <button
                             className="btn btn-default btn-sm"
+                            disabled={!this.props.loadingComplete}
                         >
                             <i className="fa fa-bookmark"></i>
                         </button>
@@ -116,8 +124,15 @@ export default class ActionButtons extends React.Component<ActionButtonsProps, {
                     placement={"top"}
                     overlay={<span>{this.downloadButtonTooltip}</span>}
                 >
-                    <button className="btn btn-default btn-sm" onClick={this.initiateDownload}
-                            data-event={serializeEvent({category:"studyPage", action:"dataDownload", label:this.props.store.queriedPhysicalStudyIds.result})}
+                    <button
+                        className="btn btn-default btn-sm"
+                        disabled={!this.props.loadingComplete}
+                        onClick={this.initiateDownload}
+                        data-event={serializeEvent({
+                            category:"studyPage",
+                            action:"dataDownload",
+                            label:this.props.store.queriedPhysicalStudyIds.result
+                        })}
                     >
                             <If condition={this.downloadingData}>
                                 <Then>


### PR DESCRIPTION
# What? Why?
Fix # 6607.

Changes proposed in this pull request:
- Make parts of the action button that don't need to wait render early

# Checks
- [x] Follows the [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/tree/master/react).

# Any screenshots or GIFs?
![new-improved](https://user-images.githubusercontent.com/20069833/65257590-6f2fcd80-dacf-11e9-826a-cf8e58cef28b.gif)
