### PR TITLE
Improve robustness of GSVA feature e2e-localdb tests

### DIFF
--- a/end-to-end-test/local/specs/gsva.spec.js
+++ b/end-to-end-test/local/specs/gsva.spec.js
@@ -77,7 +77,7 @@ describe('gsva feature', function() {
                 checkTestStudy();
                 checkGSVAprofile();
                 browser.$('button[data-test=GENESET_HIERARCHY_BUTTON]').click();
-                $('div.modal-dialog').waitForExist();
+                waitForGsvaHierarchyDialog();
             });
 
             it('adds gene set name to entry component from hierachy selector', () => {
@@ -434,6 +434,11 @@ const checkGSVAprofile = () => {
     var gsvaProfileCheckbox = browser.$("[data-test=GENESET_SCORE]");
     gsvaProfileCheckbox.click();
     $('[data-test=GENESETS_TEXT_AREA]').waitForExist();
+}
+
+const waitForGsvaHierarchyDialog = () => {
+    $('div.modal-dialog').waitForExist();
+    $('div[data-test=gsva-tree-container] ul').waitForExist();
 }
 
 module.exports = {

--- a/src/shared/components/query/GenesetsJsTree.tsx
+++ b/src/shared/components/query/GenesetsJsTree.tsx
@@ -196,7 +196,7 @@ export default class GenesetsJsTree extends React.Component<GenesetsJsTreeProps,
         return (
                 <div>
                 <LoadingIndicator isLoading={this.isLoading} />
-                <div ref={tree => this.tree = tree} style={{maxHeight: "380px", overflowY: "scroll"}}></div>
+                <div ref={tree => this.tree = tree} style={{maxHeight: "380px", overflowY: "scroll"}} data-test="gsva-tree-container" ></div>
                 <div style={{padding: "30px 0px"}}>
                 <button className="btn btn-primary btn-sm pull-right"
                     style={{margin: "2px"}}


### PR DESCRIPTION
# What? Why?
The GSVA e2e-localdb tests were brittle. The cause was asynchronous behavior of the gene set hierarchy selector.

# Fix
A waitForExist() was introduced to defend against this. 