### PR TITLE
Gene panel column data in patient view download

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -522,7 +522,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                                     columnVisibilityProps={{
                                                         onColumnToggled: this.onMutationTableColumnVisibilityToggled
                                                     }}
-                                                    />
+                                                />
                                             </div>
                                         )
                                     }
@@ -564,6 +564,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                                                     columnVisibilityProps={{
                                                         onColumnToggled: this.onCnaTableColumnVisibilityToggled
                                                     }}
+                                                    sampleToMutationGenePanelId={this.patientViewPageStore.sampleToMutationGenePanelId}
                                                     />
                                             </div>
                                         )

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -21,6 +21,7 @@ import CopyNumberCountCache from "../clinicalInformation/CopyNumberCountCache";
 import {ICivicGeneDataWrapper, ICivicVariantDataWrapper} from "shared/model/Civic.ts";
 import HeaderIconMenu from '../mutation/HeaderIconMenu';
 import GeneFilterMenu, { GeneFilterOption } from '../mutation/GeneFilterMenu';
+import PanelColumnFormatter from "shared/components/mutationTable/column/PanelColumnFormatter";
 
 class CNATableComponent extends LazyMobXTable<DiscreteCopyNumberData[]> {
 
@@ -55,6 +56,7 @@ type ICopyNumberTableWrapperProps = {
     showGeneFilterMenu?:boolean;
     currentGeneFilter:GeneFilterOption;
     onFilterGenes?:(option:GeneFilterOption)=>void;
+    sampleToMutationGenePanelId?: {[sampleId:string]:string};
 };
 
 @observer
@@ -112,6 +114,22 @@ export default class CopyNumberTableWrapper extends React.Component<ICopyNumberT
             },
             visible: true,
             order: 30
+        });
+        
+        const GenePanelProps = (d:DiscreteCopyNumberData[]) => ({
+            data: d,
+            sampleToGenePanelId: this.props.sampleToGenePanelId,
+            sampleManager: this.props.sampleManager,
+            genePanelIdToGene: this.props.genePanelIdToEntrezGeneIds
+        });
+        
+        columns.push({
+            name: "Gene panel",
+            render: (d:DiscreteCopyNumberData[]) => PanelColumnFormatter.renderFunction(GenePanelProps(d)),
+            download: (d:DiscreteCopyNumberData[]) => PanelColumnFormatter.download(GenePanelProps(d)),
+            sortBy: (d:DiscreteCopyNumberData[]) => PanelColumnFormatter.getGenePanelIds(GenePanelProps(d)),
+            visible: false,
+            order: 35
         });
 
         columns.push({

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -9,6 +9,7 @@ import {Mutation} from "shared/api/generated/CBioPortalAPI";
 import AlleleCountColumnFormatter from "shared/components/mutationTable/column/AlleleCountColumnFormatter";
 import AlleleFreqColumnFormatter from "./column/AlleleFreqColumnFormatter";
 import TumorColumnFormatter from "./column/TumorColumnFormatter";
+import PanelColumnFormatter from "shared/components/mutationTable/column/PanelColumnFormatter";
 import {isUncalled} from "shared/lib/MutationUtils";
 import TumorAlleleFreqColumnFormatter from "shared/components/mutationTable/column/TumorAlleleFreqColumnFormatter";
 import ExonColumnFormatter from "shared/components/mutationTable/column/ExonColumnFormatter";
@@ -66,7 +67,8 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             MutationTableColumnType.HGVSC,
             MutationTableColumnType.GNOMAD,
             MutationTableColumnType.CLINVAR,
-            MutationTableColumnType.DBSNP
+            MutationTableColumnType.DBSNP,
+            MutationTableColumnType.GENE_PANEL
         ]
     };
 
@@ -99,6 +101,21 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             download: (d:Mutation[])=>TumorColumnFormatter.getSample(d),
             resizable: true,
         };
+        
+        const GenePanelProps = (d:Mutation[]) => ({
+            data: d,
+            sampleToGenePanelId: this.props.sampleToGenePanelId,
+            sampleManager: this.props.sampleManager,
+            genePanelIdToGene: this.props.genePanelIdToEntrezGeneIds
+        });
+        
+        this._columns[MutationTableColumnType.GENE_PANEL] = {
+            name: "Gene panel",
+            render: (d:Mutation[]) => PanelColumnFormatter.renderFunction(GenePanelProps(d)),
+            download: (d:Mutation[]) => PanelColumnFormatter.download(GenePanelProps(d)),
+            visible: false,
+            sortBy: (d:Mutation[]) => PanelColumnFormatter.getGenePanelIds(GenePanelProps(d))
+        }
 
         // customization for allele count columns
 
@@ -137,6 +154,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
         // order columns
         this._columns[MutationTableColumnType.SAMPLES].order = 5;
         this._columns[MutationTableColumnType.GENE].order = 20;
+        this._columns[MutationTableColumnType.GENE_PANEL].order = 25;
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].order = 30;
         this._columns[MutationTableColumnType.ANNOTATION].order = 35;
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -130,7 +130,8 @@ export enum MutationTableColumnType {
     HGVSC,
     GNOMAD,
     CLINVAR,
-    DBSNP
+    DBSNP,
+    GENE_PANEL
 }
 
 type MutationTableColumn = Column<Mutation[]>&{order?:number, shouldExclude?:()=>boolean};

--- a/src/shared/components/mutationTable/column/PanelColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/PanelColumnFormatter.spec.tsx
@@ -1,0 +1,60 @@
+import PanelColumnFormatter from './PanelColumnFormatter';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import SampleManager from 'pages/patientView/SampleManager';
+
+const mockData = [
+  {
+    alteration: 1,
+    entrezGeneId: 1,
+    gene: { 
+      entrezGeneId: 1, 
+      hugoGeneSymbol: 'test', 
+      geneticEntityId: 1, 
+      type: 'test'
+    },
+    molecularProfileId: 'test',
+    patientId: 'test',
+    sampleId: 'sampleId',
+    studyId: 'test',
+    uniquePatientKey: 'test',
+    uniqueSampleKey: 'test',
+  }
+];
+
+const mockSamples = [
+  { id: 'sampleId', clinicalData: [] }
+]
+
+const mockSampleToGenePanelId = { 'sampleId': 'genePanelId' };
+const mockGenePanelIdToGene = { 'genePanelId': [1] };
+const mockSampleManager = new SampleManager(mockSamples);
+
+const mock = {
+  data: mockData,
+  sampleToGenePanelId: mockSampleToGenePanelId,
+  sampleManager: mockSampleManager,
+  genePanelIdToGene: mockGenePanelIdToGene
+}
+
+describe('PanelColumnFormatter', () => {
+  it('renders spinner icon if sampleToGenePanelId object is empty', () => {
+    const PanelColumn = shallow(PanelColumnFormatter.renderFunction({...mock, sampleToGenePanelId: {}}));
+    assert.isTrue(PanelColumn.find('i.fa-spinner').exists());
+  });
+  
+  it('renders gene panel information', () => {
+    const PanelColumn = shallow(PanelColumnFormatter.renderFunction(mock));
+    assert.isTrue(PanelColumn.text().includes('genePanelId'));
+  });
+  
+  it('returns a list of gene panel ids on download', () => {
+    const genePanelIds = PanelColumnFormatter.download(mock);
+    assert.deepEqual(genePanelIds, ['genePanelId'])
+  });
+  
+  it('returns a list of gene panel ids on getGenePanelIds', () => {
+    const genePanelIds = PanelColumnFormatter.getGenePanelIds(mock);
+    assert.deepEqual(genePanelIds, ['genePanelId'])
+  });
+})

--- a/src/shared/components/mutationTable/column/PanelColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/PanelColumnFormatter.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import {map} from 'lodash';
+import SampleManager from 'pages/patientView/SampleManager';
+import { ClinicalDataBySampleId } from 'shared/api/api-types-extended';
+import TumorColumnFormatter from 'pages/patientView/mutation/column/TumorColumnFormatter';
+
+interface PanelColumnFormatterProps {
+	data: {sampleId:string, entrezGeneId:number}[];
+	sampleToGenePanelId: {[sampleId: string]: string|undefined};
+	sampleManager: SampleManager|null;
+	genePanelIdToGene: {[genePanelId: string]: number[]}
+}
+
+class PanelColumn extends React.Component<PanelColumnFormatterProps, {}> {
+	constructor(props: PanelColumnFormatterProps) {
+		super(props);
+	}
+
+	render() {
+		const { sampleToGenePanelId, sampleManager } = this.props;
+    if (!sampleToGenePanelId || !sampleManager) return;
+
+		if (sampleToGenePanelId && !Object.keys(sampleToGenePanelId).length) {
+			return <i className='fa fa-spinner fa-pulse' />;
+		}
+
+		const genePanelIds: string[] = getGenePanelIds(this.props);
+
+		return (
+			<div style={{ position: 'relative' }}>
+				<ul style={{ marginBottom: 0 }} className='list-inline list-unstyled'>
+					{genePanelIds.join(', ')}
+				</ul>
+			</div>
+		);
+	}
+}
+
+const getGenePanelIds = (props:PanelColumnFormatterProps) => {
+	const { data, sampleToGenePanelId, sampleManager, genePanelIdToGene } = props;
+  if (sampleToGenePanelId && sampleManager) {
+		const samples =  sampleManager.samples;
+		const sampleIds = map(samples, (sample:ClinicalDataBySampleId) => sample.id)
+		const entrezGeneId = data[0].entrezGeneId;
+		const mutatedSamples = TumorColumnFormatter.getPresentSamples(data);
+		const profiledSamples = TumorColumnFormatter.getProfiledSamplesForGene(entrezGeneId, sampleIds, sampleToGenePanelId, genePanelIdToGene);
+		
+		const genePanelsIds = samples.map(sample => {
+			const isMutated = sample.id in mutatedSamples;
+			const isProfiled = sample.id in profiledSamples && profiledSamples[sample.id];
+			if (isProfiled && !isMutated) return "";
+			return sampleToGenePanelId[sample.id] || "N/A";
+		});
+		
+		return genePanelsIds.filter(id => id);
+  }
+  return [];
+};
+
+export default {
+	renderFunction: (
+		props:PanelColumnFormatterProps
+	) => (
+		<PanelColumn
+			data={props.data}
+			sampleToGenePanelId={props.sampleToGenePanelId}
+			sampleManager={props.sampleManager}
+			genePanelIdToGene={props.genePanelIdToGene}
+		/>
+	),
+	download: (
+		props:PanelColumnFormatterProps) => getGenePanelIds(props),
+	getGenePanelIds
+};


### PR DESCRIPTION
# What? Why?
Implementation of feature: Gene panel column data in patient view download

# Code changes
- Created `PanelColumnFormatter.tsx` to render the related panel data
- Added `Gene panel` column (hidden by default) to `PatientViewMutationTable.tsx` and `CopyNumberTableWrapper.tsx`

# GIF
![Peek 2019-09-30 15-41](https://user-images.githubusercontent.com/31291004/65884332-f36c3580-e398-11e9-859b-7fd09076cc6f.gif)

### Remarks:
- end-to-end-tests are failing because BACKEND_BRANCH is pointing to `patientview_genepanel_api_integration` which does not exist