### PR TITLE
Change default setting of gene filters in Patient View from portal.properties

### DIFF
--- a/end-to-end-test/local/specs/core/patientview.spec.js
+++ b/end-to-end-test/local/specs/core/patientview.spec.js
@@ -12,226 +12,205 @@ describe('patient view page', function() {
 
     if (useExternalFrontend) {
 
-        // describe('gene panel information', () => {
+        describe('gene panel information', () => {
 
-        //     before(()=>{
-        //         goToUrlAndSetLocalStorage(patienViewUrl);
-        //         waitForPatientView();
-        //     });
-
-        //     const p = 'sample-icon';
-        //     const n = 'not-profiled-icon';
-
-        //     it('mutation table shows correct sample icons, non-profiled icons and invisible icons',() => {
-
-        //         const sampleIcon = {
-        //             ERBB2:  [n, n, n, p, p],
-        //             ABLIM1: [p, p, n, p, p],
-        //             PIEZO1: [n, n, p, p, p],
-        //             CADM2:  [p, p, p, p, p]
-        //         }
-
-        //         const sampleVisibility = {
-        //             ERBB2:  [true , true, true, true , false],
-        //             ABLIM1: [true , true, true, false, false],
-        //             PIEZO1: [true , true, true, false, false],
-        //             CADM2:  [false, true, true, false, false]
-        //         }
-
-        //         const genes = _.keys(sampleIcon);
-        //         genes.forEach((gene)=>{
-        //             testSampleIcon(gene, 'patientview-mutation-table', sampleIcon[gene], sampleVisibility[gene]);
-        //         })
-
-        //     });
-
-        //     it('CNA table shows correct sample icons, non-profiled icons and invisible icons',() => {
-
-        //         const sampleIcon = {
-        //             ERBB2:  [n, n, p, p, n],
-        //             CADM2:  [p, p, p, p, p],
-        //             PIEZO1: [n, p, p, p, n]
-        //         }
-
-        //         const sampleVisibility = {
-        //             ERBB2:  [true , true, false, true , true],
-        //             CADM2:  [false, true, false, false, true],
-        //             PIEZO1: [true , true, false, false, true],
-        //         }
-
-        //         const genes = _.keys(sampleIcon);
-
-        //         genes.forEach((gene)=>{
-        //             testSampleIcon(gene, 'patientview-copynumber-table', sampleIcon[gene], sampleVisibility[gene]);
-        //         })
-
-        //     });
-
-        // });
-
-        // describe('filtering of mutation table', () => {
-
-        //     let selectMenu;
-        //     let filterIcon;
-
-        //     before(() => {
-        //         goToUrlAndSetLocalStorage(patienViewUrl);
-        //         waitForPatientView();
-        //     });
-
-        //     it('filter menu icon is shown when gene panels are used', () => {
-        //         filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
-        //         assert(filterIcon.isVisible());
-        //     });
-
-        //     it('opens selection menu when filter icon clicked', () => {
-        //         filterIcon.click();
-        //         selectMenu = $('.rc-tooltip');
-        //         assert(selectMenu.isVisible());
-        //     });
-
-        //     it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
-        //         const allGenesRadio = selectMenu.$('input[value=allSamples]');
-        //         allGenesRadio.click();
-        //         const geneEntries = $$('[data-test=mutation-table-gene-column]');
-        //         assert.equal(geneEntries.length, 1);
-        //         const geneName = geneEntries[0].getText();
-        //         assert.equal(geneName, "CADM2");
-        //     });
-
-        //     it('re-adds genes when `any genes` option selected', () => {
-        //         const anyGenesRadio = selectMenu.$('input[value=anySample]');
-        //         anyGenesRadio.click();
-        //         const geneEntries = $$('[data-test=mutation-table-gene-column]');
-        //         assert.equal(geneEntries.length, 4);
-        //     });
-
-        //     it('closes selection menu when filter icon clicked again', () => {
-        //         filterIcon.click();
-        //         selectMenu = $('.rc-tooltip');
-        //         assert(!selectMenu.isVisible());
-        //     });
-
-        //     it('filter menu icon is not shown when gene panels are not used', () => {
-        //         goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
-        //         waitForPatientView();
-        //         var filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
-        //         assert(! filterIcon.isVisible());
-        //     });
-        // });
-
-        // describe('filtering of CNA table', () => {
-
-        //     let selectMenu;
-        //     let filterIcon;
-
-        //     before(() => {
-        //         goToUrlAndSetLocalStorage(patienViewUrl);
-        //         waitForPatientView();
-        //     });
-
-        //     it('filter menu icon is shown when gene panels are used', () => {
-        //         filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
-        //         assert(filterIcon.isVisible());
-        //     });
-
-        //     it('opens selection menu when filter icon clicked', () => {
-        //         filterIcon.click();
-        //         selectMenu = $('.rc-tooltip');
-        //         assert(selectMenu.isVisible());
-        //     });
-
-        //     it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
-        //         const allGenesRadio = selectMenu.$('input[value=allSamples]');
-        //         allGenesRadio.click();
-        //         const geneEntries = $$('[data-test=cna-table-gene-column]');
-        //         assert.equal(geneEntries.length, 1);
-        //         const geneName = geneEntries[0].getText();
-        //         assert.equal(geneName, "CADM2");
-        //     });
-
-        //     it('re-adds genes when `any genes` option selected', () => {
-        //         const anyGenesRadio = selectMenu.$('input[value=anySample]');
-        //         anyGenesRadio.click();
-        //         const geneEntries = $$('[data-test=cna-table-gene-column]');
-        //         assert.equal(geneEntries.length, 3);
-        //     });
-
-        //     it('closes selection menu when filter icon clicked again', () => {
-        //         filterIcon.click();
-        //         selectMenu = $('.rc-tooltip');
-        //         assert(!selectMenu.isVisible());
-        //     });
-
-        //     it('filter menu icon is not shown when gene panels are not used', () => {
-        //         goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A2-A04U');
-        //         waitForPatientView();
-        //         var filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
-        //         assert(! filterIcon.isVisible());
-        //     });
-        // });
-
-        // describe('genomic tracks', () => {
-
-        //     before(()=>{
-        //         goToUrlAndSetLocalStorage(patienViewUrl);
-        //         waitForPatientView();
-        //     });
-
-        //     it('shows gene panel icon when gene panels are used for patient samples', () => {
-        //         assert($('[data-test=cna-track-genepanel-icon-0]').isExisting());
-        //         assert($('[data-test=mut-track-genepanel-icon-5]').isExisting());
-        //     });
-
-        //     it('shows mouse-over tooltip for gene panel icons with gene panel id', () => {
-        //         // Tooltip elements are created when hovering the gene panel icon.
-        //         // Control logic below is needed to access the last one after it
-        //         // was created.
-        //         var curNumToolTips = $$('div.qtip-content').length;
-        //         browser.moveToObject('[data-test=cna-track-genepanel-icon-1]');
-        //         browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
-        //         var toolTips = $$('div.qtip-content');
-        //         var text = toolTips[toolTips.length-1].getText();
-        //         assert.equal(text, 'Gene panel: TESTPANEL1');
-        //     });
-
-        //     it('shows mouse-over tooltip for gene panel icons with NA for whole-genome analyzed sample', () => {
-        //         // Tooltip elements are created when hovering the gene panel icon.
-        //         // Control logic below is needed to access the last one after it
-        //         // was created.
-        //         var curNumToolTips = $$('div.qtip-content').length;
-        //         browser.moveToObject('[data-test=cna-track-genepanel-icon-4]');
-        //         browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
-        //         var toolTips = $$('div.qtip-content');
-        //         var text = toolTips[toolTips.length-1].getText();
-        //         assert.equal(text, 'Gene panel information not found. Sample is presumed to be whole exome/genome sequenced.');
-        //     });
-
-        //     it('hides gene panel icons when no gene panels are used for patient samples', () => {
-        //         goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
-        //         waitForPatientView();
-        //         assert(!$('[data-test=mut-track-genepanel-icon-0]').isExisting());
-        //     });
-
-        // });
-
-        describe('gene selection filter from global config', () => {
-
-            it('reads global config and does not filter mut and cna tables when specified', () => {
-                setServerConfigAndLoadPatientView('skin_patientview_filter_genes_profiled_all_samples', false);
-                const mutGeneEntries = $$('[data-test=mutation-table-gene-column]');
-                const cnaGeneEntries = $$('[data-test=cna-table-gene-column]');
-                assert.equal(mutGeneEntries.length, 4);
-                assert.equal(cnaGeneEntries.length, 3);
+            before(()=>{
+                goToUrlAndSetLocalStorage(patienViewUrl);
+                waitForPatientView();
             });
 
-            it.only('reads global config and does filter mut and cna tables when specified', () => {
-                setServerConfigAndLoadPatientView('skin_patientview_filter_genes_profiled_all_samples', true);
-                browser.debug();
-                const mutGeneEntries = $$('[data-test=mutation-table-gene-column]');
-                const cnaGeneEntries = $$('[data-test=cna-table-gene-column]');
-                assert.equal(mutGeneEntries.length, 1);
-                assert.equal(cnaGeneEntries.length, 1);
+            const p = 'sample-icon';
+            const n = 'not-profiled-icon';
+
+            it('mutation table shows correct sample icons, non-profiled icons and invisible icons',() => {
+
+                const sampleIcon = {
+                    ERBB2:  [n, n, n, p, p],
+                    ABLIM1: [p, p, n, p, p],
+                    PIEZO1: [n, n, p, p, p],
+                    CADM2:  [p, p, p, p, p]
+                }
+
+                const sampleVisibility = {
+                    ERBB2:  [true , true, true, true , false],
+                    ABLIM1: [true , true, true, false, false],
+                    PIEZO1: [true , true, true, false, false],
+                    CADM2:  [false, true, true, false, false]
+                }
+
+                const genes = _.keys(sampleIcon);
+                genes.forEach((gene)=>{
+                    testSampleIcon(gene, 'patientview-mutation-table', sampleIcon[gene], sampleVisibility[gene]);
+                })
+
+            });
+
+            it('CNA table shows correct sample icons, non-profiled icons and invisible icons',() => {
+
+                const sampleIcon = {
+                    ERBB2:  [n, n, p, p, n],
+                    CADM2:  [p, p, p, p, p],
+                    PIEZO1: [n, p, p, p, n]
+                }
+
+                const sampleVisibility = {
+                    ERBB2:  [true , true, false, true , true],
+                    CADM2:  [false, true, false, false, true],
+                    PIEZO1: [true , true, false, false, true],
+                }
+
+                const genes = _.keys(sampleIcon);
+
+                genes.forEach((gene)=>{
+                    testSampleIcon(gene, 'patientview-copynumber-table', sampleIcon[gene], sampleVisibility[gene]);
+                })
+
+            });
+
+        });
+
+        describe('filtering of mutation table', () => {
+
+            let selectMenu;
+            let filterIcon;
+
+            before(() => {
+                goToUrlAndSetLocalStorage(patienViewUrl);
+                waitForPatientView();
+            });
+
+            it('filter menu icon is shown when gene panels are used', () => {
+                filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
+                assert(filterIcon.isVisible());
+            });
+
+            it('opens selection menu when filter icon clicked', () => {
+                filterIcon.click();
+                selectMenu = $('.rc-tooltip');
+                assert(selectMenu.isVisible());
+            });
+
+            it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
+                const allGenesRadio = selectMenu.$('input[value=allSamples]');
+                allGenesRadio.click();
+                const geneEntries = $$('[data-test=mutation-table-gene-column]');
+                assert.equal(geneEntries.length, 1);
+                const geneName = geneEntries[0].getText();
+                assert.equal(geneName, "CADM2");
+            });
+
+            it('re-adds genes when `any genes` option selected', () => {
+                const anyGenesRadio = selectMenu.$('input[value=anySample]');
+                anyGenesRadio.click();
+                const geneEntries = $$('[data-test=mutation-table-gene-column]');
+                assert.equal(geneEntries.length, 4);
+            });
+
+            it('closes selection menu when filter icon clicked again', () => {
+                filterIcon.click();
+                selectMenu = $('.rc-tooltip');
+                assert(!selectMenu.isVisible());
+            });
+
+            it('filter menu icon is not shown when gene panels are not used', () => {
+                goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
+                waitForPatientView();
+                var filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
+                assert(! filterIcon.isVisible());
+            });
+        });
+
+        describe('filtering of CNA table', () => {
+
+            let selectMenu;
+            let filterIcon;
+
+            before(() => {
+                goToUrlAndSetLocalStorage(patienViewUrl);
+                waitForPatientView();
+            });
+
+            it('filter menu icon is shown when gene panels are used', () => {
+                filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
+                assert(filterIcon.isVisible());
+            });
+
+            it('opens selection menu when filter icon clicked', () => {
+                filterIcon.click();
+                selectMenu = $('.rc-tooltip');
+                assert(selectMenu.isVisible());
+            });
+
+            it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
+                const allGenesRadio = selectMenu.$('input[value=allSamples]');
+                allGenesRadio.click();
+                const geneEntries = $$('[data-test=cna-table-gene-column]');
+                assert.equal(geneEntries.length, 1);
+                const geneName = geneEntries[0].getText();
+                assert.equal(geneName, "CADM2");
+            });
+
+            it('re-adds genes when `any genes` option selected', () => {
+                const anyGenesRadio = selectMenu.$('input[value=anySample]');
+                anyGenesRadio.click();
+                const geneEntries = $$('[data-test=cna-table-gene-column]');
+                assert.equal(geneEntries.length, 3);
+            });
+
+            it('closes selection menu when filter icon clicked again', () => {
+                filterIcon.click();
+                selectMenu = $('.rc-tooltip');
+                assert(!selectMenu.isVisible());
+            });
+
+            it('filter menu icon is not shown when gene panels are not used', () => {
+                goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A2-A04U');
+                waitForPatientView();
+                var filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
+                assert(! filterIcon.isVisible());
+            });
+        });
+
+        describe('genomic tracks', () => {
+
+            before(()=>{
+                goToUrlAndSetLocalStorage(patienViewUrl);
+                waitForPatientView();
+            });
+
+            it('shows gene panel icon when gene panels are used for patient samples', () => {
+                assert($('[data-test=cna-track-genepanel-icon-0]').isExisting());
+                assert($('[data-test=mut-track-genepanel-icon-5]').isExisting());
+            });
+
+            it('shows mouse-over tooltip for gene panel icons with gene panel id', () => {
+                // Tooltip elements are created when hovering the gene panel icon.
+                // Control logic below is needed to access the last one after it
+                // was created.
+                var curNumToolTips = $$('div.qtip-content').length;
+                browser.moveToObject('[data-test=cna-track-genepanel-icon-1]');
+                browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
+                var toolTips = $$('div.qtip-content');
+                var text = toolTips[toolTips.length-1].getText();
+                assert.equal(text, 'Gene panel: TESTPANEL1');
+            });
+
+            it('shows mouse-over tooltip for gene panel icons with NA for whole-genome analyzed sample', () => {
+                // Tooltip elements are created when hovering the gene panel icon.
+                // Control logic below is needed to access the last one after it
+                // was created.
+                var curNumToolTips = $$('div.qtip-content').length;
+                browser.moveToObject('[data-test=cna-track-genepanel-icon-4]');
+                browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
+                var toolTips = $$('div.qtip-content');
+                var text = toolTips[toolTips.length-1].getText();
+                assert.equal(text, 'Gene panel information not found. Sample is presumed to be whole exome/genome sequenced.');
+            });
+
+            it('hides gene panel icons when no gene panels are used for patient samples', () => {
+                goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
+                waitForPatientView();
+                assert(!$('[data-test=mut-track-genepanel-icon-0]').isExisting());
             });
 
         });
@@ -255,12 +234,4 @@ function testSampleIcon(geneSymbol, tableTag, sampleIconTypes, sampleVisibilitie
         assert.equal(actualVisibility, desiredVisibility, "Gene "+geneSymbol+": icon visibility at position "+i+" is not `"+desiredVisibility+"`, but is `"+actualVisibility+"`");
     });
 
-}
-
-function setServerConfigAndLoadPatientView(paramName, paramValue) {
-    browser.execute((paramName, paramValue) => {
-        window.frontendConfig.serverConfig[paramName] = paramValue;
-    });
-    goToUrlAndSetLocalStorage(patienViewUrl);
-    waitForPatientView();
 }

--- a/end-to-end-test/local/specs/core/patientview.spec.js
+++ b/end-to-end-test/local/specs/core/patientview.spec.js
@@ -12,240 +12,224 @@ describe('patient view page', function() {
 
     if (useExternalFrontend) {
 
-        describe('gene panel information', () => {
+        // describe('gene panel information', () => {
 
-            before(()=>{
-                goToUrlAndSetLocalStorage(patienViewUrl);
-                waitForPatientView();
-            });
+        //     before(()=>{
+        //         goToUrlAndSetLocalStorage(patienViewUrl);
+        //         waitForPatientView();
+        //     });
 
-            const p = 'sample-icon';
-            const n = 'not-profiled-icon';
+        //     const p = 'sample-icon';
+        //     const n = 'not-profiled-icon';
 
-            it('mutation table shows correct sample icons, non-profiled icons and invisible icons',() => {
+        //     it('mutation table shows correct sample icons, non-profiled icons and invisible icons',() => {
 
-                const sampleIcon = {
-                    ERBB2:  [n, n, n, p, p],
-                    ABLIM1: [p, p, n, p, p],
-                    PIEZO1: [n, n, p, p, p],
-                    CADM2:  [p, p, p, p, p]
-                }
+        //         const sampleIcon = {
+        //             ERBB2:  [n, n, n, p, p],
+        //             ABLIM1: [p, p, n, p, p],
+        //             PIEZO1: [n, n, p, p, p],
+        //             CADM2:  [p, p, p, p, p]
+        //         }
 
-                const sampleVisibility = {
-                    ERBB2:  [true , true, true, true , false],
-                    ABLIM1: [true , true, true, false, false],
-                    PIEZO1: [true , true, true, false, false],
-                    CADM2:  [false, true, true, false, false]
-                }
+        //         const sampleVisibility = {
+        //             ERBB2:  [true , true, true, true , false],
+        //             ABLIM1: [true , true, true, false, false],
+        //             PIEZO1: [true , true, true, false, false],
+        //             CADM2:  [false, true, true, false, false]
+        //         }
 
-                const genes = _.keys(sampleIcon);
-                genes.forEach((gene)=>{
-                    testSampleIcon(gene, 'patientview-mutation-table', sampleIcon[gene], sampleVisibility[gene]);
-                })
+        //         const genes = _.keys(sampleIcon);
+        //         genes.forEach((gene)=>{
+        //             testSampleIcon(gene, 'patientview-mutation-table', sampleIcon[gene], sampleVisibility[gene]);
+        //         })
 
-            });
+        //     });
 
-            it('CNA table shows correct sample icons, non-profiled icons and invisible icons',() => {
+        //     it('CNA table shows correct sample icons, non-profiled icons and invisible icons',() => {
 
-                const sampleIcon = {
-                    ERBB2:  [n, n, p, p, n],
-                    CADM2:  [p, p, p, p, p],
-                    PIEZO1: [n, p, p, p, n]
-                }
+        //         const sampleIcon = {
+        //             ERBB2:  [n, n, p, p, n],
+        //             CADM2:  [p, p, p, p, p],
+        //             PIEZO1: [n, p, p, p, n]
+        //         }
 
-                const sampleVisibility = {
-                    ERBB2:  [true , true, false, true , true],
-                    CADM2:  [false, true, false, false, true],
-                    PIEZO1: [true , true, false, false, true],
-                }
+        //         const sampleVisibility = {
+        //             ERBB2:  [true , true, false, true , true],
+        //             CADM2:  [false, true, false, false, true],
+        //             PIEZO1: [true , true, false, false, true],
+        //         }
 
-                const genes = _.keys(sampleIcon);
+        //         const genes = _.keys(sampleIcon);
 
-                genes.forEach((gene)=>{
-                    testSampleIcon(gene, 'patientview-copynumber-table', sampleIcon[gene], sampleVisibility[gene]);
-                })
+        //         genes.forEach((gene)=>{
+        //             testSampleIcon(gene, 'patientview-copynumber-table', sampleIcon[gene], sampleVisibility[gene]);
+        //         })
 
-            });
+        //     });
 
-        });
+        // });
 
-        describe('filtering of mutation table', () => {
+        // describe('filtering of mutation table', () => {
 
-            let selectMenu;
-            let filterIcon;
+        //     let selectMenu;
+        //     let filterIcon;
 
-            before(() => {
-                goToUrlAndSetLocalStorage(patienViewUrl);
-                waitForPatientView();
-            });
+        //     before(() => {
+        //         goToUrlAndSetLocalStorage(patienViewUrl);
+        //         waitForPatientView();
+        //     });
 
-            it('filter menu icon is shown when gene panels are used', () => {
-                filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
-                assert(filterIcon.isVisible());
-            });
+        //     it('filter menu icon is shown when gene panels are used', () => {
+        //         filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
+        //         assert(filterIcon.isVisible());
+        //     });
 
-            it('opens selection menu when filter icon clicked', () => {
-                filterIcon.click();
-                selectMenu = $('.rc-tooltip');
-                assert(selectMenu.isVisible());
-            });
+        //     it('opens selection menu when filter icon clicked', () => {
+        //         filterIcon.click();
+        //         selectMenu = $('.rc-tooltip');
+        //         assert(selectMenu.isVisible());
+        //     });
 
-            it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
-                const allGenesRadio = selectMenu.$('input[value=allSamples]');
-                allGenesRadio.click();
-                const geneEntries = $$('[data-test=mutation-table-gene-column]');
-                assert.equal(geneEntries.length, 1);
-                const geneName = geneEntries[0].getText();
-                assert.equal(geneName, "CADM2");
-            });
+        //     it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
+        //         const allGenesRadio = selectMenu.$('input[value=allSamples]');
+        //         allGenesRadio.click();
+        //         const geneEntries = $$('[data-test=mutation-table-gene-column]');
+        //         assert.equal(geneEntries.length, 1);
+        //         const geneName = geneEntries[0].getText();
+        //         assert.equal(geneName, "CADM2");
+        //     });
 
-            it('re-adds genes when `any genes` option selected', () => {
-                const anyGenesRadio = selectMenu.$('input[value=anySample]');
-                anyGenesRadio.click();
-                const geneEntries = $$('[data-test=mutation-table-gene-column]');
-                assert.equal(geneEntries.length, 4);
-            });
+        //     it('re-adds genes when `any genes` option selected', () => {
+        //         const anyGenesRadio = selectMenu.$('input[value=anySample]');
+        //         anyGenesRadio.click();
+        //         const geneEntries = $$('[data-test=mutation-table-gene-column]');
+        //         assert.equal(geneEntries.length, 4);
+        //     });
 
-            it('closes selection menu when filter icon clicked again', () => {
-                filterIcon.click();
-                selectMenu = $('.rc-tooltip');
-                assert(!selectMenu.isVisible());
-            });
+        //     it('closes selection menu when filter icon clicked again', () => {
+        //         filterIcon.click();
+        //         selectMenu = $('.rc-tooltip');
+        //         assert(!selectMenu.isVisible());
+        //     });
 
-            it('filter menu icon is not shown when gene panels are not used', () => {
-                goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
-                waitForPatientView();
-                var filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
-                assert(! filterIcon.isVisible());
-            });
-        });
+        //     it('filter menu icon is not shown when gene panels are not used', () => {
+        //         goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
+        //         waitForPatientView();
+        //         var filterIcon = $('div[data-test=patientview-mutation-table]').$('i[data-test=gene-filter-icon]');
+        //         assert(! filterIcon.isVisible());
+        //     });
+        // });
 
-        describe('filtering of CNA table', () => {
+        // describe('filtering of CNA table', () => {
 
-            let selectMenu;
-            let filterIcon;
+        //     let selectMenu;
+        //     let filterIcon;
 
-            before(() => {
-                goToUrlAndSetLocalStorage(patienViewUrl);
-                waitForPatientView();
-            });
+        //     before(() => {
+        //         goToUrlAndSetLocalStorage(patienViewUrl);
+        //         waitForPatientView();
+        //     });
 
-            it('filter menu icon is shown when gene panels are used', () => {
-                filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
-                assert(filterIcon.isVisible());
-            });
+        //     it('filter menu icon is shown when gene panels are used', () => {
+        //         filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
+        //         assert(filterIcon.isVisible());
+        //     });
 
-            it('opens selection menu when filter icon clicked', () => {
-                filterIcon.click();
-                selectMenu = $('.rc-tooltip');
-                assert(selectMenu.isVisible());
-            });
+        //     it('opens selection menu when filter icon clicked', () => {
+        //         filterIcon.click();
+        //         selectMenu = $('.rc-tooltip');
+        //         assert(selectMenu.isVisible());
+        //     });
 
-            it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
-                const allGenesRadio = selectMenu.$('input[value=allSamples]');
-                allGenesRadio.click();
-                const geneEntries = $$('[data-test=cna-table-gene-column]');
-                assert.equal(geneEntries.length, 1);
-                const geneName = geneEntries[0].getText();
-                assert.equal(geneName, "CADM2");
-            });
+        //     it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
+        //         const allGenesRadio = selectMenu.$('input[value=allSamples]');
+        //         allGenesRadio.click();
+        //         const geneEntries = $$('[data-test=cna-table-gene-column]');
+        //         assert.equal(geneEntries.length, 1);
+        //         const geneName = geneEntries[0].getText();
+        //         assert.equal(geneName, "CADM2");
+        //     });
 
-            it('re-adds genes when `any genes` option selected', () => {
-                const anyGenesRadio = selectMenu.$('input[value=anySample]');
-                anyGenesRadio.click();
-                const geneEntries = $$('[data-test=cna-table-gene-column]');
-                assert.equal(geneEntries.length, 3);
-            });
+        //     it('re-adds genes when `any genes` option selected', () => {
+        //         const anyGenesRadio = selectMenu.$('input[value=anySample]');
+        //         anyGenesRadio.click();
+        //         const geneEntries = $$('[data-test=cna-table-gene-column]');
+        //         assert.equal(geneEntries.length, 3);
+        //     });
 
-            it('closes selection menu when filter icon clicked again', () => {
-                filterIcon.click();
-                selectMenu = $('.rc-tooltip');
-                assert(!selectMenu.isVisible());
-            });
+        //     it('closes selection menu when filter icon clicked again', () => {
+        //         filterIcon.click();
+        //         selectMenu = $('.rc-tooltip');
+        //         assert(!selectMenu.isVisible());
+        //     });
 
-            it('filter menu icon is not shown when gene panels are not used', () => {
-                goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A2-A04U');
-                waitForPatientView();
-                var filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
-                assert(! filterIcon.isVisible());
-            });
-        });
+        //     it('filter menu icon is not shown when gene panels are not used', () => {
+        //         goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A2-A04U');
+        //         waitForPatientView();
+        //         var filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
+        //         assert(! filterIcon.isVisible());
+        //     });
+        // });
 
-        describe('genomic tracks', () => {
+        // describe('genomic tracks', () => {
 
-            before(()=>{
-                goToUrlAndSetLocalStorage(patienViewUrl);
-                waitForPatientView();
-            });
+        //     before(()=>{
+        //         goToUrlAndSetLocalStorage(patienViewUrl);
+        //         waitForPatientView();
+        //     });
 
-            it('shows gene panel icon when gene panels are used for patient samples', () => {
-                assert($('[data-test=cna-track-genepanel-icon-0]').isExisting());
-                assert($('[data-test=mut-track-genepanel-icon-5]').isExisting());
-            });
+        //     it('shows gene panel icon when gene panels are used for patient samples', () => {
+        //         assert($('[data-test=cna-track-genepanel-icon-0]').isExisting());
+        //         assert($('[data-test=mut-track-genepanel-icon-5]').isExisting());
+        //     });
 
-            it('shows mouse-over tooltip for gene panel icons with gene panel id', () => {
-                // Tooltip elements are created when hovering the gene panel icon.
-                // Control logic below is needed to access the last one after it
-                // was created.
-                var curNumToolTips = $$('div.qtip-content').length;
-                browser.moveToObject('[data-test=cna-track-genepanel-icon-1]');
-                browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
-                var toolTips = $$('div.qtip-content');
-                var text = toolTips[toolTips.length-1].getText();
-                assert.equal(text, 'Gene panel: TESTPANEL1');
-            });
+        //     it('shows mouse-over tooltip for gene panel icons with gene panel id', () => {
+        //         // Tooltip elements are created when hovering the gene panel icon.
+        //         // Control logic below is needed to access the last one after it
+        //         // was created.
+        //         var curNumToolTips = $$('div.qtip-content').length;
+        //         browser.moveToObject('[data-test=cna-track-genepanel-icon-1]');
+        //         browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
+        //         var toolTips = $$('div.qtip-content');
+        //         var text = toolTips[toolTips.length-1].getText();
+        //         assert.equal(text, 'Gene panel: TESTPANEL1');
+        //     });
 
-            it('shows mouse-over tooltip for gene panel icons with NA for whole-genome analyzed sample', () => {
-                // Tooltip elements are created when hovering the gene panel icon.
-                // Control logic below is needed to access the last one after it
-                // was created.
-                var curNumToolTips = $$('div.qtip-content').length;
-                browser.moveToObject('[data-test=cna-track-genepanel-icon-4]');
-                browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
-                var toolTips = $$('div.qtip-content');
-                var text = toolTips[toolTips.length-1].getText();
-                assert.equal(text, 'Gene panel information not found. Sample is presumed to be whole exome/genome sequenced.');
-            });
+        //     it('shows mouse-over tooltip for gene panel icons with NA for whole-genome analyzed sample', () => {
+        //         // Tooltip elements are created when hovering the gene panel icon.
+        //         // Control logic below is needed to access the last one after it
+        //         // was created.
+        //         var curNumToolTips = $$('div.qtip-content').length;
+        //         browser.moveToObject('[data-test=cna-track-genepanel-icon-4]');
+        //         browser.waitUntil(() => $$('div.qtip-content').length > curNumToolTips);
+        //         var toolTips = $$('div.qtip-content');
+        //         var text = toolTips[toolTips.length-1].getText();
+        //         assert.equal(text, 'Gene panel information not found. Sample is presumed to be whole exome/genome sequenced.');
+        //     });
 
-            it('hides gene panel icons when no gene panels are used for patient samples', () => {
-                goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
-                waitForPatientView();
-                assert(!$('[data-test=mut-track-genepanel-icon-0]').isExisting());
-            });
+        //     it('hides gene panel icons when no gene panels are used for patient samples', () => {
+        //         goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK');
+        //         waitForPatientView();
+        //         assert(!$('[data-test=mut-track-genepanel-icon-0]').isExisting());
+        //     });
 
-        });
-
-        describe('VAF plot', () => {
-
-            before(()=>{
-                goToUrlAndSetLocalStorage(patienViewUrl);
-                waitForPatientView();
-            });
-
-            it('shows gene panel icons when gene panels are used', () => {
-                browser.moveToObject('svg[data-test=vaf-plot]'); // moves pointer to plot thumbnail
-                $('div[role=tooltip] svg[data-test=vaf-plot]').waitForVisible();
-                var genePanelIcon = $('svg[data-test=vaf-plot] rect.genepanel-icon');
-                assert(genePanelIcon.isExisting());
-
-            });
-
-        });
+        // });
 
         describe('gene selection filter from global config', () => {
 
             it('reads global config and does not filter mut and cna tables when specified', () => {
                 setServerConfigAndLoadPatientView('skin_patientview_filter_genes_profiled_all_samples', false);
                 const mutGeneEntries = $$('[data-test=mutation-table-gene-column]');
-                const cnaGeneEntries = $$('div[data-test=patientview-mutation-table] tr');
+                const cnaGeneEntries = $$('[data-test=cna-table-gene-column]');
                 assert.equal(mutGeneEntries.length, 4);
                 assert.equal(cnaGeneEntries.length, 3);
             });
 
-            it('reads global config and does filter mut and cna tables when specified', () => {
+            it.only('reads global config and does filter mut and cna tables when specified', () => {
                 setServerConfigAndLoadPatientView('skin_patientview_filter_genes_profiled_all_samples', true);
+                browser.debug();
                 const mutGeneEntries = $$('[data-test=mutation-table-gene-column]');
-                const cnaGeneEntries = $$('div[data-test=patientview-mutation-table] tr');
+                const cnaGeneEntries = $$('[data-test=cna-table-gene-column]');
                 assert.equal(mutGeneEntries.length, 1);
                 assert.equal(cnaGeneEntries.length, 1);
             });
@@ -262,7 +246,7 @@ function testSampleIcon(geneSymbol, tableTag, sampleIconTypes, sampleVisibilitie
     const icons = samplesCell.$$("li");
 
     sampleIconTypes.forEach((desiredDataType, i) => {
-        const isExpectedIcon = icons[i].$('svg[data-test='+desiredDataType+']').isExisting();
+        const isExpectedIcon = icons[i].$('svg[data-test='+desiredDataType+']').isExistinskin_patientview_filter_genes_profiled_all_samplesg();
         assert.equal(isExpectedIcon, true, "Gene "+geneSymbol+": icon type at position "+i+" is not `"+desiredDataType+"`");
     });
 
@@ -275,7 +259,7 @@ function testSampleIcon(geneSymbol, tableTag, sampleIconTypes, sampleVisibilitie
 
 function setServerConfigAndLoadPatientView(paramName, paramValue) {
     browser.execute((paramName, paramValue) => {
-        window.frontendConfig = {serverConfig: {[paramName]: paramValue}};
+        window.frontendConfig.serverConfig[paramName] = paramValue;
     });
     goToUrlAndSetLocalStorage(patienViewUrl);
     waitForPatientView();

--- a/end-to-end-test/local/specs/core/patientview.spec.js
+++ b/end-to-end-test/local/specs/core/patientview.spec.js
@@ -214,6 +214,44 @@ describe('patient view page', function() {
             });
 
         });
+
+        describe('VAF plot', () => {
+
+            before(()=>{
+                goToUrlAndSetLocalStorage(patienViewUrl);
+                waitForPatientView();
+            });
+
+            it('shows gene panel icons when gene panels are used', () => {
+                browser.moveToObject('svg[data-test=vaf-plot]'); // moves pointer to plot thumbnail
+                $('div[role=tooltip] svg[data-test=vaf-plot]').waitForVisible();
+                var genePanelIcon = $('svg[data-test=vaf-plot] rect.genepanel-icon');
+                assert(genePanelIcon.isExisting());
+
+            });
+
+        });
+
+        describe('gene selection filter from global config', () => {
+
+            it('reads global config and does not filter mut and cna tables when specified', () => {
+                setServerConfigAndLoadPatientView('skin_patientview_filter_genes_profiled_all_samples', false);
+                const mutGeneEntries = $$('[data-test=mutation-table-gene-column]');
+                const cnaGeneEntries = $$('div[data-test=patientview-mutation-table] tr');
+                assert.equal(mutGeneEntries.length, 4);
+                assert.equal(cnaGeneEntries.length, 3);
+            });
+
+            it('reads global config and does filter mut and cna tables when specified', () => {
+                setServerConfigAndLoadPatientView('skin_patientview_filter_genes_profiled_all_samples', true);
+                const mutGeneEntries = $$('[data-test=mutation-table-gene-column]');
+                const cnaGeneEntries = $$('div[data-test=patientview-mutation-table] tr');
+                assert.equal(mutGeneEntries.length, 1);
+                assert.equal(cnaGeneEntries.length, 1);
+            });
+
+        });
+
     }
 });
 
@@ -233,4 +271,12 @@ function testSampleIcon(geneSymbol, tableTag, sampleIconTypes, sampleVisibilitie
         assert.equal(actualVisibility, desiredVisibility, "Gene "+geneSymbol+": icon visibility at position "+i+" is not `"+desiredVisibility+"`, but is `"+actualVisibility+"`");
     });
 
+}
+
+function setServerConfigAndLoadPatientView(paramName, paramValue) {
+    browser.execute((paramName, paramValue) => {
+        window.frontendConfig = {serverConfig: {[paramName]: paramValue}};
+    });
+    goToUrlAndSetLocalStorage(patienViewUrl);
+    waitForPatientView();
 }

--- a/end-to-end-test/local/specs/core/patientview.spec.js
+++ b/end-to-end-test/local/specs/core/patientview.spec.js
@@ -225,7 +225,7 @@ function testSampleIcon(geneSymbol, tableTag, sampleIconTypes, sampleVisibilitie
     const icons = samplesCell.$$("li");
 
     sampleIconTypes.forEach((desiredDataType, i) => {
-        const isExpectedIcon = icons[i].$('svg[data-test='+desiredDataType+']').isExistinskin_patientview_filter_genes_profiled_all_samplesg();
+        const isExpectedIcon = icons[i].$('svg[data-test='+desiredDataType+']').isExisting();
         assert.equal(isExpectedIcon, true, "Gene "+geneSymbol+": icon type at position "+i+" is not `"+desiredDataType+"`");
     });
 

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -92,6 +92,7 @@ export interface IServerConfig {
     skin_show_tissue_image_tab: boolean;
     skin_title: string;
     skin_authorization_message: string | null;
+    skin_patientview_filter_genes_profiled_all_samples: boolean;
     quick_search_enabled: boolean;
     default_cross_cancer_study_list: string; // this has a default
     default_cross_cancer_study_list_name: string; // this has a default

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -101,6 +101,8 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
             error, please contact us at <a style="color:#FF0000" href="mailto:cbioportal-access@cbio.mskcc.org">
             cbioportal-access@cbio.mskcc.org</a>`,
 
+    skin_patientview_filter_genes_profiled_all_samples: false,
+
     enable_darwin: false,
 
     session_url_length_threshold: '1990',

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.spec.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.spec.ts
@@ -1,9 +1,7 @@
 /**
  * Created by aaronlisman on 3/2/17.
  */
-
-import { handlePathologyReportCheckResponse, PatientViewPageStore, filterMutationsByProfiledGene } from './PatientViewPageStore';
-// import React from 'react';
+import { handlePathologyReportCheckResponse, PatientViewPageStore } from './PatientViewPageStore';
 import { assert } from 'chai';
 // import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
@@ -19,10 +17,6 @@ describe('PatientViewPageStore', () => {
 
     before(()=>{
         store = new PatientViewPageStore(new AppStore());
-    });
-
-    after(()=>{
-
     });
 
     it('if there are pdf items in response and their name starts with a given patientId, return collection, otherwise returns empty array', ()=>{

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import {ClinicalDataBySampleId} from "../../../shared/api/api-types-extended";
 import {
     ClinicalData, MolecularProfile, Sample, Mutation, DiscreteCopyNumberFilter, DiscreteCopyNumberData, MutationFilter,
     CopyNumberCount, ClinicalDataMultiStudyFilter, ReferenceGenomeGene, GenePanelData, GenePanel
@@ -7,7 +6,7 @@ import {
 import client from "../../../shared/api/cbioportalClientInstance";
 import internalClient from "../../../shared/api/cbioportalInternalClientInstance";
 import {
-    Gistic, GisticToGene, default as CBioPortalAPIInternal, MutSig
+    default as CBioPortalAPIInternal
 } from "shared/api/generated/CBioPortalAPIInternal";
 import {computed, observable, action, runInAction} from "mobx";
 import {remoteData} from "../../../public-lib/api/remoteData";
@@ -26,7 +25,6 @@ import GenomeNexusCache from "shared/cache/GenomeNexusCache";
 import GenomeNexusMyVariantInfoCache from "shared/cache/GenomeNexusMyVariantInfoCache";
 import {IOncoKbData} from "shared/model/OncoKB";
 import {IHotspotIndex, indexHotspotsData} from "react-mutation-mapper";
-import {IMutSigData} from "shared/model/MutSig";
 import {ICivicVariant, ICivicGene} from "shared/model/Civic.ts";
 import {ClinicalInformationData} from "shared/model/ClinicalInformation";
 import VariantCountCache from "shared/cache/VariantCountCache";
@@ -86,7 +84,8 @@ import { groupTrialMatchesById } from "../trialMatch/TrialMatchTableUtils";
 import { GeneFilterOption } from '../mutation/GeneFilterMenu';
 import TumorColumnFormatter from '../mutation/column/TumorColumnFormatter';
 import { AppStore, SiteError } from 'AppStore';
-
+import { getGeneFilterDefault } from './PatientViewPageStoreUtil';
+import getBrowserWindow from 'public-lib/lib/getBrowserWindow';
 
 type PageMode = 'patient' | 'sample';
 
@@ -183,8 +182,8 @@ export class PatientViewPageStore {
 
     @observable _sampleId = '';
 
-    @observable public mutationTableGeneFilterOption = GeneFilterOption.ANY_SAMPLE;
-    @observable public copyNumberTableGeneFilterOption = GeneFilterOption.ANY_SAMPLE;
+    @observable public mutationTableGeneFilterOption:GeneFilterOption = getGeneFilterDefault(getBrowserWindow().frontendConfig);
+    @observable public copyNumberTableGeneFilterOption:GeneFilterOption = getGeneFilterDefault(getBrowserWindow().frontendConfig);
 
     @computed get sampleId() {
         return this._sampleId;

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStoreUtil.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStoreUtil.ts
@@ -1,0 +1,14 @@
+import { IServerConfig } from "config/IAppConfig";
+import { GeneFilterOption } from "../mutation/GeneFilterMenu";
+
+export function getGeneFilterDefault(frontendConfig:any):GeneFilterOption {
+    if (frontendConfig && 'serverConfig' in frontendConfig) {
+        const serverConfig:IServerConfig = frontendConfig.serverConfig;
+        const propName = 'skin_patientview_filter_genes_profiled_all_samples';
+        if (serverConfig && propName in serverConfig && serverConfig[propName]) {
+            return GeneFilterOption.ALL_SAMPLES;
+        }
+
+    }
+    return GeneFilterOption.ANY_SAMPLE;
+}

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStoreUtils.spec.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStoreUtils.spec.ts
@@ -1,0 +1,28 @@
+import { handlePathologyReportCheckResponse, PatientViewPageStore } from './PatientViewPageStore';
+import { assert } from 'chai';
+import { GeneFilterOption } from '../mutation/GeneFilterMenu';
+import { IServerConfig } from 'config/IAppConfig';
+import { getGeneFilterDefault } from './PatientViewPageStoreUtil';
+
+describe('PatientViewPageStoreUtils', () => {
+
+    describe('getGeneFilterDefault()', () => {
+
+        it('sets filter to `all samples`', () => {
+            const frontendConfig = {serverConfig: { skin_patientview_filter_genes_profiled_all_samples: true} as IServerConfig};
+            assert.equal(getGeneFilterDefault(frontendConfig), GeneFilterOption.ALL_SAMPLES);
+        });
+        
+        it('sets filter to `any sample`', () => {
+            const frontendConfig = {serverConfig: { skin_patientview_filter_genes_profiled_all_samples: false} as IServerConfig};
+            assert.equal(getGeneFilterDefault(frontendConfig), GeneFilterOption.ANY_SAMPLE);
+        });
+
+        it('when missing defaults to `any sample`', () => {
+            const frontendConfig = {serverConfig: {} as IServerConfig};
+            assert.equal(getGeneFilterDefault(frontendConfig), GeneFilterOption.ANY_SAMPLE);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Note: this branch builds on top of branch `patientview_gene_coverage_filter` and the PR is to this branch for the reason of reviewing the code. This PR is therefore in _draft_ mode.

# What? Why?
Central problem with gene panels in patient view is the ambiguous interpretation of missing mutations in the mutation and copy number tables. As specified in RFC45 information on gene panels will be integrated in the PatientView component. We have implemented a filter that allows the user to toggle between display of mutation present in ANY SAMPLE (default behavior) or ALL SAMPLES in these tables.

At present, the mutation and CNA tables default to filtering genes based on the ANY SAMPLE rule. We have implemented a setting in the cbioportal backend that can change the default behavior for gene filtering to ALL SAMPLES in [PR #6658](https://github.com/cBioPortal/cbioportal/pull/6658). The Patient View does not yet respond to this variable passed by the backend. 

# Fix
- Patient View now starts up depending on the  `skin.patientview.filter_genes_profiled_all_samples` property.

# Preview
![Peek 2019-10-01 16-09](https://user-images.githubusercontent.com/745885/65969893-d94c5900-e465-11e9-81d1-161f0c9a659e.gif)
