### PR TITLE
Fix patient view crash when no mutations

### DIFF
--- a/src/pages/patientView/genomicOverview/Tracks.tsx
+++ b/src/pages/patientView/genomicOverview/Tracks.tsx
@@ -33,7 +33,7 @@ export default class Tracks extends React.Component<TracksPropTypes, {}> {
 
         // --- chromosome chart ---
         let genomeBuild = DEFAULT_GENOME_BUILD;
-        if (this.props.mutations) {
+        if (this.props.mutations && this.props.mutations.length > 0) {
             genomeBuild = this.props.mutations[0].ncbiBuild;
         }
         const chmInfo = tracksHelper.getChmInfo( genomeBuild);


### PR DESCRIPTION
For patients without mutations there was an undefined error when trying
to determine the genomeBuild.

We should have a test for this: https://github.com/cBioPortal/cbioportal/issues/6636