### PR TITLE
Ignore treatment

### DIFF
--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -985,7 +985,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
 
     @autobind
     private getControls() {
-        if (this.oncoprint && !this.oncoprint.webgl_unavailable && this.treatmentSelectOptions.isComplete)  {
+        if (this.oncoprint && !this.oncoprint.webgl_unavailable)  {
             return (<FadeInteraction showByDefault={true} show={true}>
                 <OncoprintControls
                     handlers={this.controlsHandlers}

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -985,7 +985,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
 
     @autobind
     private getControls() {
-        if (this.oncoprint && !this.oncoprint.webgl_unavailable)  {
+        if (this.oncoprint && !this.oncoprint.webgl_unavailable && (this.treatmentSelectOptions.isComplete || this.treatmentSelectOptions.isError))  {
             return (<FadeInteraction showByDefault={true} show={true}>
                 <OncoprintControls
                     handlers={this.controlsHandlers}


### PR DESCRIPTION
Temporary fix for failure of treatment service on private portals, which would keep the oncoprint controls from showing up