### PR TITLE
Update MD5 fingerprint script to use correct docker image

### DIFF
--- a/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
+++ b/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
@@ -8,9 +8,9 @@ DIR=$PWD
 
 cd $TEST_HOME/local/docker
 ./build_portal_image.sh
-MD5_ES_0=$(docker run --rm $BACKEND_PROJECT_USERNAME/cbioportal:$BACKEND_BRANCH sh -c 'find /cbioportal/core/src/test/scripts/test_data/study_es_0/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//"')
+MD5_ES_0=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'find /cbioportal/core/src/test/scripts/test_data/study_es_0/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//"')
 MD5_TEST_STUDIES=$(find $TEST_HOME/local/studies/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//")
-MD5_MIGRATION_SQL=$(docker run --rm $BACKEND_PROJECT_USERNAME/cbioportal:$BACKEND_BRANCH sh -c 'md5sum /cbioportal/db-scripts/src/main/resources/migration.sql | sed "s/\s.*$//"')
+MD5_MIGRATION_SQL=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'md5sum /cbioportal/db-scripts/src/main/resources/migration.sql | sed "s/\s.*$//"')
 
 cd $DIR
 


### PR DESCRIPTION
For e2e-localdb tests a custom image can be specified in `custom.sh`. Building of this custom image was broken because the wrong environmental variable was referenced in `db_content_fingerprint.sh`.

This PR will correct this reference and fix the building of the custom backend.