### PR TITLE
Flexible Gene Query Restrictions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
-module.exports = {
+{
     trailingComma: "es5",
     tabWidth: 4,
     singleQuote: true,
-};
+}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ yarn run prettier --write <files>
 
 To run Prettier JS on your last commit:
 ```$bash
-yarn run prettier-last-commit
+yarn run prettierLastCommit
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "export NODE_OPTIONS=--max-old-space-size=2048; karma start karma.conf.js",
     "test:watch": "yarn run test -- --watch",
     "test:debug": "yarn run test -- --debug --browsers=Chrome_with_debugging --single-run=false",
-    "prettier-last-commit": "yarn run prettier --write $(git diff-tree --no-commit-id --name-only -r $(git rev-parse HEAD))",
+    "prettierLastCommit": "yarn run prettier --write $(git diff-tree --no-commit-id --name-only -r $(git rev-parse HEAD))",
     "syncmock": "node src/test/fetchMockData.js --diff"
   },
   "engines": {
@@ -272,6 +272,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.5",
     "mocha": "^5.2.0",
+    "prettier": "1.18.2",
     "request": "^2.88.0",
     "sinon": "^4.1.3",
     "swagger-js-codegen": "git+https://github.com/cBioPortal/swagger-js-codegen.git#0362f4a1e2d116ad6dffc36e4b57cdfbc93956cf",

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -1,116 +1,116 @@
 export interface IAppConfig {
     apiRoot?: string;
-    baseUrl?:string;
+    baseUrl?: string;
     configurationServiceUrl?: string;
     frontendUrl?: string;
-    serverConfig:IServerConfig;
-    hide_login?:boolean;
+    serverConfig: IServerConfig;
+    hide_login?: boolean;
 }
 
 export type CategorizedConfigItems = {
-    [category:string]: string[]
+    [category: string]: string[];
 };
 
 export type VirtualCohort = {
-    id:string,
-    name:string,
-    description:string,
-    samples:{sampleId:string, studyId:string}[],
-    constituentStudyIds:string[]
+    id: string;
+    name: string;
+    description: string;
+    samples: { sampleId: string; studyId: string }[];
+    constituentStudyIds: string[];
 };
 
 export type StudyView = {
-    tableAttrs: string[]
-    priority: { [id: string]: number }
+    tableAttrs: string[];
+    priority: { [id: string]: number };
 };
 
 export interface IServerConfig {
-    "app_name": string | null;
-    "app_version": string|null;   // default: "1.0"
-    "authenticationMethod": string | undefined;
-    "bitly_access_token": string|null;
-    "oncoprint_custom_driver_annotation_binary_menu_label": string|null; // default:
-    "disabled_tabs": string|null;
-    "custom_tabs": any[];
-    "oncoprint_custom_driver_annotation_binary_default": boolean;
-    "oncoprint_custom_driver_annotation_tiers_default": boolean;
-    "oncoprint_oncokb_default": boolean;
-    "oncoprint_hotspots_default": boolean;
-    "genomenexus_url": string|null;
-    "mygene_info_url": string|null;
-    "g2s_url": string|null;
-    "google_analytics_profile_id": string|null;
-    "isoformOverrideSource" : string;
-    "oncoprint_hide_vus_default": boolean;
-    "mycancergenome_show": boolean | undefined;
-    "oncokb_public_api_url": string|null;
-    "digital_slide_archive_iframe_url": string|null;
-    "digital_slide_archive_meta_url": string|null;
-    "mdacc_heatmap_meta_url": string|null;
-    "mdacc_heatmap_patient_url": string|null;
-    "pubmed_url":string | null;
-    "priority_studies": string|null;
-    "api_cache_limit":number;
-    "show_hotspot": boolean | undefined;
-    "show_oncokb": boolean;
-    "show_civic": boolean;
-    "show_genomenexus": boolean;
-    "skin_documentation_about": string|null;
-    "skin_documentation_baseurl": string|null;
-    "skin_blurb": string|null;
-    "skin_custom_header_tabs": string|null;
-    "skin_data_sets_footer": string|null;
-    "skin_data_sets_header": string|null;
-    "skin_documentation_markdown": boolean;
-    "skin_description": string;
-    "skin_email_contact": string;
-    "skin_example_study_queries": string|null;
-    "skin_examples_right_column_html": string|null;
-    "skin_documentation_faq": string|null;
-    "skin_footer": string|null;
-    "skin_login_contact_html": string|null;
-    "skin_login_saml_registration_html": string|null;
-    "skin_citation_rule_text": string|null;
-    "skin_documentation_news": string|null;
-    "skin_documentation_oql": string|null;
-    "skin_query_max_tree_depth": string;
-    "skin_right_logo": string|null;
-    "skin_right_nav_show_data_sets": boolean;
-    "skin_right_nav_show_examples": boolean;
-    "skin_right_nav_show_testimonials": boolean;
-    "skin_right_nav_show_whats_new": boolean;
-    "skin_right_nav_whats_new_blurb": string|null;
-    "skin_show_about_tab": boolean;
-    "skin_show_data_tab": boolean;
-    "skin_show_faqs_tab": boolean;
-    "skin_show_news_tab":boolean;
-    "skin_show_r_matlab_tab": boolean;
-    "skin_show_tools_tab": boolean;
-    "skin_show_tutorials_tab": boolean;
-    "skin_show_web_api_tab": boolean;
-    "skin_show_tweet_button": boolean;
-    "skin_show_tissue_image_tab": boolean;
-    "skin_title": string;
-    "skin_authorization_message": string|null;
-    "quick_search_enabled": boolean;
-    "default_cross_cancer_study_list": string; // this has a default
-    "default_cross_cancer_study_list_name": string; // this has a default
-    "default_cross_cancer_study_session_id": string|null;
-    "study_view": StudyView;
-    "uniprot_id_url": string|null,
-    "studiesWithGermlineConsentedSamples":string[]|undefined;
-    "mdacc_heatmap_study_meta_url": string|null;
-    "mdacc_heatmap_study_url": string|null;
-    "oncoprint_custom_driver_annotation_tiers_menu_label": string|null;
-    "enable_darwin": boolean;
-    "query_sets_of_genes": string|null;
-    "skin_quick_select_buttons": string|null;
-    "base_url": string|null;
-    "user_email_address": string;
-    "sessionServiceEnabled": boolean;
-    "session_url_length_threshold":string;
-    "mskWholeSlideViewerToken":string;
-    "query_product_limit": number;
-    "dat_uuid_revoke_other_tokens": boolean;
-    "dat_method": string;
+    app_name: string | null;
+    app_version: string | null; // default: "1.0"
+    authenticationMethod: string | undefined;
+    bitly_access_token: string | null;
+    oncoprint_custom_driver_annotation_binary_menu_label: string | null; // default:
+    disabled_tabs: string | null;
+    custom_tabs: any[];
+    oncoprint_custom_driver_annotation_binary_default: boolean;
+    oncoprint_custom_driver_annotation_tiers_default: boolean;
+    oncoprint_oncokb_default: boolean;
+    oncoprint_hotspots_default: boolean;
+    genomenexus_url: string | null;
+    mygene_info_url: string | null;
+    g2s_url: string | null;
+    google_analytics_profile_id: string | null;
+    isoformOverrideSource: string;
+    oncoprint_hide_vus_default: boolean;
+    mycancergenome_show: boolean | undefined;
+    oncokb_public_api_url: string | null;
+    digital_slide_archive_iframe_url: string | null;
+    digital_slide_archive_meta_url: string | null;
+    mdacc_heatmap_meta_url: string | null;
+    mdacc_heatmap_patient_url: string | null;
+    pubmed_url: string | null;
+    priority_studies: string | null;
+    api_cache_limit: number;
+    show_hotspot: boolean | undefined;
+    show_oncokb: boolean;
+    show_civic: boolean;
+    show_genomenexus: boolean;
+    skin_documentation_about: string | null;
+    skin_documentation_baseurl: string | null;
+    skin_blurb: string | null;
+    skin_custom_header_tabs: string | null;
+    skin_data_sets_footer: string | null;
+    skin_data_sets_header: string | null;
+    skin_documentation_markdown: boolean;
+    skin_description: string;
+    skin_email_contact: string;
+    skin_example_study_queries: string | null;
+    skin_examples_right_column_html: string | null;
+    skin_documentation_faq: string | null;
+    skin_footer: string | null;
+    skin_login_contact_html: string | null;
+    skin_login_saml_registration_html: string | null;
+    skin_citation_rule_text: string | null;
+    skin_documentation_news: string | null;
+    skin_documentation_oql: string | null;
+    skin_query_max_tree_depth: string;
+    skin_right_logo: string | null;
+    skin_right_nav_show_data_sets: boolean;
+    skin_right_nav_show_examples: boolean;
+    skin_right_nav_show_testimonials: boolean;
+    skin_right_nav_show_whats_new: boolean;
+    skin_right_nav_whats_new_blurb: string | null;
+    skin_show_about_tab: boolean;
+    skin_show_data_tab: boolean;
+    skin_show_faqs_tab: boolean;
+    skin_show_news_tab: boolean;
+    skin_show_r_matlab_tab: boolean;
+    skin_show_tools_tab: boolean;
+    skin_show_tutorials_tab: boolean;
+    skin_show_web_api_tab: boolean;
+    skin_show_tweet_button: boolean;
+    skin_show_tissue_image_tab: boolean;
+    skin_title: string;
+    skin_authorization_message: string | null;
+    quick_search_enabled: boolean;
+    default_cross_cancer_study_list: string; // this has a default
+    default_cross_cancer_study_list_name: string; // this has a default
+    default_cross_cancer_study_session_id: string | null;
+    study_view: StudyView;
+    uniprot_id_url: string | null;
+    studiesWithGermlineConsentedSamples: string[] | undefined;
+    mdacc_heatmap_study_meta_url: string | null;
+    mdacc_heatmap_study_url: string | null;
+    oncoprint_custom_driver_annotation_tiers_menu_label: string | null;
+    enable_darwin: boolean;
+    query_sets_of_genes: string | null;
+    skin_quick_select_buttons: string | null;
+    base_url: string | null;
+    user_email_address: string;
+    sessionServiceEnabled: boolean;
+    session_url_length_threshold: string;
+    mskWholeSlideViewerToken: string;
+    query_product_limit: number;
+    dat_uuid_revoke_other_tokens: boolean;
+    dat_method: string;
 }

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -110,7 +110,7 @@ export interface IServerConfig {
     "sessionServiceEnabled": boolean;
     "session_url_length_threshold":string;
     "mskWholeSlideViewerToken":string;
-    "query_gene_limit": number;
+    "query_product_limit": number;
     "dat_uuid_revoke_other_tokens": boolean;
     "dat_method": string;
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -1,79 +1,89 @@
-import {IServerConfig} from "./IAppConfig";
+import { IServerConfig } from './IAppConfig';
 
 const ServerConfigDefaults: Partial<IServerConfig> = {
-    app_version:"1.0",
-    api_cache_limit:450,
-    dat_uuid_revoke_other_tokens:true,
-    dat_method:"none",
-    disabled_tabs:"",
-    genomenexus_url:"https://www.genomenexus.org",
-    g2s_url:"https://g2s.genomenexus.org",
-    mycancergenome_show:false,
+    app_version: '1.0',
+    api_cache_limit: 450,
+    dat_uuid_revoke_other_tokens: true,
+    dat_method: 'none',
+    disabled_tabs: '',
+    genomenexus_url: 'https://www.genomenexus.org',
+    g2s_url: 'https://g2s.genomenexus.org',
+    mycancergenome_show: false,
 
-    digital_slide_archive_iframe_url:"https://cancer.digitalslidearchive.org/index.html?patientId=",
-    digital_slide_archive_meta_url:"https://api.digitalslidearchive.org/api/v1/tcga/image?caseName=",
+    digital_slide_archive_iframe_url:
+        'https://cancer.digitalslidearchive.org/index.html?patientId=',
+    digital_slide_archive_meta_url:
+        'https://api.digitalslidearchive.org/api/v1/tcga/image?caseName=',
 
-    mdacc_heatmap_patient_url: "https://bioinformatics.mdanderson.org/participant2maps?participant=",
-    mdacc_heatmap_study_meta_url: "https://bioinformatics.mdanderson.org/study2url?studyid=",
-    mdacc_heatmap_study_url: "https:// bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?",
+    mdacc_heatmap_patient_url:
+        'https://bioinformatics.mdanderson.org/participant2maps?participant=',
+    mdacc_heatmap_study_meta_url:
+        'https://bioinformatics.mdanderson.org/study2url?studyid=',
+    mdacc_heatmap_study_url:
+        'https:// bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?',
 
-    mygene_info_url: "https://mygene.info/v3/gene/<%= entrezGeneId %>?fields=uniprot",
+    mygene_info_url:
+        'https://mygene.info/v3/gene/<%= entrezGeneId %>?fields=uniprot',
 
-    oncoprint_oncokb_default:true,
-    oncoprint_hotspots_default:true,
-    oncoprint_hide_vus_default:false,
-    oncokb_public_api_url:"oncokb.org/api/v1",
+    oncoprint_oncokb_default: true,
+    oncoprint_hotspots_default: true,
+    oncoprint_hide_vus_default: false,
+    oncokb_public_api_url: 'oncokb.org/api/v1',
 
-    pubmed_url: "https://www.ncbi.nlm.nih.gov/pubmed/<%=pmid%>",
+    pubmed_url: 'https://www.ncbi.nlm.nih.gov/pubmed/<%=pmid%>',
 
-    isoformOverrideSource:"uniprot",
-    show_hotspot:true,
-    show_oncokb:true,
-    show_civic:false,
-    skin_description:"The cBioPortal for Cancer Genomics provides visualization, analysis and download of large-scale cancer genomics data sets",
-    show_genomenexus:true,
-    skin_authorization_message:"Access to this portal is only available to authorized users.",
-    skin_documentation_about:"About-Us.md",
-    skin_documentation_baseurl:"https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/",
-    skin_documentation_markdown:true,
-    skin_email_contact:"cbioportal at googlegroups dot com",
-    skin_documentation_faq:"FAQ.md",
-    skin_login_saml_registration_html:"Sign in with MSK",
-    skin_documentation_news:"News.md",
-    skin_documentation_oql:"Onco-Query-Language.md",
-    skin_query_max_tree_depth:"3",
-    skin_right_nav_show_data_sets:true,
-    skin_right_nav_show_examples:true,
-    skin_right_nav_show_testimonials:true,
-    skin_right_nav_show_whats_new:true,
-    skin_citation_rule_text:"Please cite: <a href=\"http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract\" target=\"_blank\">Cerami et al., 2012</a> &amp; <a href=\"http://www.ncbi.nlm.nih.gov/pubmed/23550210\" target=\"_blank\">Gao et al., 2013</a>",
-    skin_show_about_tab:true,
-    skin_show_data_tab:true,
-    skin_show_faqs_tab:true,
-    skin_show_news_tab:true,
-    skin_show_r_matlab_tab:true,
-    skin_show_tools_tab:true,
-    skin_show_web_api_tab:true,
-    skin_show_tweet_button:false,
-    skin_show_tissue_image_tab:true,
+    isoformOverrideSource: 'uniprot',
+    show_hotspot: true,
+    show_oncokb: true,
+    show_civic: false,
+    skin_description:
+        'The cBioPortal for Cancer Genomics provides visualization, analysis and download of large-scale cancer genomics data sets',
+    show_genomenexus: true,
+    skin_authorization_message:
+        'Access to this portal is only available to authorized users.',
+    skin_documentation_about: 'About-Us.md',
+    skin_documentation_baseurl:
+        'https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/',
+    skin_documentation_markdown: true,
+    skin_email_contact: 'cbioportal at googlegroups dot com',
+    skin_documentation_faq: 'FAQ.md',
+    skin_login_saml_registration_html: 'Sign in with MSK',
+    skin_documentation_news: 'News.md',
+    skin_documentation_oql: 'Onco-Query-Language.md',
+    skin_query_max_tree_depth: '3',
+    skin_right_nav_show_data_sets: true,
+    skin_right_nav_show_examples: true,
+    skin_right_nav_show_testimonials: true,
+    skin_right_nav_show_whats_new: true,
+    skin_citation_rule_text:
+        'Please cite: <a href="http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract" target="_blank">Cerami et al., 2012</a> &amp; <a href="http://www.ncbi.nlm.nih.gov/pubmed/23550210" target="_blank">Gao et al., 2013</a>',
+    skin_show_about_tab: true,
+    skin_show_data_tab: true,
+    skin_show_faqs_tab: true,
+    skin_show_news_tab: true,
+    skin_show_r_matlab_tab: true,
+    skin_show_tools_tab: true,
+    skin_show_web_api_tab: true,
+    skin_show_tweet_button: false,
+    skin_show_tissue_image_tab: true,
     quick_search_enabled: false,
     default_cross_cancer_study_list:
-        "laml_tcga_pan_can_atlas_2018,acc_tcga_pan_can_atlas_2018,blca_tcga_pan_can_atlas_2018," +
-        "lgg_tcga_pan_can_atlas_2018,brca_tcga_pan_can_atlas_2018,cesc_tcga_pan_can_atlas_2018,chol_tcga_pan_can_atlas_2018," +
-        "coadread_tcga_pan_can_atlas_2018,dlbc_tcga_pan_can_atlas_2018,esca_tcga_pan_can_atlas_2018,gbm_tcga_pan_can_atlas_2018," +
-        "hnsc_tcga_pan_can_atlas_2018,kich_tcga_pan_can_atlas_2018,kirc_tcga_pan_can_atlas_2018,kirp_tcga_pan_can_atlas_2018," +
-        "lihc_tcga_pan_can_atlas_2018,luad_tcga_pan_can_atlas_2018,lusc_tcga_pan_can_atlas_2018,meso_tcga_pan_can_atlas_2018," +
-        "ov_tcga_pan_can_atlas_2018,paad_tcga_pan_can_atlas_2018,pcpg_tcga_pan_can_atlas_2018,prad_tcga_pan_can_atlas_2018," +
-        "sarc_tcga_pan_can_atlas_2018,skcm_tcga_pan_can_atlas_2018,stad_tcga_pan_can_atlas_2018," +
-        "tgct_tcga_pan_can_atlas_2018,thym_tcga_pan_can_atlas_2018,thca_tcga_pan_can_atlas_2018,ucs_tcga_pan_can_atlas_2018," +
-        "ucec_tcga_pan_can_atlas_2018,uvm_tcga_pan_can_atlas_2018",
-    default_cross_cancer_study_list_name: "TCGA PanCancer Atlas studies",
-    skin_title:"cBioPortal for Cancer Genomics",
+        'laml_tcga_pan_can_atlas_2018,acc_tcga_pan_can_atlas_2018,blca_tcga_pan_can_atlas_2018,' +
+        'lgg_tcga_pan_can_atlas_2018,brca_tcga_pan_can_atlas_2018,cesc_tcga_pan_can_atlas_2018,chol_tcga_pan_can_atlas_2018,' +
+        'coadread_tcga_pan_can_atlas_2018,dlbc_tcga_pan_can_atlas_2018,esca_tcga_pan_can_atlas_2018,gbm_tcga_pan_can_atlas_2018,' +
+        'hnsc_tcga_pan_can_atlas_2018,kich_tcga_pan_can_atlas_2018,kirc_tcga_pan_can_atlas_2018,kirp_tcga_pan_can_atlas_2018,' +
+        'lihc_tcga_pan_can_atlas_2018,luad_tcga_pan_can_atlas_2018,lusc_tcga_pan_can_atlas_2018,meso_tcga_pan_can_atlas_2018,' +
+        'ov_tcga_pan_can_atlas_2018,paad_tcga_pan_can_atlas_2018,pcpg_tcga_pan_can_atlas_2018,prad_tcga_pan_can_atlas_2018,' +
+        'sarc_tcga_pan_can_atlas_2018,skcm_tcga_pan_can_atlas_2018,stad_tcga_pan_can_atlas_2018,' +
+        'tgct_tcga_pan_can_atlas_2018,thym_tcga_pan_can_atlas_2018,thca_tcga_pan_can_atlas_2018,ucs_tcga_pan_can_atlas_2018,' +
+        'ucec_tcga_pan_can_atlas_2018,uvm_tcga_pan_can_atlas_2018',
+    default_cross_cancer_study_list_name: 'TCGA PanCancer Atlas studies',
+    skin_title: 'cBioPortal for Cancer Genomics',
 
-    skin_data_sets_footer:`Data sets of TCGA studies were downloaded from Broad 
+    skin_data_sets_footer: `Data sets of TCGA studies were downloaded from Broad 
             Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the 
             TCGA working groups directly.`,
-    skin_data_sets_header:`The portal currently contains data from the following 
+    skin_data_sets_header: `The portal currently contains data from the following 
             cancer genomics studies.  The table below lists the number of available samples per data type and tumor.`,
 
     skin_example_study_queries: `tcga pancancer atlas\n
@@ -91,58 +101,55 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
             error, please contact us at <a style="color:#FF0000" href="mailto:cbioportal-access@cbio.mskcc.org">
             cbioportal-access@cbio.mskcc.org</a>`,
 
-    enable_darwin:false,
+    enable_darwin: false,
 
-    session_url_length_threshold:"1990",
+    session_url_length_threshold: '1990',
 
     study_view: {
         tableAttrs: ['SAMPLE_CANCER_TYPE', 'SAMPLE_CANCER_TYPE_DETAILED'],
         priority: {
-            "SAMPLE_CANCER_TYPE": 3000,
-            "PATIENT_CANCER_TYPE": 3000,
-            "SAMPLE_CANCER_TYPE_DETAILED": 2000,
-            "PATIENT_CANCER_TYPE_DETAILED": 2000,
-            "OS_SURVIVAL": 400,
-            "DFS_SURVIVAL": 300,
-            "MUTATION_COUNT_CNA_FRACTION": 200,
-            "MUTATED_GENES_TABLE": 90,
-            "CNA_GENES_TABLE": 80,
-            "CANCER_STUDIES": 70,
-            "SEQUENCED": 60,
-            "HAS_CNA_DATA": 50,
-            "PATIENT_SAMPLE_COUNT": 40,
-            "MUTATION_COUNT": 30,
-            "FRACTION_GENOME_ALTERED": 20,
-            "PATIENT_GENDER": 9,
-            "SAMPLE_GENDER": 9,
-            "PATIENT_SEX": 9,
-            "SAMPLE_SEX": 9,
-            "PATIENT_AGE": 9,
-            "SAMPLE_AGE": 9,
-            "PATIENT_RACE": 8,
-            "SAMPLE_RACE": 8,
-            "PATIENT_ETHNICITY": 8,
-            "SAMPLE_ETHNICITY": 8,
-            "SAMPLE_SAMPLE_TYPE": 8,
-            "PATIENT_SAMPLE_TYPE": 8,
-            "PATIENT_HISTOLOGY": 8,
-            "SAMPLE_HISTOLOGY": 8,
-            "SAMPLE_TUMOR_TYPE": 8,
-            "PATIENT_TUMOR_TYPE": 8,
-            "PATIENT_SUBTYPE": 8,
-            "SAMPLE_SUBTYPE": 8,
-            "PATIENT_TUMOR_SITE": 8,
-            "SAMPLE_TUMOR_SITE": 8
-        }
+            SAMPLE_CANCER_TYPE: 3000,
+            PATIENT_CANCER_TYPE: 3000,
+            SAMPLE_CANCER_TYPE_DETAILED: 2000,
+            PATIENT_CANCER_TYPE_DETAILED: 2000,
+            OS_SURVIVAL: 400,
+            DFS_SURVIVAL: 300,
+            MUTATION_COUNT_CNA_FRACTION: 200,
+            MUTATED_GENES_TABLE: 90,
+            CNA_GENES_TABLE: 80,
+            CANCER_STUDIES: 70,
+            SEQUENCED: 60,
+            HAS_CNA_DATA: 50,
+            PATIENT_SAMPLE_COUNT: 40,
+            MUTATION_COUNT: 30,
+            FRACTION_GENOME_ALTERED: 20,
+            PATIENT_GENDER: 9,
+            SAMPLE_GENDER: 9,
+            PATIENT_SEX: 9,
+            SAMPLE_SEX: 9,
+            PATIENT_AGE: 9,
+            SAMPLE_AGE: 9,
+            PATIENT_RACE: 8,
+            SAMPLE_RACE: 8,
+            PATIENT_ETHNICITY: 8,
+            SAMPLE_ETHNICITY: 8,
+            SAMPLE_SAMPLE_TYPE: 8,
+            PATIENT_SAMPLE_TYPE: 8,
+            PATIENT_HISTOLOGY: 8,
+            SAMPLE_HISTOLOGY: 8,
+            SAMPLE_TUMOR_TYPE: 8,
+            PATIENT_TUMOR_TYPE: 8,
+            PATIENT_SUBTYPE: 8,
+            SAMPLE_SUBTYPE: 8,
+            PATIENT_TUMOR_SITE: 8,
+            SAMPLE_TUMOR_SITE: 8,
+        },
     },
 
-    uniprot_id_url:"https://www.uniprot.org/uniprot/?query=accession:<%= swissProtAccession %>&format=tab&columns=entry+name",
+    uniprot_id_url:
+        'https://www.uniprot.org/uniprot/?query=accession:<%= swissProtAccession %>&format=tab&columns=entry+name',
 
     query_product_limit: 1000000,
-
-
-
 };
 
 export default ServerConfigDefaults;
-

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -138,7 +138,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
 
     uniprot_id_url:"https://www.uniprot.org/uniprot/?query=accession:<%= swissProtAccession %>&format=tab&columns=entry+name",
 
-    query_gene_limit: 100
+    query_product_limit: 1000000,
 
 
 

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -37,6 +37,7 @@ import QueryAndDownloadTabs from "shared/components/query/QueryAndDownloadTabs";
 import {createQueryStore} from "pages/home/HomePage";
 import ExtendedRouterStore from "shared/lib/ExtendedRouterStore";
 import {CancerStudyQueryUrlParams} from "../../shared/components/query/QueryStore";
+import GeneSymbolValidationError from "shared/components/query/GeneSymbolValidationError";
 
 function initStore(appStore:AppStore) {
 
@@ -431,16 +432,16 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
                 />
             </div>);
         } else {
-            return (<>
-                {
-                    // if query invalid(we only check gene length for now), return error page
-                    (this.resultsViewPageStore.isQueryInvalid) && (
-                        <div className="alert alert-danger queryInvalid" style={{marginBottom: "15px"}} role="alert">
-                            <p>
-                                Queries are limited to 100 genes. Please <a
-                                href={`mailto:${AppConfig.serverConfig.skin_email_contact}`}>let us know</a> your use
-                                case(s) if you need to query more than 100 genes.
-                            </p>
+            return (
+                <>
+                {// if query invalid(we only check gene count * sample count < 1,000,000 for now), return error page
+                    this.resultsViewPageStore.isQueryInvalid && (
+                        <div className="alert alert-danger queryInvalid" style={{ marginBottom: "40px" }} role="alert">
+                            <GeneSymbolValidationError
+                                sampleCount={this.resultsViewPageStore.samples.result.length}
+                                queryProductLimit={AppConfig.serverConfig.query_product_limit}
+                                email={AppConfig.serverConfig.skin_email_contact}
+                            />
                         </div>
                     )
                 }

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -1,59 +1,73 @@
-import * as React from "react";
-import * as _ from "lodash";
-import $ from "jquery";
+import * as React from 'react';
+import * as _ from 'lodash';
+import $ from 'jquery';
 import URL from 'url';
-import {inject, observer} from "mobx-react";
-import {computed, observable, reaction, runInAction} from "mobx";
-import {ResultsViewPageStore} from "./ResultsViewPageStore";
-import CancerSummaryContainer from "pages/resultsView/cancerSummary/CancerSummaryContainer";
-import Mutations from "./mutation/Mutations";
-import MutualExclusivityTab from "./mutualExclusivity/MutualExclusivityTab";
-import SurvivalTab from "./survival/SurvivalTab";
-import DownloadTab from "./download/DownloadTab";
-import AppConfig from "appConfig";
-import CNSegments from "./cnSegments/CNSegments";
-import "./styles.scss";
-import Network from "./network/Network";
-import ResultsViewOncoprint from "shared/components/oncoprint/ResultsViewOncoprint";
-import QuerySummary from "./querySummary/QuerySummary";
-import ExpressionWrapper from "./expression/ExpressionWrapper";
-import EnrichmentsTab from "pages/resultsView/enrichments/EnrichmentsTab";
-import PlotsTab from "./plots/PlotsTab";
-import {MSKTab, MSKTabs} from "../../shared/components/MSKTabs/MSKTabs";
-import {PageLayout} from "../../shared/components/PageLayout/PageLayout";
-import autobind from "autobind-decorator";
-import {ITabConfiguration} from "../../shared/model/ITabConfiguration";
-import getBrowserWindow from "../../public-lib/lib/getBrowserWindow";
-import CoExpressionTab from "./coExpression/CoExpressionTab";
-import Helmet from "react-helmet";
-import {showCustomTab} from "../../shared/lib/customTabs";
-import {getTabId, parseConfigDisabledTabs, parseSamplesSpecifications, ResultsViewTab} from "./ResultsViewPageHelpers";
-import {buildResultsViewPageTitle, doesQueryHaveCNSegmentData} from "./ResultsViewPageStoreUtils";
-import {AppStore} from "../../AppStore";
-import {updateResultsViewQuery} from "./ResultsViewQuery";
-import {trackQuery} from "../../shared/lib/tracking";
-import {onMobxPromise} from "../../shared/lib/onMobxPromise";
-import QueryAndDownloadTabs from "shared/components/query/QueryAndDownloadTabs";
-import {createQueryStore} from "pages/home/HomePage";
-import ExtendedRouterStore from "shared/lib/ExtendedRouterStore";
-import {CancerStudyQueryUrlParams} from "../../shared/components/query/QueryStore";
-import GeneSymbolValidationError from "shared/components/query/GeneSymbolValidationError";
+import { inject, observer } from 'mobx-react';
+import { computed, observable, reaction, runInAction } from 'mobx';
+import { ResultsViewPageStore } from './ResultsViewPageStore';
+import CancerSummaryContainer from 'pages/resultsView/cancerSummary/CancerSummaryContainer';
+import Mutations from './mutation/Mutations';
+import MutualExclusivityTab from './mutualExclusivity/MutualExclusivityTab';
+import SurvivalTab from './survival/SurvivalTab';
+import DownloadTab from './download/DownloadTab';
+import AppConfig from 'appConfig';
+import CNSegments from './cnSegments/CNSegments';
+import './styles.scss';
+import Network from './network/Network';
+import ResultsViewOncoprint from 'shared/components/oncoprint/ResultsViewOncoprint';
+import QuerySummary from './querySummary/QuerySummary';
+import ExpressionWrapper from './expression/ExpressionWrapper';
+import EnrichmentsTab from 'pages/resultsView/enrichments/EnrichmentsTab';
+import PlotsTab from './plots/PlotsTab';
+import { MSKTab, MSKTabs } from '../../shared/components/MSKTabs/MSKTabs';
+import { PageLayout } from '../../shared/components/PageLayout/PageLayout';
+import autobind from 'autobind-decorator';
+import { ITabConfiguration } from '../../shared/model/ITabConfiguration';
+import getBrowserWindow from '../../public-lib/lib/getBrowserWindow';
+import CoExpressionTab from './coExpression/CoExpressionTab';
+import Helmet from 'react-helmet';
+import { showCustomTab } from '../../shared/lib/customTabs';
+import {
+    getTabId,
+    parseConfigDisabledTabs,
+    parseSamplesSpecifications,
+    ResultsViewTab,
+} from './ResultsViewPageHelpers';
+import {
+    buildResultsViewPageTitle,
+    doesQueryHaveCNSegmentData,
+} from './ResultsViewPageStoreUtils';
+import { AppStore } from '../../AppStore';
+import { updateResultsViewQuery } from './ResultsViewQuery';
+import { trackQuery } from '../../shared/lib/tracking';
+import { onMobxPromise } from '../../shared/lib/onMobxPromise';
+import QueryAndDownloadTabs from 'shared/components/query/QueryAndDownloadTabs';
+import { createQueryStore } from 'pages/home/HomePage';
+import ExtendedRouterStore from 'shared/lib/ExtendedRouterStore';
+import { CancerStudyQueryUrlParams } from '../../shared/components/query/QueryStore';
+import GeneSymbolValidationError from 'shared/components/query/GeneSymbolValidationError';
 
-function initStore(appStore:AppStore) {
+function initStore(appStore: AppStore) {
+    const resultsViewPageStore = new ResultsViewPageStore(
+        appStore,
+        getBrowserWindow().globalStores.routing
+    );
 
-    const resultsViewPageStore = new ResultsViewPageStore(appStore, getBrowserWindow().globalStores.routing);
+    resultsViewPageStore.tabId = getTabId(
+        getBrowserWindow().globalStores.routing.location.pathname
+    );
 
-    resultsViewPageStore.tabId = getTabId(getBrowserWindow().globalStores.routing.location.pathname);
-
-    let lastQuery:any;
-    let lastPathname:string;
+    let lastQuery: any;
+    let lastPathname: string;
 
     const queryReactionDisposer = reaction(
         () => {
-            return [getBrowserWindow().globalStores.routing.query, getBrowserWindow().globalStores.routing.location.pathname];
+            return [
+                getBrowserWindow().globalStores.routing.query,
+                getBrowserWindow().globalStores.routing.location.pathname,
+            ];
         },
-        (x:any) => {
-
+        (x: any) => {
             const query = x[0] as CancerStudyQueryUrlParams;
             const pathname = x[1];
 
@@ -61,37 +75,58 @@ function initStore(appStore:AppStore) {
             // TODO: see if we can figure out why query is getting changed and
             // if there's any way to do shallow equality check to avoid this expensive operation
             const queryChanged = !_.isEqual(lastQuery, query);
-            const pathnameChanged = (pathname !== lastPathname);
+            const pathnameChanged = pathname !== lastPathname;
             if (!queryChanged && !pathnameChanged) {
                 return;
             } else {
-
-                if (!getBrowserWindow().globalStores.routing.location.pathname.includes("/results")) {
-                   return;
+                if (
+                    !getBrowserWindow().globalStores.routing.location.pathname.includes(
+                        '/results'
+                    )
+                ) {
+                    return;
                 }
-                runInAction(()=>{
+                runInAction(() => {
                     // set query and pathname separately according to which changed, to avoid unnecessary
                     //  recomputation by updating the query if only the pathname changed
                     if (queryChanged) {
                         // update query
                         // normalize cancer_study_list this handles legacy sessions/urls where queries with single study had different param name
-                        const cancer_study_list = query.cancer_study_list || query.cancer_study_id;
+                        const cancer_study_list =
+                            query.cancer_study_list || query.cancer_study_id;
 
-                        const cancerStudyIds: string[] = cancer_study_list.split(",");
+                        const cancerStudyIds: string[] = cancer_study_list.split(
+                            ','
+                        );
 
                         const oql = decodeURIComponent(query.gene_list);
 
-                        let samplesSpecification = parseSamplesSpecifications(query, cancerStudyIds);
+                        let samplesSpecification = parseSamplesSpecifications(
+                            query,
+                            cancerStudyIds
+                        );
 
-                        const changes = updateResultsViewQuery(resultsViewPageStore.rvQuery, query, samplesSpecification, cancerStudyIds, oql);
+                        const changes = updateResultsViewQuery(
+                            resultsViewPageStore.rvQuery,
+                            query,
+                            samplesSpecification,
+                            cancerStudyIds,
+                            oql
+                        );
                         if (changes.cohortIdsList) {
                             resultsViewPageStore.initDriverAnnotationSettings();
                         }
 
-                        onMobxPromise(resultsViewPageStore.studyIds, ()=>{
+                        onMobxPromise(resultsViewPageStore.studyIds, () => {
                             try {
-                                trackQuery(resultsViewPageStore.studyIds.result!, oql, resultsViewPageStore.hugoGeneSymbols, resultsViewPageStore.queriedVirtualStudies.result!.length > 0);
-                            } catch {};
+                                trackQuery(
+                                    resultsViewPageStore.studyIds.result!,
+                                    oql,
+                                    resultsViewPageStore.hugoGeneSymbols,
+                                    resultsViewPageStore.queriedVirtualStudies
+                                        .result!.length > 0
+                                );
+                            } catch {}
                         });
 
                         lastQuery = query;
@@ -110,7 +145,7 @@ function initStore(appStore:AppStore) {
                 });
             }
         },
-        {fireImmediately: true}
+        { fireImmediately: true }
     );
 
     resultsViewPageStore.queryReactionDisposer = queryReactionDisposer;
@@ -118,8 +153,7 @@ function initStore(appStore:AppStore) {
     return resultsViewPageStore;
 }
 
-
-function addOnBecomeVisibleListener(callback:()=>void) {
+function addOnBecomeVisibleListener(callback: () => void) {
     $('#oncoprint-result-tab').click(callback);
 }
 
@@ -129,10 +163,12 @@ export interface IResultsViewPageProps {
     params: any; // from react router
 }
 
-@inject('appStore','routing')
+@inject('appStore', 'routing')
 @observer
-export default class ResultsViewPage extends React.Component<IResultsViewPageProps, {}> {
-
+export default class ResultsViewPage extends React.Component<
+    IResultsViewPageProps,
+    {}
+> {
     private resultsViewPageStore: ResultsViewPageStore;
 
     @observable showTabs = true;
@@ -145,261 +181,406 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
         getBrowserWindow().resultsViewPageStore = this.resultsViewPageStore;
     }
 
-    private handleTabChange(id: string, replace?:boolean) {
-        this.props.routing.updateRoute({},`results/${id}`, false, replace);
+    private handleTabChange(id: string, replace?: boolean) {
+        this.props.routing.updateRoute({}, `results/${id}`, false, replace);
     }
 
     @autobind
-    private customTabCallback(div:HTMLDivElement,tab:any, isUnmount = false){
-        showCustomTab(div, tab, getBrowserWindow().location.href, this.resultsViewPageStore, isUnmount);
+    private customTabCallback(
+        div: HTMLDivElement,
+        tab: any,
+        isUnmount = false
+    ) {
+        showCustomTab(
+            div,
+            tab,
+            getBrowserWindow().location.href,
+            this.resultsViewPageStore,
+            isUnmount
+        );
     }
 
-    componentWillUnmount(){
+    componentWillUnmount() {
         this.resultsViewPageStore.queryReactionDisposer();
     }
 
     @computed
     private get tabs() {
-
         const store = this.resultsViewPageStore;
 
-        const tabMap:ITabConfiguration[] = [
-
+        const tabMap: ITabConfiguration[] = [
             {
-                id:ResultsViewTab.ONCOPRINT,
+                id: ResultsViewTab.ONCOPRINT,
                 getTab: () => {
-                    return <MSKTab key={0} id={ResultsViewTab.ONCOPRINT} linkText="OncoPrint">
-                        <ResultsViewOncoprint
-                            divId={'oncoprintDiv'}
-                            store={store}
-                            key={store.hugoGeneSymbols.join(",")}
-                            routing={this.props.routing}
-                            addOnBecomeVisibleListener={addOnBecomeVisibleListener}
-                        />
-                    </MSKTab>
-                }
-            },
-
-            {
-                id:ResultsViewTab.CANCER_TYPES_SUMMARY,
-                getTab: () => {
-                    return (<MSKTab key={1} id={ResultsViewTab.CANCER_TYPES_SUMMARY} linkText="Cancer Types Summary">
-                        <CancerSummaryContainer
-                            store={store}
-                        />
-                    </MSKTab>)
-                }
-            },
-
-            {
-                id:ResultsViewTab.MUTUAL_EXCLUSIVITY,
-                getTab: () => {
-                    return <MSKTab key={5} id={ResultsViewTab.MUTUAL_EXCLUSIVITY} linkText="Mutual Exclusivity">
-                        <MutualExclusivityTab store={store} isSampleAlteredMap={store.isSampleAlteredMap}/>
-                    </MSKTab>
+                    return (
+                        <MSKTab
+                            key={0}
+                            id={ResultsViewTab.ONCOPRINT}
+                            linkText="OncoPrint"
+                        >
+                            <ResultsViewOncoprint
+                                divId={'oncoprintDiv'}
+                                store={store}
+                                key={store.hugoGeneSymbols.join(',')}
+                                routing={this.props.routing}
+                                addOnBecomeVisibleListener={
+                                    addOnBecomeVisibleListener
+                                }
+                            />
+                        </MSKTab>
+                    );
                 },
-                hide:()=>{
-                    // we are using the size of isSampleAlteredMap as a proxy for the number of things we have to compare
-                    return !this.resultsViewPageStore.isSampleAlteredMap.isComplete || _.size(this.resultsViewPageStore.isSampleAlteredMap.result) < 2;
-                }
             },
 
             {
-                id:ResultsViewTab.PLOTS,
-                hide:()=>{
+                id: ResultsViewTab.CANCER_TYPES_SUMMARY,
+                getTab: () => {
+                    return (
+                        <MSKTab
+                            key={1}
+                            id={ResultsViewTab.CANCER_TYPES_SUMMARY}
+                            linkText="Cancer Types Summary"
+                        >
+                            <CancerSummaryContainer store={store} />
+                        </MSKTab>
+                    );
+                },
+            },
+
+            {
+                id: ResultsViewTab.MUTUAL_EXCLUSIVITY,
+                getTab: () => {
+                    return (
+                        <MSKTab
+                            key={5}
+                            id={ResultsViewTab.MUTUAL_EXCLUSIVITY}
+                            linkText="Mutual Exclusivity"
+                        >
+                            <MutualExclusivityTab
+                                store={store}
+                                isSampleAlteredMap={store.isSampleAlteredMap}
+                            />
+                        </MSKTab>
+                    );
+                },
+                hide: () => {
+                    // we are using the size of isSampleAlteredMap as a proxy for the number of things we have to compare
+                    return (
+                        !this.resultsViewPageStore.isSampleAlteredMap
+                            .isComplete ||
+                        _.size(
+                            this.resultsViewPageStore.isSampleAlteredMap.result
+                        ) < 2
+                    );
+                },
+            },
+
+            {
+                id: ResultsViewTab.PLOTS,
+                hide: () => {
                     if (!this.resultsViewPageStore.studies.isComplete) {
                         return true;
                     } else {
-                        return this.resultsViewPageStore.studies.result!.length > 1;
+                        return (
+                            this.resultsViewPageStore.studies.result!.length > 1
+                        );
                     }
                 },
                 getTab: () => {
-                    return <MSKTab key={12} id={ResultsViewTab.PLOTS} linkText={'Plots'}>
-                        <PlotsTab store={store}/>
-                    </MSKTab>
-                }
+                    return (
+                        <MSKTab
+                            key={12}
+                            id={ResultsViewTab.PLOTS}
+                            linkText={'Plots'}
+                        >
+                            <PlotsTab store={store} />
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.MUTATIONS,
+                id: ResultsViewTab.MUTATIONS,
                 getTab: () => {
-                    return <MSKTab key={3} id={ResultsViewTab.MUTATIONS} linkText="Mutations">
-                        <Mutations store={store} appStore={ this.props.appStore } />
-                    </MSKTab>
-                }
+                    return (
+                        <MSKTab
+                            key={3}
+                            id={ResultsViewTab.MUTATIONS}
+                            linkText="Mutations"
+                        >
+                            <Mutations
+                                store={store}
+                                appStore={this.props.appStore}
+                            />
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.COEXPRESSION,
-                hide:()=>{
-                    if (!this.resultsViewPageStore.isThereDataForCoExpressionTab.isComplete ||
-                        !this.resultsViewPageStore.studies.isComplete) {
+                id: ResultsViewTab.COEXPRESSION,
+                hide: () => {
+                    if (
+                        !this.resultsViewPageStore.isThereDataForCoExpressionTab
+                            .isComplete ||
+                        !this.resultsViewPageStore.studies.isComplete
+                    ) {
                         return true;
                     } else {
-                        const tooManyStudies = this.resultsViewPageStore.studies.result!.length > 1;
-                        const noData = !this.resultsViewPageStore.isThereDataForCoExpressionTab.result;
+                        const tooManyStudies =
+                            this.resultsViewPageStore.studies.result!.length >
+                            1;
+                        const noData = !this.resultsViewPageStore
+                            .isThereDataForCoExpressionTab.result;
                         return tooManyStudies || noData;
                     }
                 },
                 getTab: () => {
-                    return <MSKTab key={7} id={ResultsViewTab.COEXPRESSION} linkText={'Co-expression'}>
-                        <CoExpressionTab
-                            store={store}
-                        />
-                    </MSKTab>
-                }
+                    return (
+                        <MSKTab
+                            key={7}
+                            id={ResultsViewTab.COEXPRESSION}
+                            linkText={'Co-expression'}
+                        >
+                            <CoExpressionTab store={store} />
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.ENRICHMENTS,
-                hide:()=>{
+                id: ResultsViewTab.ENRICHMENTS,
+                hide: () => {
                     return !this.resultsViewPageStore.studies.isComplete;
                 },
                 getTab: () => {
-                    return <MSKTab key={10} id={ResultsViewTab.ENRICHMENTS} linkText={'Enrichments'}>
-                        <EnrichmentsTab store={store}/>
-                    </MSKTab>
-                }
+                    return (
+                        <MSKTab
+                            key={10}
+                            id={ResultsViewTab.ENRICHMENTS}
+                            linkText={'Enrichments'}
+                        >
+                            <EnrichmentsTab store={store} />
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.SURVIVAL,
-                hide:()=>{
-                    return !this.resultsViewPageStore.survivalClinicalDataExists.isComplete ||
-                        !this.resultsViewPageStore.survivalClinicalDataExists.result!;
+                id: ResultsViewTab.SURVIVAL,
+                hide: () => {
+                    return (
+                        !this.resultsViewPageStore.survivalClinicalDataExists
+                            .isComplete ||
+                        !this.resultsViewPageStore.survivalClinicalDataExists
+                            .result!
+                    );
                 },
                 getTab: () => {
-                    return <MSKTab key={4} id={ResultsViewTab.SURVIVAL} linkText="Survival">
-                        <SurvivalTab store={store}/>
-                    </MSKTab>
-                }
+                    return (
+                        <MSKTab
+                            key={4}
+                            id={ResultsViewTab.SURVIVAL}
+                            linkText="Survival"
+                        >
+                            <SurvivalTab store={store} />
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.CN_SEGMENTS,
-                hide:() => {
+                id: ResultsViewTab.CN_SEGMENTS,
+                hide: () => {
                     return (
                         !this.resultsViewPageStore.studies.isComplete ||
                         !this.resultsViewPageStore.genes.isComplete ||
                         !this.resultsViewPageStore.referenceGenes.isComplete ||
-                        !doesQueryHaveCNSegmentData(this.resultsViewPageStore.samples.result)
+                        !doesQueryHaveCNSegmentData(
+                            this.resultsViewPageStore.samples.result
+                        )
                     );
                 },
                 getTab: () => {
-                    return <MSKTab key={6} id={ResultsViewTab.CN_SEGMENTS}
-                                   linkText="CN Segments">
-                        <CNSegments store={store}/>
-                    </MSKTab>;
-                }
+                    return (
+                        <MSKTab
+                            key={6}
+                            id={ResultsViewTab.CN_SEGMENTS}
+                            linkText="CN Segments"
+                        >
+                            <CNSegments store={store} />
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.NETWORK,
-                hide:()=>{
+                id: ResultsViewTab.NETWORK,
+                hide: () => {
                     if (!this.resultsViewPageStore.studies.isComplete) {
                         return true;
                     } else {
-                        return this.resultsViewPageStore.studies.result!.length > 1;
+                        return (
+                            this.resultsViewPageStore.studies.result!.length > 1
+                        );
                     }
                 },
                 getTab: () => {
-                    return <MSKTab key={9} id={ResultsViewTab.NETWORK} linkText={'Network'}>
-                        {
-                            (store.studies.isComplete && store.sampleLists.isComplete && store.samples.isComplete) &&
-                            (<Network genes={store.genes.result!}
-                                      profileIds={store.rvQuery.selectedMolecularProfileIds}
-                                      cancerStudyId={(store.studies.result.length > 0) ? store.studies.result![0].studyId : ""}
-                                      zScoreThreshold={store.rvQuery.zScoreThreshold}
-                                      caseSetId={(store.sampleLists.result!.length > 0) ? store.sampleLists.result![0].sampleListId : "-1"}
-                                      sampleIds={store.samples.result.map((sample)=>sample.sampleId)}
-                                      caseIdsKey={""}
-                            />)
-                        }
-                    </MSKTab>
-                }
+                    return (
+                        <MSKTab
+                            key={9}
+                            id={ResultsViewTab.NETWORK}
+                            linkText={'Network'}
+                        >
+                            {store.studies.isComplete &&
+                                store.sampleLists.isComplete &&
+                                store.samples.isComplete && (
+                                    <Network
+                                        genes={store.genes.result!}
+                                        profileIds={
+                                            store.rvQuery
+                                                .selectedMolecularProfileIds
+                                        }
+                                        cancerStudyId={
+                                            store.studies.result.length > 0
+                                                ? store.studies.result![0]
+                                                      .studyId
+                                                : ''
+                                        }
+                                        zScoreThreshold={
+                                            store.rvQuery.zScoreThreshold
+                                        }
+                                        caseSetId={
+                                            store.sampleLists.result!.length > 0
+                                                ? store.sampleLists.result![0]
+                                                      .sampleListId
+                                                : '-1'
+                                        }
+                                        sampleIds={store.samples.result.map(
+                                            sample => sample.sampleId
+                                        )}
+                                        caseIdsKey={''}
+                                    />
+                                )}
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.EXPRESSION,
-                hide:()=> {
-                    return this.resultsViewPageStore.expressionProfiles.result.length === 0
-                        || this.resultsViewPageStore.studies.result.length < 2;
+                id: ResultsViewTab.EXPRESSION,
+                hide: () => {
+                    return (
+                        this.resultsViewPageStore.expressionProfiles.result
+                            .length === 0 ||
+                        this.resultsViewPageStore.studies.result.length < 2
+                    );
                 },
                 getTab: () => {
-
-                    return <MSKTab key={8} id={ResultsViewTab.EXPRESSION}
-
-                                   linkText={'Expression'}
-                    >
-                        {
-                            (store.studyIdToStudy.isComplete
-                                && store.filteredAndAnnotatedMutations.isComplete
-                                && store.genes.isComplete
-                                && store.coverageInformation.isComplete) &&
-                            (<ExpressionWrapper store={store}
-                                studyMap={store.studyIdToStudy.result}
-                                genes={store.genes.result}
-                                expressionProfiles={store.expressionProfiles}
-                                numericGeneMolecularDataCache={store.numericGeneMolecularDataCache}
-                                mutations={store.filteredAndAnnotatedMutations.result!}
-                                coverageInformation={store.coverageInformation.result}
-                            />)
-                        }
-                    </MSKTab>
-                }
+                    return (
+                        <MSKTab
+                            key={8}
+                            id={ResultsViewTab.EXPRESSION}
+                            linkText={'Expression'}
+                        >
+                            {store.studyIdToStudy.isComplete &&
+                                store.filteredAndAnnotatedMutations
+                                    .isComplete &&
+                                store.genes.isComplete &&
+                                store.coverageInformation.isComplete && (
+                                    <ExpressionWrapper
+                                        store={store}
+                                        studyMap={store.studyIdToStudy.result}
+                                        genes={store.genes.result}
+                                        expressionProfiles={
+                                            store.expressionProfiles
+                                        }
+                                        numericGeneMolecularDataCache={
+                                            store.numericGeneMolecularDataCache
+                                        }
+                                        mutations={
+                                            store.filteredAndAnnotatedMutations
+                                                .result!
+                                        }
+                                        coverageInformation={
+                                            store.coverageInformation.result
+                                        }
+                                    />
+                                )}
+                        </MSKTab>
+                    );
+                },
             },
 
             {
-                id:ResultsViewTab.DOWNLOAD,
+                id: ResultsViewTab.DOWNLOAD,
                 getTab: () => {
-                    return <MSKTab key={11} id={ResultsViewTab.DOWNLOAD} linkText={'Download'}>
-                        <DownloadTab store={store}/>
-                    </MSKTab>
-                }
-            }
+                    return (
+                        <MSKTab
+                            key={11}
+                            id={ResultsViewTab.DOWNLOAD}
+                            linkText={'Download'}
+                        >
+                            <DownloadTab store={store} />
+                        </MSKTab>
+                    );
+                },
+            },
         ];
 
-        let filteredTabs = tabMap.filter(this.evaluateTabInclusion).map((tab)=>tab.getTab());
+        let filteredTabs = tabMap
+            .filter(this.evaluateTabInclusion)
+            .map(tab => tab.getTab());
 
         // now add custom tabs
         if (AppConfig.serverConfig.custom_tabs) {
-            const customResultsTabs = AppConfig.serverConfig.custom_tabs.filter((tab: any) => tab.location === "RESULTS_PAGE").map((tab: any, i: number) => {
-                return (<MSKTab key={100 + i} id={'customTab' + i} unmountOnHide={(tab.unmountOnHide === true)}
-                                onTabDidMount={(div) => {
-                                    this.customTabCallback(div, tab);
-                                }}
-                                onTabUnmount={(div) => {
-                                    this.customTabCallback(div, tab, true);
-                                }}
-                                linkText={tab.title}
-                    />
-                )
-            });
+            const customResultsTabs = AppConfig.serverConfig.custom_tabs
+                .filter((tab: any) => tab.location === 'RESULTS_PAGE')
+                .map((tab: any, i: number) => {
+                    return (
+                        <MSKTab
+                            key={100 + i}
+                            id={'customTab' + i}
+                            unmountOnHide={tab.unmountOnHide === true}
+                            onTabDidMount={div => {
+                                this.customTabCallback(div, tab);
+                            }}
+                            onTabUnmount={div => {
+                                this.customTabCallback(div, tab, true);
+                            }}
+                            linkText={tab.title}
+                        />
+                    );
+                });
             filteredTabs = filteredTabs.concat(customResultsTabs);
         }
 
         return filteredTabs;
-
     }
 
     @autobind
-    public evaluateTabInclusion(tab:ITabConfiguration){
-        const excludedTabs = AppConfig.serverConfig.disabled_tabs || "";
-        const isExcludedInList = parseConfigDisabledTabs(excludedTabs).includes(tab.id);
-        const isRoutedTo = (this.resultsViewPageStore.tabId === tab.id);
-        const isExcluded = (tab.hide) ? tab.hide() : false;
+    public evaluateTabInclusion(tab: ITabConfiguration) {
+        const excludedTabs = AppConfig.serverConfig.disabled_tabs || '';
+        const isExcludedInList = parseConfigDisabledTabs(excludedTabs).includes(
+            tab.id
+        );
+        const isRoutedTo = this.resultsViewPageStore.tabId === tab.id;
+        const isExcluded = tab.hide ? tab.hide() : false;
 
         // we show no matter what if its routed to
         return isRoutedTo || (!isExcludedInList && !isExcluded);
     }
 
-    public currentTab(tabId:string|undefined):string {
+    public currentTab(tabId: string | undefined): string {
         // if we have no tab defined (query submission, no tab click)
         // we need to evaluate which should be the default tab
         // this can only be determined by know the count of physical studies in the query
         // (for virtual studies we need to fetch data determine constituent physical studies)
         if (tabId === undefined) {
-            if (this.resultsViewPageStore.studies.result!.length > 1 && this.resultsViewPageStore.hugoGeneSymbols.length === 1) {
+            if (
+                this.resultsViewPageStore.studies.result!.length > 1 &&
+                this.resultsViewPageStore.hugoGeneSymbols.length === 1
+            ) {
                 return ResultsViewTab.CANCER_TYPES_SUMMARY; // cancer type study
             } else {
                 return ResultsViewTab.ONCOPRINT; // this will resolve to first tab
@@ -410,97 +591,127 @@ export default class ResultsViewPage extends React.Component<IResultsViewPagePro
     }
 
     @autobind
-    private getTabHref(tabId:string) {
+    private getTabHref(tabId: string) {
         return URL.format({
-            pathname:tabId,
-            query:this.props.routing.location.query,
-            hash:this.props.routing.location.hash
+            pathname: tabId,
+            query: this.props.routing.location.query,
+            hash: this.props.routing.location.hash,
         });
     }
 
-    @computed get pageContent(){
-
+    @computed get pageContent() {
         if (this.resultsViewPageStore.invalidStudyIds.result.length > 0) {
-            return (<div>
-                <div className={'headBlock'}></div>
-                <QueryAndDownloadTabs
-                      forkedMode={false}
-                      showQuickSearchTab={false}
-                      showDownloadTab={false}
-                      showAlerts={true}
-                      getQueryStore={()=>createQueryStore(this.props.routing.query)}
-                />
-            </div>);
+            return (
+                <div>
+                    <div className={'headBlock'}></div>
+                    <QueryAndDownloadTabs
+                        forkedMode={false}
+                        showQuickSearchTab={false}
+                        showDownloadTab={false}
+                        showAlerts={true}
+                        getQueryStore={() =>
+                            createQueryStore(this.props.routing.query)
+                        }
+                    />
+                </div>
+            );
         } else {
             return (
                 <>
-                {// if query invalid(we only check gene count * sample count < 1,000,000 for now), return error page
+                    {// if query invalid(we only check gene count * sample count < 1,000,000 for now), return error page
                     this.resultsViewPageStore.isQueryInvalid && (
-                        <div className="alert alert-danger queryInvalid" style={{ marginBottom: "40px" }} role="alert">
+                        <div
+                            className="alert alert-danger queryInvalid"
+                            style={{ marginBottom: '40px' }}
+                            role="alert"
+                        >
                             <GeneSymbolValidationError
-                                sampleCount={this.resultsViewPageStore.samples.result.length}
-                                queryProductLimit={AppConfig.serverConfig.query_product_limit}
-                                email={AppConfig.serverConfig.skin_email_contact}
+                                sampleCount={
+                                    this.resultsViewPageStore.samples.result
+                                        .length
+                                }
+                                queryProductLimit={
+                                    AppConfig.serverConfig.query_product_limit
+                                }
+                                email={
+                                    AppConfig.serverConfig.skin_email_contact
+                                }
                             />
                         </div>
-                    )
-                }
-                {
-                    (this.resultsViewPageStore.studies.isComplete) && (
+                    )}
+                    {this.resultsViewPageStore.studies.isComplete && (
                         <Helmet>
-                            <title>{buildResultsViewPageTitle(this.resultsViewPageStore.hugoGeneSymbols, this.resultsViewPageStore.studies.result)}</title>
+                            <title>
+                                {buildResultsViewPageTitle(
+                                    this.resultsViewPageStore.hugoGeneSymbols,
+                                    this.resultsViewPageStore.studies.result
+                                )}
+                            </title>
                         </Helmet>
-                    )
-                }
-                {(this.resultsViewPageStore.studies.isComplete) && (
-                    <div>
-                        <div className={'headBlock'}>
-                            <QuerySummary
-                                routingStore={this.props.routing}
-                                store={this.resultsViewPageStore}
-                                onToggleQueryFormVisiblity={(visible) => {
-                                    this.showTabs = visible;
-                                }}
-                            />
+                    )}
+                    {this.resultsViewPageStore.studies.isComplete && (
+                        <div>
+                            <div className={'headBlock'}>
+                                <QuerySummary
+                                    routingStore={this.props.routing}
+                                    store={this.resultsViewPageStore}
+                                    onToggleQueryFormVisiblity={visible => {
+                                        this.showTabs = visible;
+                                    }}
+                                />
+                            </div>
+
+                            {// we don't show the result tabs if we don't have valid query
+                            this.showTabs &&
+                                !this.resultsViewPageStore.genesInvalid &&
+                                !this.resultsViewPageStore.isQueryInvalid && (
+                                    <MSKTabs
+                                        key={
+                                            this.resultsViewPageStore.rvQuery
+                                                .hash
+                                        }
+                                        activeTabId={this.currentTab(
+                                            this.resultsViewPageStore.tabId
+                                        )}
+                                        unmountOnHide={false}
+                                        onTabClick={(id: string) =>
+                                            this.handleTabChange(id)
+                                        }
+                                        className="mainTabs"
+                                        getTabHref={this.getTabHref}
+                                    >
+                                        {this.tabs}
+                                    </MSKTabs>
+                                )}
                         </div>
-
-                        {
-                            // we don't show the result tabs if we don't have valid query
-                            (this.showTabs && !this.resultsViewPageStore.genesInvalid && !this.resultsViewPageStore.isQueryInvalid) && (
-                                <MSKTabs key={this.resultsViewPageStore.rvQuery.hash} activeTabId={this.currentTab(this.resultsViewPageStore.tabId)} unmountOnHide={false}
-                                         onTabClick={(id: string) => this.handleTabChange(id)} className="mainTabs"
-                                         getTabHref={this.getTabHref}
-                                >
-                                    {
-                                        this.tabs
-                                    }
-                                </MSKTabs>
-                            )
-                        }
-
-                    </div>
-                )
-                }
-            </>);
+                    )}
+                </>
+            );
         }
     }
 
     public render() {
-        if (this.resultsViewPageStore.studies.isComplete && !this.resultsViewPageStore.tabId) {
-            setTimeout(()=>{
-                this.handleTabChange(this.currentTab(this.resultsViewPageStore.tabId), true);
+        if (
+            this.resultsViewPageStore.studies.isComplete &&
+            !this.resultsViewPageStore.tabId
+        ) {
+            setTimeout(() => {
+                this.handleTabChange(
+                    this.currentTab(this.resultsViewPageStore.tabId),
+                    true
+                );
             });
             return null;
         } else {
             return (
-                <PageLayout noMargin={true} hideFooter={true} className={"subhead-dark"}>
-                    {
-                        this.pageContent
-                    }
+                <PageLayout
+                    noMargin={true}
+                    hideFooter={true}
+                    className={'subhead-dark'}
+                >
+                    {this.pageContent}
                 </PageLayout>
-            )
+            );
         }
     }
-
 }
-

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -2707,7 +2707,13 @@ export class ResultsViewPageStore {
     }
 
     @computed get isQueryInvalid() {
-        return this.hugoGeneSymbols.length > AppConfig.serverConfig.query_gene_limit;
+        return (
+            this.hugoGeneSymbols.length * this.samples.result.length > AppConfig.serverConfig.query_product_limit
+        );
+    }
+
+    @computed get geneLimit(): number {
+        return Math.floor(AppConfig.serverConfig.query_product_limit / this.samples.result.length);
     }
 
     readonly genesets = remoteData<Geneset[]>({

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1,6 +1,7 @@
 import {
     CancerStudy,
-    ClinicalAttribute, ClinicalAttributeCount,
+    ClinicalAttribute,
+    ClinicalAttributeCount,
     ClinicalAttributeCountFilter,
     ClinicalData,
     ClinicalDataMultiStudyFilter,
@@ -26,27 +27,28 @@ import {
     SampleIdentifier,
     SampleList,
     SampleMolecularIdentifier,
-    ReferenceGenomeGene
-} from "shared/api/generated/CBioPortalAPI";
-import client from "shared/api/cbioportalClientInstance";
-import {action, computed, observable, ObservableMap} from "mobx";
-import {remoteData} from "public-lib/api/remoteData";
-import {cached, labelMobxPromises, MobxPromise} from "mobxpromise";
-import OncoKbEvidenceCache from "shared/cache/OncoKbEvidenceCache";
-import PubMedCache from "shared/cache/PubMedCache";
-import GenomeNexusCache from "shared/cache/GenomeNexusCache";
-import GenomeNexusMyVariantInfoCache from "shared/cache/GenomeNexusMyVariantInfoCache";
-import CancerTypeCache from "shared/cache/CancerTypeCache";
-import MutationCountCache from "shared/cache/MutationCountCache";
-import DiscreteCNACache from "shared/cache/DiscreteCNACache";
-import PdbHeaderCache from "shared/cache/PdbHeaderCache";
+    ReferenceGenomeGene,
+} from 'shared/api/generated/CBioPortalAPI';
+import client from 'shared/api/cbioportalClientInstance';
+import { action, computed, observable, ObservableMap } from 'mobx';
+import { remoteData } from 'public-lib/api/remoteData';
+import { cached, labelMobxPromises, MobxPromise } from 'mobxpromise';
+import OncoKbEvidenceCache from 'shared/cache/OncoKbEvidenceCache';
+import PubMedCache from 'shared/cache/PubMedCache';
+import GenomeNexusCache from 'shared/cache/GenomeNexusCache';
+import GenomeNexusMyVariantInfoCache from 'shared/cache/GenomeNexusMyVariantInfoCache';
+import CancerTypeCache from 'shared/cache/CancerTypeCache';
+import MutationCountCache from 'shared/cache/MutationCountCache';
+import DiscreteCNACache from 'shared/cache/DiscreteCNACache';
+import PdbHeaderCache from 'shared/cache/PdbHeaderCache';
 import {
     cancerTypeForOncoKb,
     fetchCnaOncoKbDataWithNumericGeneMolecularData,
     fetchCopyNumberSegmentsForSamples,
     fetchGenes,
     fetchGermlineConsentedSamples,
-    fetchMyCancerGenomeData, fetchOncoKbCancerGenes,
+    fetchMyCancerGenomeData,
+    fetchOncoKbCancerGenes,
     fetchOncoKbData,
     fetchStudiesForSamplesWithoutCancerTypeClinicalData,
     generateDataQueryFilter,
@@ -56,37 +58,41 @@ import {
     isMutationProfile,
     fetchVariantAnnotationsIndexedByGenomicLocation,
     ONCOKB_DEFAULT,
-    fetchAllReferenceGenomeGenes, fetchReferenceGenomeGenes
-} from "shared/lib/StoreUtils"
-import {IHotspotIndex, indexHotspotsData} from "react-mutation-mapper";
-import {fetchHotspotsData} from "shared/lib/CancerHotspotsUtils";
-import ResultsViewMutationMapperStore from "./mutation/ResultsViewMutationMapperStore";
-import AppConfig from "appConfig";
-import * as _ from "lodash";
-import {stringListToSet} from "../../public-lib/lib/StringUtils";
-import {toSampleUuid} from "../../shared/lib/UuidUtils";
-import MutationDataCache from "../../shared/cache/MutationDataCache";
-import AccessorsForOqlFilter, {SimplifiedMutationType} from "../../shared/lib/oql/AccessorsForOqlFilter";
-import {AugmentedData, CacheData} from "../../shared/lib/LazyMobXCache";
-import {PatientSurvival} from "../../shared/model/PatientSurvival";
+    fetchAllReferenceGenomeGenes,
+    fetchReferenceGenomeGenes,
+} from 'shared/lib/StoreUtils';
+import { IHotspotIndex, indexHotspotsData } from 'react-mutation-mapper';
+import { fetchHotspotsData } from 'shared/lib/CancerHotspotsUtils';
+import ResultsViewMutationMapperStore from './mutation/ResultsViewMutationMapperStore';
+import AppConfig from 'appConfig';
+import * as _ from 'lodash';
+import { stringListToSet } from '../../public-lib/lib/StringUtils';
+import { toSampleUuid } from '../../shared/lib/UuidUtils';
+import MutationDataCache from '../../shared/cache/MutationDataCache';
+import AccessorsForOqlFilter, {
+    SimplifiedMutationType,
+} from '../../shared/lib/oql/AccessorsForOqlFilter';
+import { AugmentedData, CacheData } from '../../shared/lib/LazyMobXCache';
+import { PatientSurvival } from '../../shared/model/PatientSurvival';
 import {
     doesQueryContainMutationOQL,
     doesQueryContainOQL,
     filterCBioPortalWebServiceData,
     filterCBioPortalWebServiceDataByOQLLine,
-    filterCBioPortalWebServiceDataByUnflattenedOQLLine, uniqueGenesInOQLQuery,
+    filterCBioPortalWebServiceDataByUnflattenedOQLLine,
+    uniqueGenesInOQLQuery,
     OQLLineFilterOutput,
     UnflattenedOQLLineFilterOutput,
-} from "../../shared/lib/oql/oqlfilter";
-import GeneMolecularDataCache from "../../shared/cache/GeneMolecularDataCache";
-import GenesetMolecularDataCache from "../../shared/cache/GenesetMolecularDataCache";
-import GenesetCorrelatedGeneCache from "../../shared/cache/GenesetCorrelatedGeneCache";
-import TreatmentMolecularDataCache from "../../shared/cache/TreatmentMolecularDataCache";
-import GeneCache from "../../shared/cache/GeneCache";
-import GenesetCache from "../../shared/cache/GenesetCache";
-import TreatmentCache from "../../shared/cache/TreatmentCache";
-import {IOncoKbData} from "../../shared/model/OncoKB";
-import {generateQueryVariantId} from "../../public-lib/lib/OncoKbUtils";
+} from '../../shared/lib/oql/oqlfilter';
+import GeneMolecularDataCache from '../../shared/cache/GeneMolecularDataCache';
+import GenesetMolecularDataCache from '../../shared/cache/GenesetMolecularDataCache';
+import GenesetCorrelatedGeneCache from '../../shared/cache/GenesetCorrelatedGeneCache';
+import TreatmentMolecularDataCache from '../../shared/cache/TreatmentMolecularDataCache';
+import GeneCache from '../../shared/cache/GeneCache';
+import GenesetCache from '../../shared/cache/GenesetCache';
+import TreatmentCache from '../../shared/cache/TreatmentCache';
+import { IOncoKbData } from '../../shared/model/OncoKB';
+import { generateQueryVariantId } from '../../public-lib/lib/OncoKbUtils';
 import {
     AlterationEnrichment,
     CosmicMutation,
@@ -95,16 +101,25 @@ import {
     GenesetMolecularData,
     Treatment,
     TreatmentFilter,
-    MolecularProfileCasesGroupFilter
-} from "../../shared/api/generated/CBioPortalAPIInternal";
-import internalClient from "../../shared/api/cbioportalInternalClientInstance";
-import {CancerGene, IndicatorQueryResp} from "../../public-lib/api/generated/OncoKbAPI";
-import {getAlterationString} from "../../shared/lib/CopyNumberUtils";
-import memoize from "memoize-weak-decorator";
-import request from "superagent";
-import {countMutations, mutationCountByPositionKey} from "./mutationCountHelpers";
-import {getPatientSurvivals} from "./SurvivalStoreHelper";
-import {CancerStudyQueryUrlParams, QueryStore} from "shared/components/query/QueryStore";
+    MolecularProfileCasesGroupFilter,
+} from '../../shared/api/generated/CBioPortalAPIInternal';
+import internalClient from '../../shared/api/cbioportalInternalClientInstance';
+import {
+    CancerGene,
+    IndicatorQueryResp,
+} from '../../public-lib/api/generated/OncoKbAPI';
+import { getAlterationString } from '../../shared/lib/CopyNumberUtils';
+import memoize from 'memoize-weak-decorator';
+import request from 'superagent';
+import {
+    countMutations,
+    mutationCountByPositionKey,
+} from './mutationCountHelpers';
+import { getPatientSurvivals } from './SurvivalStoreHelper';
+import {
+    CancerStudyQueryUrlParams,
+    QueryStore,
+} from 'shared/components/query/QueryStore';
 import {
     annotateMolecularDatum,
     computeCustomDriverAnnotationReport,
@@ -117,66 +132,83 @@ import {
     groupDataByCase,
     initializeCustomDriverAnnotationSettings,
     isRNASeqProfile,
-    getSampleAlteredMap, makeEnrichmentDataPromise, fetchPatients, FilteredAndAnnotatedMutationsReport, compileMutations
-} from "./ResultsViewPageStoreUtils";
-import MobxPromiseCache from "../../shared/lib/MobxPromiseCache";
-import {
-    isSampleProfiledInMultiple
-} from "../../shared/lib/isSampleProfiled";
-import {BookmarkLinks} from "../../shared/model/BookmarkLinks";
-import {getBitlyServiceUrl} from "../../shared/api/urls";
-import url from "url";
+    getSampleAlteredMap,
+    makeEnrichmentDataPromise,
+    fetchPatients,
+    FilteredAndAnnotatedMutationsReport,
+    compileMutations,
+} from './ResultsViewPageStoreUtils';
+import MobxPromiseCache from '../../shared/lib/MobxPromiseCache';
+import { isSampleProfiledInMultiple } from '../../shared/lib/isSampleProfiled';
+import { BookmarkLinks } from '../../shared/model/BookmarkLinks';
+import { getBitlyServiceUrl } from '../../shared/api/urls';
+import url from 'url';
 import ClinicalDataCache, {
     clinicalAttributeIsINCOMPARISONGROUP,
-    SpecialAttribute
-} from "../../shared/cache/ClinicalDataCache";
-import {getDefaultMolecularProfiles} from "../../shared/lib/getDefaultMolecularProfiles";
-import {getProteinPositionFromProteinChange} from "public-lib/lib/ProteinChangeUtils";
-import {isMutation} from "../../shared/lib/CBioPortalAPIUtils";
-import {VariantAnnotation} from "public-lib/api/generated/GenomeNexusAPI";
-import {ServerConfigHelpers} from "../../config/config";
+    SpecialAttribute,
+} from '../../shared/cache/ClinicalDataCache';
+import { getDefaultMolecularProfiles } from '../../shared/lib/getDefaultMolecularProfiles';
+import { getProteinPositionFromProteinChange } from 'public-lib/lib/ProteinChangeUtils';
+import { isMutation } from '../../shared/lib/CBioPortalAPIUtils';
+import { VariantAnnotation } from 'public-lib/api/generated/GenomeNexusAPI';
+import { ServerConfigHelpers } from '../../config/config';
 import {
-    populateSampleSpecificationsFromVirtualStudies, ResultsViewTab,
-    substitutePhysicalStudiesForVirtualStudies
-} from "./ResultsViewPageHelpers";
-import {filterAndSortProfiles, getGenesetProfiles,
-    sortRnaSeqProfilesToTop} from "./coExpression/CoExpressionTabUtils";
-import {isRecurrentHotspot} from "../../shared/lib/AnnotationUtils";
-import {generateDownloadFilenamePrefixByStudies} from "shared/lib/FilenameUtils";
+    populateSampleSpecificationsFromVirtualStudies,
+    ResultsViewTab,
+    substitutePhysicalStudiesForVirtualStudies,
+} from './ResultsViewPageHelpers';
+import {
+    filterAndSortProfiles,
+    getGenesetProfiles,
+    sortRnaSeqProfilesToTop,
+} from './coExpression/CoExpressionTabUtils';
+import { isRecurrentHotspot } from '../../shared/lib/AnnotationUtils';
+import { generateDownloadFilenamePrefixByStudies } from 'shared/lib/FilenameUtils';
 import {
     convertComparisonGroupClinicalAttribute,
     makeComparisonGroupClinicalAttributes,
-    makeProfiledInClinicalAttributes
-} from "../../shared/components/oncoprint/ResultsViewOncoprintUtils";
-import {ResultsViewQuery} from "./ResultsViewQuery";
-import {annotateAlterationTypes} from "../../shared/lib/oql/annotateAlterationTypes";
-import {ErrorMessages} from "../../shared/enums/ErrorEnums";
+    makeProfiledInClinicalAttributes,
+} from '../../shared/components/oncoprint/ResultsViewOncoprintUtils';
+import { ResultsViewQuery } from './ResultsViewQuery';
+import { annotateAlterationTypes } from '../../shared/lib/oql/annotateAlterationTypes';
+import { ErrorMessages } from '../../shared/enums/ErrorEnums';
 import {
     pickCopyNumberEnrichmentProfiles,
     pickMRNAEnrichmentProfiles,
-    pickMutationEnrichmentProfiles, pickProteinEnrichmentProfiles
-} from "./enrichments/EnrichmentsUtil";
-import { SURVIVAL_CHART_ATTRIBUTES } from "./survival/SurvivalChart";
-import sessionServiceClient from "../../shared/api/sessionServiceInstance";
-import { VirtualStudy } from "shared/model/VirtualStudy";
-import { ISurvivalDescription } from "./survival/SurvivalDescriptionTable";
-import comparisonClient from "../../shared/api/comparisonGroupClientInstance";
-import {Group} from "../../shared/api/ComparisonGroupClient";
-import {AppStore} from "../../AppStore";
-import {CLINICAL_TRACKS_URL_PARAM} from "../../shared/components/oncoprint/ResultsViewOncoprint";
-import {getNumSamples} from "../groupComparison/GroupComparisonUtils";
-import autobind from "autobind-decorator";
-import {DEFAULT_GENOME} from "pages/resultsView/ResultsViewPageStoreUtils";
-import { StudyWithSamples, getFilteredStudiesWithSamples, ChartMeta, getClinicalAttributeUniqueKey, getChartMetaDataType, getPriorityByClinicalAttribute, UniqueKey, getDefaultPriorityByUniqueKey } from "pages/studyView/StudyViewUtils";
-import { MUTATION_COUNT, FRACTION_GENOME_ALTERED } from "pages/studyView/StudyViewPageStore";
-import { IVirtualStudyProps } from "pages/studyView/virtualStudy/VirtualStudy";
-import { decideMolecularProfileSortingOrder } from "./download/DownloadUtils";
+    pickMutationEnrichmentProfiles,
+    pickProteinEnrichmentProfiles,
+} from './enrichments/EnrichmentsUtil';
+import { SURVIVAL_CHART_ATTRIBUTES } from './survival/SurvivalChart';
+import sessionServiceClient from '../../shared/api/sessionServiceInstance';
+import { VirtualStudy } from 'shared/model/VirtualStudy';
+import { ISurvivalDescription } from './survival/SurvivalDescriptionTable';
+import comparisonClient from '../../shared/api/comparisonGroupClientInstance';
+import { Group } from '../../shared/api/ComparisonGroupClient';
+import { AppStore } from '../../AppStore';
+import { CLINICAL_TRACKS_URL_PARAM } from '../../shared/components/oncoprint/ResultsViewOncoprint';
+import { getNumSamples } from '../groupComparison/GroupComparisonUtils';
+import autobind from 'autobind-decorator';
+import { DEFAULT_GENOME } from 'pages/resultsView/ResultsViewPageStoreUtils';
+import {
+    StudyWithSamples,
+    getFilteredStudiesWithSamples,
+    ChartMeta,
+    getClinicalAttributeUniqueKey,
+    getChartMetaDataType,
+    getPriorityByClinicalAttribute,
+    UniqueKey,
+    getDefaultPriorityByUniqueKey,
+} from 'pages/studyView/StudyViewUtils';
+import {
+    MUTATION_COUNT,
+    FRACTION_GENOME_ALTERED,
+} from 'pages/studyView/StudyViewPageStore';
+import { IVirtualStudyProps } from 'pages/studyView/virtualStudy/VirtualStudy';
+import { decideMolecularProfileSortingOrder } from './download/DownloadUtils';
 
-type Optional<T> = (
-    {isApplicable: true, value: T}
-    | {isApplicable: false, value?: undefined}
-);
-
+type Optional<T> =
+    | { isApplicable: true; value: T }
+    | { isApplicable: false; value?: undefined };
 
 export const AlterationTypeConstants = {
     MUTATION_EXTENDED: 'MUTATION_EXTENDED',
@@ -186,68 +218,73 @@ export const AlterationTypeConstants = {
     FUSION: 'FUSION',
     GENESET_SCORE: 'GENESET_SCORE',
     METHYLATION: 'METHYLATION',
-    GENERIC_ASSAY: 'GENERIC_ASSAY'
+    GENERIC_ASSAY: 'GENERIC_ASSAY',
 };
 
 export const AlterationTypeDisplayConstants = {
     COPY_NUMBER_ALTERATION: 'CNA',
     MRNA_EXPRESSION: 'EXP',
     PROTEIN_LEVEL: 'PROT',
-    MUTATION_EXTENDED: ['MUT', 'FUSION']
+    MUTATION_EXTENDED: ['MUT', 'FUSION'],
 };
 
 export const DataTypeConstants = {
-    DISCRETE: "DISCRETE",
-    CONTINUOUS: "CONTINUOUS",
-    ZSCORE: "Z-SCORE",
-    MAF: "MAF",
-    LOGVALUE:"LOG-VALUE",
-    LOG2VALUE:"LOG2-VALUE"
+    DISCRETE: 'DISCRETE',
+    CONTINUOUS: 'CONTINUOUS',
+    ZSCORE: 'Z-SCORE',
+    MAF: 'MAF',
+    LOGVALUE: 'LOG-VALUE',
+    LOG2VALUE: 'LOG2-VALUE',
 };
 
 export enum SampleListCategoryType {
-    "w_mut"="w_mut",
-    "w_cna"="w_cna",
-    "w_mut_cna"="w_mut_cna"
+    'w_mut' = 'w_mut',
+    'w_cna' = 'w_cna',
+    'w_mut_cna' = 'w_mut_cna',
 }
 
 export enum GeneticEntityType {
-    "GENE"="gene",
-    "GENESET"="geneset"
+    'GENE' = 'gene',
+    'GENESET' = 'geneset',
 }
 
 export const SampleListCategoryTypeToFullId = {
-    [SampleListCategoryType.w_mut]:"all_cases_with_mutation_data",
-    [SampleListCategoryType.w_cna]:"all_cases_with_cna_data",
-    [SampleListCategoryType.w_mut_cna]:"all_cases_with_mutation_and_cna_data"
+    [SampleListCategoryType.w_mut]: 'all_cases_with_mutation_data',
+    [SampleListCategoryType.w_cna]: 'all_cases_with_cna_data',
+    [SampleListCategoryType.w_mut_cna]: 'all_cases_with_mutation_and_cna_data',
 };
 
-export type SamplesSpecificationElement = {studyId: string, sampleId: string, sampleListId: undefined} |
-    {studyId: string, sampleId: undefined, sampleListId: string};
+export type SamplesSpecificationElement =
+    | { studyId: string; sampleId: string; sampleListId: undefined }
+    | { studyId: string; sampleId: undefined; sampleListId: string };
 
 export interface ExtendedAlteration extends Mutation, NumericGeneMolecularData {
-    hugoGeneSymbol:string;
-    molecularProfileAlterationType: MolecularProfile["molecularAlterationType"];
+    hugoGeneSymbol: string;
+    molecularProfileAlterationType: MolecularProfile['molecularAlterationType'];
     // TODO: what is difference molecularProfileAlterationType and
     // alterationType?
-    alterationType: string
-    alterationSubType: string
-};
+    alterationType: string;
+    alterationSubType: string;
+}
 
 export interface AnnotatedMutation extends Mutation {
-    hugoGeneSymbol:string;
+    hugoGeneSymbol: string;
     putativeDriver: boolean;
-    oncoKbOncogenic:string;
-    isHotspot:boolean;
+    oncoKbOncogenic: string;
+    isHotspot: boolean;
     simplifiedMutationType: SimplifiedMutationType;
 }
 
-export interface AnnotatedNumericGeneMolecularData extends NumericGeneMolecularData {
+export interface AnnotatedNumericGeneMolecularData
+    extends NumericGeneMolecularData {
     hugoGeneSymbol: string;
     oncoKbOncogenic: string;
 }
 
-export interface AnnotatedExtendedAlteration extends ExtendedAlteration, AnnotatedMutation, AnnotatedNumericGeneMolecularData {};
+export interface AnnotatedExtendedAlteration
+    extends ExtendedAlteration,
+        AnnotatedMutation,
+        AnnotatedNumericGeneMolecularData {}
 
 export interface ExtendedSample extends Sample {
     cancerType: string;
@@ -255,8 +292,8 @@ export interface ExtendedSample extends Sample {
 }
 
 export type CaseAggregatedData<T> = {
-    samples: {[uniqueSampleKey:string]:T[]};
-    patients: {[uniquePatientKey:string]:T[]};
+    samples: { [uniqueSampleKey: string]: T[] };
+    patients: { [uniquePatientKey: string]: T[] };
 };
 
 /*
@@ -280,50 +317,59 @@ export interface IQueriedMergedTrackCaseData {
 }
 
 export type GeneticEntity = {
-    geneticEntityName: string, // hugo gene symbol for gene, gene set name for geneset
-    geneticEntityType: GeneticEntityType,
-    geneticEntityId: string|number, //entrezGeneId (number) for "gene", genesetId (string) for "geneset"
-    cytoband: string, //will be "" for "geneset"
-    geneticEntityData: Gene|Geneset
-}
+    geneticEntityName: string; // hugo gene symbol for gene, gene set name for geneset
+    geneticEntityType: GeneticEntityType;
+    geneticEntityId: string | number; //entrezGeneId (number) for "gene", genesetId (string) for "geneset"
+    cytoband: string; //will be "" for "geneset"
+    geneticEntityData: Gene | Geneset;
+};
 
-export function buildDefaultOQLProfile(profilesTypes: string[], zScoreThreshold: number, rppaScoreThreshold: number) {
-
+export function buildDefaultOQLProfile(
+    profilesTypes: string[],
+    zScoreThreshold: number,
+    rppaScoreThreshold: number
+) {
     var default_oql_uniq: any = {};
     for (var i = 0; i < profilesTypes.length; i++) {
         var type = profilesTypes[i];
         switch (type) {
-            case "MUTATION_EXTENDED":
-                default_oql_uniq["MUT"] = true;
-                default_oql_uniq["FUSION"] = true;
+            case 'MUTATION_EXTENDED':
+                default_oql_uniq['MUT'] = true;
+                default_oql_uniq['FUSION'] = true;
                 break;
-            case "COPY_NUMBER_ALTERATION":
-                default_oql_uniq["AMP"] = true;
-                default_oql_uniq["HOMDEL"] = true;
+            case 'COPY_NUMBER_ALTERATION':
+                default_oql_uniq['AMP'] = true;
+                default_oql_uniq['HOMDEL'] = true;
                 break;
-            case "MRNA_EXPRESSION":
-                default_oql_uniq["EXP>=" + zScoreThreshold] = true;
-                default_oql_uniq["EXP<=-" + zScoreThreshold] = true;
+            case 'MRNA_EXPRESSION':
+                default_oql_uniq['EXP>=' + zScoreThreshold] = true;
+                default_oql_uniq['EXP<=-' + zScoreThreshold] = true;
                 break;
-            case "PROTEIN_LEVEL":
-                default_oql_uniq["PROT>=" + rppaScoreThreshold] = true;
-                default_oql_uniq["PROT<=-" + rppaScoreThreshold] = true;
+            case 'PROTEIN_LEVEL':
+                default_oql_uniq['PROT>=' + rppaScoreThreshold] = true;
+                default_oql_uniq['PROT<=-' + rppaScoreThreshold] = true;
                 break;
         }
     }
-    return Object.keys(default_oql_uniq).join(" ");
-
+    return Object.keys(default_oql_uniq).join(' ');
 }
 
-export function extendSamplesWithCancerType(samples:Sample[], clinicalDataForSamples:ClinicalData[], studies:CancerStudy[]){
-
-    const clinicalDataGroupedBySampleId = _.groupBy(clinicalDataForSamples, (clinicalData:ClinicalData)=>clinicalData.uniqueSampleKey);
+export function extendSamplesWithCancerType(
+    samples: Sample[],
+    clinicalDataForSamples: ClinicalData[],
+    studies: CancerStudy[]
+) {
+    const clinicalDataGroupedBySampleId = _.groupBy(
+        clinicalDataForSamples,
+        (clinicalData: ClinicalData) => clinicalData.uniqueSampleKey
+    );
     // note that this table is actually mutating underlying sample.  it's not worth it to clone samples just
     // for purity
-    const extendedSamples = samples.map((sample: ExtendedSample)=>{
-        const clinicalData = clinicalDataGroupedBySampleId[sample.uniqueSampleKey];
+    const extendedSamples = samples.map((sample: ExtendedSample) => {
+        const clinicalData =
+            clinicalDataGroupedBySampleId[sample.uniqueSampleKey];
         if (clinicalData) {
-            clinicalData.forEach((clinicalDatum:ClinicalData)=>{
+            clinicalData.forEach((clinicalDatum: ClinicalData) => {
                 switch (clinicalDatum.clinicalAttributeId) {
                     case 'CANCER_TYPE_DETAILED':
                         sample.cancerTypeDetailed = clinicalDatum.value;
@@ -340,10 +386,10 @@ export function extendSamplesWithCancerType(samples:Sample[], clinicalDataForSam
     });
 
     //make a map by studyId for easy access in following loop
-    const studyMap = _.keyBy(studies,(study:CancerStudy)=>study.studyId);
+    const studyMap = _.keyBy(studies, (study: CancerStudy) => study.studyId);
 
     // now we need to fix any samples which do not have both cancerType and cancerTypeDetailed
-    extendedSamples.forEach((sample:ExtendedSample)=>{
+    extendedSamples.forEach((sample: ExtendedSample) => {
         //if we have no cancer subtype, then make the subtype the parent type
         if (!sample.cancerType) {
             // we need to fall back to studies cancerType
@@ -351,7 +397,7 @@ export function extendSamplesWithCancerType(samples:Sample[], clinicalDataForSam
             if (study) {
                 sample.cancerType = study.cancerType.name;
             } else {
-                sample.cancerType = "Unknown";
+                sample.cancerType = 'Unknown';
             }
         }
         if (sample.cancerType && !sample.cancerTypeDetailed) {
@@ -360,35 +406,33 @@ export function extendSamplesWithCancerType(samples:Sample[], clinicalDataForSam
     });
 
     return extendedSamples;
-
 }
 
 export type DriverAnnotationSettings = {
     excludeVUS: boolean;
-    cbioportalCount:boolean;
-    cbioportalCountThreshold:number;
-    cosmicCount:boolean;
-    cosmicCountThreshold:number;
-    customBinary:boolean;
+    cbioportalCount: boolean;
+    cbioportalCountThreshold: number;
+    cosmicCount: boolean;
+    cosmicCountThreshold: number;
+    customBinary: boolean;
     customTiersDefault: boolean;
-    driverTiers:ObservableMap<boolean>;
-    hotspots:boolean;
-    oncoKb:boolean;
-    driversAnnotated:boolean;
+    driverTiers: ObservableMap<boolean>;
+    hotspots: boolean;
+    oncoKb: boolean;
+    driversAnnotated: boolean;
 };
 
 export type ModifyQueryParams = {
     selectedSampleListId: string;
     selectedSampleIds: string[];
-    caseIdsMode: "sample" | "patient";
+    caseIdsMode: 'sample' | 'patient';
 };
 
 /* fields and methods in the class below are ordered based on roughly
 /* chronological setup concerns, rather than on encapsulation and public API */
 /* tslint:disable: member-ordering */
 export class ResultsViewPageStore {
-
-    constructor(private appStore:AppStore, private routing:any) {
+    constructor(private appStore: AppStore, private routing: any) {
         labelMobxPromises(this);
 
         // addErrorHandler((error: any) => {
@@ -406,58 +450,79 @@ export class ResultsViewPageStore {
             driverTiers: observable.map<boolean>(),
 
             _customBinary: undefined,
-            _hotspots:false,
-            _oncoKb:false,
+            _hotspots: false,
+            _oncoKb: false,
             _excludeVUS: false,
 
-            set hotspots(val:boolean) {
+            set hotspots(val: boolean) {
                 this._hotspots = val;
             },
             get hotspots() {
-                return !!AppConfig.serverConfig.show_hotspot && this._hotspots && !store.didHotspotFailInOncoprint;
+                return (
+                    !!AppConfig.serverConfig.show_hotspot &&
+                    this._hotspots &&
+                    !store.didHotspotFailInOncoprint
+                );
             },
-            set oncoKb(val:boolean) {
+            set oncoKb(val: boolean) {
                 this._oncoKb = val;
             },
             get oncoKb() {
-                return AppConfig.serverConfig.show_oncokb && this._oncoKb && !store.didOncoKbFailInOncoprint;
+                return (
+                    AppConfig.serverConfig.show_oncokb &&
+                    this._oncoKb &&
+                    !store.didOncoKbFailInOncoprint
+                );
             },
-            set excludeVUS(val:boolean) {
+            set excludeVUS(val: boolean) {
                 this._excludeVUS = val;
             },
             get excludeVUS() {
                 return this._excludeVUS && this.driversAnnotated;
             },
             get driversAnnotated() {
-                const anySelected = this.oncoKb ||
+                const anySelected =
+                    this.oncoKb ||
                     this.hotspots ||
                     this.cbioportalCount ||
                     this.cosmicCount ||
                     this.customBinary ||
-                    this.driverTiers.entries().reduce((oneSelected:boolean, nextEntry:[string, boolean])=>{
-                        return oneSelected || nextEntry[1];
-                    }, false);
+                    this.driverTiers
+                        .entries()
+                        .reduce(
+                            (
+                                oneSelected: boolean,
+                                nextEntry: [string, boolean]
+                            ) => {
+                                return oneSelected || nextEntry[1];
+                            },
+                            false
+                        );
 
                 return anySelected;
             },
 
             get customBinary() {
-                return this._customBinary === undefined ? AppConfig.serverConfig.oncoprint_custom_driver_annotation_binary_default : this._customBinary;
+                return this._customBinary === undefined
+                    ? AppConfig.serverConfig
+                          .oncoprint_custom_driver_annotation_binary_default
+                    : this._customBinary;
             },
 
             get customTiersDefault() {
-                return AppConfig.serverConfig.oncoprint_custom_driver_annotation_tiers_default;
-            }
+                return AppConfig.serverConfig
+                    .oncoprint_custom_driver_annotation_tiers_default;
+            },
         });
 
         this.initDriverAnnotationSettings();
     }
 
-    public queryReactionDisposer:any;
+    public queryReactionDisposer: any;
 
-    public rvQuery:ResultsViewQuery = new ResultsViewQuery();
+    public rvQuery: ResultsViewQuery = new ResultsViewQuery();
 
-    @observable tabId: ResultsViewTab|undefined = undefined;
+    @observable tabId: ResultsViewTab | undefined = undefined;
 
     @observable public checkingVirtualStudies = false;
 
@@ -465,7 +530,7 @@ export class ResultsViewPageStore {
 
     @observable public urlValidationError: string | null = null;
 
-    @computed get profileFilter(){
+    @computed get profileFilter() {
         return this.rvQuery.profileFilter || 0;
     }
 
@@ -476,97 +541,157 @@ export class ResultsViewPageStore {
     @observable queryFormVisible: boolean = false;
 
     @computed get doNonSelectedMolecularProfilesExist() {
-        return this.nonSelectedMolecularProfilesGroupByName.result && _.keys(this.nonSelectedMolecularProfilesGroupByName.result).length > 0;
+        return (
+            this.nonSelectedMolecularProfilesGroupByName.result &&
+            _.keys(this.nonSelectedMolecularProfilesGroupByName.result).length >
+                0
+        );
     }
 
-    @observable public modifyQueryParams: ModifyQueryParams | undefined = undefined;
+    @observable public modifyQueryParams:
+        | ModifyQueryParams
+        | undefined = undefined;
 
-    public driverAnnotationSettings:DriverAnnotationSettings;
+    public driverAnnotationSettings: DriverAnnotationSettings;
     @observable public excludeGermlineMutations = false;
 
-    @observable.ref private _mutationEnrichmentProfileMap:{[id:string]:MolecularProfile} = {};
-    @observable.ref private _copyNumberEnrichmentProfileMap:{[id:string]:MolecularProfile} = {};
-    @observable.ref private _mRNAEnrichmentProfileMap:{[id:string]:MolecularProfile} = {};
-    @observable.ref private _proteinEnrichmentProfileMap:{[id:string]:MolecularProfile} = {};
+    @observable.ref private _mutationEnrichmentProfileMap: {
+        [id: string]: MolecularProfile;
+    } = {};
+    @observable.ref private _copyNumberEnrichmentProfileMap: {
+        [id: string]: MolecularProfile;
+    } = {};
+    @observable.ref private _mRNAEnrichmentProfileMap: {
+        [id: string]: MolecularProfile;
+    } = {};
+    @observable.ref private _proteinEnrichmentProfileMap: {
+        [id: string]: MolecularProfile;
+    } = {};
 
     readonly selectedMutationEnrichmentProfileMap = remoteData({
-        await:()=>[this.mutationEnrichmentProfiles],
-        invoke:()=>{
+        await: () => [this.mutationEnrichmentProfiles],
+        invoke: () => {
             if (_.isEmpty(this._mutationEnrichmentProfileMap)) {
-                const molecularProfilesMap = _.groupBy(this.mutationEnrichmentProfiles.result!,profile=>profile.studyId);
-                return Promise.resolve(_.mapValues(molecularProfilesMap,molecularProfiles=>molecularProfiles[0]));
+                const molecularProfilesMap = _.groupBy(
+                    this.mutationEnrichmentProfiles.result!,
+                    profile => profile.studyId
+                );
+                return Promise.resolve(
+                    _.mapValues(
+                        molecularProfilesMap,
+                        molecularProfiles => molecularProfiles[0]
+                    )
+                );
             } else {
                 return Promise.resolve(this._mutationEnrichmentProfileMap);
             }
-        }
+        },
     });
 
     readonly selectedCopyNumberEnrichmentProfileMap = remoteData({
         await: () => [this.copyNumberEnrichmentProfiles],
         invoke: () => {
             if (_.isEmpty(this._copyNumberEnrichmentProfileMap)) {
-                const molecularProfilesMap = _.groupBy(this.copyNumberEnrichmentProfiles.result!, profile => profile.studyId);
-                return Promise.resolve(_.mapValues(molecularProfilesMap, molecularProfiles => molecularProfiles[0]));
+                const molecularProfilesMap = _.groupBy(
+                    this.copyNumberEnrichmentProfiles.result!,
+                    profile => profile.studyId
+                );
+                return Promise.resolve(
+                    _.mapValues(
+                        molecularProfilesMap,
+                        molecularProfiles => molecularProfiles[0]
+                    )
+                );
             } else {
                 return Promise.resolve(this._copyNumberEnrichmentProfileMap);
             }
-        }
+        },
     });
 
     readonly selectedmRNAEnrichmentProfileMap = remoteData({
         await: () => [this.mRNAEnrichmentProfiles],
         invoke: () => {
             if (_.isEmpty(this._mRNAEnrichmentProfileMap)) {
-                const molecularProfilesMap = _.groupBy(this.mRNAEnrichmentProfiles.result!, profile => profile.studyId);
-                return Promise.resolve(_.mapValues(molecularProfilesMap, molecularProfiles => molecularProfiles[0]));
+                const molecularProfilesMap = _.groupBy(
+                    this.mRNAEnrichmentProfiles.result!,
+                    profile => profile.studyId
+                );
+                return Promise.resolve(
+                    _.mapValues(
+                        molecularProfilesMap,
+                        molecularProfiles => molecularProfiles[0]
+                    )
+                );
             } else {
                 return Promise.resolve(this._mRNAEnrichmentProfileMap);
             }
-        }
+        },
     });
 
     readonly selectedProteinEnrichmentProfileMap = remoteData({
         await: () => [this.proteinEnrichmentProfiles],
         invoke: () => {
             if (_.isEmpty(this._proteinEnrichmentProfileMap)) {
-                const molecularProfilesMap = _.groupBy(this.proteinEnrichmentProfiles.result!, profile => profile.studyId);
-                return Promise.resolve(_.mapValues(molecularProfilesMap, molecularProfiles => molecularProfiles[0]));
+                const molecularProfilesMap = _.groupBy(
+                    this.proteinEnrichmentProfiles.result!,
+                    profile => profile.studyId
+                );
+                return Promise.resolve(
+                    _.mapValues(
+                        molecularProfilesMap,
+                        molecularProfiles => molecularProfiles[0]
+                    )
+                );
             } else {
                 return Promise.resolve(this._proteinEnrichmentProfileMap);
             }
-        }
+        },
     });
 
     @action
-    public setMutationEnrichmentProfileMap(profiles:{[id:string]:MolecularProfile}) {
+    public setMutationEnrichmentProfileMap(profiles: {
+        [id: string]: MolecularProfile;
+    }) {
         this._mutationEnrichmentProfileMap = profiles;
     }
 
     @action
-    public setCopyNumberEnrichmentProfileMap(profiles:{[id:string]:MolecularProfile}) {
+    public setCopyNumberEnrichmentProfileMap(profiles: {
+        [id: string]: MolecularProfile;
+    }) {
         this._copyNumberEnrichmentProfileMap = profiles;
     }
 
     @action
-    public setmRNAEnrichmentProfile(profiles:{[id:string]:MolecularProfile}) {
+    public setmRNAEnrichmentProfile(profiles: {
+        [id: string]: MolecularProfile;
+    }) {
         this._mRNAEnrichmentProfileMap = profiles;
     }
 
     @action
-    public setProteinEnrichmentProfile(profiles:{[id:string]:MolecularProfile}) {
+    public setProteinEnrichmentProfile(profiles: {
+        [id: string]: MolecularProfile;
+    }) {
         this._proteinEnrichmentProfileMap = profiles;
     }
 
     public get usePatientLevelEnrichments() {
-        return (this.routing.location.query as CancerStudyQueryUrlParams).patient_enrichments === "true";
+        return (
+            (this.routing.location.query as CancerStudyQueryUrlParams)
+                .patient_enrichments === 'true'
+        );
     }
 
     @autobind
-    @action public setUsePatientLevelEnrichments(e:boolean) {
-        this.routing.updateRoute({ patient_enrichments: e.toString()} as Partial<CancerStudyQueryUrlParams>);
+    @action
+    public setUsePatientLevelEnrichments(e: boolean) {
+        this.routing.updateRoute({
+            patient_enrichments: e.toString(),
+        } as Partial<CancerStudyQueryUrlParams>);
     }
 
-    @computed get hugoGeneSymbols(){
+    @computed get hugoGeneSymbols() {
         if (this.rvQuery.oqlQuery.length > 0) {
             return uniqueGenesInOQLQuery(this.rvQuery.oqlQuery);
         } else {
@@ -588,20 +713,23 @@ export class ResultsViewPageStore {
         this.driverAnnotationSettings.cosmicCount = false;
         this.driverAnnotationSettings.cosmicCountThreshold = 10;
         this.driverAnnotationSettings.driverTiers = observable.map<boolean>();
-        (this.driverAnnotationSettings as any)._oncoKb = !!AppConfig.serverConfig.oncoprint_oncokb_default;
-        this.driverAnnotationSettings.hotspots = !!AppConfig.serverConfig.oncoprint_hotspots_default;
-        (this.driverAnnotationSettings as any)._excludeVUS = !!AppConfig.serverConfig.oncoprint_hide_vus_default;
+        (this.driverAnnotationSettings as any)._oncoKb = !!AppConfig
+            .serverConfig.oncoprint_oncokb_default;
+        this.driverAnnotationSettings.hotspots = !!AppConfig.serverConfig
+            .oncoprint_hotspots_default;
+        (this.driverAnnotationSettings as any)._excludeVUS = !!AppConfig
+            .serverConfig.oncoprint_hide_vus_default;
     }
 
     private makeMutationsTabFilteringSettings() {
         const self = this;
-        let _excludeVus = observable.box<boolean|undefined>(undefined);
-        let _excludeGermline = observable.box<boolean|undefined>(undefined);
+        let _excludeVus = observable.box<boolean | undefined>(undefined);
+        let _excludeGermline = observable.box<boolean | undefined>(undefined);
         return observable({
-            useOql:true,
+            useOql: true,
             get excludeVus() {
                 if (_excludeVus.get() === undefined) {
-                    return self.driverAnnotationSettings.excludeVUS
+                    return self.driverAnnotationSettings.excludeVUS;
                 } else {
                     return _excludeVus.get()!;
                 }
@@ -613,57 +741,68 @@ export class ResultsViewPageStore {
                     return _excludeGermline.get()!;
                 }
             },
-            set excludeVus(s:boolean) {
+            set excludeVus(s: boolean) {
                 _excludeVus.set(s);
             },
-            set excludeGermline(s:boolean) {
+            set excludeGermline(s: boolean) {
                 _excludeGermline.set(s);
-            }
+            },
         });
     }
 
     private getURL() {
         const shareURL = window.location.href;
 
-        if (!shareURL.includes("session_id")) return;
+        if (!shareURL.includes('session_id')) return;
 
-        const showSamples = shareURL.indexOf("&show");
+        const showSamples = shareURL.indexOf('&show');
         if (showSamples > -1) {
             this.sessionIdURL = shareURL.slice(0, showSamples);
         }
     }
 
     readonly selectedMolecularProfiles = remoteData<MolecularProfile[]>({
-        await: ()=>[
-            this.studyToMolecularProfiles,
-            this.studies
-        ],
+        await: () => [this.studyToMolecularProfiles, this.studies],
         invoke: () => {
-
             // if there are multiple studies or if there are no selected molecular profiles in query
             // derive default profiles based on profileFilter (refers to old data priority)
-            if (this.studies.result.length > 1 || this.rvQuery.selectedMolecularProfileIds.length === 0) {
-                return Promise.resolve(getDefaultMolecularProfiles(this.studyToMolecularProfiles.result!, this.profileFilter));
+            if (
+                this.studies.result.length > 1 ||
+                this.rvQuery.selectedMolecularProfileIds.length === 0
+            ) {
+                return Promise.resolve(
+                    getDefaultMolecularProfiles(
+                        this.studyToMolecularProfiles.result!,
+                        this.profileFilter
+                    )
+                );
             } else {
                 // if we have only one study, then consult the selectedMolecularProfileIds because
                 // user can directly select set
-                const idLookupMap = _.keyBy(this.rvQuery.selectedMolecularProfileIds,(id:string)=>id); // optimization
-                return Promise.resolve(this.molecularProfilesInStudies.result!.filter(
-                    (profile:MolecularProfile)=>(profile.molecularProfileId in idLookupMap))
+                const idLookupMap = _.keyBy(
+                    this.rvQuery.selectedMolecularProfileIds,
+                    (id: string) => id
+                ); // optimization
+                return Promise.resolve(
+                    this.molecularProfilesInStudies.result!.filter(
+                        (profile: MolecularProfile) =>
+                            profile.molecularProfileId in idLookupMap
+                    )
                 );
             }
-
-        }
+        },
     });
 
-    readonly clinicalAttributes_profiledIn = remoteData<(ClinicalAttribute & {molecularProfileIds:string[]})[]>({
-        await:()=>[
+    readonly clinicalAttributes_profiledIn = remoteData<
+        (ClinicalAttribute & { molecularProfileIds: string[] })[]
+    >({
+        await: () => [
             this.coverageInformation,
             this.molecularProfileIdToMolecularProfile,
             this.selectedMolecularProfiles,
-            this.studyIds
+            this.studyIds,
         ],
-        invoke:()=>{
+        invoke: () => {
             return Promise.resolve(
                 makeProfiledInClinicalAttributes(
                     this.coverageInformation.result!.samples,
@@ -676,173 +815,228 @@ export class ResultsViewPageStore {
     });
 
     readonly comparisonGroups = remoteData<Group[]>({
-        await:()=>[this.studyIds],
-        invoke:async()=>{
-            let ret:Group[] = [];
+        await: () => [this.studyIds],
+        invoke: async () => {
+            let ret: Group[] = [];
             if (this.appStore.isLoggedIn) {
                 try {
-                    ret = ret.concat(await comparisonClient.getGroupsForStudies(this.studyIds.result!));
+                    ret = ret.concat(
+                        await comparisonClient.getGroupsForStudies(
+                            this.studyIds.result!
+                        )
+                    );
                 } catch (e) {
                     // fail silently
                 }
             }
             // add any groups that are referenced in URL
-            const clinicalTracksParam = this.routing.location.query[CLINICAL_TRACKS_URL_PARAM];
+            const clinicalTracksParam = this.routing.location.query[
+                CLINICAL_TRACKS_URL_PARAM
+            ];
             if (clinicalTracksParam) {
-                const groupIds = clinicalTracksParam.split(",") // split by comma
-                    .filter((clinicalAttributeId:string)=>clinicalAttributeIsINCOMPARISONGROUP({clinicalAttributeId})) // filter for comparison group tracks
-                    .map((clinicalAttributeId:string)=>convertComparisonGroupClinicalAttribute(clinicalAttributeId, false)); // convert track ids to group ids
+                const groupIds = clinicalTracksParam
+                    .split(',') // split by comma
+                    .filter((clinicalAttributeId: string) =>
+                        clinicalAttributeIsINCOMPARISONGROUP({
+                            clinicalAttributeId,
+                        })
+                    ) // filter for comparison group tracks
+                    .map((clinicalAttributeId: string) =>
+                        convertComparisonGroupClinicalAttribute(
+                            clinicalAttributeId,
+                            false
+                        )
+                    ); // convert track ids to group ids
 
                 for (const id of groupIds) {
                     ret.push(await comparisonClient.getGroup(id));
                 }
             }
             return ret;
-        }
+        },
     });
 
-    readonly clinicalAttributes_comparisonGroupMembership = remoteData<(ClinicalAttribute & {comparisonGroup:Group})[]>({
-        await:()=>[
-            this.comparisonGroups
-        ],
-        invoke:()=>Promise.resolve(makeComparisonGroupClinicalAttributes(this.comparisonGroups.result!))
+    readonly clinicalAttributes_comparisonGroupMembership = remoteData<
+        (ClinicalAttribute & { comparisonGroup: Group })[]
+    >({
+        await: () => [this.comparisonGroups],
+        invoke: () =>
+            Promise.resolve(
+                makeComparisonGroupClinicalAttributes(
+                    this.comparisonGroups.result!
+                )
+            ),
     });
 
     readonly alterationsBySelectedMolecularProfiles = remoteData<string[]>({
-        await: ()=>[
-            this.selectedMolecularProfiles
-        ],
+        await: () => [this.selectedMolecularProfiles],
         invoke: () => {
-            const profiles: MolecularProfile[] = this.selectedMolecularProfiles.result!;
+            const profiles: MolecularProfile[] = this.selectedMolecularProfiles
+                .result!;
             const alterations: string[] = [];
             profiles.forEach(profile => {
-                switch(profile.molecularAlterationType){
+                switch (profile.molecularAlterationType) {
                     case AlterationTypeConstants.COPY_NUMBER_ALTERATION:
-                        alterations.push(AlterationTypeDisplayConstants.COPY_NUMBER_ALTERATION);
+                        alterations.push(
+                            AlterationTypeDisplayConstants.COPY_NUMBER_ALTERATION
+                        );
                         break;
                     case AlterationTypeConstants.MRNA_EXPRESSION:
-                        alterations.push(AlterationTypeDisplayConstants.MRNA_EXPRESSION);
+                        alterations.push(
+                            AlterationTypeDisplayConstants.MRNA_EXPRESSION
+                        );
                         break;
                     case AlterationTypeConstants.PROTEIN_LEVEL:
-                        alterations.push(AlterationTypeDisplayConstants.PROTEIN_LEVEL);
+                        alterations.push(
+                            AlterationTypeDisplayConstants.PROTEIN_LEVEL
+                        );
                         break;
                     case AlterationTypeConstants.MUTATION_EXTENDED:
-                        AlterationTypeDisplayConstants.MUTATION_EXTENDED.forEach(mutationSubType => alterations.push(mutationSubType));
+                        AlterationTypeDisplayConstants.MUTATION_EXTENDED.forEach(
+                            mutationSubType => alterations.push(mutationSubType)
+                        );
                         break;
                     default:
                 }
             });
             return Promise.resolve(_.uniq(alterations));
-        }
+        },
     });
 
-    readonly selectedMolecularProfileIdsByAlterationType = remoteData<{ [alterationType: string]: MolecularProfile[] }>({
-        await: () => [
-            this.selectedMolecularProfiles
-        ],
+    readonly selectedMolecularProfileIdsByAlterationType = remoteData<{
+        [alterationType: string]: MolecularProfile[];
+    }>({
+        await: () => [this.selectedMolecularProfiles],
         invoke: () => {
-            const profiles: MolecularProfile[] = this.selectedMolecularProfiles.result!;
-            return Promise.resolve(_.groupBy(profiles, "molecularAlterationType"));
-        }
+            const profiles: MolecularProfile[] = this.selectedMolecularProfiles
+                .result!;
+            return Promise.resolve(
+                _.groupBy(profiles, 'molecularAlterationType')
+            );
+        },
     });
 
-    readonly clinicalAttributes = remoteData<(ClinicalAttribute & { molecularProfileIds?: string[] })[]>({
-        await:()=>[
+    readonly clinicalAttributes = remoteData<
+        (ClinicalAttribute & { molecularProfileIds?: string[] })[]
+    >({
+        await: () => [
             this.studyIds,
             this.clinicalAttributes_profiledIn,
             this.clinicalAttributes_comparisonGroupMembership,
             this.samples,
-            this.patients
+            this.patients,
         ],
-        invoke:async()=>{
-            const serverAttributes = await client.fetchClinicalAttributesUsingPOST({
-                studyIds:this.studyIds.result!
-            });
+        invoke: async () => {
+            const serverAttributes = await client.fetchClinicalAttributesUsingPOST(
+                {
+                    studyIds: this.studyIds.result!,
+                }
+            );
             const specialAttributes = [
                 {
                     clinicalAttributeId: SpecialAttribute.MutationSpectrum,
-                    datatype: "COUNTS_MAP",
-                    description: "Number of point mutations in the sample counted by different types of nucleotide changes.",
-                    displayName: "Mutation spectrum",
+                    datatype: 'COUNTS_MAP',
+                    description:
+                        'Number of point mutations in the sample counted by different types of nucleotide changes.',
+                    displayName: 'Mutation spectrum',
                     patientAttribute: false,
-                    studyId: "",
-                    priority:"0" // TODO: change?
-                } as ClinicalAttribute
+                    studyId: '',
+                    priority: '0', // TODO: change?
+                } as ClinicalAttribute,
             ];
             if (this.studyIds.result!.length > 1) {
                 // if more than one study, add "Study of Origin" attribute
                 specialAttributes.push({
                     clinicalAttributeId: SpecialAttribute.StudyOfOrigin,
-                    datatype: "STRING",
-                    description: "Study which the sample is a part of.",
-                    displayName: "Study of origin",
+                    datatype: 'STRING',
+                    description: 'Study which the sample is a part of.',
+                    displayName: 'Study of origin',
                     patientAttribute: false,
-                    studyId: "",
-                    priority:"0" // TODO: change?
+                    studyId: '',
+                    priority: '0', // TODO: change?
                 } as ClinicalAttribute);
             }
             if (this.samples.result!.length !== this.patients.result!.length) {
                 // if different number of samples and patients, add "Num Samples of Patient" attribute
                 specialAttributes.push({
                     clinicalAttributeId: SpecialAttribute.NumSamplesPerPatient,
-                    datatype: "NUMBER",
-                    description: "Number of queried samples for each patient.",
-                    displayName: "# Samples per Patient",
-                    patientAttribute: true
+                    datatype: 'NUMBER',
+                    description: 'Number of queried samples for each patient.',
+                    displayName: '# Samples per Patient',
+                    patientAttribute: true,
                 } as ClinicalAttribute);
             }
             return serverAttributes
                 .concat(specialAttributes)
                 .concat(this.clinicalAttributes_profiledIn.result!)
-                .concat(this.clinicalAttributes_comparisonGroupMembership.result!);
-        }
+                .concat(
+                    this.clinicalAttributes_comparisonGroupMembership.result!
+                );
+        },
     });
 
     readonly clinicalAttributeIdToClinicalAttribute = remoteData({
-        await:()=>[this.clinicalAttributes],
-        invoke:()=>Promise.resolve(_.keyBy(this.clinicalAttributes.result!, "clinicalAttributeId"))
+        await: () => [this.clinicalAttributes],
+        invoke: () =>
+            Promise.resolve(
+                _.keyBy(this.clinicalAttributes.result!, 'clinicalAttributeId')
+            ),
     });
 
     readonly clinicalAttributeIdToAvailableSampleCount = remoteData({
-        await:()=>[
+        await: () => [
             this.samples,
             this.studies,
             this.clinicalAttributes,
             this.studyToDataQueryFilter,
             this.clinicalAttributes_profiledIn,
-            this.clinicalAttributes_comparisonGroupMembership
+            this.clinicalAttributes_comparisonGroupMembership,
         ],
-        invoke:async()=>{
-            let clinicalAttributeCountFilter:ClinicalAttributeCountFilter;
+        invoke: async () => {
+            let clinicalAttributeCountFilter: ClinicalAttributeCountFilter;
             if (this.studies.result.length === 1) {
                 // try using sample list id
                 const studyId = this.studies.result![0].studyId;
                 const dqf = this.studyToDataQueryFilter.result[studyId];
                 if (dqf.sampleListId) {
                     clinicalAttributeCountFilter = {
-                        sampleListId: dqf.sampleListId
+                        sampleListId: dqf.sampleListId,
                     } as ClinicalAttributeCountFilter;
                 } else {
                     clinicalAttributeCountFilter = {
-                        sampleIdentifiers: dqf.sampleIds!.map(sampleId=>({ sampleId, studyId }))
+                        sampleIdentifiers: dqf.sampleIds!.map(sampleId => ({
+                            sampleId,
+                            studyId,
+                        })),
                     } as ClinicalAttributeCountFilter;
                 }
             } else {
                 // use sample identifiers
                 clinicalAttributeCountFilter = {
-                    sampleIdentifiers: this.samples.result!.map(sample=>({sampleId:sample.sampleId, studyId:sample.studyId}))
+                    sampleIdentifiers: this.samples.result!.map(sample => ({
+                        sampleId: sample.sampleId,
+                        studyId: sample.studyId,
+                    })),
                 } as ClinicalAttributeCountFilter;
             }
 
             const result = await client.getClinicalAttributeCountsUsingPOST({
-                clinicalAttributeCountFilter
+                clinicalAttributeCountFilter,
             });
             // build map
-            const ret:{[clinicalAttributeId:string]:number} = _.reduce(result, (map:{[clinicalAttributeId:string]:number}, next:ClinicalAttributeCount)=>{
-                map[next.clinicalAttributeId] = map[next.clinicalAttributeId] || 0;
-                map[next.clinicalAttributeId] += next.count;
-                return map;
-            }, {});
+            const ret: { [clinicalAttributeId: string]: number } = _.reduce(
+                result,
+                (
+                    map: { [clinicalAttributeId: string]: number },
+                    next: ClinicalAttributeCount
+                ) => {
+                    map[next.clinicalAttributeId] =
+                        map[next.clinicalAttributeId] || 0;
+                    map[next.clinicalAttributeId] += next.count;
+                    return map;
+                },
+                {}
+            );
             // add count = 0 for any remaining clinical attributes, since service doesnt return count 0
             for (const clinicalAttribute of this.clinicalAttributes.result!) {
                 if (!(clinicalAttribute.clinicalAttributeId in ret)) {
@@ -850,9 +1044,12 @@ export class ResultsViewPageStore {
                 }
             }
             // add counts for "special" clinical attributes
-            ret[SpecialAttribute.NumSamplesPerPatient] = this.samples.result!.length;
+            ret[
+                SpecialAttribute.NumSamplesPerPatient
+            ] = this.samples.result!.length;
             ret[SpecialAttribute.StudyOfOrigin] = this.samples.result!.length;
-            let samplesWithMutationData = 0, samplesWithCNAData = 0;
+            let samplesWithMutationData = 0,
+                samplesWithCNAData = 0;
             for (const sample of this.samples.result!) {
                 samplesWithMutationData += +!!sample.sequenced;
                 samplesWithCNAData += +!!sample.copyNumberSegmentPresent;
@@ -863,78 +1060,117 @@ export class ResultsViewPageStore {
                 ret[attr.clinicalAttributeId] = this.samples.result!.length;
             }
             // add counts for "ComparisonGroup" clinical attributes
-            for (const attr of this.clinicalAttributes_comparisonGroupMembership.result!) {
-                ret[attr.clinicalAttributeId] = getNumSamples(attr.comparisonGroup!.data);
+            for (const attr of this.clinicalAttributes_comparisonGroupMembership
+                .result!) {
+                ret[attr.clinicalAttributeId] = getNumSamples(
+                    attr.comparisonGroup!.data
+                );
             }
             return ret;
-        }
+        },
     });
 
-    readonly cnSegments = remoteData<CopyNumberSeg[]>({
-        await: () => [
-            this.samples
-        ],
-        invoke: () => fetchCopyNumberSegmentsForSamples(this.samples.result)
-    }, []);
+    readonly cnSegments = remoteData<CopyNumberSeg[]>(
+        {
+            await: () => [this.samples],
+            invoke: () =>
+                fetchCopyNumberSegmentsForSamples(this.samples.result),
+        },
+        []
+    );
 
-    readonly cnSegmentsByChromosome = remoteData<{ [chromosome: string]: MobxPromise<CopyNumberSeg[]> }>({
-        await: () => [
-            this.genes,
-            this.samples,
-            this.referenceGenes
-        ],
-        invoke: () => {
-            const uniqueReferenceGeneChromosomes = _.uniq(this.referenceGenes.result!.map(g => g.chromosome));
-            return Promise.resolve(uniqueReferenceGeneChromosomes.reduce(
-                (map: { [chromosome: string]: MobxPromise<CopyNumberSeg[]> }, chromosome: string) => {
-                    map[chromosome] = remoteData<CopyNumberSeg[]> ({
-                        invoke: () => fetchCopyNumberSegmentsForSamples(this.samples.result, chromosome)
-                    });
-                    return map;
-                },{}));
-        }
-    }, {});
-
+    readonly cnSegmentsByChromosome = remoteData<{
+        [chromosome: string]: MobxPromise<CopyNumberSeg[]>;
+    }>(
+        {
+            await: () => [this.genes, this.samples, this.referenceGenes],
+            invoke: () => {
+                const uniqueReferenceGeneChromosomes = _.uniq(
+                    this.referenceGenes.result!.map(g => g.chromosome)
+                );
+                return Promise.resolve(
+                    uniqueReferenceGeneChromosomes.reduce(
+                        (
+                            map: {
+                                [chromosome: string]: MobxPromise<
+                                    CopyNumberSeg[]
+                                >;
+                            },
+                            chromosome: string
+                        ) => {
+                            map[chromosome] = remoteData<CopyNumberSeg[]>({
+                                invoke: () =>
+                                    fetchCopyNumberSegmentsForSamples(
+                                        this.samples.result,
+                                        chromosome
+                                    ),
+                            });
+                            return map;
+                        },
+                        {}
+                    )
+                );
+            },
+        },
+        {}
+    );
 
     readonly molecularData = remoteData<NumericGeneMolecularData[]>({
         await: () => [
             this.studyToDataQueryFilter,
             this.genes,
             this.selectedMolecularProfiles,
-            this.samples
+            this.samples,
         ],
         invoke: () => {
             // we get mutations with mutations endpoint, all other alterations with this one, so filter out mutation genetic profile
-            const profilesWithoutMutationProfile = _.filter(this.selectedMolecularProfiles.result, (profile: MolecularProfile) => profile.molecularAlterationType !== 'MUTATION_EXTENDED');
+            const profilesWithoutMutationProfile = _.filter(
+                this.selectedMolecularProfiles.result,
+                (profile: MolecularProfile) =>
+                    profile.molecularAlterationType !== 'MUTATION_EXTENDED'
+            );
             const genes = this.genes.result;
 
-            if (profilesWithoutMutationProfile.length && genes != undefined && genes.length) {
+            if (
+                profilesWithoutMutationProfile.length &&
+                genes != undefined &&
+                genes.length
+            ) {
+                const identifiers: SampleMolecularIdentifier[] = [];
 
-                const identifiers : SampleMolecularIdentifier[] = [];
-
-                profilesWithoutMutationProfile.forEach((profile:MolecularProfile)=>{
-                    // for each profile, find samples which share studyId with profile and add identifier
-                    this.samples.result.forEach((sample:Sample)=>{
-                        if (sample.studyId === profile.studyId) {
-                            identifiers.push({ molecularProfileId:profile.molecularProfileId, sampleId:sample.sampleId })
-                        }
-                    });
-                });
+                profilesWithoutMutationProfile.forEach(
+                    (profile: MolecularProfile) => {
+                        // for each profile, find samples which share studyId with profile and add identifier
+                        this.samples.result.forEach((sample: Sample) => {
+                            if (sample.studyId === profile.studyId) {
+                                identifiers.push({
+                                    molecularProfileId:
+                                        profile.molecularProfileId,
+                                    sampleId: sample.sampleId,
+                                });
+                            }
+                        });
+                    }
+                );
 
                 if (identifiers.length) {
-                    return client.fetchMolecularDataInMultipleMolecularProfilesUsingPOST({
-                        projection:'DETAILED',
-                        molecularDataMultipleStudyFilter:({
-                            entrezGeneIds: _.map(this.genes.result,(gene:Gene)=>gene.entrezGeneId),
-                            sampleMolecularIdentifiers:identifiers
-                        } as MolecularDataMultipleStudyFilter)
-                    });
+                    return client.fetchMolecularDataInMultipleMolecularProfilesUsingPOST(
+                        {
+                            projection: 'DETAILED',
+                            molecularDataMultipleStudyFilter: {
+                                entrezGeneIds: _.map(
+                                    this.genes.result,
+                                    (gene: Gene) => gene.entrezGeneId
+                                ),
+                                sampleMolecularIdentifiers: identifiers,
+                            } as MolecularDataMultipleStudyFilter,
+                        }
+                    );
                 }
             }
 
             return Promise.resolve([]);
-
-        }
+        },
     });
 
     // other molecular profiles data download needs the data from non queried molecular profiles
@@ -943,126 +1179,200 @@ export class ResultsViewPageStore {
             this.studyToDataQueryFilter,
             this.genes,
             this.nonSelectedMolecularProfiles,
-            this.samples
+            this.samples,
         ],
         invoke: () => {
             // we get mutations with mutations endpoint, all other alterations with this one, so filter out mutation genetic profile
-            const profilesWithoutMutationProfile = _.filter(this.nonSelectedMolecularProfiles.result, (profile: MolecularProfile) => profile.molecularAlterationType !== AlterationTypeConstants.MUTATION_EXTENDED);
+            const profilesWithoutMutationProfile = _.filter(
+                this.nonSelectedMolecularProfiles.result,
+                (profile: MolecularProfile) =>
+                    profile.molecularAlterationType !==
+                    AlterationTypeConstants.MUTATION_EXTENDED
+            );
             const genes = this.genes.result;
 
-            if (profilesWithoutMutationProfile.length && genes != undefined && genes.length) {
-
-                const profilesWithoutMutationProfileGroupByStudyId = _.groupBy(profilesWithoutMutationProfile, (profile) => profile.studyId);
+            if (
+                profilesWithoutMutationProfile.length &&
+                genes != undefined &&
+                genes.length
+            ) {
+                const profilesWithoutMutationProfileGroupByStudyId = _.groupBy(
+                    profilesWithoutMutationProfile,
+                    profile => profile.studyId
+                );
                 // find samples which share studyId with profile and add identifier
-                const sampleIdentifiers : SampleMolecularIdentifier[] = this.samples.result.filter((sample)=> sample.studyId in profilesWithoutMutationProfileGroupByStudyId).reduce((acc: SampleMolecularIdentifier[], sample) => {
-                    acc = acc.concat(profilesWithoutMutationProfileGroupByStudyId[sample.studyId].map((profile) => {
-                        return { 'molecularProfileId':profile.molecularProfileId, 'sampleId':sample.sampleId } as SampleMolecularIdentifier;
-                    }));
-                    return acc;
-                },[]);
+                const sampleIdentifiers: SampleMolecularIdentifier[] = this.samples.result
+                    .filter(
+                        sample =>
+                            sample.studyId in
+                            profilesWithoutMutationProfileGroupByStudyId
+                    )
+                    .reduce((acc: SampleMolecularIdentifier[], sample) => {
+                        acc = acc.concat(
+                            profilesWithoutMutationProfileGroupByStudyId[
+                                sample.studyId
+                            ].map(profile => {
+                                return {
+                                    molecularProfileId:
+                                        profile.molecularProfileId,
+                                    sampleId: sample.sampleId,
+                                } as SampleMolecularIdentifier;
+                            })
+                        );
+                        return acc;
+                    }, []);
 
                 if (sampleIdentifiers.length) {
-                    return client.fetchMolecularDataInMultipleMolecularProfilesUsingPOST({
-                        projection:'DETAILED',
-                        molecularDataMultipleStudyFilter:({
-                            entrezGeneIds: _.map(this.genes.result,(gene:Gene)=>gene.entrezGeneId),
-                            sampleMolecularIdentifiers:sampleIdentifiers
-                        } as MolecularDataMultipleStudyFilter)
-                    });
+                    return client.fetchMolecularDataInMultipleMolecularProfilesUsingPOST(
+                        {
+                            projection: 'DETAILED',
+                            molecularDataMultipleStudyFilter: {
+                                entrezGeneIds: _.map(
+                                    this.genes.result,
+                                    (gene: Gene) => gene.entrezGeneId
+                                ),
+                                sampleMolecularIdentifiers: sampleIdentifiers,
+                            } as MolecularDataMultipleStudyFilter,
+                        }
+                    );
                 }
             }
 
             return Promise.resolve([]);
-
-        }
+        },
     });
 
     readonly coexpressionTabMolecularProfiles = remoteData<MolecularProfile[]>({
-        await:()=>[this.molecularProfilesWithData],
-        invoke:()=>Promise.resolve(sortRnaSeqProfilesToTop(filterAndSortProfiles(this.molecularProfilesWithData.result!).
-            concat(getGenesetProfiles(this.molecularProfilesWithData.result!))))
+        await: () => [this.molecularProfilesWithData],
+        invoke: () =>
+            Promise.resolve(
+                sortRnaSeqProfilesToTop(
+                    filterAndSortProfiles(
+                        this.molecularProfilesWithData.result!
+                    ).concat(
+                        getGenesetProfiles(
+                            this.molecularProfilesWithData.result!
+                        )
+                    )
+                )
+            ),
     });
 
     readonly isThereDataForCoExpressionTab = remoteData<boolean>({
-        await:()=>[this.molecularProfilesInStudies, this.genes, this.samples],
-        invoke:()=>{
-            const coExpressionProfiles = filterAndSortProfiles(this.molecularProfilesInStudies.result!);
-            const studyToProfiles = _.groupBy(coExpressionProfiles, "studyId");
+        await: () => [
+            this.molecularProfilesInStudies,
+            this.genes,
+            this.samples,
+        ],
+        invoke: () => {
+            const coExpressionProfiles = filterAndSortProfiles(
+                this.molecularProfilesInStudies.result!
+            );
+            const studyToProfiles = _.groupBy(coExpressionProfiles, 'studyId');
             // we know these are all mrna and protein profiles
             const sampleMolecularIdentifiers = _.flatten(
-                this.samples.result!.map(
-                    s=>{
-                        const profiles = studyToProfiles[s.studyId];
-                        if (profiles) {
-                            return profiles.map(p=>({ molecularProfileId: p.molecularProfileId, sampleId: s.sampleId }));
-                        } else {
-                            return [];
-                        }
+                this.samples.result!.map(s => {
+                    const profiles = studyToProfiles[s.studyId];
+                    if (profiles) {
+                        return profiles.map(p => ({
+                            molecularProfileId: p.molecularProfileId,
+                            sampleId: s.sampleId,
+                        }));
+                    } else {
+                        return [];
                     }
-                )
+                })
             );
-            const entrezGeneIds = this.genes.result!.map(g=>g.entrezGeneId);
-            if (sampleMolecularIdentifiers.length > 0 &&
-                entrezGeneIds.length > 0) {
-                return client.fetchMolecularDataInMultipleMolecularProfilesUsingPOSTWithHttpInfo({
-                    molecularDataMultipleStudyFilter:{
-                        entrezGeneIds,
-                        sampleMolecularIdentifiers
-                    } as MolecularDataMultipleStudyFilter,
-                    projection:"META"
-                }).then(function(response: request.Response) {
-                    const count = parseInt(response.header["total-count"], 10);
-                    return count > 0;
-                });
+            const entrezGeneIds = this.genes.result!.map(g => g.entrezGeneId);
+            if (
+                sampleMolecularIdentifiers.length > 0 &&
+                entrezGeneIds.length > 0
+            ) {
+                return client
+                    .fetchMolecularDataInMultipleMolecularProfilesUsingPOSTWithHttpInfo(
+                        {
+                            molecularDataMultipleStudyFilter: {
+                                entrezGeneIds,
+                                sampleMolecularIdentifiers,
+                            } as MolecularDataMultipleStudyFilter,
+                            projection: 'META',
+                        }
+                    )
+                    .then(function(response: request.Response) {
+                        const count = parseInt(
+                            response.header['total-count'],
+                            10
+                        );
+                        return count > 0;
+                    });
             } else {
                 return Promise.resolve(false);
             }
-        }
+        },
     });
 
     readonly molecularProfilesWithData = remoteData<MolecularProfile[]>({
-        await:()=>[
+        await: () => [
             this.molecularProfilesInStudies,
             this.studyToDataQueryFilter,
             this.genes,
             this.genesets,
-            this.treatmentsInStudies
+            this.treatmentsInStudies,
         ],
-        invoke:async()=>{
-            const ret:MolecularProfile[] = [];
+        invoke: async () => {
+            const ret: MolecularProfile[] = [];
             const promises = [];
             const studyToDataQueryFilter = this.studyToDataQueryFilter.result!;
             for (const profile of this.molecularProfilesInStudies.result!) {
                 const dataQueryFilter = studyToDataQueryFilter[profile.studyId];
 
                 // there could be no samples if a study doesn't have a sample list matching a specified category (e.g. cna only)
-                if (!dataQueryFilter || (!dataQueryFilter.sampleIds && !dataQueryFilter.sampleListId)) {
+                if (
+                    !dataQueryFilter ||
+                    (!dataQueryFilter.sampleIds &&
+                        !dataQueryFilter.sampleListId)
+                ) {
                     continue;
                 }
 
                 const molecularProfileId = profile.molecularProfileId;
-                const projection = "META";
+                const projection = 'META';
                 const dataFilter = {
-                    entrezGeneIds: this.genes.result!.map(g=>g.entrezGeneId),
-                    ...dataQueryFilter
+                    entrezGeneIds: this.genes.result!.map(g => g.entrezGeneId),
+                    ...dataQueryFilter,
                 } as MolecularDataFilter & MutationFilter;
 
-                if (profile.molecularAlterationType === AlterationTypeConstants.MUTATION_EXTENDED) {
+                if (
+                    profile.molecularAlterationType ===
+                    AlterationTypeConstants.MUTATION_EXTENDED
+                ) {
                     // handle mutation profile
-                    promises.push(client.fetchMutationsInMolecularProfileUsingPOSTWithHttpInfo({
-                        molecularProfileId,
-                        mutationFilter: dataFilter,
-                        projection
-                    }).then(function(response: request.Response) {
-                        const count = parseInt(response.header["sample-count"], 10);
-                        if (count > 0) {
-                            // theres data for at least one of the query genes
-                            ret.push(profile);
-                        }
-                    }));
-                } else if (profile.molecularAlterationType === AlterationTypeConstants.GENESET_SCORE
-                            || profile.molecularAlterationType === AlterationTypeConstants.GENERIC_ASSAY
-                    ) {
+                    promises.push(
+                        client
+                            .fetchMutationsInMolecularProfileUsingPOSTWithHttpInfo(
+                                {
+                                    molecularProfileId,
+                                    mutationFilter: dataFilter,
+                                    projection,
+                                }
+                            )
+                            .then(function(response: request.Response) {
+                                const count = parseInt(
+                                    response.header['sample-count'],
+                                    10
+                                );
+                                if (count > 0) {
+                                    // theres data for at least one of the query genes
+                                    ret.push(profile);
+                                }
+                            })
+                    );
+                } else if (
+                    profile.molecularAlterationType ===
+                        AlterationTypeConstants.GENESET_SCORE ||
+                    profile.molecularAlterationType ===
+                        AlterationTypeConstants.GENERIC_ASSAY
+                ) {
                     // geneset profile, we dont have the META projection for geneset data, so just add it
                     /*promises.push(internalClient.fetchGeneticDataItemsUsingPOST({
                         geneticProfileId: molecularProfileId,
@@ -1081,135 +1391,191 @@ export class ResultsViewPageStore {
                     ret.push(profile);
                 } else {
                     // handle non-mutation profile
-                    promises.push(client.fetchAllMolecularDataInMolecularProfileUsingPOSTWithHttpInfo({
-                        molecularProfileId,
-                        molecularDataFilter: dataFilter,
-                        projection
-                    }).then(function(response: request.Response) {
-                        const count = parseInt(response.header["total-count"], 10);
-                        if (count > 0) {
-                            // theres data for at least one of the query genes
-                            ret.push(profile);
-                        }
-                    }));
+                    promises.push(
+                        client
+                            .fetchAllMolecularDataInMolecularProfileUsingPOSTWithHttpInfo(
+                                {
+                                    molecularProfileId,
+                                    molecularDataFilter: dataFilter,
+                                    projection,
+                                }
+                            )
+                            .then(function(response: request.Response) {
+                                const count = parseInt(
+                                    response.header['total-count'],
+                                    10
+                                );
+                                if (count > 0) {
+                                    // theres data for at least one of the query genes
+                                    ret.push(profile);
+                                }
+                            })
+                    );
                 }
             }
             await Promise.all(promises);
             return ret;
-        }
+        },
     });
 
     readonly nonOqlFilteredAlterations = remoteData<ExtendedAlteration[]>({
-        await: ()=>[
+        await: () => [
             this.filteredAndAnnotatedMutations,
             this.filteredAndAnnotatedMolecularData,
             this.selectedMolecularProfiles,
-            this.entrezGeneIdToGene
+            this.entrezGeneIdToGene,
         ],
-        invoke: ()=>{
-            const accessors = new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!);
+        invoke: () => {
+            const accessors = new AccessorsForOqlFilter(
+                this.selectedMolecularProfiles.result!
+            );
             const entrezGeneIdToGene = this.entrezGeneIdToGene.result!;
-            let result:(AnnotatedMutation|AnnotatedNumericGeneMolecularData)[] = [];
+            let result: (
+                | AnnotatedMutation
+                | AnnotatedNumericGeneMolecularData)[] = [];
             result = result.concat(this.filteredAndAnnotatedMutations.result!);
-            result = result.concat(this.filteredAndAnnotatedMolecularData.result!);
-            return Promise.resolve(result.map(d=>{
-                const extendedD:ExtendedAlteration = annotateAlterationTypes(d, accessors);
-                extendedD.hugoGeneSymbol = entrezGeneIdToGene[d.entrezGeneId].hugoGeneSymbol;
-                extendedD.molecularProfileAlterationType = accessors.molecularAlterationType(d.molecularProfileId);
-                return extendedD;
-            }));
-        }
+            result = result.concat(
+                this.filteredAndAnnotatedMolecularData.result!
+            );
+            return Promise.resolve(
+                result.map(d => {
+                    const extendedD: ExtendedAlteration = annotateAlterationTypes(
+                        d,
+                        accessors
+                    );
+                    extendedD.hugoGeneSymbol =
+                        entrezGeneIdToGene[d.entrezGeneId].hugoGeneSymbol;
+                    extendedD.molecularProfileAlterationType = accessors.molecularAlterationType(
+                        d.molecularProfileId
+                    );
+                    return extendedD;
+                })
+            );
+        },
     });
 
     readonly oqlFilteredMutationsReport = remoteData({
-        await:()=>[
+        await: () => [
             this._filteredAndAnnotatedMutationsReport,
             this.selectedMolecularProfiles,
-            this.defaultOQLQuery
+            this.defaultOQLQuery,
         ],
-        invoke:()=>{
-            return Promise.resolve(_.mapValues(
-                this._filteredAndAnnotatedMutationsReport.result!,
-                data=>filterCBioPortalWebServiceData(
-                    this.rvQuery.oqlQuery,
-                    data,
-                    (new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!)),
-                    this.defaultOQLQuery.result!
+        invoke: () => {
+            return Promise.resolve(
+                _.mapValues(
+                    this._filteredAndAnnotatedMutationsReport.result!,
+                    data =>
+                        filterCBioPortalWebServiceData(
+                            this.rvQuery.oqlQuery,
+                            data,
+                            new AccessorsForOqlFilter(
+                                this.selectedMolecularProfiles.result!
+                            ),
+                            this.defaultOQLQuery.result!
+                        )
                 )
-            ));
-        }
+            );
+        },
     });
 
     readonly oqlFilteredMolecularDataReport = remoteData({
-        await:()=>[
+        await: () => [
             this._filteredAndAnnotatedMolecularDataReport,
             this.selectedMolecularProfiles,
-            this.defaultOQLQuery
+            this.defaultOQLQuery,
         ],
-        invoke:()=>{
-            return Promise.resolve(_.mapValues(
-                this._filteredAndAnnotatedMolecularDataReport.result!,
-                data=>filterCBioPortalWebServiceData(
-                    this.rvQuery.oqlQuery,
-                    data,
-                    (new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!)),
-                    this.defaultOQLQuery.result!
+        invoke: () => {
+            return Promise.resolve(
+                _.mapValues(
+                    this._filteredAndAnnotatedMolecularDataReport.result!,
+                    data =>
+                        filterCBioPortalWebServiceData(
+                            this.rvQuery.oqlQuery,
+                            data,
+                            new AccessorsForOqlFilter(
+                                this.selectedMolecularProfiles.result!
+                            ),
+                            this.defaultOQLQuery.result!
+                        )
                 )
-            ));
-        }
+            );
+        },
     });
 
     readonly oqlFilteredAlterations = remoteData<ExtendedAlteration[]>({
-        await:()=>[
+        await: () => [
             this.filteredAndAnnotatedMutations,
             this.filteredAndAnnotatedMolecularData,
             this.selectedMolecularProfiles,
-            this.defaultOQLQuery
+            this.defaultOQLQuery,
         ],
-        invoke:()=>{
-            if (this.rvQuery.oqlQuery.trim() != "") {
-                let data:(AnnotatedMutation|AnnotatedNumericGeneMolecularData)[] = [];
+        invoke: () => {
+            if (this.rvQuery.oqlQuery.trim() != '') {
+                let data: (
+                    | AnnotatedMutation
+                    | AnnotatedNumericGeneMolecularData)[] = [];
                 data = data.concat(this.filteredAndAnnotatedMutations.result!);
-                data = data.concat(this.filteredAndAnnotatedMolecularData.result!);
+                data = data.concat(
+                    this.filteredAndAnnotatedMolecularData.result!
+                );
                 return Promise.resolve(
-                    filterCBioPortalWebServiceData(this.rvQuery.oqlQuery, data, (new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!)), this.defaultOQLQuery.result!)
+                    filterCBioPortalWebServiceData(
+                        this.rvQuery.oqlQuery,
+                        data,
+                        new AccessorsForOqlFilter(
+                            this.selectedMolecularProfiles.result!
+                        ),
+                        this.defaultOQLQuery.result!
+                    )
                 );
             } else {
                 return Promise.resolve([]);
             }
-        }
+        },
     });
 
-    readonly oqlFilteredCaseAggregatedData = remoteData<CaseAggregatedData<ExtendedAlteration>>({
-        await: ()=>[
-            this.oqlFilteredAlterations,
-            this.samples,
-            this.patients
-        ],
-        invoke: ()=>{
+    readonly oqlFilteredCaseAggregatedData = remoteData<
+        CaseAggregatedData<ExtendedAlteration>
+    >({
+        await: () => [this.oqlFilteredAlterations, this.samples, this.patients],
+        invoke: () => {
             return Promise.resolve({
-                samples:
-                    groupBy(this.oqlFilteredAlterations.result!, alteration=>alteration.uniqueSampleKey, this.samples.result!.map(sample=>sample.uniqueSampleKey)),
-                patients:
-                    groupBy(this.oqlFilteredAlterations.result!, alteration=>alteration.uniquePatientKey, this.patients.result!.map(sample=>sample.uniquePatientKey))
+                samples: groupBy(
+                    this.oqlFilteredAlterations.result!,
+                    alteration => alteration.uniqueSampleKey,
+                    this.samples.result!.map(sample => sample.uniqueSampleKey)
+                ),
+                patients: groupBy(
+                    this.oqlFilteredAlterations.result!,
+                    alteration => alteration.uniquePatientKey,
+                    this.patients.result!.map(sample => sample.uniquePatientKey)
+                ),
             });
-        }
+        },
     });
 
-    readonly nonOqlFilteredCaseAggregatedData = remoteData<CaseAggregatedData<ExtendedAlteration>>({
-        await: ()=>[
+    readonly nonOqlFilteredCaseAggregatedData = remoteData<
+        CaseAggregatedData<ExtendedAlteration>
+    >({
+        await: () => [
             this.nonOqlFilteredAlterations,
             this.samples,
-            this.patients
+            this.patients,
         ],
-        invoke: ()=>{
+        invoke: () => {
             return Promise.resolve({
-                samples:
-                    groupBy(this.nonOqlFilteredAlterations.result!, alteration=>alteration.uniqueSampleKey, this.samples.result!.map(sample=>sample.uniqueSampleKey)),
-                patients:
-                    groupBy(this.nonOqlFilteredAlterations.result!, alteration=>alteration.uniquePatientKey, this.patients.result!.map(sample=>sample.uniquePatientKey))
+                samples: groupBy(
+                    this.nonOqlFilteredAlterations.result!,
+                    alteration => alteration.uniqueSampleKey,
+                    this.samples.result!.map(sample => sample.uniqueSampleKey)
+                ),
+                patients: groupBy(
+                    this.nonOqlFilteredAlterations.result!,
+                    alteration => alteration.uniquePatientKey,
+                    this.patients.result!.map(sample => sample.uniquePatientKey)
+                ),
             });
-        }
+        },
     });
 
     readonly oqlFilteredCaseAggregatedDataByUnflattenedOQLLine = remoteData<
@@ -1221,11 +1587,16 @@ export class ResultsViewPageStore {
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
             this.samples,
-            this.patients
+            this.patients,
         ],
         invoke: () => {
-            const data = [...(this.filteredAndAnnotatedMutations.result!), ...(this.filteredAndAnnotatedMolecularData.result!)];
-            const accessorsInstance = new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!);
+            const data = [
+                ...this.filteredAndAnnotatedMutations.result!,
+                ...this.filteredAndAnnotatedMolecularData.result!,
+            ];
+            const accessorsInstance = new AccessorsForOqlFilter(
+                this.selectedMolecularProfiles.result!
+            );
             const defaultOQLQuery = this.defaultOQLQuery.result!;
             const samples = this.samples.result!;
             const patients = this.patients.result!;
@@ -1233,447 +1604,647 @@ export class ResultsViewPageStore {
             if (this.rvQuery.oqlQuery.trim() === '') {
                 return Promise.resolve([]);
             } else {
-                const filteredAlterationsByOQLLine: UnflattenedOQLLineFilterOutput<AnnotatedExtendedAlteration>[] = (
-                    filterCBioPortalWebServiceDataByUnflattenedOQLLine(
-                        this.rvQuery.oqlQuery,
-                        data,
-                        accessorsInstance,
-                        defaultOQLQuery
-                    )
+                const filteredAlterationsByOQLLine: UnflattenedOQLLineFilterOutput<
+                    AnnotatedExtendedAlteration
+                >[] = filterCBioPortalWebServiceDataByUnflattenedOQLLine(
+                    this.rvQuery.oqlQuery,
+                    data,
+                    accessorsInstance,
+                    defaultOQLQuery
                 );
 
-                return Promise.resolve(filteredAlterationsByOQLLine.map(
-                    (oqlLine) => ({
+                return Promise.resolve(
+                    filteredAlterationsByOQLLine.map(oqlLine => ({
                         cases: groupDataByCase(oqlLine, samples, patients),
                         oql: oqlLine,
                         mergedTrackOqlList: filterSubQueryData(
-                            oqlLine, defaultOQLQuery,
-                            data, accessorsInstance,
-                            samples, patients
-                        )
-                    })
-                ));
+                            oqlLine,
+                            defaultOQLQuery,
+                            data,
+                            accessorsInstance,
+                            samples,
+                            patients
+                        ),
+                    }))
+                );
             }
-        }
+        },
     });
-
 
     readonly isSampleAlteredMap = remoteData({
-        await: () => [this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine, this.samples, this.coverageInformation, this.selectedMolecularProfiles, this.studyToMolecularProfiles],
-        invoke: async() => {
-            return getSampleAlteredMap(this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine.result!, this.samples.result, this.rvQuery.oqlQuery, this.coverageInformation.result, this.selectedMolecularProfiles.result!.map((profile) => profile.molecularProfileId), this.studyToMolecularProfiles.result!);
-        }
+        await: () => [
+            this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine,
+            this.samples,
+            this.coverageInformation,
+            this.selectedMolecularProfiles,
+            this.studyToMolecularProfiles,
+        ],
+        invoke: async () => {
+            return getSampleAlteredMap(
+                this.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine.result!,
+                this.samples.result,
+                this.rvQuery.oqlQuery,
+                this.coverageInformation.result,
+                this.selectedMolecularProfiles.result!.map(
+                    profile => profile.molecularProfileId
+                ),
+                this.studyToMolecularProfiles.result!
+            );
+        },
     });
 
-    readonly oqlFilteredCaseAggregatedDataByOQLLine = remoteData<IQueriedCaseData<AnnotatedExtendedAlteration>[]>({
-        await:()=>[
+    readonly oqlFilteredCaseAggregatedDataByOQLLine = remoteData<
+        IQueriedCaseData<AnnotatedExtendedAlteration>[]
+    >({
+        await: () => [
             this.filteredAndAnnotatedMutations,
             this.filteredAndAnnotatedMolecularData,
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
             this.samples,
-            this.patients
+            this.patients,
         ],
         invoke: () => {
             if (this.rvQuery.oqlQuery.trim() === '') {
                 return Promise.resolve([]);
             } else {
-                const filteredAlterationsByOQLLine:OQLLineFilterOutput<AnnotatedExtendedAlteration>[] = filterCBioPortalWebServiceDataByOQLLine(
+                const filteredAlterationsByOQLLine: OQLLineFilterOutput<
+                    AnnotatedExtendedAlteration
+                >[] = filterCBioPortalWebServiceDataByOQLLine(
                     this.rvQuery.oqlQuery,
-                    [...(this.filteredAndAnnotatedMutations.result!), ...(this.filteredAndAnnotatedMolecularData.result!)],
-                    (new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!)),
+                    [
+                        ...this.filteredAndAnnotatedMutations.result!,
+                        ...this.filteredAndAnnotatedMolecularData.result!,
+                    ],
+                    new AccessorsForOqlFilter(
+                        this.selectedMolecularProfiles.result!
+                    ),
                     this.defaultOQLQuery.result!
                 );
 
-                return Promise.resolve(filteredAlterationsByOQLLine.map(
-                    (oql) => ({
-                        cases: groupDataByCase(oql, this.samples.result!, this.patients.result!),
-                        oql
-                    })
-                ));
+                return Promise.resolve(
+                    filteredAlterationsByOQLLine.map(oql => ({
+                        cases: groupDataByCase(
+                            oql,
+                            this.samples.result!,
+                            this.patients.result!
+                        ),
+                        oql,
+                    }))
+                );
             }
-        }
+        },
     });
 
     readonly studyToMolecularProfiles = remoteData({
-        await:()=>[this.molecularProfilesInStudies],
-        invoke:()=>{
-            return Promise.resolve(_.groupBy(this.molecularProfilesInStudies.result!, profile=>profile.studyId));
-        }
+        await: () => [this.molecularProfilesInStudies],
+        invoke: () => {
+            return Promise.resolve(
+                _.groupBy(
+                    this.molecularProfilesInStudies.result!,
+                    profile => profile.studyId
+                )
+            );
+        },
     });
 
-    readonly coverageInformation = remoteData<CoverageInformation>({
-        await:()=>[
-            this.studyToMolecularProfiles,
-            this.genes,
-            this.samples,
-            this.patients
-        ],
-        invoke:async()=>{
-            //const studyToMolecularProfiles = _.groupBy(this.studyToMolecularProfiles.result!, profile=>profile.studyId);
-            const sampleMolecularIdentifiers:SampleMolecularIdentifier[] = [];
-            this.samples.result!.forEach(sample=>{
-                const profiles = this.studyToMolecularProfiles.result![sample.studyId];
-                if (profiles) {
-                    const sampleId = sample.sampleId;
-                    for (const profile of profiles) {
-                        sampleMolecularIdentifiers.push({
-                            molecularProfileId: profile.molecularProfileId,
-                            sampleId
-                        });
+    readonly coverageInformation = remoteData<CoverageInformation>(
+        {
+            await: () => [
+                this.studyToMolecularProfiles,
+                this.genes,
+                this.samples,
+                this.patients,
+            ],
+            invoke: async () => {
+                //const studyToMolecularProfiles = _.groupBy(this.studyToMolecularProfiles.result!, profile=>profile.studyId);
+                const sampleMolecularIdentifiers: SampleMolecularIdentifier[] = [];
+                this.samples.result!.forEach(sample => {
+                    const profiles = this.studyToMolecularProfiles.result![
+                        sample.studyId
+                    ];
+                    if (profiles) {
+                        const sampleId = sample.sampleId;
+                        for (const profile of profiles) {
+                            sampleMolecularIdentifiers.push({
+                                molecularProfileId: profile.molecularProfileId,
+                                sampleId,
+                            });
+                        }
                     }
+                });
+                let genePanelData: GenePanelData[];
+                if (
+                    sampleMolecularIdentifiers.length &&
+                    this.genes.result!.length
+                ) {
+                    genePanelData = await client.fetchGenePanelDataInMultipleMolecularProfilesUsingPOST(
+                        {
+                            sampleMolecularIdentifiers: sampleMolecularIdentifiers,
+                        }
+                    );
+                } else {
+                    genePanelData = [];
                 }
-            });
-            let genePanelData:GenePanelData[];
-            if (sampleMolecularIdentifiers.length && this.genes.result!.length) {
-                genePanelData = await client.fetchGenePanelDataInMultipleMolecularProfilesUsingPOST({
-                    sampleMolecularIdentifiers:
-                        sampleMolecularIdentifiers
-                });
-            } else {
-                genePanelData = [];
-            }
 
-            const genePanelIds = _.uniq(genePanelData.map(gpData=>gpData.genePanelId).filter(id=>!!id));
-            let genePanels:GenePanel[] = [];
-            if (genePanelIds.length) {
-                genePanels = await client.fetchGenePanelsUsingPOST({
-                    genePanelIds,
-                    projection:"DETAILED"
-                });
-            }
-            return computeGenePanelInformation(genePanelData, genePanels, this.samples.result!, this.patients.result!, this.genes.result!);
-        }
-    }, { samples: {}, patients: {} });
+                const genePanelIds = _.uniq(
+                    genePanelData
+                        .map(gpData => gpData.genePanelId)
+                        .filter(id => !!id)
+                );
+                let genePanels: GenePanel[] = [];
+                if (genePanelIds.length) {
+                    genePanels = await client.fetchGenePanelsUsingPOST({
+                        genePanelIds,
+                        projection: 'DETAILED',
+                    });
+                }
+                return computeGenePanelInformation(
+                    genePanelData,
+                    genePanels,
+                    this.samples.result!,
+                    this.patients.result!,
+                    this.genes.result!
+                );
+            },
+        },
+        { samples: {}, patients: {} }
+    );
 
     readonly sequencedSampleKeys = remoteData<string[]>({
-        await:()=>[
+        await: () => [
             this.samples,
             this.coverageInformation,
-            this.selectedMolecularProfiles
+            this.selectedMolecularProfiles,
         ],
-        invoke:()=>{
+        invoke: () => {
             const genePanelInformation = this.coverageInformation.result!;
-            const profileIds = this.selectedMolecularProfiles.result!.map(p=>p.molecularProfileId);
-            return Promise.resolve(_.chain(this.samples.result!).filter(sample=>{
-                return _.some(isSampleProfiledInMultiple(sample.uniqueSampleKey, profileIds, genePanelInformation));
-            }).map(s=>s.uniqueSampleKey).value());
-        }
+            const profileIds = this.selectedMolecularProfiles.result!.map(
+                p => p.molecularProfileId
+            );
+            return Promise.resolve(
+                _.chain(this.samples.result!)
+                    .filter(sample => {
+                        return _.some(
+                            isSampleProfiledInMultiple(
+                                sample.uniqueSampleKey,
+                                profileIds,
+                                genePanelInformation
+                            )
+                        );
+                    })
+                    .map(s => s.uniqueSampleKey)
+                    .value()
+            );
+        },
     });
 
     readonly sequencedPatientKeys = remoteData<string[]>({
-        await:()=>[
-            this.sampleKeyToSample,
-            this.sequencedSampleKeys
-        ],
-        invoke:async()=>{
+        await: () => [this.sampleKeyToSample, this.sequencedSampleKeys],
+        invoke: async () => {
             const sampleKeyToSample = this.sampleKeyToSample.result!;
-            return _.chain(this.sequencedSampleKeys.result!).map(k=>sampleKeyToSample[k].uniquePatientKey).uniq().value();
-        }
+            return _.chain(this.sequencedSampleKeys.result!)
+                .map(k => sampleKeyToSample[k].uniquePatientKey)
+                .uniq()
+                .value();
+        },
     });
 
-    readonly sequencedSampleKeysByGene = remoteData<{[hugoGeneSymbol:string]:string[]}>({
-        await: ()=>[
+    readonly sequencedSampleKeysByGene = remoteData<{
+        [hugoGeneSymbol: string]: string[];
+    }>({
+        await: () => [
             this.samples,
             this.genes,
             this.coverageInformation,
-            this.selectedMolecularProfiles
+            this.selectedMolecularProfiles,
         ],
-        invoke:()=>{
+        invoke: () => {
             const genePanelInformation = this.coverageInformation.result!;
-            const profileIds = this.selectedMolecularProfiles.result!.map(p=>p.molecularProfileId);
-            return Promise.resolve(this.genes.result!.reduce((map:{[hugoGeneSymbol:string]:string[]}, next:Gene)=>{
-                map[next.hugoGeneSymbol] = this.samples.result!.map(s=>s.uniqueSampleKey).filter(k=>{
-                    return _.some(isSampleProfiledInMultiple(k, profileIds, genePanelInformation, next.hugoGeneSymbol));
-                });
-                return map;
-            }, {}));
-        }
+            const profileIds = this.selectedMolecularProfiles.result!.map(
+                p => p.molecularProfileId
+            );
+            return Promise.resolve(
+                this.genes.result!.reduce(
+                    (
+                        map: { [hugoGeneSymbol: string]: string[] },
+                        next: Gene
+                    ) => {
+                        map[next.hugoGeneSymbol] = this.samples
+                            .result!.map(s => s.uniqueSampleKey)
+                            .filter(k => {
+                                return _.some(
+                                    isSampleProfiledInMultiple(
+                                        k,
+                                        profileIds,
+                                        genePanelInformation,
+                                        next.hugoGeneSymbol
+                                    )
+                                );
+                            });
+                        return map;
+                    },
+                    {}
+                )
+            );
+        },
     });
 
     readonly existUnsequencedSamplesInAGene = remoteData<boolean>({
-        await:()=>[this.samples, this.sequencedSampleKeysByGene],
-        invoke:()=>{
+        await: () => [this.samples, this.sequencedSampleKeysByGene],
+        invoke: () => {
             const totalSamples = this.samples.result!.length;
             return Promise.resolve(
-                _.some(this.sequencedSampleKeysByGene.result!, sampleKeys=>{
+                _.some(this.sequencedSampleKeysByGene.result!, sampleKeys => {
                     return sampleKeys.length < totalSamples;
                 })
             );
-        }
+        },
     });
 
-    readonly sequencedPatientKeysByGene = remoteData<{[hugoGeneSymbol:string]:string[]}>({
-        await: ()=>[
-            this.sampleKeyToSample,
-            this.sequencedSampleKeysByGene
-        ],
-        invoke:async()=>{
+    readonly sequencedPatientKeysByGene = remoteData<{
+        [hugoGeneSymbol: string]: string[];
+    }>({
+        await: () => [this.sampleKeyToSample, this.sequencedSampleKeysByGene],
+        invoke: async () => {
             const sampleKeyToSample = this.sampleKeyToSample.result!;
-            return _.mapValues(this.sequencedSampleKeysByGene.result!, sampleKeys=>{
-                return _.chain(sampleKeys).map(k=>sampleKeyToSample[k].uniquePatientKey).uniq().value();
-            });
-        }
+            return _.mapValues(
+                this.sequencedSampleKeysByGene.result!,
+                sampleKeys => {
+                    return _.chain(sampleKeys)
+                        .map(k => sampleKeyToSample[k].uniquePatientKey)
+                        .uniq()
+                        .value();
+                }
+            );
+        },
     });
 
     readonly alteredSampleKeys = remoteData({
-        await:()=>[
-            this.samples,
-            this.oqlFilteredCaseAggregatedData
-        ],
-        invoke:()=>{
-            const caseAggregatedData = this.oqlFilteredCaseAggregatedData.result!.samples;
+        await: () => [this.samples, this.oqlFilteredCaseAggregatedData],
+        invoke: () => {
+            const caseAggregatedData = this.oqlFilteredCaseAggregatedData
+                .result!.samples;
             return Promise.resolve(
-                this.samples.result!.map(s=>s.uniqueSampleKey).filter(sampleKey=>{
-                    return caseAggregatedData[sampleKey].length > 0;
-                })
+                this.samples
+                    .result!.map(s => s.uniqueSampleKey)
+                    .filter(sampleKey => {
+                        return caseAggregatedData[sampleKey].length > 0;
+                    })
             );
-        }
+        },
     });
 
-    readonly alteredSamples = remoteData<Sample[]>({
-        await: () => [
-            this.sampleKeyToSample,
-            this.alteredSampleKeys
-        ],
-        invoke: () => {
-            return Promise.resolve(this.alteredSampleKeys.result!.map(a => this.sampleKeyToSample.result![a]));
-        }
-    }, []);
+    readonly alteredSamples = remoteData<Sample[]>(
+        {
+            await: () => [this.sampleKeyToSample, this.alteredSampleKeys],
+            invoke: () => {
+                return Promise.resolve(
+                    this.alteredSampleKeys.result!.map(
+                        a => this.sampleKeyToSample.result![a]
+                    )
+                );
+            },
+        },
+        []
+    );
 
     readonly alteredPatients = remoteData({
-        await:()=>[
-            this.patients,
-            this.oqlFilteredCaseAggregatedData
-        ],
-        invoke:()=>{
-            const caseAggregatedData = this.oqlFilteredCaseAggregatedData.result!;
+        await: () => [this.patients, this.oqlFilteredCaseAggregatedData],
+        invoke: () => {
+            const caseAggregatedData = this.oqlFilteredCaseAggregatedData
+                .result!;
             return Promise.resolve(
-                this.patients.result!.filter(patient=>!!caseAggregatedData.patients[patient.uniquePatientKey].length)
+                this.patients.result!.filter(
+                    patient =>
+                        !!caseAggregatedData.patients[patient.uniquePatientKey]
+                            .length
+                )
             );
-        }
+        },
     });
 
     readonly alteredPatientKeys = remoteData({
-        await:()=>[this.alteredPatients],
-        invoke:()=>Promise.resolve(this.alteredPatients.result!.map(p=>p.uniquePatientKey))
+        await: () => [this.alteredPatients],
+        invoke: () =>
+            Promise.resolve(
+                this.alteredPatients.result!.map(p => p.uniquePatientKey)
+            ),
     });
 
     readonly unalteredSampleKeys = remoteData({
-        await:()=>[
-            this.samples,
-            this.oqlFilteredCaseAggregatedData
-        ],
-        invoke:()=>{
-            const caseAggregatedData = this.oqlFilteredCaseAggregatedData.result!;
+        await: () => [this.samples, this.oqlFilteredCaseAggregatedData],
+        invoke: () => {
+            const caseAggregatedData = this.oqlFilteredCaseAggregatedData
+                .result!;
             return Promise.resolve(
-                this.samples.result!.map(s=>s.uniqueSampleKey).filter(sampleKey=>!caseAggregatedData.samples[sampleKey].length)
+                this.samples
+                    .result!.map(s => s.uniqueSampleKey)
+                    .filter(
+                        sampleKey =>
+                            !caseAggregatedData.samples[sampleKey].length
+                    )
             );
-        }
+        },
     });
 
-    readonly unalteredSamples = remoteData<Sample[]>({
-        await: () => [
-            this.sampleKeyToSample,
-            this.unalteredSampleKeys
-        ],
-        invoke: () => {
-            const unalteredSamples: Sample[] = [];
-            this.unalteredSampleKeys.result!.forEach(a => unalteredSamples.push(this.sampleKeyToSample.result![a]));
-            return Promise.resolve(unalteredSamples);
-        }
-    }, []);
+    readonly unalteredSamples = remoteData<Sample[]>(
+        {
+            await: () => [this.sampleKeyToSample, this.unalteredSampleKeys],
+            invoke: () => {
+                const unalteredSamples: Sample[] = [];
+                this.unalteredSampleKeys.result!.forEach(a =>
+                    unalteredSamples.push(this.sampleKeyToSample.result![a])
+                );
+                return Promise.resolve(unalteredSamples);
+            },
+        },
+        []
+    );
 
     readonly unalteredPatientKeys = remoteData({
-        await:()=>[this.unalteredPatients],
-        invoke:()=>Promise.resolve(this.unalteredPatients.result!.map(p=>p.uniquePatientKey))
+        await: () => [this.unalteredPatients],
+        invoke: () =>
+            Promise.resolve(
+                this.unalteredPatients.result!.map(p => p.uniquePatientKey)
+            ),
     });
 
     readonly unalteredPatients = remoteData({
-        await:()=>[
-            this.patients,
-            this.oqlFilteredCaseAggregatedData
-        ],
-        invoke:()=>{
-            const caseAggregatedData = this.oqlFilteredCaseAggregatedData.result!;
+        await: () => [this.patients, this.oqlFilteredCaseAggregatedData],
+        invoke: () => {
+            const caseAggregatedData = this.oqlFilteredCaseAggregatedData
+                .result!;
             return Promise.resolve(
-                this.patients.result!.filter(patient=>!caseAggregatedData.patients[patient.uniquePatientKey].length)
+                this.patients.result!.filter(
+                    patient =>
+                        !caseAggregatedData.patients[patient.uniquePatientKey]
+                            .length
+                )
             );
-        }
+        },
     });
 
-    readonly oqlFilteredAlterationsByGene = remoteData<{[hugoGeneSymbol:string]:ExtendedAlteration[]}>({
-        await: () => [
-            this.genes,
-            this.oqlFilteredAlterations
-        ],
+    readonly oqlFilteredAlterationsByGene = remoteData<{
+        [hugoGeneSymbol: string]: ExtendedAlteration[];
+    }>({
+        await: () => [this.genes, this.oqlFilteredAlterations],
         invoke: () => {
             // first group them by gene symbol
-            const groupedGenesMap = _.groupBy(this.oqlFilteredAlterations.result!, alteration=>alteration.gene.hugoGeneSymbol);
+            const groupedGenesMap = _.groupBy(
+                this.oqlFilteredAlterations.result!,
+                alteration => alteration.gene.hugoGeneSymbol
+            );
             // kind of ugly but this fixes a bug where sort order of genes not respected
             // yes we are relying on add order of js map. in theory not guaranteed, in practice guaranteed
-            const ret = this.genes.result!.reduce((memo:{[hugoGeneSymbol:string]:ExtendedAlteration[]}, gene:Gene)=>{
-                memo[gene.hugoGeneSymbol] = groupedGenesMap[gene.hugoGeneSymbol];
-                return memo;
-            },{});
+            const ret = this.genes.result!.reduce(
+                (
+                    memo: { [hugoGeneSymbol: string]: ExtendedAlteration[] },
+                    gene: Gene
+                ) => {
+                    memo[gene.hugoGeneSymbol] =
+                        groupedGenesMap[gene.hugoGeneSymbol];
+                    return memo;
+                },
+                {}
+            );
 
             return Promise.resolve(ret);
-        }
+        },
     });
-
 
     readonly defaultOQLQuery = remoteData({
         await: () => [this.selectedMolecularProfiles],
         invoke: () => {
-            const profileTypes = _.uniq(_.map(this.selectedMolecularProfiles.result, (profile) => profile.molecularAlterationType));
-            return Promise.resolve(buildDefaultOQLProfile(profileTypes, this.rvQuery.zScoreThreshold, this.rvQuery.rppaScoreThreshold));
-        }
-
+            const profileTypes = _.uniq(
+                _.map(
+                    this.selectedMolecularProfiles.result,
+                    profile => profile.molecularAlterationType
+                )
+            );
+            return Promise.resolve(
+                buildDefaultOQLProfile(
+                    profileTypes,
+                    this.rvQuery.zScoreThreshold,
+                    this.rvQuery.rppaScoreThreshold
+                )
+            );
+        },
     });
 
-    readonly samplesByDetailedCancerType = remoteData<{[cancerType:string]:Sample[]}>({
-        await: () => [
-            this.samples,
-            this.clinicalDataForSamples
-        ],
+    readonly samplesByDetailedCancerType = remoteData<{
+        [cancerType: string]: Sample[];
+    }>({
+        await: () => [this.samples, this.clinicalDataForSamples],
         invoke: () => {
-            let groupedSamples = this.groupSamplesByCancerType(this.clinicalDataForSamples.result,this.samples.result, 'CANCER_TYPE');
+            let groupedSamples = this.groupSamplesByCancerType(
+                this.clinicalDataForSamples.result,
+                this.samples.result,
+                'CANCER_TYPE'
+            );
             if (_.size(groupedSamples) === 1) {
-                groupedSamples = this.groupSamplesByCancerType(this.clinicalDataForSamples.result, this.samples.result, 'CANCER_TYPE_DETAILED');
+                groupedSamples = this.groupSamplesByCancerType(
+                    this.clinicalDataForSamples.result,
+                    this.samples.result,
+                    'CANCER_TYPE_DETAILED'
+                );
             }
             return Promise.resolve(groupedSamples);
-        }
+        },
     });
 
     readonly samplesExtendedWithClinicalData = remoteData<ExtendedSample[]>({
-        await: () => [
-            this.samples,
-            this.clinicalDataForSamples,
-            this.studies
-        ],
+        await: () => [this.samples, this.clinicalDataForSamples, this.studies],
         invoke: () => {
-            return Promise.resolve(extendSamplesWithCancerType(this.samples.result, this.clinicalDataForSamples.result,this.studies.result));
-        }
+            return Promise.resolve(
+                extendSamplesWithCancerType(
+                    this.samples.result,
+                    this.clinicalDataForSamples.result,
+                    this.studies.result
+                )
+            );
+        },
     });
 
-    public groupSamplesByCancerType(clinicalDataForSamples: ClinicalData[], samples: Sample[], cancerTypeLevel:'CANCER_TYPE' | 'CANCER_TYPE_DETAILED') {
-
+    public groupSamplesByCancerType(
+        clinicalDataForSamples: ClinicalData[],
+        samples: Sample[],
+        cancerTypeLevel: 'CANCER_TYPE' | 'CANCER_TYPE_DETAILED'
+    ) {
         // first generate map of sampleId to it's cancer type
-        const sampleKeyToCancerTypeClinicalDataMap = _.reduce(clinicalDataForSamples, (memo, clinicalData: ClinicalData) => {
-            if (clinicalData.clinicalAttributeId === cancerTypeLevel) {
-                memo[clinicalData.uniqueSampleKey] = clinicalData.value;
-            }
-
-            // if we were told CANCER_TYPE and we find CANCER_TYPE_DETAILED, then fall back on it. if we encounter
-            // a CANCER_TYPE later, it will override this.
-            if (cancerTypeLevel === 'CANCER_TYPE') {
-                if (!memo[clinicalData.uniqueSampleKey] && clinicalData.clinicalAttributeId === 'CANCER_TYPE_DETAILED') {
+        const sampleKeyToCancerTypeClinicalDataMap = _.reduce(
+            clinicalDataForSamples,
+            (memo, clinicalData: ClinicalData) => {
+                if (clinicalData.clinicalAttributeId === cancerTypeLevel) {
                     memo[clinicalData.uniqueSampleKey] = clinicalData.value;
                 }
-            }
 
-            return memo;
-        }, {} as { [uniqueSampleId:string]:string });
+                // if we were told CANCER_TYPE and we find CANCER_TYPE_DETAILED, then fall back on it. if we encounter
+                // a CANCER_TYPE later, it will override this.
+                if (cancerTypeLevel === 'CANCER_TYPE') {
+                    if (
+                        !memo[clinicalData.uniqueSampleKey] &&
+                        clinicalData.clinicalAttributeId ===
+                            'CANCER_TYPE_DETAILED'
+                    ) {
+                        memo[clinicalData.uniqueSampleKey] = clinicalData.value;
+                    }
+                }
+
+                return memo;
+            },
+            {} as { [uniqueSampleId: string]: string }
+        );
 
         // now group samples by cancer type
-        let samplesGroupedByCancerType = _.reduce(samples, (memo:{[cancerType:string]:Sample[]} , sample: Sample) => {
-            // if it appears in map, then we have a cancer type
-            if (sample.uniqueSampleKey in sampleKeyToCancerTypeClinicalDataMap) {
-                memo[sampleKeyToCancerTypeClinicalDataMap[sample.uniqueSampleKey]] = memo[sampleKeyToCancerTypeClinicalDataMap[sample.uniqueSampleKey]] || [];
-                memo[sampleKeyToCancerTypeClinicalDataMap[sample.uniqueSampleKey]].push(sample);
-            } else {
-                // TODO: we need to fall back to study cancer type
-            }
-            return memo;
-        }, {} as { [cancerType:string]:Sample[] });
+        let samplesGroupedByCancerType = _.reduce(
+            samples,
+            (memo: { [cancerType: string]: Sample[] }, sample: Sample) => {
+                // if it appears in map, then we have a cancer type
+                if (
+                    sample.uniqueSampleKey in
+                    sampleKeyToCancerTypeClinicalDataMap
+                ) {
+                    memo[
+                        sampleKeyToCancerTypeClinicalDataMap[
+                            sample.uniqueSampleKey
+                        ]
+                    ] =
+                        memo[
+                            sampleKeyToCancerTypeClinicalDataMap[
+                                sample.uniqueSampleKey
+                            ]
+                        ] || [];
+                    memo[
+                        sampleKeyToCancerTypeClinicalDataMap[
+                            sample.uniqueSampleKey
+                        ]
+                    ].push(sample);
+                } else {
+                    // TODO: we need to fall back to study cancer type
+                }
+                return memo;
+            },
+            {} as { [cancerType: string]: Sample[] }
+        );
 
         return samplesGroupedByCancerType;
-//
+        //
     }
 
-    readonly oqlFilteredAlterationsByGeneBySampleKey = remoteData<{[hugoGeneSymbol:string]:{ [uniquSampleKey:string]:ExtendedAlteration[] }}>({
-        await: () => [
-            this.oqlFilteredAlterationsByGene,
-            this.samples
-        ],
-        invoke: async() => {
-            return _.mapValues(this.oqlFilteredAlterationsByGene.result, (alterations: ExtendedAlteration[]) => {
-                return _.groupBy(alterations, (alteration: ExtendedAlteration) => alteration.uniqueSampleKey);
-            });
-        }
+    readonly oqlFilteredAlterationsByGeneBySampleKey = remoteData<{
+        [hugoGeneSymbol: string]: {
+            [uniquSampleKey: string]: ExtendedAlteration[];
+        };
+    }>({
+        await: () => [this.oqlFilteredAlterationsByGene, this.samples],
+        invoke: async () => {
+            return _.mapValues(
+                this.oqlFilteredAlterationsByGene.result,
+                (alterations: ExtendedAlteration[]) => {
+                    return _.groupBy(
+                        alterations,
+                        (alteration: ExtendedAlteration) =>
+                            alteration.uniqueSampleKey
+                    );
+                }
+            );
+        },
     });
 
     //contains all the physical studies for the current selected cohort ids
     //selected cohort ids can be any combination of physical_study_id and virtual_study_id(shared or saved ones)
-    public get physicalStudySet():{ [studyId:string]:CancerStudy } {
-        return _.keyBy(this.studies.result, (study:CancerStudy)=>study.studyId);
+    public get physicalStudySet(): { [studyId: string]: CancerStudy } {
+        return _.keyBy(
+            this.studies.result,
+            (study: CancerStudy) => study.studyId
+        );
     }
 
     // used in building virtual study
     readonly studyWithSamples = remoteData<StudyWithSamples[]>({
-        await: () => [this.samples, this.queriedStudies, this.queriedVirtualStudies],
+        await: () => [
+            this.samples,
+            this.queriedStudies,
+            this.queriedVirtualStudies,
+        ],
         invoke: () => {
-            return Promise.resolve(getFilteredStudiesWithSamples(
-                this.samples.result,
-                this.queriedStudies.result,
-                this.queriedVirtualStudies.result));
+            return Promise.resolve(
+                getFilteredStudiesWithSamples(
+                    this.samples.result,
+                    this.queriedStudies.result,
+                    this.queriedVirtualStudies.result
+                )
+            );
         },
-        onError: (error => {}),
-        default: []
+        onError: error => {},
+        default: [],
     });
 
     readonly mutationProfiles = remoteData({
-        await: ()=>[this.selectedMolecularProfiles],
-        invoke: async ()=>{
-            return this.selectedMolecularProfiles.result!.filter(profile => profile.molecularAlterationType === "MUTATION_EXTENDED")
+        await: () => [this.selectedMolecularProfiles],
+        invoke: async () => {
+            return this.selectedMolecularProfiles.result!.filter(
+                profile =>
+                    profile.molecularAlterationType === 'MUTATION_EXTENDED'
+            );
         },
-        onError: (error => {}),
-        default: []
+        onError: error => {},
+        default: [],
     });
 
-
     readonly cnaProfiles = remoteData({
-        await: ()=>[this.selectedMolecularProfiles],
-        invoke: async ()=>{
-            return  this.selectedMolecularProfiles
-            .result!
-            .filter(profile => profile.molecularAlterationType === "COPY_NUMBER_ALTERATION" && profile.datatype === "DISCRETE")
-
+        await: () => [this.selectedMolecularProfiles],
+        invoke: async () => {
+            return this.selectedMolecularProfiles.result!.filter(
+                profile =>
+                    profile.molecularAlterationType ===
+                        'COPY_NUMBER_ALTERATION' &&
+                    profile.datatype === 'DISCRETE'
+            );
         },
-        onError: (error => {}),
-        default: []
+        onError: error => {},
+        default: [],
     });
 
     @computed
     get chartMetaSet(): { [id: string]: ChartMeta } {
-        let _chartMetaSet: { [id: string]: ChartMeta } = {} as { [id: string]: ChartMeta };
+        let _chartMetaSet: { [id: string]: ChartMeta } = {} as {
+            [id: string]: ChartMeta;
+        };
 
         // Add meta information for each of the clinical attribute
         // Convert to a Set for easy access and to update attribute meta information(would be useful while adding new features)
-        _.reduce(this.clinicalAttributes.result, (acc: { [id: string]: ChartMeta }, attribute) => {
-            const uniqueKey = getClinicalAttributeUniqueKey(attribute);
-            acc[uniqueKey] = {
-                displayName: attribute.displayName,
-                uniqueKey: uniqueKey,
-                dataType: getChartMetaDataType(uniqueKey),
-                patientAttribute:attribute.patientAttribute,
-                description: attribute.description,
-                priority: getPriorityByClinicalAttribute(attribute),
-                renderWhenDataChange: false,
-                clinicalAttribute: attribute
-            };
-            return acc
-        }, _chartMetaSet);
+        _.reduce(
+            this.clinicalAttributes.result,
+            (acc: { [id: string]: ChartMeta }, attribute) => {
+                const uniqueKey = getClinicalAttributeUniqueKey(attribute);
+                acc[uniqueKey] = {
+                    displayName: attribute.displayName,
+                    uniqueKey: uniqueKey,
+                    dataType: getChartMetaDataType(uniqueKey),
+                    patientAttribute: attribute.patientAttribute,
+                    description: attribute.description,
+                    priority: getPriorityByClinicalAttribute(attribute),
+                    renderWhenDataChange: false,
+                    clinicalAttribute: attribute,
+                };
+                return acc;
+            },
+            _chartMetaSet
+        );
 
         if (!_.isEmpty(this.mutationProfiles.result!)) {
             _chartMetaSet[UniqueKey.MUTATED_GENES_TABLE] = {
                 uniqueKey: UniqueKey.MUTATED_GENES_TABLE,
                 dataType: getChartMetaDataType(UniqueKey.MUTATED_GENES_TABLE),
-                patientAttribute:false,
+                patientAttribute: false,
                 displayName: 'Mutated Genes',
-                priority: getDefaultPriorityByUniqueKey(UniqueKey.MUTATED_GENES_TABLE),
+                priority: getDefaultPriorityByUniqueKey(
+                    UniqueKey.MUTATED_GENES_TABLE
+                ),
                 renderWhenDataChange: false,
-                description: ''
+                description: '',
             };
         }
 
@@ -1681,93 +2252,131 @@ export class ResultsViewPageStore {
             _chartMetaSet[UniqueKey.CNA_GENES_TABLE] = {
                 uniqueKey: UniqueKey.CNA_GENES_TABLE,
                 dataType: getChartMetaDataType(UniqueKey.CNA_GENES_TABLE),
-                patientAttribute:false,
+                patientAttribute: false,
                 displayName: 'CNA Genes',
                 renderWhenDataChange: false,
-                priority: getDefaultPriorityByUniqueKey(UniqueKey.CNA_GENES_TABLE),
-                description: ''
+                priority: getDefaultPriorityByUniqueKey(
+                    UniqueKey.CNA_GENES_TABLE
+                ),
+                description: '',
             };
         }
 
-        const scatterRequiredParams = _.reduce(this.clinicalAttributes.result, (acc, next) => {
-            if (MUTATION_COUNT === next.clinicalAttributeId) {
-                acc[MUTATION_COUNT] = true
-            }
-            if (FRACTION_GENOME_ALTERED === next.clinicalAttributeId) {
-                acc[FRACTION_GENOME_ALTERED] = true
-            }
-            return acc;
-        }, {[MUTATION_COUNT]: false, [FRACTION_GENOME_ALTERED]: false});
+        const scatterRequiredParams = _.reduce(
+            this.clinicalAttributes.result,
+            (acc, next) => {
+                if (MUTATION_COUNT === next.clinicalAttributeId) {
+                    acc[MUTATION_COUNT] = true;
+                }
+                if (FRACTION_GENOME_ALTERED === next.clinicalAttributeId) {
+                    acc[FRACTION_GENOME_ALTERED] = true;
+                }
+                return acc;
+            },
+            { [MUTATION_COUNT]: false, [FRACTION_GENOME_ALTERED]: false }
+        );
 
-        if (scatterRequiredParams[MUTATION_COUNT] && scatterRequiredParams[FRACTION_GENOME_ALTERED]) {
+        if (
+            scatterRequiredParams[MUTATION_COUNT] &&
+            scatterRequiredParams[FRACTION_GENOME_ALTERED]
+        ) {
             _chartMetaSet[UniqueKey.MUTATION_COUNT_CNA_FRACTION] = {
-                dataType: getChartMetaDataType(UniqueKey.MUTATION_COUNT_CNA_FRACTION),
-                patientAttribute:false,
+                dataType: getChartMetaDataType(
+                    UniqueKey.MUTATION_COUNT_CNA_FRACTION
+                ),
+                patientAttribute: false,
                 uniqueKey: UniqueKey.MUTATION_COUNT_CNA_FRACTION,
                 displayName: 'Mutation Count vs Fraction of Genome Altered',
-                priority: getDefaultPriorityByUniqueKey(UniqueKey.MUTATION_COUNT_CNA_FRACTION),
+                priority: getDefaultPriorityByUniqueKey(
+                    UniqueKey.MUTATION_COUNT_CNA_FRACTION
+                ),
                 renderWhenDataChange: false,
-                description: ''
+                description: '',
             };
         }
         return _chartMetaSet;
     }
 
     readonly virtualStudyParams = remoteData<IVirtualStudyProps>({
-        await:()=>[this.samples, this.studyIds, this.studyWithSamples, this.queriedVirtualStudies],
-        invoke:()=>Promise.resolve(
-            {
-                "user": this.appStore.userName,
-                "name": this.queriedVirtualStudies.result.length === 1 ? this.queriedVirtualStudies.result[0].data.name : undefined,
-                "description": this.queriedVirtualStudies.result.length === 1 ? this.queriedVirtualStudies.result[0].data.description : undefined,
-                "studyWithSamples": this.studyWithSamples.result,
-                "selectedSamples": this.samples.result,
-                "filter": {"studyIds": this.studyIds.result},
-                "attributesMetaSet": this.chartMetaSet
-            } as IVirtualStudyProps
-        )
+        await: () => [
+            this.samples,
+            this.studyIds,
+            this.studyWithSamples,
+            this.queriedVirtualStudies,
+        ],
+        invoke: () =>
+            Promise.resolve({
+                user: this.appStore.userName,
+                name:
+                    this.queriedVirtualStudies.result.length === 1
+                        ? this.queriedVirtualStudies.result[0].data.name
+                        : undefined,
+                description:
+                    this.queriedVirtualStudies.result.length === 1
+                        ? this.queriedVirtualStudies.result[0].data.description
+                        : undefined,
+                studyWithSamples: this.studyWithSamples.result,
+                selectedSamples: this.samples.result,
+                filter: { studyIds: this.studyIds.result },
+                attributesMetaSet: this.chartMetaSet,
+            } as IVirtualStudyProps),
     });
 
     readonly oqlFilteredAlterationsByGeneAsSampleKeyArrays = remoteData({
-        await: () => [
-            this.oqlFilteredAlterationsByGene
-        ],
-        invoke: async() => {
-            return _.mapValues(this.oqlFilteredAlterationsByGene.result, (mutations: Mutation[]) => _.map(mutations, mutation=>mutation.uniqueSampleKey));
-        }
+        await: () => [this.oqlFilteredAlterationsByGene],
+        invoke: async () => {
+            return _.mapValues(
+                this.oqlFilteredAlterationsByGene.result,
+                (mutations: Mutation[]) =>
+                    _.map(mutations, mutation => mutation.uniqueSampleKey)
+            );
+        },
     });
 
     readonly givenSampleOrder = remoteData<Sample[]>({
-        await: ()=>[
-            this.samples,
-            this.samplesSpecification
-        ],
-        invoke: async()=>{
+        await: () => [this.samples, this.samplesSpecification],
+        invoke: async () => {
             // for now, just assume we won't mix sample lists and samples in the specification
-            if (this.samplesSpecification.result!.find(x=>!x.sampleId)) {
+            if (this.samplesSpecification.result!.find(x => !x.sampleId)) {
                 // for now, if theres any sample list id specification, then there is no given sample order
                 return [];
             }
             // at this point, we know samplesSpecification is a list of samples
-            const studyToSampleToIndex:{[studyId:string]:{[sampleId:string]:number}} =
-                _.reduce(this.samplesSpecification.result,
-                    (map:{[studyId:string]:{[sampleId:string]:number}}, next:SamplesSpecificationElement, index:number)=>{
-                        map[next.studyId] = map[next.studyId] || {};
-                        map[next.studyId][next.sampleId!] = index; // we know sampleId defined otherwise we would have returned from function already
-                        return map;
-                    },
-                {});
-            return _.sortBy(this.samples.result, sample=>studyToSampleToIndex[sample.studyId][sample.sampleId]);
-        }
+            const studyToSampleToIndex: {
+                [studyId: string]: { [sampleId: string]: number };
+            } = _.reduce(
+                this.samplesSpecification.result,
+                (
+                    map: { [studyId: string]: { [sampleId: string]: number } },
+                    next: SamplesSpecificationElement,
+                    index: number
+                ) => {
+                    map[next.studyId] = map[next.studyId] || {};
+                    map[next.studyId][next.sampleId!] = index; // we know sampleId defined otherwise we would have returned from function already
+                    return map;
+                },
+                {}
+            );
+            return _.sortBy(
+                this.samples.result,
+                sample => studyToSampleToIndex[sample.studyId][sample.sampleId]
+            );
+        },
     });
 
-    readonly studyToSampleIds = remoteData<{ [studyId: string]: { [sampleId: string]: boolean } }>({
-        await:()=>[
-            this.samplesSpecification
-        ],
-        invoke: async ()=>{
-                const sampleListsToQuery: { studyId: string, sampleListId: string }[] = [];
-                const ret: { [studyId: string]: { [sampleId: string]: boolean } } = {};
+    readonly studyToSampleIds = remoteData<{
+        [studyId: string]: { [sampleId: string]: boolean };
+    }>(
+        {
+            await: () => [this.samplesSpecification],
+            invoke: async () => {
+                const sampleListsToQuery: {
+                    studyId: string;
+                    sampleListId: string;
+                }[] = [];
+                const ret: {
+                    [studyId: string]: { [sampleId: string]: boolean };
+                } = {};
                 for (const sampleSpec of this.samplesSpecification.result!) {
                     if (sampleSpec.sampleId) {
                         // add sample id to study
@@ -1775,51 +2384,63 @@ export class ResultsViewPageStore {
                         ret[sampleSpec.studyId][sampleSpec.sampleId] = true;
                     } else if (sampleSpec.sampleListId) {
                         // mark sample list to query later
-                        sampleListsToQuery.push(sampleSpec as { studyId: string, sampleListId: string });
+                        sampleListsToQuery.push(sampleSpec as {
+                            studyId: string;
+                            sampleListId: string;
+                        });
                     }
                 }
                 // query for sample lists
                 if (sampleListsToQuery.length > 0) {
-                    const sampleLists: SampleList[] = await client.fetchSampleListsUsingPOST({
-                        sampleListIds: sampleListsToQuery.map(spec=>spec.sampleListId),
-                        projection: "DETAILED"
-                    });
+                    const sampleLists: SampleList[] = await client.fetchSampleListsUsingPOST(
+                        {
+                            sampleListIds: sampleListsToQuery.map(
+                                spec => spec.sampleListId
+                            ),
+                            projection: 'DETAILED',
+                        }
+                    );
                     // add samples from those sample lists to corresponding study
                     for (const sampleList of sampleLists) {
-                        ret[sampleList.studyId] = stringListToSet(sampleList.sampleIds);
+                        ret[sampleList.studyId] = stringListToSet(
+                            sampleList.sampleIds
+                        );
                     }
                 }
                 return ret;
-        }
-
-    }, {});
+            },
+        },
+        {}
+    );
 
     readonly studyToSampleListId = remoteData<{ [studyId: string]: string }>({
-        await:()=>[
-            this.samplesSpecification
-        ],
-        invoke: async ()=>{
-            return this.samplesSpecification.result!.reduce((map, next) => {
-                if (next.sampleListId) {
-                    map[next.studyId] = next.sampleListId;
-                }
-                return map;
-            }, {} as {[studyId: string]: string});
-        }
+        await: () => [this.samplesSpecification],
+        invoke: async () => {
+            return this.samplesSpecification.result!.reduce(
+                (map, next) => {
+                    if (next.sampleListId) {
+                        map[next.studyId] = next.sampleListId;
+                    }
+                    return map;
+                },
+                {} as { [studyId: string]: string }
+            );
+        },
     });
-
 
     readonly samplesSpecification = remoteData({
         await: () => [this.queriedVirtualStudies],
         invoke: async () => {
-
             // is this a sample list category query?
             // if YES, we need to derive the sample lists by:
             // 1. looking up all sample lists in selected studies
             // 2. using those with matching category
             if (!this.rvQuery.sampleListCategory) {
-                if (this.queriedVirtualStudies.result!.length > 0){
-                    return populateSampleSpecificationsFromVirtualStudies(this.rvQuery.samplesSpecification, this.queriedVirtualStudies.result!);
+                if (this.queriedVirtualStudies.result!.length > 0) {
+                    return populateSampleSpecificationsFromVirtualStudies(
+                        this.rvQuery.samplesSpecification,
+                        this.queriedVirtualStudies.result!
+                    );
                 } else {
                     return this.rvQuery.samplesSpecification;
                 }
@@ -1828,104 +2449,136 @@ export class ResultsViewPageStore {
                 // but this will only ever happen one for each study selected (and in queries where a sample list is specified)
                 let samplesSpecifications = [];
                 // get sample specifications from physical studies if we are querying virtual study
-                if (this.queriedVirtualStudies.result!.length > 0){
-                    samplesSpecifications = populateSampleSpecificationsFromVirtualStudies(this.rvQuery.samplesSpecification, this.queriedVirtualStudies.result!);
+                if (this.queriedVirtualStudies.result!.length > 0) {
+                    samplesSpecifications = populateSampleSpecificationsFromVirtualStudies(
+                        this.rvQuery.samplesSpecification,
+                        this.queriedVirtualStudies.result!
+                    );
                 } else {
                     samplesSpecifications = this.rvQuery.samplesSpecification;
                 }
                 // get unique study ids to reduce the API requests
                 const uniqueStudyIds = _.chain(samplesSpecifications)
-                                      .map((specification) => specification.studyId)
-                                      .uniq()
-                                      .value();
-                const allSampleLists = await Promise.all(uniqueStudyIds.map((studyId) => {
-                    return client.getAllSampleListsInStudyUsingGET({
-                        studyId: studyId,
-                        projection: 'SUMMARY'
+                    .map(specification => specification.studyId)
+                    .uniq()
+                    .value();
+                const allSampleLists = await Promise.all(
+                    uniqueStudyIds.map(studyId => {
+                        return client.getAllSampleListsInStudyUsingGET({
+                            studyId: studyId,
+                            projection: 'SUMMARY',
+                        });
                     })
-                }));
+                );
 
-                const category = SampleListCategoryTypeToFullId[this.rvQuery.sampleListCategory!];
-                const specs = allSampleLists.reduce((aggregator: SamplesSpecificationElement[], sampleLists) => {
-                    //find the sample list matching the selected category using the map from shortname to full category name :(
-                    const matchingList = _.find(sampleLists, (list) => list.category === category);
-                    if (matchingList) {
-                        aggregator.push({
-                            studyId: matchingList.studyId,
-                            sampleListId: matchingList.sampleListId,
-                            sampleId: undefined
-                        } as SamplesSpecificationElement);
-                    }
-                    return aggregator;
-                }, []);
+                const category =
+                    SampleListCategoryTypeToFullId[
+                        this.rvQuery.sampleListCategory!
+                    ];
+                const specs = allSampleLists.reduce(
+                    (
+                        aggregator: SamplesSpecificationElement[],
+                        sampleLists
+                    ) => {
+                        //find the sample list matching the selected category using the map from shortname to full category name :(
+                        const matchingList = _.find(
+                            sampleLists,
+                            list => list.category === category
+                        );
+                        if (matchingList) {
+                            aggregator.push({
+                                studyId: matchingList.studyId,
+                                sampleListId: matchingList.sampleListId,
+                                sampleId: undefined,
+                            } as SamplesSpecificationElement);
+                        }
+                        return aggregator;
+                    },
+                    []
+                );
 
                 return specs;
             }
-        }
+        },
     });
 
-    readonly studyToMutationMolecularProfile = remoteData<{[studyId: string]: MolecularProfile}>({
-        await: () => [
-            this.molecularProfilesInStudies
-        ],
-        invoke: () => {
-            const ret: {[studyId: string]: MolecularProfile} = {};
-            for (const profile of this.molecularProfilesInStudies.result) {
-                const studyId = profile.studyId;
-                if (!ret[studyId] && isMutationProfile(profile)) {
-                    ret[studyId] = profile;
+    readonly studyToMutationMolecularProfile = remoteData<{
+        [studyId: string]: MolecularProfile;
+    }>(
+        {
+            await: () => [this.molecularProfilesInStudies],
+            invoke: () => {
+                const ret: { [studyId: string]: MolecularProfile } = {};
+                for (const profile of this.molecularProfilesInStudies.result) {
+                    const studyId = profile.studyId;
+                    if (!ret[studyId] && isMutationProfile(profile)) {
+                        ret[studyId] = profile;
+                    }
                 }
-            }
-            return Promise.resolve(ret);
-        }
-    }, {});
-
-    readonly allStudies = remoteData({
-        invoke: async()=>(await client.getAllStudiesUsingGET({projection: "SUMMARY"}))
-    }, []);
-
-    readonly queriedVirtualStudies = remoteData({
-        await: () => [
-            this.allStudies,
-        ],
-        invoke: async ()=> {
-            const allCancerStudies = this.allStudies.result;
-            const cancerStudyIds = this.rvQuery.cohortIdsList;
-
-            const missingFromCancerStudies = _.differenceWith(cancerStudyIds, allCancerStudies,(id:string, study:CancerStudy)=>id===study.studyId);
-            let ret:VirtualStudy[] = [];
-
-            for (const missingId of missingFromCancerStudies) {
-                try {
-                    const vs = await sessionServiceClient.getVirtualStudy(missingId);
-                    ret = ret.concat(vs);
-                } catch (error) {
-                    // ignore missing studies
-                    continue;
-                }
-            }
-            return Promise.resolve(ret);
+                return Promise.resolve(ret);
+            },
         },
-        onError: () => {
-            // fail silently when an error occurs with the virtual studies
-        }
-        // just return empty array if session service is disabled
-    }, []);
+        {}
+    );
+
+    readonly allStudies = remoteData(
+        {
+            invoke: async () =>
+                await client.getAllStudiesUsingGET({ projection: 'SUMMARY' }),
+        },
+        []
+    );
+
+    readonly queriedVirtualStudies = remoteData(
+        {
+            await: () => [this.allStudies],
+            invoke: async () => {
+                const allCancerStudies = this.allStudies.result;
+                const cancerStudyIds = this.rvQuery.cohortIdsList;
+
+                const missingFromCancerStudies = _.differenceWith(
+                    cancerStudyIds,
+                    allCancerStudies,
+                    (id: string, study: CancerStudy) => id === study.studyId
+                );
+                let ret: VirtualStudy[] = [];
+
+                for (const missingId of missingFromCancerStudies) {
+                    try {
+                        const vs = await sessionServiceClient.getVirtualStudy(
+                            missingId
+                        );
+                        ret = ret.concat(vs);
+                    } catch (error) {
+                        // ignore missing studies
+                        continue;
+                    }
+                }
+                return Promise.resolve(ret);
+            },
+            onError: () => {
+                // fail silently when an error occurs with the virtual studies
+            },
+            // just return empty array if session service is disabled
+        },
+        []
+    );
 
     readonly studyIds = remoteData({
-        await:()=>[
-            this.queriedVirtualStudies
-        ],
-        invoke: ()=>{
-            let physicalStudies:string[];
+        await: () => [this.queriedVirtualStudies],
+        invoke: () => {
+            let physicalStudies: string[];
             if (this.queriedVirtualStudies.result!.length > 0) {
                 // we want to replace virtual studies with their underlying physical studies
-                physicalStudies = substitutePhysicalStudiesForVirtualStudies(this.rvQuery.cohortIdsList, this.queriedVirtualStudies.result!);
+                physicalStudies = substitutePhysicalStudiesForVirtualStudies(
+                    this.rvQuery.cohortIdsList,
+                    this.queriedVirtualStudies.result!
+                );
             } else {
                 physicalStudies = this.rvQuery.cohortIdsList.slice();
             }
             return Promise.resolve(physicalStudies);
-        }
+        },
     });
 
     // this is less than desirable way of validating studyIds
@@ -1933,24 +2586,31 @@ export class ResultsViewPageStore {
     // we assume it's a virtual study and try to retrieve it as such
     // if there's no corresponding virtual study
     // we assume it's an invalid studyId
-    readonly invalidStudyIds = remoteData({
-        await: ()=>[
-            this.allStudies,
-            this.queriedVirtualStudies
-        ],
-        invoke:()=>{
-            const allCancerStudies = this.allStudies.result;
-            const cancerStudyIds = this.rvQuery.cohortIdsList;
+    readonly invalidStudyIds = remoteData(
+        {
+            await: () => [this.allStudies, this.queriedVirtualStudies],
+            invoke: () => {
+                const allCancerStudies = this.allStudies.result;
+                const cancerStudyIds = this.rvQuery.cohortIdsList;
 
-            const missingFromCancerStudies = _.differenceWith(cancerStudyIds, allCancerStudies,(id:string, study:CancerStudy)=>id===study.studyId);
+                const missingFromCancerStudies = _.differenceWith(
+                    cancerStudyIds,
+                    allCancerStudies,
+                    (id: string, study: CancerStudy) => id === study.studyId
+                );
 
-            if (missingFromCancerStudies.length && this.queriedVirtualStudies.result.length === 0) {
-                return Promise.resolve(missingFromCancerStudies);
-            } else {
-                return Promise.resolve([]);
-            }
-        }
-    }, []);
+                if (
+                    missingFromCancerStudies.length &&
+                    this.queriedVirtualStudies.result.length === 0
+                ) {
+                    return Promise.resolve(missingFromCancerStudies);
+                } else {
+                    return Promise.resolve([]);
+                }
+            },
+        },
+        []
+    );
 
     @computed get downloadFilenamePrefix() {
         return generateDownloadFilenamePrefixByStudies(this.studies.result);
@@ -1962,77 +2622,92 @@ export class ResultsViewPageStore {
 
     // TODO: refactor b/c we already have sample lists summary so
     readonly sampleLists = remoteData<SampleList[]>({
-        await:()=>[
-          this.studyToSampleListId
-        ],
-        invoke:()=>{
+        await: () => [this.studyToSampleListId],
+        invoke: () => {
             const sampleListIds = _.values(this.studyToSampleListId.result!);
             if (sampleListIds.length > 0) {
-                return client.fetchSampleListsUsingPOST({sampleListIds});
+                return client.fetchSampleListsUsingPOST({ sampleListIds });
             } else {
                 return Promise.resolve([]);
             }
-        }
+        },
     });
 
     readonly mutations = remoteData<Mutation[]>({
-        await:()=>[
+        await: () => [
             this.genes,
             this.selectedMolecularProfiles,
             this.samples,
-            this.studyIdToStudy
+            this.studyIdToStudy,
         ],
-        invoke: async ()=>{
-
-            const mutationProfiles = _.filter(this.selectedMolecularProfiles.result,(profile:MolecularProfile)=>profile.molecularAlterationType==='MUTATION_EXTENDED');
+        invoke: async () => {
+            const mutationProfiles = _.filter(
+                this.selectedMolecularProfiles.result,
+                (profile: MolecularProfile) =>
+                    profile.molecularAlterationType === 'MUTATION_EXTENDED'
+            );
 
             if (mutationProfiles.length === 0) {
                 return [];
             }
 
-            const studyIdToProfileMap:{ [studyId:string] : MolecularProfile } = _.keyBy(mutationProfiles,(profile:MolecularProfile)=>profile.studyId);
+            const studyIdToProfileMap: {
+                [studyId: string]: MolecularProfile;
+            } = _.keyBy(
+                mutationProfiles,
+                (profile: MolecularProfile) => profile.studyId
+            );
 
-            const filters = this.samples.result.reduce((memo, sample:Sample)=>{
-                if (sample.studyId in studyIdToProfileMap) {
-                    memo.push({
-                        molecularProfileId: studyIdToProfileMap[sample.studyId].molecularProfileId,
-                        sampleId: sample.sampleId
-                    });
+            const filters = this.samples.result.reduce(
+                (memo, sample: Sample) => {
+                    if (sample.studyId in studyIdToProfileMap) {
+                        memo.push({
+                            molecularProfileId:
+                                studyIdToProfileMap[sample.studyId]
+                                    .molecularProfileId,
+                            sampleId: sample.sampleId,
+                        });
+                    }
+                    return memo;
+                },
+                [] as any[]
+            );
+
+            const data = {
+                entrezGeneIds: _.map(
+                    this.genes.result,
+                    (gene: Gene) => gene.entrezGeneId
+                ),
+                sampleMolecularIdentifiers: filters,
+            } as MutationMultipleStudyFilter;
+
+            return await client.fetchMutationsInMultipleMolecularProfilesUsingPOST(
+                {
+                    projection: 'DETAILED',
+                    mutationMultipleStudyFilter: data,
                 }
-                return memo;
-            }, [] as any[]);
-
-            const data = ({
-                entrezGeneIds: _.map(this.genes.result,(gene:Gene)=>gene.entrezGeneId),
-                sampleMolecularIdentifiers: filters
-            } as MutationMultipleStudyFilter);
-
-            return await client.fetchMutationsInMultipleMolecularProfilesUsingPOST({
-                projection:'DETAILED',
-                mutationMultipleStudyFilter:data
-            });
-
-        }
-
+            );
+        },
     });
 
     public mutationsTabFilteringSettings = this.makeMutationsTabFilteringSettings();
 
-
-    readonly mutationsReportByGene = remoteData<{ [hugeGeneSymbol:string]:FilteredAndAnnotatedMutationsReport}>({
-        await:()=>[
-            this._filteredAndAnnotatedMutationsReport,
-            this.genes
-        ],
-        invoke:()=>{
-            let mutationGroups:FilteredAndAnnotatedMutationsReport = this._filteredAndAnnotatedMutationsReport.result!;
-            const ret:{[hugoGeneSymbol:string]:FilteredAndAnnotatedMutationsReport} = {};
+    readonly mutationsReportByGene = remoteData<{
+        [hugeGeneSymbol: string]: FilteredAndAnnotatedMutationsReport;
+    }>({
+        await: () => [this._filteredAndAnnotatedMutationsReport, this.genes],
+        invoke: () => {
+            let mutationGroups: FilteredAndAnnotatedMutationsReport = this
+                ._filteredAndAnnotatedMutationsReport.result!;
+            const ret: {
+                [hugoGeneSymbol: string]: FilteredAndAnnotatedMutationsReport;
+            } = {};
             for (const gene of this.genes.result!) {
                 ret[gene.hugoGeneSymbol] = {
-                    data:[],
-                    vus:[],
-                    germline:[],
-                    vusAndGermline:[]
+                    data: [],
+                    vus: [],
+                    germline: [],
+                    vusAndGermline: [],
                 };
             }
             for (const mutation of mutationGroups.data) {
@@ -2048,456 +2723,675 @@ export class ResultsViewPageStore {
                 ret[mutation.gene.hugoGeneSymbol].vusAndGermline.push(mutation);
             }
             return Promise.resolve(ret);
-        }
+        },
     });
 
-    readonly mutationsByGene = remoteData<{[hugoGeneSymbol:string]:Mutation[]}>({
-        await:()=>[
+    readonly mutationsByGene = remoteData<{
+        [hugoGeneSymbol: string]: Mutation[];
+    }>({
+        await: () => [
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
-            this.mutationsReportByGene
-        ],
-        invoke:()=>{
-            return Promise.resolve(_.mapValues(this.mutationsReportByGene.result!, (mutationGroups:FilteredAndAnnotatedMutationsReport)=>{
-                if (this.mutationsTabFilteringSettings.useOql && this.queryContainsMutationOql) {
-                    // use oql filtering in mutations tab only if query contains mutation oql
-                    mutationGroups = _.mapValues(mutationGroups, mutations=>(
-                        filterCBioPortalWebServiceData(
-                            this.rvQuery.oqlQuery,
-                            mutations,
-                            (new AccessorsForOqlFilter(this.selectedMolecularProfiles.result!)),
-                            this.defaultOQLQuery.result!
-                        )
-                    ));
-                }
-                return compileMutations(mutationGroups, this.mutationsTabFilteringSettings.excludeVus, this.mutationsTabFilteringSettings.excludeGermline);
-            }));
-        }
-    });
-
-    readonly mutationMapperStores = remoteData<{ [hugoGeneSymbol: string]: ResultsViewMutationMapperStore }>({
-        await: () => [
-            this.genes,
-            this.oncoKbCancerGenes,
-            this.uniqueSampleKeyToTumorType,
-            this.mutations,
-            this.mutationsByGene
+            this.mutationsReportByGene,
         ],
         invoke: () => {
-            if (this.genes.result) {
-                // we have to use _.reduce, otherwise this.genes.result (Immutable, due to remoteData) will return
-                //  an Immutable as the result of reduce, and MutationMapperStore when it is made immutable all the
-                //  mobx machinery going on in the readonly remoteDatas and observables somehow gets messed up.
-                return Promise.resolve(_.reduce(this.genes.result, (map: { [hugoGeneSymbol: string]: ResultsViewMutationMapperStore }, gene: Gene) => {
-                    map[gene.hugoGeneSymbol] = new ResultsViewMutationMapperStore(AppConfig.serverConfig,
-                        {},
-                        gene,
-                        this.samples,
-                        this.oncoKbCancerGenes,
-                        () => (this.mutationsByGene.result![gene.hugoGeneSymbol] || []),
-                        () => (this.mutationCountCache),
-                        () => (this.genomeNexusCache),
-                        () => (this.genomeNexusMyVariantInfoCache),
-                        () => (this.discreteCNACache),
-                        this.studyToMolecularProfileDiscrete.result!,
-                        this.studyIdToStudy,
-                        this.molecularProfileIdToMolecularProfile,
-                        this.clinicalDataForSamples,
-                        this.studiesForSamplesWithoutCancerTypeClinicalData,
-                        this.germlineConsentedSamples,
-                        this.indexedHotspotData,
-                        this.indexedVariantAnnotations,
-                        this.uniqueSampleKeyToTumorType.result!,
-                        this.oncoKbData
-                    );
-                    return map;
-                }, {}));
-            } else {
-                return Promise.resolve({});
-            }
-        }
-    }, {});
+            return Promise.resolve(
+                _.mapValues(
+                    this.mutationsReportByGene.result!,
+                    (mutationGroups: FilteredAndAnnotatedMutationsReport) => {
+                        if (
+                            this.mutationsTabFilteringSettings.useOql &&
+                            this.queryContainsMutationOql
+                        ) {
+                            // use oql filtering in mutations tab only if query contains mutation oql
+                            mutationGroups = _.mapValues(
+                                mutationGroups,
+                                mutations =>
+                                    filterCBioPortalWebServiceData(
+                                        this.rvQuery.oqlQuery,
+                                        mutations,
+                                        new AccessorsForOqlFilter(
+                                            this.selectedMolecularProfiles.result!
+                                        ),
+                                        this.defaultOQLQuery.result!
+                                    )
+                            );
+                        }
+                        return compileMutations(
+                            mutationGroups,
+                            this.mutationsTabFilteringSettings.excludeVus,
+                            this.mutationsTabFilteringSettings.excludeGermline
+                        );
+                    }
+                )
+            );
+        },
+    });
 
-    public getMutationMapperStore(hugoGeneSymbol: string): ResultsViewMutationMapperStore | undefined {
+    readonly mutationMapperStores = remoteData<{
+        [hugoGeneSymbol: string]: ResultsViewMutationMapperStore;
+    }>(
+        {
+            await: () => [
+                this.genes,
+                this.oncoKbCancerGenes,
+                this.uniqueSampleKeyToTumorType,
+                this.mutations,
+                this.mutationsByGene,
+            ],
+            invoke: () => {
+                if (this.genes.result) {
+                    // we have to use _.reduce, otherwise this.genes.result (Immutable, due to remoteData) will return
+                    //  an Immutable as the result of reduce, and MutationMapperStore when it is made immutable all the
+                    //  mobx machinery going on in the readonly remoteDatas and observables somehow gets messed up.
+                    return Promise.resolve(
+                        _.reduce(
+                            this.genes.result,
+                            (
+                                map: {
+                                    [hugoGeneSymbol: string]: ResultsViewMutationMapperStore;
+                                },
+                                gene: Gene
+                            ) => {
+                                map[
+                                    gene.hugoGeneSymbol
+                                ] = new ResultsViewMutationMapperStore(
+                                    AppConfig.serverConfig,
+                                    {},
+                                    gene,
+                                    this.samples,
+                                    this.oncoKbCancerGenes,
+                                    () =>
+                                        this.mutationsByGene.result![
+                                            gene.hugoGeneSymbol
+                                        ] || [],
+                                    () => this.mutationCountCache,
+                                    () => this.genomeNexusCache,
+                                    () => this.genomeNexusMyVariantInfoCache,
+                                    () => this.discreteCNACache,
+                                    this.studyToMolecularProfileDiscrete.result!,
+                                    this.studyIdToStudy,
+                                    this.molecularProfileIdToMolecularProfile,
+                                    this.clinicalDataForSamples,
+                                    this.studiesForSamplesWithoutCancerTypeClinicalData,
+                                    this.germlineConsentedSamples,
+                                    this.indexedHotspotData,
+                                    this.indexedVariantAnnotations,
+                                    this.uniqueSampleKeyToTumorType.result!,
+                                    this.oncoKbData
+                                );
+                                return map;
+                            },
+                            {}
+                        )
+                    );
+                } else {
+                    return Promise.resolve({});
+                }
+            },
+        },
+        {}
+    );
+
+    public getMutationMapperStore(
+        hugoGeneSymbol: string
+    ): ResultsViewMutationMapperStore | undefined {
         return this.mutationMapperStores.result[hugoGeneSymbol];
     }
 
-    readonly oncoKbCancerGenes = remoteData({
-        invoke: () => {
-            if (AppConfig.serverConfig.show_oncokb) {
-                return fetchOncoKbCancerGenes();
-            } else {
-                return Promise.resolve([]);
-            }
-        }
-    }, []);
+    readonly oncoKbCancerGenes = remoteData(
+        {
+            invoke: () => {
+                if (AppConfig.serverConfig.show_oncokb) {
+                    return fetchOncoKbCancerGenes();
+                } else {
+                    return Promise.resolve([]);
+                }
+            },
+        },
+        []
+    );
 
-    readonly oncoKbAnnotatedGenes = remoteData({
-        await: () => [this.oncoKbCancerGenes],
-        invoke: () => {
-            if (AppConfig.serverConfig.show_oncokb) {
-                return Promise.resolve(_.reduce(this.oncoKbCancerGenes.result, (map: { [entrezGeneId: number]: boolean }, next: CancerGene) => {
-                    if (next.oncokbAnnotated) {
-                        map[next.entrezGeneId] = true;
-                    }
-                    return map;
-                }, {}));
-            } else {
-                return Promise.resolve({});
-            }
-        }
-    }, {});
+    readonly oncoKbAnnotatedGenes = remoteData(
+        {
+            await: () => [this.oncoKbCancerGenes],
+            invoke: () => {
+                if (AppConfig.serverConfig.show_oncokb) {
+                    return Promise.resolve(
+                        _.reduce(
+                            this.oncoKbCancerGenes.result,
+                            (
+                                map: { [entrezGeneId: number]: boolean },
+                                next: CancerGene
+                            ) => {
+                                if (next.oncokbAnnotated) {
+                                    map[next.entrezGeneId] = true;
+                                }
+                                return map;
+                            },
+                            {}
+                        )
+                    );
+                } else {
+                    return Promise.resolve({});
+                }
+            },
+        },
+        {}
+    );
 
-    readonly clinicalDataForSamples = remoteData<ClinicalData[]>({
-        await: () => [
-            this.studies,
-            this.samples
-        ],
-        invoke: () => this.getClinicalData("SAMPLE", this.studies.result!, this.samples.result, ["CANCER_TYPE", "CANCER_TYPE_DETAILED"])
-    }, []);
+    readonly clinicalDataForSamples = remoteData<ClinicalData[]>(
+        {
+            await: () => [this.studies, this.samples],
+            invoke: () =>
+                this.getClinicalData(
+                    'SAMPLE',
+                    this.studies.result!,
+                    this.samples.result,
+                    ['CANCER_TYPE', 'CANCER_TYPE_DETAILED']
+                ),
+        },
+        []
+    );
 
-    private getClinicalData(clinicalDataType: "SAMPLE" | "PATIENT", studies:any[], entities: any[], attributeIds: string[]):
-    Promise<Array<ClinicalData>> {
-
+    private getClinicalData(
+        clinicalDataType: 'SAMPLE' | 'PATIENT',
+        studies: any[],
+        entities: any[],
+        attributeIds: string[]
+    ): Promise<Array<ClinicalData>> {
         // single study query endpoint is optimal so we should use it
         // when there's only one study
         if (studies.length === 1) {
             const study = this.studies.result[0];
             const filter: ClinicalDataSingleStudyFilter = {
                 attributeIds: attributeIds,
-                ids: _.map(entities, clinicalDataType === "SAMPLE" ? 'sampleId' : 'patientId')
+                ids: _.map(
+                    entities,
+                    clinicalDataType === 'SAMPLE' ? 'sampleId' : 'patientId'
+                ),
             };
             return client.fetchAllClinicalDataInStudyUsingPOST({
-                studyId:study.studyId,
+                studyId: study.studyId,
                 clinicalDataSingleStudyFilter: filter,
-                clinicalDataType: clinicalDataType
+                clinicalDataType: clinicalDataType,
             });
         } else {
             const filter: ClinicalDataMultiStudyFilter = {
                 attributeIds: attributeIds,
-                identifiers: entities.map((s: any) => clinicalDataType === "SAMPLE" ?
-                    ({entityId: s.sampleId, studyId: s.studyId}) : ({entityId: s.patientId, studyId: s.studyId}))
+                identifiers: entities.map((s: any) =>
+                    clinicalDataType === 'SAMPLE'
+                        ? { entityId: s.sampleId, studyId: s.studyId }
+                        : { entityId: s.patientId, studyId: s.studyId }
+                ),
             };
             return client.fetchClinicalDataUsingPOST({
                 clinicalDataType: clinicalDataType,
-                clinicalDataMultiStudyFilter: filter
+                clinicalDataMultiStudyFilter: filter,
             });
         }
     }
 
-    private getClinicalDataCount(clinicalDataType: "SAMPLE" | "PATIENT", studies:any[], entities: any[], attributeIds: string[]):
-    Promise<number> {
-
-        const projection = "META";
+    private getClinicalDataCount(
+        clinicalDataType: 'SAMPLE' | 'PATIENT',
+        studies: any[],
+        entities: any[],
+        attributeIds: string[]
+    ): Promise<number> {
+        const projection = 'META';
         // single study query endpoint is optimal so we should use it
         // when there's only one study
         if (studies.length === 1) {
             const study = this.studies.result[0];
             const filter: ClinicalDataSingleStudyFilter = {
                 attributeIds: attributeIds,
-                ids: _.map(entities, clinicalDataType === "SAMPLE" ? 'sampleId' : 'patientId')
+                ids: _.map(
+                    entities,
+                    clinicalDataType === 'SAMPLE' ? 'sampleId' : 'patientId'
+                ),
             };
-            return client.fetchAllClinicalDataInStudyUsingPOSTWithHttpInfo({
-                studyId:study.studyId,
-                clinicalDataSingleStudyFilter: filter,
-                clinicalDataType: clinicalDataType,
-                projection
-            }).then(function(response: request.Response) {
-                return parseInt(response.header["total-count"], 10);
-            });
+            return client
+                .fetchAllClinicalDataInStudyUsingPOSTWithHttpInfo({
+                    studyId: study.studyId,
+                    clinicalDataSingleStudyFilter: filter,
+                    clinicalDataType: clinicalDataType,
+                    projection,
+                })
+                .then(function(response: request.Response) {
+                    return parseInt(response.header['total-count'], 10);
+                });
         } else {
             const filter: ClinicalDataMultiStudyFilter = {
                 attributeIds: attributeIds,
-                identifiers: entities.map((s: any) => clinicalDataType === "SAMPLE" ?
-                    ({entityId: s.sampleId, studyId: s.studyId}) : ({entityId: s.patientId, studyId: s.studyId}))
+                identifiers: entities.map((s: any) =>
+                    clinicalDataType === 'SAMPLE'
+                        ? { entityId: s.sampleId, studyId: s.studyId }
+                        : { entityId: s.patientId, studyId: s.studyId }
+                ),
             };
-            return client.fetchClinicalDataUsingPOSTWithHttpInfo({
-                clinicalDataType: clinicalDataType,
-                clinicalDataMultiStudyFilter: filter,
-                projection
-            }).then(function(response: request.Response) {
-                return parseInt(response.header["total-count"], 10);
-            });
+            return client
+                .fetchClinicalDataUsingPOSTWithHttpInfo({
+                    clinicalDataType: clinicalDataType,
+                    clinicalDataMultiStudyFilter: filter,
+                    projection,
+                })
+                .then(function(response: request.Response) {
+                    return parseInt(response.header['total-count'], 10);
+                });
         }
     }
 
     readonly survivalClinicalDataExists = remoteData<boolean>({
-        await:()=>[
-            this.studies,
-            this.patients
-        ],
-        invoke:async()=>{
-            const count =
-                await this.getClinicalDataCount("PATIENT", this.studies.result!, this.patients.result, SURVIVAL_CHART_ATTRIBUTES);
+        await: () => [this.studies, this.patients],
+        invoke: async () => {
+            const count = await this.getClinicalDataCount(
+                'PATIENT',
+                this.studies.result!,
+                this.patients.result,
+                SURVIVAL_CHART_ATTRIBUTES
+            );
             return count > 0;
-        }
-    });
-
-    readonly survivalClinicalData = remoteData<ClinicalData[]>({
-        await: () => [
-            this.studies,
-            this.patients
-        ],
-        invoke: () => this.getClinicalData("PATIENT", this.studies.result!, this.patients.result, SURVIVAL_CHART_ATTRIBUTES)
-    }, []);
-
-    readonly survivalClinicalDataGroupByUniquePatientKey = remoteData<{[key: string]: ClinicalData[]}>({
-        await: () => [
-            this.survivalClinicalData,
-        ],
-        invoke: async() => {
-            return _.groupBy(this.survivalClinicalData.result, 'uniquePatientKey');
-        }
-    });
-
-    readonly overallAlteredPatientSurvivals = remoteData<PatientSurvival[]>({
-        await: () => [
-            this.survivalClinicalDataGroupByUniquePatientKey,
-            this.alteredPatientKeys,
-            this.patients
-        ],
-        invoke: async() => {
-            return getPatientSurvivals(this.survivalClinicalDataGroupByUniquePatientKey.result,
-                this.alteredPatientKeys.result!, 'OS_STATUS', 'OS_MONTHS', s => s === 'DECEASED');
-        }
-    }, []);
-
-    readonly overallUnalteredPatientSurvivals = remoteData<PatientSurvival[]>({
-        await: () => [
-            this.survivalClinicalDataGroupByUniquePatientKey,
-            this.unalteredPatientKeys,
-            this.patients
-        ],
-        invoke: async() => {
-            return getPatientSurvivals(this.survivalClinicalDataGroupByUniquePatientKey.result,
-                this.unalteredPatientKeys.result!, 'OS_STATUS', 'OS_MONTHS', s => s === 'DECEASED');
-        }
-    }, []);
-
-    readonly diseaseFreeAlteredPatientSurvivals = remoteData<PatientSurvival[]>({
-        await: () => [
-            this.survivalClinicalDataGroupByUniquePatientKey,
-            this.alteredPatientKeys,
-            this.patients
-        ],
-        invoke: async() => {
-            return getPatientSurvivals(this.survivalClinicalDataGroupByUniquePatientKey.result,
-                this.alteredPatientKeys.result!, 'DFS_STATUS', 'DFS_MONTHS', s => s === 'Recurred/Progressed' || s === 'Recurred');
-        }
-    }, []);
-
-    readonly diseaseFreeUnalteredPatientSurvivals = remoteData<PatientSurvival[]>({
-        await: () => [
-            this.survivalClinicalDataGroupByUniquePatientKey,
-            this.unalteredPatientKeys,
-            this.patients
-        ],
-        invoke: async() => {
-            return getPatientSurvivals(this.survivalClinicalDataGroupByUniquePatientKey.result,
-                this.unalteredPatientKeys.result!, 'DFS_STATUS', 'DFS_MONTHS', s => s === 'Recurred/Progressed' || s === 'Recurred');
-        }
-    }, []);
-
-    readonly germlineConsentedSamples = remoteData<SampleIdentifier[]>({
-        await:()=>[
-            this.studyIds,
-            this.samples
-        ],
-        invoke: async() => {
-            const germlineConsentedSamples = await fetchGermlineConsentedSamples(
-                this.studyIds, AppConfig.serverConfig.studiesWithGermlineConsentedSamples);
-            const sampleIds = this.samples.result ? this.samples.result.map(s => s.sampleId): [];
-
-            // do not simply return all germline consented samples,
-            // only include the ones matching current sample selection
-            return germlineConsentedSamples.filter(s => sampleIds.includes(s.sampleId));
         },
-        onError: () => {
-            // fail silently
-        }
-    }, []);
+    });
 
-    readonly samples = remoteData({
-        await: () => [
-            this.studyToDataQueryFilter
-        ],
-        invoke: async() => {
+    readonly survivalClinicalData = remoteData<ClinicalData[]>(
+        {
+            await: () => [this.studies, this.patients],
+            invoke: () =>
+                this.getClinicalData(
+                    'PATIENT',
+                    this.studies.result!,
+                    this.patients.result,
+                    SURVIVAL_CHART_ATTRIBUTES
+                ),
+        },
+        []
+    );
 
-            let sampleIdentifiers: SampleIdentifier[] = [];
-            let sampleListIds: string[] = [];
-            _.each(this.studyToDataQueryFilter.result, (dataQueryFilter: IDataQueryFilter, studyId: string) => {
-                if (dataQueryFilter.sampleIds) {
-                    sampleIdentifiers = sampleIdentifiers.concat(dataQueryFilter.sampleIds.map(sampleId => ({
-                        sampleId,
-                        studyId
-                    })));
-                } else if (dataQueryFilter.sampleListId) {
-                    sampleListIds.push(dataQueryFilter.sampleListId);
+    readonly survivalClinicalDataGroupByUniquePatientKey = remoteData<{
+        [key: string]: ClinicalData[];
+    }>({
+        await: () => [this.survivalClinicalData],
+        invoke: async () => {
+            return _.groupBy(
+                this.survivalClinicalData.result,
+                'uniquePatientKey'
+            );
+        },
+    });
+
+    readonly overallAlteredPatientSurvivals = remoteData<PatientSurvival[]>(
+        {
+            await: () => [
+                this.survivalClinicalDataGroupByUniquePatientKey,
+                this.alteredPatientKeys,
+                this.patients,
+            ],
+            invoke: async () => {
+                return getPatientSurvivals(
+                    this.survivalClinicalDataGroupByUniquePatientKey.result,
+                    this.alteredPatientKeys.result!,
+                    'OS_STATUS',
+                    'OS_MONTHS',
+                    s => s === 'DECEASED'
+                );
+            },
+        },
+        []
+    );
+
+    readonly overallUnalteredPatientSurvivals = remoteData<PatientSurvival[]>(
+        {
+            await: () => [
+                this.survivalClinicalDataGroupByUniquePatientKey,
+                this.unalteredPatientKeys,
+                this.patients,
+            ],
+            invoke: async () => {
+                return getPatientSurvivals(
+                    this.survivalClinicalDataGroupByUniquePatientKey.result,
+                    this.unalteredPatientKeys.result!,
+                    'OS_STATUS',
+                    'OS_MONTHS',
+                    s => s === 'DECEASED'
+                );
+            },
+        },
+        []
+    );
+
+    readonly diseaseFreeAlteredPatientSurvivals = remoteData<PatientSurvival[]>(
+        {
+            await: () => [
+                this.survivalClinicalDataGroupByUniquePatientKey,
+                this.alteredPatientKeys,
+                this.patients,
+            ],
+            invoke: async () => {
+                return getPatientSurvivals(
+                    this.survivalClinicalDataGroupByUniquePatientKey.result,
+                    this.alteredPatientKeys.result!,
+                    'DFS_STATUS',
+                    'DFS_MONTHS',
+                    s => s === 'Recurred/Progressed' || s === 'Recurred'
+                );
+            },
+        },
+        []
+    );
+
+    readonly diseaseFreeUnalteredPatientSurvivals = remoteData<
+        PatientSurvival[]
+    >(
+        {
+            await: () => [
+                this.survivalClinicalDataGroupByUniquePatientKey,
+                this.unalteredPatientKeys,
+                this.patients,
+            ],
+            invoke: async () => {
+                return getPatientSurvivals(
+                    this.survivalClinicalDataGroupByUniquePatientKey.result,
+                    this.unalteredPatientKeys.result!,
+                    'DFS_STATUS',
+                    'DFS_MONTHS',
+                    s => s === 'Recurred/Progressed' || s === 'Recurred'
+                );
+            },
+        },
+        []
+    );
+
+    readonly germlineConsentedSamples = remoteData<SampleIdentifier[]>(
+        {
+            await: () => [this.studyIds, this.samples],
+            invoke: async () => {
+                const germlineConsentedSamples = await fetchGermlineConsentedSamples(
+                    this.studyIds,
+                    AppConfig.serverConfig.studiesWithGermlineConsentedSamples
+                );
+                const sampleIds = this.samples.result
+                    ? this.samples.result.map(s => s.sampleId)
+                    : [];
+
+                // do not simply return all germline consented samples,
+                // only include the ones matching current sample selection
+                return germlineConsentedSamples.filter(s =>
+                    sampleIds.includes(s.sampleId)
+                );
+            },
+            onError: () => {
+                // fail silently
+            },
+        },
+        []
+    );
+
+    readonly samples = remoteData(
+        {
+            await: () => [this.studyToDataQueryFilter],
+            invoke: async () => {
+                let sampleIdentifiers: SampleIdentifier[] = [];
+                let sampleListIds: string[] = [];
+                _.each(
+                    this.studyToDataQueryFilter.result,
+                    (dataQueryFilter: IDataQueryFilter, studyId: string) => {
+                        if (dataQueryFilter.sampleIds) {
+                            sampleIdentifiers = sampleIdentifiers.concat(
+                                dataQueryFilter.sampleIds.map(sampleId => ({
+                                    sampleId,
+                                    studyId,
+                                }))
+                            );
+                        } else if (dataQueryFilter.sampleListId) {
+                            sampleListIds.push(dataQueryFilter.sampleListId);
+                        }
+                    }
+                );
+                let promises: Promise<Sample[]>[] = [];
+                if (sampleIdentifiers.length) {
+                    promises.push(
+                        client.fetchSamplesUsingPOST({
+                            sampleFilter: {
+                                sampleIdentifiers,
+                            } as SampleFilter,
+                            projection: 'DETAILED',
+                        })
+                    );
                 }
-            });
-            let promises:Promise<Sample[]>[] = [];
-            if (sampleIdentifiers.length) {
-                promises.push(client.fetchSamplesUsingPOST({
-                    sampleFilter: {
-                        sampleIdentifiers
-                    } as SampleFilter,
-                    projection: "DETAILED"
-                }));
-            }
-            if (sampleListIds.length) {
-                promises.push(client.fetchSamplesUsingPOST({
-                    sampleFilter: {
-                        sampleListIds
-                    } as SampleFilter,
-                    projection:"DETAILED"
-                }));
-            }
-            return _.flatten(await Promise.all(promises));
-        }
-    }, []);
+                if (sampleListIds.length) {
+                    promises.push(
+                        client.fetchSamplesUsingPOST({
+                            sampleFilter: {
+                                sampleListIds,
+                            } as SampleFilter,
+                            projection: 'DETAILED',
+                        })
+                    );
+                }
+                return _.flatten(await Promise.all(promises));
+            },
+        },
+        []
+    );
 
     readonly sampleKeyToSample = remoteData({
-        await: ()=>[
-            this.samples
-        ],
-        invoke: ()=>{
-            return Promise.resolve(_.keyBy(this.samples.result!, sample=>sample.uniqueSampleKey));
-        }
+        await: () => [this.samples],
+        invoke: () => {
+            return Promise.resolve(
+                _.keyBy(this.samples.result!, sample => sample.uniqueSampleKey)
+            );
+        },
     });
 
     readonly patientKeyToPatient = remoteData({
-        await: ()=>[
-            this.patients
-        ],
-        invoke: ()=>{
-            return Promise.resolve(_.keyBy(this.patients.result!, patient=>patient.uniquePatientKey));
-        }
+        await: () => [this.patients],
+        invoke: () => {
+            return Promise.resolve(
+                _.keyBy(
+                    this.patients.result!,
+                    patient => patient.uniquePatientKey
+                )
+            );
+        },
     });
 
     readonly patientKeyToSamples = remoteData({
-        await:()=>[
-            this.samples
-        ],
-        invoke: ()=>{
-            return Promise.resolve(_.groupBy(this.samples.result!, sample=>sample.uniquePatientKey));
-        }
+        await: () => [this.samples],
+        invoke: () => {
+            return Promise.resolve(
+                _.groupBy(
+                    this.samples.result!,
+                    sample => sample.uniquePatientKey
+                )
+            );
+        },
     });
 
     readonly patients = remoteData({
-        await: ()=>[
-            this.samples
-        ],
-        invoke: ()=>fetchPatients(this.samples.result!),
-        default: []
+        await: () => [this.samples],
+        invoke: () => fetchPatients(this.samples.result!),
+        default: [],
     });
 
-    readonly samplesWithoutCancerTypeClinicalData = remoteData<Sample[]>({
-        await: () => [
-            this.samples,
-            this.clinicalDataForSamples
-        ],
-        invoke: () => {
-            const sampleHasData: { [sampleUid: string]: boolean } = {};
-            for (const data of this.clinicalDataForSamples.result) {
-                sampleHasData[toSampleUuid(data.studyId, data.sampleId)] = true;
-            }
-            return Promise.resolve(this.samples.result.filter(sample => {
-                return !sampleHasData[toSampleUuid(sample.studyId, sample.sampleId)];
-            }));
-        }
-    }, []);
+    readonly samplesWithoutCancerTypeClinicalData = remoteData<Sample[]>(
+        {
+            await: () => [this.samples, this.clinicalDataForSamples],
+            invoke: () => {
+                const sampleHasData: { [sampleUid: string]: boolean } = {};
+                for (const data of this.clinicalDataForSamples.result) {
+                    sampleHasData[
+                        toSampleUuid(data.studyId, data.sampleId)
+                    ] = true;
+                }
+                return Promise.resolve(
+                    this.samples.result.filter(sample => {
+                        return !sampleHasData[
+                            toSampleUuid(sample.studyId, sample.sampleId)
+                        ];
+                    })
+                );
+            },
+        },
+        []
+    );
 
-    readonly studiesForSamplesWithoutCancerTypeClinicalData = remoteData({
-        await: () => [
-            this.samplesWithoutCancerTypeClinicalData
-        ],
-        invoke: async () => fetchStudiesForSamplesWithoutCancerTypeClinicalData(this.samplesWithoutCancerTypeClinicalData)
-    }, []);
+    readonly studiesForSamplesWithoutCancerTypeClinicalData = remoteData(
+        {
+            await: () => [this.samplesWithoutCancerTypeClinicalData],
+            invoke: async () =>
+                fetchStudiesForSamplesWithoutCancerTypeClinicalData(
+                    this.samplesWithoutCancerTypeClinicalData
+                ),
+        },
+        []
+    );
 
-    readonly studies = remoteData({
-        await: ()=>[this.studyIds],
-        invoke: async () => {
-            return client.fetchStudiesUsingPOST({
-                studyIds:this.studyIds.result!,
-                projection:'DETAILED'
-            })
-        }
-    }, []);
+    readonly studies = remoteData(
+        {
+            await: () => [this.studyIds],
+            invoke: async () => {
+                return client.fetchStudiesUsingPOST({
+                    studyIds: this.studyIds.result!,
+                    projection: 'DETAILED',
+                });
+            },
+        },
+        []
+    );
 
     //this is only required to show study name and description on the results page
     //CancerStudy objects for all the cohortIds
     readonly queriedStudies = remoteData({
-        await: ()=>[this.studyIdToStudy, this.queriedVirtualStudies],
-		invoke: async ()=>{
-            if(!_.isEmpty(this.rvQuery.cohortIdsList)){
-                return fetchQueriedStudies(this.studyIdToStudy.result, this.rvQuery.cohortIdsList, this.queriedVirtualStudies.result? this.queriedVirtualStudies.result : []);
+        await: () => [this.studyIdToStudy, this.queriedVirtualStudies],
+        invoke: async () => {
+            if (!_.isEmpty(this.rvQuery.cohortIdsList)) {
+                return fetchQueriedStudies(
+                    this.studyIdToStudy.result,
+                    this.rvQuery.cohortIdsList,
+                    this.queriedVirtualStudies.result
+                        ? this.queriedVirtualStudies.result
+                        : []
+                );
             } else {
-                return []
+                return [];
             }
-		},
-		default: [],
+        },
+        default: [],
     });
 
-    readonly studyIdToStudy = remoteData({
-        await: ()=>[this.studies],
-        invoke:()=>Promise.resolve(_.keyBy(this.studies.result, x=>x.studyId))
-    }, {});
+    readonly studyIdToStudy = remoteData(
+        {
+            await: () => [this.studies],
+            invoke: () =>
+                Promise.resolve(_.keyBy(this.studies.result, x => x.studyId)),
+        },
+        {}
+    );
 
-    readonly molecularProfilesInStudies = remoteData<MolecularProfile[]>({
-        await:()=>[this.studyIds],
-        invoke: async () => {
-            return client.fetchMolecularProfilesUsingPOST({
-                molecularProfileFilter: { studyIds:this.studyIds.result! } as MolecularProfileFilter
-            })
-        }
-    }, []);
+    readonly molecularProfilesInStudies = remoteData<MolecularProfile[]>(
+        {
+            await: () => [this.studyIds],
+            invoke: async () => {
+                return client.fetchMolecularProfilesUsingPOST({
+                    molecularProfileFilter: {
+                        studyIds: this.studyIds.result!,
+                    } as MolecularProfileFilter,
+                });
+            },
+        },
+        []
+    );
 
-    readonly nonSelectedMolecularProfiles = remoteData<MolecularProfile[]>({
-        await:()=>[this.molecularProfilesInStudies, this.selectedMolecularProfiles],
-        invoke:() => {   
-            return Promise.resolve(_.difference(this.molecularProfilesInStudies.result!, this.selectedMolecularProfiles.result!));
-        }
-    }, []);
+    readonly nonSelectedMolecularProfiles = remoteData<MolecularProfile[]>(
+        {
+            await: () => [
+                this.molecularProfilesInStudies,
+                this.selectedMolecularProfiles,
+            ],
+            invoke: () => {
+                return Promise.resolve(
+                    _.difference(
+                        this.molecularProfilesInStudies.result!,
+                        this.selectedMolecularProfiles.result!
+                    )
+                );
+            },
+        },
+        []
+    );
 
     // If we have same profile accros multiple studies, they should have the same name, so we can group them by name to get all related molecular profiles in multiple studies.
-    readonly nonSelectedMolecularProfilesGroupByName = remoteData<{ [profileName: string]: MolecularProfile[] }>({
-        await:()=>[this.nonSelectedMolecularProfiles],
-        invoke:() => {
-            const sortedProfiles = _.sortBy(this.nonSelectedMolecularProfiles.result, (profile) => decideMolecularProfileSortingOrder(profile.molecularAlterationType));
-            return Promise.resolve(_.groupBy(sortedProfiles, (profile) => profile.name));
-        }
-    }, {});
+    readonly nonSelectedMolecularProfilesGroupByName = remoteData<{
+        [profileName: string]: MolecularProfile[];
+    }>(
+        {
+            await: () => [this.nonSelectedMolecularProfiles],
+            invoke: () => {
+                const sortedProfiles = _.sortBy(
+                    this.nonSelectedMolecularProfiles.result,
+                    profile =>
+                        decideMolecularProfileSortingOrder(
+                            profile.molecularAlterationType
+                        )
+                );
+                return Promise.resolve(
+                    _.groupBy(sortedProfiles, profile => profile.name)
+                );
+            },
+        },
+        {}
+    );
 
-    readonly molecularProfileIdToMolecularProfile = remoteData<{ [molecularProfileId: string]: MolecularProfile }>({
-        await: () => [this.molecularProfilesInStudies],
-        invoke: () => {
-            return Promise.resolve(this.molecularProfilesInStudies.result.reduce((map: { [molecularProfileId: string]: MolecularProfile }, next: MolecularProfile) => {
-                map[next.molecularProfileId] = next;
-                return map;
-            }, {}));
-        }
-    }, {});
+    readonly molecularProfileIdToMolecularProfile = remoteData<{
+        [molecularProfileId: string]: MolecularProfile;
+    }>(
+        {
+            await: () => [this.molecularProfilesInStudies],
+            invoke: () => {
+                return Promise.resolve(
+                    this.molecularProfilesInStudies.result.reduce(
+                        (
+                            map: {
+                                [molecularProfileId: string]: MolecularProfile;
+                            },
+                            next: MolecularProfile
+                        ) => {
+                            map[next.molecularProfileId] = next;
+                            return map;
+                        },
+                        {}
+                    )
+                );
+            },
+        },
+        {}
+    );
 
-    readonly studyToMolecularProfileDiscrete = remoteData<{ [studyId: string]: MolecularProfile }>({
-        await: () => [
-            this.molecularProfilesInStudies
-        ],
-        invoke: async () => {
-            const ret: { [studyId: string]: MolecularProfile } = {};
-            for (const molecularProfile of this.molecularProfilesInStudies.result) {
-                if (molecularProfile.datatype === "DISCRETE") {
-                    ret[molecularProfile.studyId] = molecularProfile;
+    readonly studyToMolecularProfileDiscrete = remoteData<{
+        [studyId: string]: MolecularProfile;
+    }>(
+        {
+            await: () => [this.molecularProfilesInStudies],
+            invoke: async () => {
+                const ret: { [studyId: string]: MolecularProfile } = {};
+                for (const molecularProfile of this.molecularProfilesInStudies
+                    .result) {
+                    if (molecularProfile.datatype === 'DISCRETE') {
+                        ret[molecularProfile.studyId] = molecularProfile;
+                    }
                 }
-            }
-            return ret;
-        }
-    }, {});
+                return ret;
+            },
+        },
+        {}
+    );
 
     readonly heatmapMolecularProfiles = remoteData<MolecularProfile[]>({
         await: () => [
             this.molecularProfilesInStudies,
             this.selectedMolecularProfiles,
-            this.genesetMolecularProfile
+            this.genesetMolecularProfile,
         ],
         invoke: () => {
             const MRNA_EXPRESSION = AlterationTypeConstants.MRNA_EXPRESSION;
@@ -2505,20 +3399,28 @@ export class ResultsViewPageStore {
             const METHYLATION = AlterationTypeConstants.METHYLATION;
             const GENERIC_ASSAY = AlterationTypeConstants.GENERIC_ASSAY;
             const selectedMolecularProfileIds = stringListToSet(
-                this.selectedMolecularProfiles.result!.map((profile)=>profile.molecularProfileId)
+                this.selectedMolecularProfiles.result!.map(
+                    profile => profile.molecularProfileId
+                )
             );
 
             const expressionHeatmaps = _.sortBy(
-                _.filter(this.molecularProfilesInStudies.result!, profile=>{
-                    return ((profile.molecularAlterationType === MRNA_EXPRESSION ||
-                        profile.molecularAlterationType === PROTEIN_LEVEL ||
-                        profile.molecularAlterationType === GENERIC_ASSAY) && profile.showProfileInAnalysisTab) ||
+                _.filter(this.molecularProfilesInStudies.result!, profile => {
+                    return (
+                        ((profile.molecularAlterationType === MRNA_EXPRESSION ||
+                            profile.molecularAlterationType === PROTEIN_LEVEL ||
+                            profile.molecularAlterationType ===
+                                GENERIC_ASSAY) &&
+                            profile.showProfileInAnalysisTab) ||
                         profile.molecularAlterationType === METHYLATION
-                    }
-                ),
-                profile=>{
+                    );
+                }),
+                profile => {
                     // Sort order: selected and [mrna, protein, methylation, treatment], unselected and [mrna, protein, meth, treatment]
-                    if (profile.molecularProfileId in selectedMolecularProfileIds) {
+                    if (
+                        profile.molecularProfileId in
+                        selectedMolecularProfileIds
+                    ) {
                         switch (profile.molecularAlterationType) {
                             case MRNA_EXPRESSION:
                                 return 0;
@@ -2530,7 +3432,7 @@ export class ResultsViewPageStore {
                                 return 3;
                         }
                     } else {
-                        switch(profile.molecularAlterationType) {
+                        switch (profile.molecularAlterationType) {
                             case MRNA_EXPRESSION:
                                 return 4;
                             case PROTEIN_LEVEL:
@@ -2543,67 +3445,71 @@ export class ResultsViewPageStore {
                     }
                 }
             );
-            const genesetMolecularProfile = this.genesetMolecularProfile.result!;
-            const genesetHeatmaps = (
-                genesetMolecularProfile.isApplicable
+            const genesetMolecularProfile = this.genesetMolecularProfile
+                .result!;
+            const genesetHeatmaps = genesetMolecularProfile.isApplicable
                 ? [genesetMolecularProfile.value]
-                : []
-            );
+                : [];
             return Promise.resolve(expressionHeatmaps.concat(genesetHeatmaps));
-        }
+        },
     });
 
     readonly genesetMolecularProfile = remoteData<Optional<MolecularProfile>>({
-        await: () => [
-            this.selectedMolecularProfiles
-        ],
+        await: () => [this.selectedMolecularProfiles],
         invoke: () => {
             const applicableProfiles = _.filter(
                 this.selectedMolecularProfiles.result!,
-                profile => (
-                    profile.molecularAlterationType === AlterationTypeConstants.GENESET_SCORE
-                    && profile.showProfileInAnalysisTab
-                )
+                profile =>
+                    profile.molecularAlterationType ===
+                        AlterationTypeConstants.GENESET_SCORE &&
+                    profile.showProfileInAnalysisTab
             );
             if (applicableProfiles.length > 1) {
-                return Promise.reject(new Error("Queried more than one gene set score profile"));
+                return Promise.reject(
+                    new Error('Queried more than one gene set score profile')
+                );
             }
             const genesetProfile = applicableProfiles.pop();
-            const value: Optional<MolecularProfile> = (
-                genesetProfile
-                ? {isApplicable: true, value: genesetProfile}
-                : {isApplicable: false}
-            );
+            const value: Optional<MolecularProfile> = genesetProfile
+                ? { isApplicable: true, value: genesetProfile }
+                : { isApplicable: false };
             return Promise.resolve(value);
-        }
+        },
     });
 
-    readonly studyToDataQueryFilter = remoteData<{ [studyId: string]: IDataQueryFilter }>({
-        await: () => [this.studyToSampleIds, this.studyIds, this.studyToSampleListId],
-        invoke: () => {
-            const studies = this.studyIds.result!;
-            const ret: { [studyId: string]: IDataQueryFilter } = {};
-            for (const studyId of studies) {
-                ret[studyId] = generateDataQueryFilter(this.studyToSampleListId.result![studyId] || null, Object.keys(this.studyToSampleIds.result[studyId] || {}))
-            }
-            return Promise.resolve(ret);
-        }
-    }, {});
+    readonly studyToDataQueryFilter = remoteData<{
+        [studyId: string]: IDataQueryFilter;
+    }>(
+        {
+            await: () => [
+                this.studyToSampleIds,
+                this.studyIds,
+                this.studyToSampleListId,
+            ],
+            invoke: () => {
+                const studies = this.studyIds.result!;
+                const ret: { [studyId: string]: IDataQueryFilter } = {};
+                for (const studyId of studies) {
+                    ret[studyId] = generateDataQueryFilter(
+                        this.studyToSampleListId.result![studyId] || null,
+                        Object.keys(this.studyToSampleIds.result[studyId] || {})
+                    );
+                }
+                return Promise.resolve(ret);
+            },
+        },
+        {}
+    );
 
-
-    public getSessionIdInUrl(){
+    public getSessionIdInUrl() {
         const parsedQString = url.parse((window as any).location.href, true);
         return parsedQString.query.session_id;
     }
 
     readonly bookmarkLinks = remoteData<BookmarkLinks>({
-
-        await:()=>[
-            this.studies
-        ],
+        await: () => [this.studies],
 
         invoke: async () => {
-
             const win = window as any;
 
             let longUrl = win.location.href;
@@ -2612,213 +3518,264 @@ export class ResultsViewPageStore {
 
             // if we have a session service, lets get the url for the session
             if (ServerConfigHelpers.sessionServiceIsEnabled()) {
-                longUrl = await new Promise((resolve, reject)=>{
-                    win.getSessionServiceBookmark(window.location.href, $("#bookmark-result-tab").data('session'), function(url:string){
-;                        resolve(url);
-                    });
+                longUrl = await new Promise((resolve, reject) => {
+                    win.getSessionServiceBookmark(
+                        window.location.href,
+                        $('#bookmark-result-tab').data('session'),
+                        function(url: string) {
+                            resolve(url);
+                        }
+                    );
                 });
             }
 
             const queryData = {
-                version:3.0,
-                longUrl:longUrl,
-                session_id:longUrl.match(/session_id=(.*)$/)[1],
-                history:0,
-                format:"json"
+                version: 3.0,
+                longUrl: longUrl,
+                session_id: longUrl.match(/session_id=(.*)$/)[1],
+                history: 0,
+                format: 'json',
             };
 
-            const bitlyResponse = await request.get(getBitlyServiceUrl())
-                .query(queryData) as any;
+            const bitlyResponse = (await request
+                .get(getBitlyServiceUrl())
+                .query(queryData)) as any;
 
             const parsedBitlyResponse = JSON.parse(bitlyResponse.body) as any;
-            return { longUrl , shortenedUrl:(_.values(parsedBitlyResponse.results)[0] as any).shortUrl  }
-        }
-
+            return {
+                longUrl,
+                shortenedUrl: (_.values(parsedBitlyResponse.results)[0] as any)
+                    .shortUrl,
+            };
+        },
     });
 
-    readonly molecularProfileIdToDataQueryFilter = remoteData<{[molecularProfileId:string]:IDataQueryFilter}>({
-        await: ()=>[
+    readonly molecularProfileIdToDataQueryFilter = remoteData<{
+        [molecularProfileId: string]: IDataQueryFilter;
+    }>({
+        await: () => [
             this.molecularProfilesInStudies,
-            this.studyToDataQueryFilter
+            this.studyToDataQueryFilter,
         ],
-        invoke: ()=>{
-            const ret:{[molecularProfileId:string]:IDataQueryFilter} = {};
-            for (const molecularProfile of this.molecularProfilesInStudies.result!) {
-                ret[molecularProfile.molecularProfileId] = this.studyToDataQueryFilter.result![molecularProfile.studyId];
+        invoke: () => {
+            const ret: { [molecularProfileId: string]: IDataQueryFilter } = {};
+            for (const molecularProfile of this.molecularProfilesInStudies
+                .result!) {
+                ret[
+                    molecularProfile.molecularProfileId
+                ] = this.studyToDataQueryFilter.result![
+                    molecularProfile.studyId
+                ];
             }
             return Promise.resolve(ret);
         },
-        default: {}
+        default: {},
     });
 
     readonly genes = remoteData<Gene[]>({
         invoke: async () => {
-
             const genes = await fetchGenes(this.hugoGeneSymbols);
 
             // Check that the same genes are in the OQL query as in the API response (order doesnt matter).
             // This ensures that all the genes in OQL are valid. If not, we throw an error.
-            if (_.isEqual(_.sortBy(this.hugoGeneSymbols), _.sortBy(genes.map((gene)=>gene.hugoGeneSymbol)))) {
+            if (
+                _.isEqual(
+                    _.sortBy(this.hugoGeneSymbols),
+                    _.sortBy(genes.map(gene => gene.hugoGeneSymbol))
+                )
+            ) {
                 return genes;
             } else {
-                throw(new Error(ErrorMessages.InvalidGenes));
+                throw new Error(ErrorMessages.InvalidGenes);
             }
         },
-        onResult:(genes:Gene[])=>{
+        onResult: (genes: Gene[]) => {
             this.geneCache.addData(genes);
         },
-        onError:(err)=>{
+        onError: err => {
             // throwing this allows sentry to report it
-            throw(err);
-        }
+            throw err;
+        },
     });
 
     readonly referenceGenes = remoteData<ReferenceGenomeGene[]>({
-        await: ()=>[
-            this.studies
-        ],
+        await: () => [this.studies],
         invoke: () => {
             if (this.studies.result!.length > 0) {
-                return fetchAllReferenceGenomeGenes(this.studies.result[0].referenceGenome);
+                return fetchAllReferenceGenomeGenes(
+                    this.studies.result[0].referenceGenome
+                );
             } else {
                 return Promise.resolve([]);
             }
-        }
+        },
     });
 
-    readonly hugoGeneSymbolToReferenceGene = remoteData<{[hugoSymbol:string]:ReferenceGenomeGene}>({
-        await: ()=>[
-            this.referenceGenes
-        ],
-        invoke: ()=>{
+    readonly hugoGeneSymbolToReferenceGene = remoteData<{
+        [hugoSymbol: string]: ReferenceGenomeGene;
+    }>({
+        await: () => [this.referenceGenes],
+        invoke: () => {
             // build reference gene map
-            return Promise.resolve(_.keyBy(this.referenceGenes.result!, g=>g.hugoGeneSymbol));
-        }
+            return Promise.resolve(
+                _.keyBy(this.referenceGenes.result!, g => g.hugoGeneSymbol)
+            );
+        },
     });
 
     @computed get referenceGenome() {
-        const study = this.studies.result?
-            this.studies.result[0]: undefined;
-        return study? study.referenceGenome: DEFAULT_GENOME;
+        const study = this.studies.result ? this.studies.result[0] : undefined;
+        return study ? study.referenceGenome : DEFAULT_GENOME;
     }
 
-    @computed get genesInvalid(){
+    @computed get genesInvalid() {
         return this.genes.isError;
     }
 
     @computed get isQueryInvalid() {
         return (
-            this.hugoGeneSymbols.length * this.samples.result.length > AppConfig.serverConfig.query_product_limit
+            this.hugoGeneSymbols.length * this.samples.result.length >
+            AppConfig.serverConfig.query_product_limit
         );
     }
 
     @computed get geneLimit(): number {
-        return Math.floor(AppConfig.serverConfig.query_product_limit / this.samples.result.length);
+        return Math.floor(
+            AppConfig.serverConfig.query_product_limit /
+                this.samples.result.length
+        );
     }
 
     readonly genesets = remoteData<Geneset[]>({
         invoke: () => {
             if (this.rvQuery.genesetIds && this.rvQuery.genesetIds.length > 0) {
-                return internalClient.fetchGenesetsUsingPOST({genesetIds: this.rvQuery.genesetIds.slice()});
+                return internalClient.fetchGenesetsUsingPOST({
+                    genesetIds: this.rvQuery.genesetIds.slice(),
+                });
             } else {
                 return Promise.resolve([]);
             }
         },
-        onResult:(genesets:Geneset[])=>{
+        onResult: (genesets: Geneset[]) => {
             this.genesetCache.addData(genesets);
-        }
+        },
     });
 
     readonly geneticEntities = remoteData<GeneticEntity[]>({
-        await: ()=>[
+        await: () => [
             this.genes,
             this.genesets,
-            this.hugoGeneSymbolToReferenceGene
+            this.hugoGeneSymbolToReferenceGene,
         ],
         invoke: () => {
             const res: GeneticEntity[] = [];
             for (const gene of this.genes.result!) {
-                res.push({geneticEntityName: gene.hugoGeneSymbol, geneticEntityType: GeneticEntityType.GENE,
+                res.push({
+                    geneticEntityName: gene.hugoGeneSymbol,
+                    geneticEntityType: GeneticEntityType.GENE,
                     geneticEntityId: gene.entrezGeneId,
-                    cytoband: this.hugoGeneSymbolToReferenceGene.result![gene.hugoGeneSymbol].cytoband,
-                    geneticEntityData: gene});
+                    cytoband: this.hugoGeneSymbolToReferenceGene.result![
+                        gene.hugoGeneSymbol
+                    ].cytoband,
+                    geneticEntityData: gene,
+                });
             }
             for (const geneset of this.genesets.result!) {
-                res.push({geneticEntityName: geneset.name, geneticEntityType: GeneticEntityType.GENESET,
-                    geneticEntityId: geneset.genesetId, cytoband: "-", geneticEntityData: geneset});
+                res.push({
+                    geneticEntityName: geneset.name,
+                    geneticEntityType: GeneticEntityType.GENESET,
+                    geneticEntityId: geneset.genesetId,
+                    cytoband: '-',
+                    geneticEntityData: geneset,
+                });
             }
             return Promise.resolve(res);
-
-        }
+        },
     });
 
     readonly treatmentsInStudies = remoteData<Treatment[]>({
-        await:()=>[this.studyIds],
+        await: () => [this.studyIds],
         invoke: async () => {
             return internalClient.fetchTreatmentsUsingPOST({
-                treatmentFilter: { studyIds:this.studyIds.result! } as TreatmentFilter
-            })
+                treatmentFilter: {
+                    studyIds: this.studyIds.result!,
+                } as TreatmentFilter,
+            });
         },
-        onResult:(treatments:Treatment[])=>{
+        onResult: (treatments: Treatment[]) => {
             this.treatmentCache.addData(treatments);
-        }
+        },
     });
 
     readonly selectedTreatments = remoteData<Treatment[]>({
-        await: ()=>[this.treatmentsInStudies],
+        await: () => [this.treatmentsInStudies],
         invoke: () => {
-            const treatmentIdFromUrl =  this.rvQuery.treatmentIds;
-            return Promise.resolve(_.filter(this.treatmentsInStudies.result!, (d:Treatment) => treatmentIdFromUrl.includes(d.treatmentId)));
-        }
+            const treatmentIdFromUrl = this.rvQuery.treatmentIds;
+            return Promise.resolve(
+                _.filter(this.treatmentsInStudies.result!, (d: Treatment) =>
+                    treatmentIdFromUrl.includes(d.treatmentId)
+                )
+            );
+        },
     });
 
-    readonly entrezGeneIdToGene = remoteData<{[entrezGeneId:number]:Gene}>({
-        await: ()=>[this.genes],
-        invoke: ()=>Promise.resolve(_.keyBy(this.genes.result!, gene=>gene.entrezGeneId))
+    readonly entrezGeneIdToGene = remoteData<{ [entrezGeneId: number]: Gene }>({
+        await: () => [this.genes],
+        invoke: () =>
+            Promise.resolve(
+                _.keyBy(this.genes.result!, gene => gene.entrezGeneId)
+            ),
     });
 
-    readonly genesetLinkMap = remoteData<{[genesetId: string]: string}>({
+    readonly genesetLinkMap = remoteData<{ [genesetId: string]: string }>({
         invoke: async () => {
             if (this.rvQuery.genesetIds && this.rvQuery.genesetIds.length) {
-                const genesets = await internalClient.fetchGenesetsUsingPOST(
-                    {genesetIds: this.rvQuery.genesetIds.slice()}
-                );
-                const linkMap: {[genesetId: string]: string} = {};
-                genesets.forEach(({genesetId, refLink}) => {
+                const genesets = await internalClient.fetchGenesetsUsingPOST({
+                    genesetIds: this.rvQuery.genesetIds.slice(),
+                });
+                const linkMap: { [genesetId: string]: string } = {};
+                genesets.forEach(({ genesetId, refLink }) => {
                     linkMap[genesetId] = refLink;
                 });
                 return linkMap;
             } else {
                 return {};
             }
-        }
+        },
     });
 
-    readonly treatmentLinkMap = remoteData<{[treatmentId: string]: string}>({
+    readonly treatmentLinkMap = remoteData<{ [treatmentId: string]: string }>({
         invoke: async () => {
             if (this.rvQuery.treatmentIds && this.rvQuery.treatmentIds.length) {
-                const treatments = await internalClient.fetchTreatmentsUsingPOST({
-                    treatmentFilter: { studyIds:this.studyIds.result! } as TreatmentFilter
-                });
-                const linkMap: {[treatmentId: string]: string} = {};
-                treatments.forEach(({treatmentId, refLink}) => {
+                const treatments = await internalClient.fetchTreatmentsUsingPOST(
+                    {
+                        treatmentFilter: {
+                            studyIds: this.studyIds.result!,
+                        } as TreatmentFilter,
+                    }
+                );
+                const linkMap: { [treatmentId: string]: string } = {};
+                treatments.forEach(({ treatmentId, refLink }) => {
                     linkMap[treatmentId] = refLink;
                 });
                 return linkMap;
             } else {
                 return {};
             }
-        }
+        },
     });
 
-    readonly customDriverAnnotationReport = remoteData<{ hasBinary:boolean, tiers:string[] }>({
-        await:()=>[
-            this.mutations
-        ],
-        invoke:()=>{
-            return Promise.resolve(computeCustomDriverAnnotationReport(this.mutations.result!));
+    readonly customDriverAnnotationReport = remoteData<{
+        hasBinary: boolean;
+        tiers: string[];
+    }>({
+        await: () => [this.mutations],
+        invoke: () => {
+            return Promise.resolve(
+                computeCustomDriverAnnotationReport(this.mutations.result!)
+            );
         },
-        onResult:result=>{
+        onResult: result => {
             initializeCustomDriverAnnotationSettings(
                 result!,
                 this.driverAnnotationSettings,
@@ -2826,136 +3783,186 @@ export class ResultsViewPageStore {
                 this.driverAnnotationSettings.oncoKb,
                 this.driverAnnotationSettings.hotspots
             );
-        }
+        },
     });
 
     readonly _filteredAndAnnotatedMutationsReport = remoteData({
-        await:()=>[
+        await: () => [
             this.mutations,
             this.getPutativeDriverInfo,
-            this.entrezGeneIdToGene
+            this.entrezGeneIdToGene,
         ],
-        invoke:()=>{
-            return Promise.resolve(filterAndAnnotateMutations(
-                this.mutations.result!, this.getPutativeDriverInfo.result!,
-                this.entrezGeneIdToGene.result!
-            ));
-        }
+        invoke: () => {
+            return Promise.resolve(
+                filterAndAnnotateMutations(
+                    this.mutations.result!,
+                    this.getPutativeDriverInfo.result!,
+                    this.entrezGeneIdToGene.result!
+                )
+            );
+        },
     });
 
     readonly filteredAndAnnotatedMutations = remoteData<AnnotatedMutation[]>({
-       await:()=>[this._filteredAndAnnotatedMutationsReport],
-       invoke:()=>Promise.resolve(compileMutations(
-           this._filteredAndAnnotatedMutationsReport.result!,
-           this.driverAnnotationSettings.excludeVUS,
-           this.excludeGermlineMutations
-       ))
+        await: () => [this._filteredAndAnnotatedMutationsReport],
+        invoke: () =>
+            Promise.resolve(
+                compileMutations(
+                    this._filteredAndAnnotatedMutationsReport.result!,
+                    this.driverAnnotationSettings.excludeVUS,
+                    this.excludeGermlineMutations
+                )
+            ),
     });
 
-    public annotatedMutationCache = new MobxPromiseCache<{entrezGeneId:number}, AnnotatedMutation[]>(
-        q=>({
-            await: ()=>[
-                this.mutationCache.get(q),
-                this.getPutativeDriverInfo,
-                this.entrezGeneIdToGene
-            ],
-            invoke: ()=>{
-                const filteredAndAnnotatedReport = filterAndAnnotateMutations(
-                    this.mutationCache.get(q).result!, this.getPutativeDriverInfo.result!,
-                    this.entrezGeneIdToGene.result!
-                );
-                const data = filteredAndAnnotatedReport.data
-                    .concat(filteredAndAnnotatedReport.vus)
-                    .concat(filteredAndAnnotatedReport.germline);
+    public annotatedMutationCache = new MobxPromiseCache<
+        { entrezGeneId: number },
+        AnnotatedMutation[]
+    >(q => ({
+        await: () => [
+            this.mutationCache.get(q),
+            this.getPutativeDriverInfo,
+            this.entrezGeneIdToGene,
+        ],
+        invoke: () => {
+            const filteredAndAnnotatedReport = filterAndAnnotateMutations(
+                this.mutationCache.get(q).result!,
+                this.getPutativeDriverInfo.result!,
+                this.entrezGeneIdToGene.result!
+            );
+            const data = filteredAndAnnotatedReport.data
+                .concat(filteredAndAnnotatedReport.vus)
+                .concat(filteredAndAnnotatedReport.germline);
 
-                return Promise.resolve(data);
-            }
-        })
-    );
+            return Promise.resolve(data);
+        },
+    }));
 
     readonly _filteredAndAnnotatedMolecularDataReport = remoteData({
-        await: ()=>[
+        await: () => [
             this.molecularData,
             this.entrezGeneIdToGene,
             this.getOncoKbCnaAnnotationForOncoprint,
-            this.molecularProfileIdToMolecularProfile
+            this.molecularProfileIdToMolecularProfile,
         ],
-        invoke:()=>{
+        invoke: () => {
             const entrezGeneIdToGene = this.entrezGeneIdToGene.result!;
-            let getOncoKbAnnotation:(datum:NumericGeneMolecularData)=>IndicatorQueryResp|undefined;
-            if (this.getOncoKbCnaAnnotationForOncoprint.result! instanceof Error) {
-                getOncoKbAnnotation = ()=>undefined;
+            let getOncoKbAnnotation: (
+                datum: NumericGeneMolecularData
+            ) => IndicatorQueryResp | undefined;
+            if (
+                this.getOncoKbCnaAnnotationForOncoprint.result! instanceof Error
+            ) {
+                getOncoKbAnnotation = () => undefined;
             } else {
-                getOncoKbAnnotation = this.getOncoKbCnaAnnotationForOncoprint.result! as typeof getOncoKbAnnotation;
+                getOncoKbAnnotation = this.getOncoKbCnaAnnotationForOncoprint
+                    .result! as typeof getOncoKbAnnotation;
             }
-            const profileIdToProfile = this.molecularProfileIdToMolecularProfile.result!;
-            const vus:AnnotatedNumericGeneMolecularData[] = [];
-            const data = this.molecularData.result!.reduce((acc:AnnotatedNumericGeneMolecularData[], next)=>{
-                const d = annotateMolecularDatum(
-                    next,
-                    getOncoKbAnnotation,
-                    profileIdToProfile,
-                    entrezGeneIdToGene
-                );
-                if (d.oncoKbOncogenic) { // truthy check - empty string means not driver
-                    acc.push(d);
-                } else {
-                    vus.push(d);
-                }
-                return acc;
-            }, [] as AnnotatedNumericGeneMolecularData[]);
+            const profileIdToProfile = this.molecularProfileIdToMolecularProfile
+                .result!;
+            const vus: AnnotatedNumericGeneMolecularData[] = [];
+            const data = this.molecularData.result!.reduce(
+                (acc: AnnotatedNumericGeneMolecularData[], next) => {
+                    const d = annotateMolecularDatum(
+                        next,
+                        getOncoKbAnnotation,
+                        profileIdToProfile,
+                        entrezGeneIdToGene
+                    );
+                    if (d.oncoKbOncogenic) {
+                        // truthy check - empty string means not driver
+                        acc.push(d);
+                    } else {
+                        vus.push(d);
+                    }
+                    return acc;
+                },
+                [] as AnnotatedNumericGeneMolecularData[]
+            );
             return Promise.resolve({
-                data, vus
+                data,
+                vus,
             });
-        }
+        },
     });
 
-    readonly filteredAndAnnotatedMolecularData = remoteData<AnnotatedNumericGeneMolecularData[]>({
-        await:()=>[this._filteredAndAnnotatedMolecularDataReport],
-        invoke:()=>{
-            let data = this._filteredAndAnnotatedMolecularDataReport.result!.data;
+    readonly filteredAndAnnotatedMolecularData = remoteData<
+        AnnotatedNumericGeneMolecularData[]
+    >({
+        await: () => [this._filteredAndAnnotatedMolecularDataReport],
+        invoke: () => {
+            let data = this._filteredAndAnnotatedMolecularDataReport.result!
+                .data;
             if (!this.driverAnnotationSettings.excludeVUS) {
-                data = data.concat(this._filteredAndAnnotatedMolecularDataReport.result!.vus);
+                data = data.concat(
+                    this._filteredAndAnnotatedMolecularDataReport.result!.vus
+                );
             }
             return Promise.resolve(data);
-        }
+        },
     });
 
-    public annotatedCnaCache =
-        new MobxPromiseCache<{entrezGeneId:number}, AnnotatedNumericGeneMolecularData[]>(
-            q=>({
-                await: ()=>this.numericGeneMolecularDataCache.await(
-                    [this.studyToMolecularProfileDiscrete, this.entrezGeneIdToGene, this.getOncoKbCnaAnnotationForOncoprint, this.molecularProfileIdToMolecularProfile],
-                    (studyToMolecularProfileDiscrete)=>{
-                        return _.values(studyToMolecularProfileDiscrete).map(p=>({entrezGeneId: q.entrezGeneId, molecularProfileId: p.molecularProfileId}));
-                    }),
-                invoke:()=>{
-                    const results = _.flatten(this.numericGeneMolecularDataCache.getAll(
-                        _.values(this.studyToMolecularProfileDiscrete.result!).map(p=>({entrezGeneId: q.entrezGeneId, molecularProfileId: p.molecularProfileId}))
-                    ).map(p=>p.result!));
-                    const entrezGeneIdToGene = this.entrezGeneIdToGene.result!;
-                    let getOncoKbAnnotation:(datum:NumericGeneMolecularData)=>IndicatorQueryResp|undefined;
-                    if (this.getOncoKbCnaAnnotationForOncoprint.result! instanceof Error) {
-                        getOncoKbAnnotation = ()=>undefined;
-                    } else {
-                        getOncoKbAnnotation = this.getOncoKbCnaAnnotationForOncoprint.result! as typeof getOncoKbAnnotation;
-                    }
-                    const profileIdToProfile = this.molecularProfileIdToMolecularProfile.result!;
-                    return Promise.resolve(results.map(d=>{
-                            return annotateMolecularDatum(
-                                d,
-                                getOncoKbAnnotation,
-                                profileIdToProfile,
-                                entrezGeneIdToGene
-                            );
-                        })
-                    );
+    public annotatedCnaCache = new MobxPromiseCache<
+        { entrezGeneId: number },
+        AnnotatedNumericGeneMolecularData[]
+    >(q => ({
+        await: () =>
+            this.numericGeneMolecularDataCache.await(
+                [
+                    this.studyToMolecularProfileDiscrete,
+                    this.entrezGeneIdToGene,
+                    this.getOncoKbCnaAnnotationForOncoprint,
+                    this.molecularProfileIdToMolecularProfile,
+                ],
+                studyToMolecularProfileDiscrete => {
+                    return _.values(studyToMolecularProfileDiscrete).map(p => ({
+                        entrezGeneId: q.entrezGeneId,
+                        molecularProfileId: p.molecularProfileId,
+                    }));
                 }
-            })
-        );
+            ),
+        invoke: () => {
+            const results = _.flatten(
+                this.numericGeneMolecularDataCache
+                    .getAll(
+                        _.values(
+                            this.studyToMolecularProfileDiscrete.result!
+                        ).map(p => ({
+                            entrezGeneId: q.entrezGeneId,
+                            molecularProfileId: p.molecularProfileId,
+                        }))
+                    )
+                    .map(p => p.result!)
+            );
+            const entrezGeneIdToGene = this.entrezGeneIdToGene.result!;
+            let getOncoKbAnnotation: (
+                datum: NumericGeneMolecularData
+            ) => IndicatorQueryResp | undefined;
+            if (
+                this.getOncoKbCnaAnnotationForOncoprint.result! instanceof Error
+            ) {
+                getOncoKbAnnotation = () => undefined;
+            } else {
+                getOncoKbAnnotation = this.getOncoKbCnaAnnotationForOncoprint
+                    .result! as typeof getOncoKbAnnotation;
+            }
+            const profileIdToProfile = this.molecularProfileIdToMolecularProfile
+                .result!;
+            return Promise.resolve(
+                results.map(d => {
+                    return annotateMolecularDatum(
+                        d,
+                        getOncoKbAnnotation,
+                        profileIdToProfile,
+                        entrezGeneIdToGene
+                    );
+                })
+            );
+        },
+    }));
 
     readonly getPutativeDriverInfo = remoteData({
-        await:()=>{
+        await: () => {
             const toAwait = [];
             if (this.driverAnnotationSettings.oncoKb) {
                 toAwait.push(this.getOncoKbMutationAnnotationForOncoprint);
@@ -2971,42 +3978,63 @@ export class ResultsViewPageStore {
             }
             return toAwait;
         },
-        invoke:()=>{
-            return Promise.resolve((mutation:Mutation):{oncoKb:string, hotspots:boolean, cbioportalCount:boolean, cosmicCount:boolean, customDriverBinary:boolean, customDriverTier?:string}=>{
-                const getOncoKbMutationAnnotationForOncoprint = this.getOncoKbMutationAnnotationForOncoprint.result!;
-                const oncoKbDatum:IndicatorQueryResp | undefined | null | false = this.driverAnnotationSettings.oncoKb &&
+        invoke: () => {
+            return Promise.resolve((mutation: Mutation): {
+                oncoKb: string;
+                hotspots: boolean;
+                cbioportalCount: boolean;
+                cosmicCount: boolean;
+                customDriverBinary: boolean;
+                customDriverTier?: string;
+            } => {
+                const getOncoKbMutationAnnotationForOncoprint = this
+                    .getOncoKbMutationAnnotationForOncoprint.result!;
+                const oncoKbDatum:
+                    | IndicatorQueryResp
+                    | undefined
+                    | null
+                    | false =
+                    this.driverAnnotationSettings.oncoKb &&
                     getOncoKbMutationAnnotationForOncoprint &&
-                    (!(getOncoKbMutationAnnotationForOncoprint instanceof Error)) &&
+                    !(
+                        getOncoKbMutationAnnotationForOncoprint instanceof Error
+                    ) &&
                     getOncoKbMutationAnnotationForOncoprint(mutation);
 
-                let oncoKb:string = "";
+                let oncoKb: string = '';
                 if (oncoKbDatum) {
                     oncoKb = getOncoKbOncogenic(oncoKbDatum);
                 }
 
-                const hotspots:boolean =
-                    (this.driverAnnotationSettings.hotspots &&
-                    (!(this.isHotspotForOncoprint.result instanceof Error)) &&
-                    this.isHotspotForOncoprint.result!(mutation));
+                const hotspots: boolean =
+                    this.driverAnnotationSettings.hotspots &&
+                    !(this.isHotspotForOncoprint.result instanceof Error) &&
+                    this.isHotspotForOncoprint.result!(mutation);
 
-                const cbioportalCount:boolean =
-                    (this.driverAnnotationSettings.cbioportalCount &&
+                const cbioportalCount: boolean =
+                    this.driverAnnotationSettings.cbioportalCount &&
                     this.getCBioportalCount.isComplete &&
                     this.getCBioportalCount.result!(mutation) >=
-                    this.driverAnnotationSettings.cbioportalCountThreshold);
+                        this.driverAnnotationSettings.cbioportalCountThreshold;
 
-                const cosmicCount:boolean =
-                    (this.driverAnnotationSettings.cosmicCount &&
+                const cosmicCount: boolean =
+                    this.driverAnnotationSettings.cosmicCount &&
                     this.getCosmicCount.isComplete &&
-                    this.getCosmicCount.result!(mutation) >= this.driverAnnotationSettings.cosmicCountThreshold);
+                    this.getCosmicCount.result!(mutation) >=
+                        this.driverAnnotationSettings.cosmicCountThreshold;
 
-                const customDriverBinary:boolean =
+                const customDriverBinary: boolean =
                     (this.driverAnnotationSettings.customBinary &&
-                        mutation.driverFilter === "Putative_Driver") || false;
+                        mutation.driverFilter === 'Putative_Driver') ||
+                    false;
 
-                const customDriverTier:string|undefined =
-                    (mutation.driverTiersFilter && this.driverAnnotationSettings.driverTiers.get(mutation.driverTiersFilter)) ?
-                    mutation.driverTiersFilter : undefined;
+                const customDriverTier: string | undefined =
+                    mutation.driverTiersFilter &&
+                    this.driverAnnotationSettings.driverTiers.get(
+                        mutation.driverTiersFilter
+                    )
+                        ? mutation.driverTiersFilter
+                        : undefined;
 
                 return {
                     oncoKb,
@@ -3014,221 +4042,268 @@ export class ResultsViewPageStore {
                     cbioportalCount,
                     cosmicCount,
                     customDriverBinary,
-                    customDriverTier
-                }
+                    customDriverTier,
+                };
             });
-        }
+        },
     });
 
     // Mutation annotation
     // genome nexus
-    readonly indexedVariantAnnotations = remoteData<{[genomicLocation: string]: VariantAnnotation} | undefined>({
-        await:()=>[
-            this.mutations
-        ],
-        invoke: async () => this.mutations.result? await fetchVariantAnnotationsIndexedByGenomicLocation(this.mutations.result, ["annotation_summary", "hotspots"], AppConfig.serverConfig.isoformOverrideSource) : undefined,
-        onError: (err: Error) => {
-            // fail silently, leave the error handling responsibility to the data consumer
-        }
-    }, undefined);
+    readonly indexedVariantAnnotations = remoteData<
+        { [genomicLocation: string]: VariantAnnotation } | undefined
+    >(
+        {
+            await: () => [this.mutations],
+            invoke: async () =>
+                this.mutations.result
+                    ? await fetchVariantAnnotationsIndexedByGenomicLocation(
+                          this.mutations.result,
+                          ['annotation_summary', 'hotspots'],
+                          AppConfig.serverConfig.isoformOverrideSource
+                      )
+                    : undefined,
+            onError: (err: Error) => {
+                // fail silently, leave the error handling responsibility to the data consumer
+            },
+        },
+        undefined
+    );
 
     // Hotspots
     readonly hotspotData = remoteData({
-        await:()=>[
-            this.mutations
-        ],
-        invoke:()=>{
+        await: () => [this.mutations],
+        invoke: () => {
             return fetchHotspotsData(this.mutations);
-        }
+        },
     });
 
-    readonly indexedHotspotData = remoteData<IHotspotIndex|undefined>({
-        await:()=>[
-            this.hotspotData
-        ],
-        invoke: ()=>Promise.resolve(indexHotspotsData(this.hotspotData))
+    readonly indexedHotspotData = remoteData<IHotspotIndex | undefined>({
+        await: () => [this.hotspotData],
+        invoke: () => Promise.resolve(indexHotspotsData(this.hotspotData)),
     });
 
-    public readonly isHotspotForOncoprint = remoteData<((m:Mutation)=>boolean) | Error>({
-        invoke:()=>{
+    public readonly isHotspotForOncoprint = remoteData<
+        ((m: Mutation) => boolean) | Error
+    >({
+        invoke: () => {
             // have to do it like this so that an error doesnt cause chain reaction of errors and app crash
             if (this.indexedHotspotData.isComplete) {
                 const indexedHotspotData = this.indexedHotspotData.result;
                 if (indexedHotspotData) {
-                    return Promise.resolve((mutation:Mutation)=>{
+                    return Promise.resolve((mutation: Mutation) => {
                         return isRecurrentHotspot(mutation, indexedHotspotData);
                     });
                 } else {
-                    return Promise.resolve(((mutation:Mutation)=>false) as (m:Mutation)=>boolean);
+                    return Promise.resolve(((mutation: Mutation) => false) as (
+                        m: Mutation
+                    ) => boolean);
                 }
             } else if (this.indexedHotspotData.isError) {
                 return Promise.resolve(new Error());
             } else {
                 // pending: return endless promise to keep isHotspotForOncoprint pending
-                return new Promise(()=>{});
+                return new Promise(() => {});
             }
-        }
+        },
     });
     //OncoKb
-    readonly uniqueSampleKeyToTumorType = remoteData<{[uniqueSampleKey: string]: string}>({
-        await:()=>[
+    readonly uniqueSampleKeyToTumorType = remoteData<{
+        [uniqueSampleKey: string]: string;
+    }>({
+        await: () => [
             this.clinicalDataForSamples,
             this.studiesForSamplesWithoutCancerTypeClinicalData,
-            this.samplesWithoutCancerTypeClinicalData
+            this.samplesWithoutCancerTypeClinicalData,
         ],
-        invoke: ()=>{
-            return Promise.resolve(generateUniqueSampleKeyToTumorTypeMap(this.clinicalDataForSamples,
-                this.studiesForSamplesWithoutCancerTypeClinicalData,
-                this.samplesWithoutCancerTypeClinicalData));
-        }
+        invoke: () => {
+            return Promise.resolve(
+                generateUniqueSampleKeyToTumorTypeMap(
+                    this.clinicalDataForSamples,
+                    this.studiesForSamplesWithoutCancerTypeClinicalData,
+                    this.samplesWithoutCancerTypeClinicalData
+                )
+            );
+        },
     });
 
-    readonly oncoKbData = remoteData<IOncoKbData|Error>({
-        await: () => [
-            this.mutations,
-            this.clinicalDataForSamples,
-            this.studiesForSamplesWithoutCancerTypeClinicalData,
-            this.uniqueSampleKeyToTumorType,
-            this.oncoKbAnnotatedGenes
-        ],
-        invoke: () => {
-            if (AppConfig.serverConfig.show_oncokb) {
-                return fetchOncoKbData(this.uniqueSampleKeyToTumorType.result!, this.oncoKbAnnotatedGenes.result!, this.mutations);
-            } else {
-                return Promise.resolve(ONCOKB_DEFAULT);
-            }
-        },
-        onError: (err: Error) => {
-            // fail silently, leave the error handling responsibility to the data consumer
-        }
-    }, ONCOKB_DEFAULT);
-
-    //we need seperate oncokb data because oncoprint requires onkb queries across cancertype
-    //mutations tab the opposite
-    readonly oncoKbDataForOncoprint = remoteData<IOncoKbData|Error>({
-        await: () => [
-            this.mutations,
-            this.oncoKbAnnotatedGenes
-        ],
-        invoke: async() => {
-            if (AppConfig.serverConfig.show_oncokb) {
-                let result;
-                try {
-                    result = await fetchOncoKbData({}, this.oncoKbAnnotatedGenes.result!, this.mutations, 'ONCOGENIC')
-                } catch(e) {
-                    result = new Error();
+    readonly oncoKbData = remoteData<IOncoKbData | Error>(
+        {
+            await: () => [
+                this.mutations,
+                this.clinicalDataForSamples,
+                this.studiesForSamplesWithoutCancerTypeClinicalData,
+                this.uniqueSampleKeyToTumorType,
+                this.oncoKbAnnotatedGenes,
+            ],
+            invoke: () => {
+                if (AppConfig.serverConfig.show_oncokb) {
+                    return fetchOncoKbData(
+                        this.uniqueSampleKeyToTumorType.result!,
+                        this.oncoKbAnnotatedGenes.result!,
+                        this.mutations
+                    );
+                } else {
+                    return Promise.resolve(ONCOKB_DEFAULT);
                 }
-                return result;
-            } else {
-                return ONCOKB_DEFAULT;
-            }
+            },
+            onError: (err: Error) => {
+                // fail silently, leave the error handling responsibility to the data consumer
+            },
         },
-        onError: (err: Error) => {
-            // fail silently, leave the error handling responsibility to the data consumer
-        }
-    }, ONCOKB_DEFAULT);
-
-    readonly cnaOncoKbData = remoteData<IOncoKbData>({
-        await: ()=> [
-            this.uniqueSampleKeyToTumorType,
-            this.oncoKbAnnotatedGenes,
-            this.molecularData,
-            this.molecularProfileIdToMolecularProfile
-        ],
-        invoke: () => {
-            if (AppConfig.serverConfig.show_oncokb) {
-                return fetchCnaOncoKbDataWithNumericGeneMolecularData(
-                    this.uniqueSampleKeyToTumorType.result!,
-                    this.oncoKbAnnotatedGenes.result!,
-                    this.molecularData,
-                    this.molecularProfileIdToMolecularProfile.result!
-                );
-            } else {
-                return Promise.resolve(ONCOKB_DEFAULT);
-            }
-        }
-    }, ONCOKB_DEFAULT);
+        ONCOKB_DEFAULT
+    );
 
     //we need seperate oncokb data because oncoprint requires onkb queries across cancertype
     //mutations tab the opposite
-    readonly cnaOncoKbDataForOncoprint = remoteData<IOncoKbData|Error>({
-        await: ()=> [
-            this.uniqueSampleKeyToTumorType,
-            this.oncoKbAnnotatedGenes,
-            this.molecularData,
-            this.molecularProfileIdToMolecularProfile
-        ],
-        invoke: async() => {
-            if (AppConfig.serverConfig.show_oncokb) {
-                let result;
-                try {
-                    result = await fetchCnaOncoKbDataWithNumericGeneMolecularData(
-                        {},
+    readonly oncoKbDataForOncoprint = remoteData<IOncoKbData | Error>(
+        {
+            await: () => [this.mutations, this.oncoKbAnnotatedGenes],
+            invoke: async () => {
+                if (AppConfig.serverConfig.show_oncokb) {
+                    let result;
+                    try {
+                        result = await fetchOncoKbData(
+                            {},
+                            this.oncoKbAnnotatedGenes.result!,
+                            this.mutations,
+                            'ONCOGENIC'
+                        );
+                    } catch (e) {
+                        result = new Error();
+                    }
+                    return result;
+                } else {
+                    return ONCOKB_DEFAULT;
+                }
+            },
+            onError: (err: Error) => {
+                // fail silently, leave the error handling responsibility to the data consumer
+            },
+        },
+        ONCOKB_DEFAULT
+    );
+
+    readonly cnaOncoKbData = remoteData<IOncoKbData>(
+        {
+            await: () => [
+                this.uniqueSampleKeyToTumorType,
+                this.oncoKbAnnotatedGenes,
+                this.molecularData,
+                this.molecularProfileIdToMolecularProfile,
+            ],
+            invoke: () => {
+                if (AppConfig.serverConfig.show_oncokb) {
+                    return fetchCnaOncoKbDataWithNumericGeneMolecularData(
+                        this.uniqueSampleKeyToTumorType.result!,
                         this.oncoKbAnnotatedGenes.result!,
                         this.molecularData,
-                        this.molecularProfileIdToMolecularProfile.result!,
-                        'ONCOGENIC'
+                        this.molecularProfileIdToMolecularProfile.result!
                     );
-                } catch(e) {
-                    result = new Error();
+                } else {
+                    return Promise.resolve(ONCOKB_DEFAULT);
                 }
-                return result;
-            } else {
-                return ONCOKB_DEFAULT;
-            }
-        }
-    }, ONCOKB_DEFAULT);
+            },
+        },
+        ONCOKB_DEFAULT
+    );
+
+    //we need seperate oncokb data because oncoprint requires onkb queries across cancertype
+    //mutations tab the opposite
+    readonly cnaOncoKbDataForOncoprint = remoteData<IOncoKbData | Error>(
+        {
+            await: () => [
+                this.uniqueSampleKeyToTumorType,
+                this.oncoKbAnnotatedGenes,
+                this.molecularData,
+                this.molecularProfileIdToMolecularProfile,
+            ],
+            invoke: async () => {
+                if (AppConfig.serverConfig.show_oncokb) {
+                    let result;
+                    try {
+                        result = await fetchCnaOncoKbDataWithNumericGeneMolecularData(
+                            {},
+                            this.oncoKbAnnotatedGenes.result!,
+                            this.molecularData,
+                            this.molecularProfileIdToMolecularProfile.result!,
+                            'ONCOGENIC'
+                        );
+                    } catch (e) {
+                        result = new Error();
+                    }
+                    return result;
+                } else {
+                    return ONCOKB_DEFAULT;
+                }
+            },
+        },
+        ONCOKB_DEFAULT
+    );
 
     @computed get didOncoKbFailInOncoprint() {
         // check in this order so that we don't trigger invoke
-        return this.getOncoKbMutationAnnotationForOncoprint.peekStatus === "complete" &&
-            (this.getOncoKbMutationAnnotationForOncoprint.result instanceof Error);
+        return (
+            this.getOncoKbMutationAnnotationForOncoprint.peekStatus ===
+                'complete' &&
+            this.getOncoKbMutationAnnotationForOncoprint.result instanceof Error
+        );
     }
 
     @computed get didHotspotFailInOncoprint() {
         // check in this order so that we don't trigger invoke
-        return this.isHotspotForOncoprint.peekStatus === "complete" &&
-            (this.isHotspotForOncoprint.result instanceof Error);
+        return (
+            this.isHotspotForOncoprint.peekStatus === 'complete' &&
+            this.isHotspotForOncoprint.result instanceof Error
+        );
     }
 
-    readonly getOncoKbMutationAnnotationForOncoprint = remoteData<Error|((mutation:Mutation)=>(IndicatorQueryResp|undefined))>({
-        await: ()=>[
-            this.oncoKbDataForOncoprint
-        ],
-        invoke: ()=>{
+    readonly getOncoKbMutationAnnotationForOncoprint = remoteData<
+        Error | ((mutation: Mutation) => IndicatorQueryResp | undefined)
+    >({
+        await: () => [this.oncoKbDataForOncoprint],
+        invoke: () => {
             const oncoKbDataForOncoprint = this.oncoKbDataForOncoprint.result!;
             if (oncoKbDataForOncoprint instanceof Error) {
                 return Promise.resolve(new Error());
             } else {
-                return Promise.resolve((mutation:Mutation)=>{
+                return Promise.resolve((mutation: Mutation) => {
                     const uniqueSampleKeyToTumorType = oncoKbDataForOncoprint.uniqueSampleKeyToTumorType!;
                     const id = generateQueryVariantId(
                         mutation.entrezGeneId,
-                        cancerTypeForOncoKb(mutation.uniqueSampleKey, uniqueSampleKeyToTumorType),
+                        cancerTypeForOncoKb(
+                            mutation.uniqueSampleKey,
+                            uniqueSampleKeyToTumorType
+                        ),
                         mutation.proteinChange,
                         mutation.mutationType
                     );
                     return oncoKbDataForOncoprint.indicatorMap![id];
                 });
             }
-        }
+        },
     });
 
-    readonly getOncoKbCnaAnnotationForOncoprint = remoteData<Error|((data:NumericGeneMolecularData)=>(IndicatorQueryResp|undefined))>({
-        await: ()=>[
-            this.cnaOncoKbDataForOncoprint
-        ],
-        invoke: ()=>{
-            const cnaOncoKbDataForOncoprint = this.cnaOncoKbDataForOncoprint.result!;
+    readonly getOncoKbCnaAnnotationForOncoprint = remoteData<
+        | Error
+        | ((data: NumericGeneMolecularData) => IndicatorQueryResp | undefined)
+    >({
+        await: () => [this.cnaOncoKbDataForOncoprint],
+        invoke: () => {
+            const cnaOncoKbDataForOncoprint = this.cnaOncoKbDataForOncoprint
+                .result!;
             if (cnaOncoKbDataForOncoprint instanceof Error) {
                 return Promise.resolve(new Error());
             } else {
-                return Promise.resolve((data:NumericGeneMolecularData)=>{
+                return Promise.resolve((data: NumericGeneMolecularData) => {
                     if (this.driverAnnotationSettings.oncoKb) {
                         const uniqueSampleKeyToTumorType = cnaOncoKbDataForOncoprint.uniqueSampleKeyToTumorType!;
                         const id = generateQueryVariantId(
                             data.entrezGeneId,
-                            cancerTypeForOncoKb(data.uniqueSampleKey, uniqueSampleKeyToTumorType),
+                            cancerTypeForOncoKb(
+                                data.uniqueSampleKey,
+                                uniqueSampleKeyToTumorType
+                            ),
                             getAlterationString(data.value)
                         );
                         return cnaOncoKbDataForOncoprint.indicatorMap![id];
@@ -3237,74 +4312,89 @@ export class ResultsViewPageStore {
                     }
                 });
             }
-        }
+        },
     });
 
-    readonly cbioportalMutationCountData = remoteData<MutationCountByPosition[]>({
-        await: ()=>[
-            this.mutations
-        ],
-        invoke: ()=>{
-
-            const mutationPositionIdentifiers = countMutations(this.mutations.result!);
+    readonly cbioportalMutationCountData = remoteData<
+        MutationCountByPosition[]
+    >({
+        await: () => [this.mutations],
+        invoke: () => {
+            const mutationPositionIdentifiers = countMutations(
+                this.mutations.result!
+            );
 
             return client.fetchMutationCountsByPositionUsingPOST({
-                mutationPositionIdentifiers: _.values(mutationPositionIdentifiers)
+                mutationPositionIdentifiers: _.values(
+                    mutationPositionIdentifiers
+                ),
             });
-        }
+        },
     });
 
-    readonly getCBioportalCount:MobxPromise<(mutation:Mutation)=>number> = remoteData({
-        await: ()=>[
-            this.cbioportalMutationCountData
-        ],
-        invoke: ()=>{
-            const countsMap = _.groupBy(this.cbioportalMutationCountData.result!, count=>mutationCountByPositionKey(count));
-            return Promise.resolve((mutation:Mutation):number=>{
+    readonly getCBioportalCount: MobxPromise<
+        (mutation: Mutation) => number
+    > = remoteData({
+        await: () => [this.cbioportalMutationCountData],
+        invoke: () => {
+            const countsMap = _.groupBy(
+                this.cbioportalMutationCountData.result!,
+                count => mutationCountByPositionKey(count)
+            );
+            return Promise.resolve((mutation: Mutation): number => {
                 const key = mutationCountByPositionKey(mutation);
                 const counts = countsMap[key];
                 if (counts) {
-                    return counts.reduce((count, next)=>{
+                    return counts.reduce((count, next) => {
                         return count + next.count;
                     }, 0);
                 } else {
                     return -1;
                 }
             });
-        }
+        },
     });
     //COSMIC count
     readonly cosmicCountData = remoteData<CosmicMutation[]>({
-        await: ()=>[
-            this.mutations
-        ],
-        invoke: ()=>{
+        await: () => [this.mutations],
+        invoke: () => {
             return internalClient.fetchCosmicCountsUsingPOST({
-                keywords: _.uniq(this.mutations.result!.filter((m:Mutation)=>{
-                    // keyword is what we use to query COSMIC count with, so we need
-                    //  the unique list of mutation keywords to query. If a mutation has
-                    //  no keyword, it cannot be queried for.
-                    return !!m.keyword;
-                }).map((m:Mutation)=>m.keyword))
+                keywords: _.uniq(
+                    this.mutations
+                        .result!.filter((m: Mutation) => {
+                            // keyword is what we use to query COSMIC count with, so we need
+                            //  the unique list of mutation keywords to query. If a mutation has
+                            //  no keyword, it cannot be queried for.
+                            return !!m.keyword;
+                        })
+                        .map((m: Mutation) => m.keyword)
+                ),
             });
-        }
+        },
     });
 
-    readonly getCosmicCount:MobxPromise<(mutation:Mutation)=>number> = remoteData({
-        await: ()=>[
-            this.cosmicCountData
-        ],
-        invoke: ()=>{
-            const countMap = _.groupBy(this.cosmicCountData.result!, d=>d.keyword);
-            return Promise.resolve((mutation:Mutation):number=>{
+    readonly getCosmicCount: MobxPromise<
+        (mutation: Mutation) => number
+    > = remoteData({
+        await: () => [this.cosmicCountData],
+        invoke: () => {
+            const countMap = _.groupBy(
+                this.cosmicCountData.result!,
+                d => d.keyword
+            );
+            return Promise.resolve((mutation: Mutation): number => {
                 const keyword = mutation.keyword;
                 const counts = countMap[keyword];
-                const targetPosObj = getProteinPositionFromProteinChange(mutation.proteinChange);
+                const targetPosObj = getProteinPositionFromProteinChange(
+                    mutation.proteinChange
+                );
                 if (counts && targetPosObj) {
                     const targetPos = targetPosObj.start;
-                    return counts.reduce((count, next:CosmicMutation)=>{
-                        const pos = getProteinPositionFromProteinChange(next.proteinChange);
-                        if (pos && (pos.start === targetPos)) {
+                    return counts.reduce((count, next: CosmicMutation) => {
+                        const pos = getProteinPositionFromProteinChange(
+                            next.proteinChange
+                        );
+                        if (pos && pos.start === targetPos) {
                             // only tally cosmic entries with same keyword and same start position
                             return count + next.count;
                         } else {
@@ -3315,150 +4405,209 @@ export class ResultsViewPageStore {
                     return -1;
                 }
             });
-        }
+        },
     });
 
     readonly mutationEnrichmentProfiles = remoteData<MolecularProfile[]>({
-        await: () => [
-            this.molecularProfilesInStudies,
-        ],
-        invoke: async () => pickMutationEnrichmentProfiles(this.molecularProfilesInStudies.result!)
+        await: () => [this.molecularProfilesInStudies],
+        invoke: async () =>
+            pickMutationEnrichmentProfiles(
+                this.molecularProfilesInStudies.result!
+            ),
     });
 
     readonly mutationEnrichmentData = makeEnrichmentDataPromise({
-        store:this,
+        store: this,
         await: () => [
             this.alteredSamples,
             this.unalteredSamples,
             this.alteredPatients,
             this.unalteredPatients,
-            this.selectedMutationEnrichmentProfileMap
+            this.selectedMutationEnrichmentProfileMap,
         ],
         referenceGenesPromise: this.hugoGeneSymbolToReferenceGene,
-        getSelectedProfileMap:()=>this.selectedMutationEnrichmentProfileMap.result!,
-        fetchData:()=>{
-            const molecularProfile = this.selectedMutationEnrichmentProfileMap.result!;
-            const alteredGroup:(Sample|Patient)[]= (this.usePatientLevelEnrichments ? this.alteredPatients.result! : this.alteredSamples.result!);
-            const unalteredGroup:(Sample|Patient)[] = (this.usePatientLevelEnrichments ? this.unalteredPatients.result! : this.unalteredSamples.result!);
+        getSelectedProfileMap: () =>
+            this.selectedMutationEnrichmentProfileMap.result!,
+        fetchData: () => {
+            const molecularProfile = this.selectedMutationEnrichmentProfileMap
+                .result!;
+            const alteredGroup: (Sample | Patient)[] = this
+                .usePatientLevelEnrichments
+                ? this.alteredPatients.result!
+                : this.alteredSamples.result!;
+            const unalteredGroup: (Sample | Patient)[] = this
+                .usePatientLevelEnrichments
+                ? this.unalteredPatients.result!
+                : this.unalteredSamples.result!;
             return internalClient.fetchMutationEnrichmentsUsingPOST({
-                enrichmentType: this.usePatientLevelEnrichments ? "PATIENT" : "SAMPLE",
+                enrichmentType: this.usePatientLevelEnrichments
+                    ? 'PATIENT'
+                    : 'SAMPLE',
                 groups: [
                     {
                         molecularProfileCaseIdentifiers: alteredGroup
-                            .filter(s => molecularProfile[s.studyId] !== undefined)
+                            .filter(
+                                s => molecularProfile[s.studyId] !== undefined
+                            )
                             .map(c => ({
-                                caseId:(this.usePatientLevelEnrichments ? c.patientId : (c as Sample).sampleId),
-                                molecularProfileId: molecularProfile[c.studyId].molecularProfileId
+                                caseId: this.usePatientLevelEnrichments
+                                    ? c.patientId
+                                    : (c as Sample).sampleId,
+                                molecularProfileId:
+                                    molecularProfile[c.studyId]
+                                        .molecularProfileId,
                             })),
-                        name: 'Altered group'
-                    }, {
+                        name: 'Altered group',
+                    },
+                    {
                         molecularProfileCaseIdentifiers: unalteredGroup
-                            .filter(s => molecularProfile[s.studyId] !== undefined)
+                            .filter(
+                                s => molecularProfile[s.studyId] !== undefined
+                            )
                             .map(c => ({
-                                caseId:(this.usePatientLevelEnrichments ? c.patientId : (c as Sample).sampleId),
-                                molecularProfileId: molecularProfile[c.studyId].molecularProfileId
+                                caseId: this.usePatientLevelEnrichments
+                                    ? c.patientId
+                                    : (c as Sample).sampleId,
+                                molecularProfileId:
+                                    molecularProfile[c.studyId]
+                                        .molecularProfileId,
                             })),
-                        name: 'Unaltered group'
-                    }
-                ]
+                        name: 'Unaltered group',
+                    },
+                ],
             });
-        }
+        },
     });
 
     readonly copyNumberEnrichmentProfiles = remoteData<MolecularProfile[]>({
-        await: () => [
-            this.molecularProfilesInStudies,
-        ],
-        invoke: async () => pickCopyNumberEnrichmentProfiles(this.molecularProfilesInStudies.result!)
+        await: () => [this.molecularProfilesInStudies],
+        invoke: async () =>
+            pickCopyNumberEnrichmentProfiles(
+                this.molecularProfilesInStudies.result!
+            ),
     });
 
     readonly copyNumberHomdelEnrichmentData = makeEnrichmentDataPromise({
-        store:this,
+        store: this,
         referenceGenesPromise: this.hugoGeneSymbolToReferenceGene,
         await: () => [
             this.alteredSamples,
             this.unalteredSamples,
-            this.selectedCopyNumberEnrichmentProfileMap
+            this.selectedCopyNumberEnrichmentProfileMap,
         ],
-        getSelectedProfileMap:()=>this.selectedCopyNumberEnrichmentProfileMap.result!,
-        fetchData:()=>this.getCopyNumberEnrichmentData("HOMDEL")
-        }
-    );
-
-    readonly copyNumberAmpEnrichmentData = makeEnrichmentDataPromise({
-        store:this,
-        referenceGenesPromise: this.hugoGeneSymbolToReferenceGene,
-        await: () => [
-            this.alteredSamples,
-            this.unalteredSamples,
-            this.selectedCopyNumberEnrichmentProfileMap
-        ],
-        getSelectedProfileMap:()=>this.selectedCopyNumberEnrichmentProfileMap.result!,
-        fetchData:()=>this.getCopyNumberEnrichmentData("AMP")
+        getSelectedProfileMap: () =>
+            this.selectedCopyNumberEnrichmentProfileMap.result!,
+        fetchData: () => this.getCopyNumberEnrichmentData('HOMDEL'),
     });
 
-    private getCopyNumberEnrichmentData(copyNumberEventType: "HOMDEL" | "AMP"): Promise<AlterationEnrichment[]> {
-        const molecularProfile = this.selectedCopyNumberEnrichmentProfileMap.result!;
-        const alteredGroup:(Sample|Patient)[]= (this.usePatientLevelEnrichments ? this.alteredPatients.result! : this.alteredSamples.result!);
-        const unalteredGroup:(Sample|Patient)[] = (this.usePatientLevelEnrichments ? this.unalteredPatients.result! : this.unalteredSamples.result!);
+    readonly copyNumberAmpEnrichmentData = makeEnrichmentDataPromise({
+        store: this,
+        referenceGenesPromise: this.hugoGeneSymbolToReferenceGene,
+        await: () => [
+            this.alteredSamples,
+            this.unalteredSamples,
+            this.selectedCopyNumberEnrichmentProfileMap,
+        ],
+        getSelectedProfileMap: () =>
+            this.selectedCopyNumberEnrichmentProfileMap.result!,
+        fetchData: () => this.getCopyNumberEnrichmentData('AMP'),
+    });
+
+    private getCopyNumberEnrichmentData(
+        copyNumberEventType: 'HOMDEL' | 'AMP'
+    ): Promise<AlterationEnrichment[]> {
+        const molecularProfile = this.selectedCopyNumberEnrichmentProfileMap
+            .result!;
+        const alteredGroup: (Sample | Patient)[] = this
+            .usePatientLevelEnrichments
+            ? this.alteredPatients.result!
+            : this.alteredSamples.result!;
+        const unalteredGroup: (Sample | Patient)[] = this
+            .usePatientLevelEnrichments
+            ? this.unalteredPatients.result!
+            : this.unalteredSamples.result!;
         return internalClient.fetchCopyNumberEnrichmentsUsingPOST({
             copyNumberEventType: copyNumberEventType,
-            enrichmentType: this.usePatientLevelEnrichments ? "PATIENT" : "SAMPLE",
+            enrichmentType: this.usePatientLevelEnrichments
+                ? 'PATIENT'
+                : 'SAMPLE',
             groups: [
                 {
                     molecularProfileCaseIdentifiers: alteredGroup
                         .filter(s => molecularProfile[s.studyId] !== undefined)
                         .map(c => ({
-                            caseId:(this.usePatientLevelEnrichments ? c.patientId : (c as Sample).sampleId),
-                            molecularProfileId:molecularProfile[c.studyId].molecularProfileId
+                            caseId: this.usePatientLevelEnrichments
+                                ? c.patientId
+                                : (c as Sample).sampleId,
+                            molecularProfileId:
+                                molecularProfile[c.studyId].molecularProfileId,
                         })),
-                    name: 'Altered group'
-                }, {
+                    name: 'Altered group',
+                },
+                {
                     molecularProfileCaseIdentifiers: unalteredGroup
                         .filter(s => molecularProfile[s.studyId] !== undefined)
                         .map(c => ({
-                            caseId:(this.usePatientLevelEnrichments ? c.patientId : (c as Sample).sampleId),
-                            molecularProfileId: molecularProfile[c.studyId].molecularProfileId
+                            caseId: this.usePatientLevelEnrichments
+                                ? c.patientId
+                                : (c as Sample).sampleId,
+                            molecularProfileId:
+                                molecularProfile[c.studyId].molecularProfileId,
                         })),
-                    name: 'Unaltered group'
-                }
-            ]
+                    name: 'Unaltered group',
+                },
+            ],
         });
     }
 
     readonly mRNAEnrichmentProfiles = remoteData<MolecularProfile[]>({
-        await:()=>[this.molecularProfilesInStudies],
-        invoke:()=>Promise.resolve(pickMRNAEnrichmentProfiles(this.molecularProfilesInStudies.result!))
+        await: () => [this.molecularProfilesInStudies],
+        invoke: () =>
+            Promise.resolve(
+                pickMRNAEnrichmentProfiles(
+                    this.molecularProfilesInStudies.result!
+                )
+            ),
     });
 
     readonly mRNAEnrichmentData = makeEnrichmentDataPromise({
         store: this,
-        await: () => [
-            this.alteredSamples,
-            this.unalteredSamples
-        ],
+        await: () => [this.alteredSamples, this.unalteredSamples],
         referenceGenesPromise: this.hugoGeneSymbolToReferenceGene,
-        getSelectedProfileMap: () => this.selectedmRNAEnrichmentProfileMap.result!,// returns an empty array if the selected study doesn't have any mRNA profiles
+        getSelectedProfileMap: () =>
+            this.selectedmRNAEnrichmentProfileMap.result!, // returns an empty array if the selected study doesn't have any mRNA profiles
         fetchData: () => {
-            let studyIds = Object.keys(this.selectedmRNAEnrichmentProfileMap.result!);
+            let studyIds = Object.keys(
+                this.selectedmRNAEnrichmentProfileMap.result!
+            );
             if (studyIds.length === 1) {
-                const molecularProfileId = this.selectedmRNAEnrichmentProfileMap.result![studyIds[0]].molecularProfileId;
-                const groups: MolecularProfileCasesGroupFilter[] = [{
-                    molecularProfileCaseIdentifiers: this.alteredSamples.result!
-                        .filter(s => (s.studyId === studyIds[0]))
-                        .map(s => ({ caseId: s.sampleId, molecularProfileId })),
-                    name: "Altered group"
-                }, {
-                    molecularProfileCaseIdentifiers: this.unalteredSamples.result
-                        .filter(s => (s.studyId === studyIds[0]))
-                        .map(s => ({ caseId: s.sampleId, molecularProfileId })),
-                    name: "Unaltered group"
-                }];
+                const molecularProfileId = this.selectedmRNAEnrichmentProfileMap
+                    .result![studyIds[0]].molecularProfileId;
+                const groups: MolecularProfileCasesGroupFilter[] = [
+                    {
+                        molecularProfileCaseIdentifiers: this.alteredSamples
+                            .result!.filter(s => s.studyId === studyIds[0])
+                            .map(s => ({
+                                caseId: s.sampleId,
+                                molecularProfileId,
+                            })),
+                        name: 'Altered group',
+                    },
+                    {
+                        molecularProfileCaseIdentifiers: this.unalteredSamples.result
+                            .filter(s => s.studyId === studyIds[0])
+                            .map(s => ({
+                                caseId: s.sampleId,
+                                molecularProfileId,
+                            })),
+                        name: 'Unaltered group',
+                    },
+                ];
 
                 return internalClient.fetchExpressionEnrichmentsUsingPOST({
-                    enrichmentType: "SAMPLE",
-                    groups
-                })
+                    enrichmentType: 'SAMPLE',
+                    groups,
+                });
             } else {
                 return Promise.resolve([]);
             }
@@ -3466,72 +4615,90 @@ export class ResultsViewPageStore {
     });
 
     readonly proteinEnrichmentProfiles = remoteData<MolecularProfile[]>({
-        await:()=>[this.molecularProfilesInStudies],
-        invoke:()=>Promise.resolve(pickProteinEnrichmentProfiles(this.molecularProfilesInStudies.result!))
+        await: () => [this.molecularProfilesInStudies],
+        invoke: () =>
+            Promise.resolve(
+                pickProteinEnrichmentProfiles(
+                    this.molecularProfilesInStudies.result!
+                )
+            ),
     });
 
     readonly proteinEnrichmentData = makeEnrichmentDataPromise({
         store: this,
-        await: () => [
-            this.alteredSamples,
-            this.unalteredSamples
-        ],
+        await: () => [this.alteredSamples, this.unalteredSamples],
         referenceGenesPromise: this.hugoGeneSymbolToReferenceGene,
-        getSelectedProfileMap: () => this.selectedProteinEnrichmentProfileMap.result!, // returns an empty array if the selected study doesn't have any protein profiles
+        getSelectedProfileMap: () =>
+            this.selectedProteinEnrichmentProfileMap.result!, // returns an empty array if the selected study doesn't have any protein profiles
         fetchData: () => {
-            let studyIds = Object.keys(this.selectedProteinEnrichmentProfileMap.result!);
+            let studyIds = Object.keys(
+                this.selectedProteinEnrichmentProfileMap.result!
+            );
             if (studyIds.length === 1) {
-                const molecularProfileId = this.selectedProteinEnrichmentProfileMap.result![studyIds[0]].molecularProfileId;
-                const groups: MolecularProfileCasesGroupFilter[] = [{
-                    molecularProfileCaseIdentifiers: this.alteredSamples.result
-                        .filter(s => (s.studyId === studyIds[0]))
-                        .map(s => ({ caseId: s.sampleId, molecularProfileId })),
-                    name: "Altered group"
-                }, {
-                    molecularProfileCaseIdentifiers: this.unalteredSamples.result
-                        .filter(s => (s.studyId === studyIds[0]))
-                        .map(s => ({ caseId: s.sampleId, molecularProfileId })),
-                    name: "Unaltered group"
-                }];
+                const molecularProfileId = this
+                    .selectedProteinEnrichmentProfileMap.result![studyIds[0]]
+                    .molecularProfileId;
+                const groups: MolecularProfileCasesGroupFilter[] = [
+                    {
+                        molecularProfileCaseIdentifiers: this.alteredSamples.result
+                            .filter(s => s.studyId === studyIds[0])
+                            .map(s => ({
+                                caseId: s.sampleId,
+                                molecularProfileId,
+                            })),
+                        name: 'Altered group',
+                    },
+                    {
+                        molecularProfileCaseIdentifiers: this.unalteredSamples.result
+                            .filter(s => s.studyId === studyIds[0])
+                            .map(s => ({
+                                caseId: s.sampleId,
+                                molecularProfileId,
+                            })),
+                        name: 'Unaltered group',
+                    },
+                ];
 
                 return internalClient.fetchExpressionEnrichmentsUsingPOST({
-                    enrichmentType: "SAMPLE",
-                    groups
+                    enrichmentType: 'SAMPLE',
+                    groups,
                 });
             } else {
                 return Promise.resolve([]);
             }
-        }
+        },
     });
 
     readonly molecularProfileIdToProfiledSampleCount = remoteData({
-        await: ()=>[
+        await: () => [
             this.samples,
             this.coverageInformation,
-            this.molecularProfilesInStudies
+            this.molecularProfilesInStudies,
         ],
-        invoke: ()=>{
-            const ret:{[molecularProfileId:string]:number} = {};
-            const profileIds = this.molecularProfilesInStudies.result.map(x=>x.molecularProfileId);
+        invoke: () => {
+            const ret: { [molecularProfileId: string]: number } = {};
+            const profileIds = this.molecularProfilesInStudies.result.map(
+                x => x.molecularProfileId
+            );
             const coverageInformation = this.coverageInformation.result!;
             for (const profileId of profileIds) {
                 ret[profileId] = 0;
             }
-            let profiledReport:boolean[] = [];
+            let profiledReport: boolean[] = [];
             for (const sample of this.samples.result!) {
                 profiledReport = isSampleProfiledInMultiple(
                     sample.uniqueSampleKey,
                     profileIds,
                     coverageInformation
                 );
-                for (let i=0; i<profileIds.length; i++) {
+                for (let i = 0; i < profileIds.length; i++) {
                     if (profiledReport[i]) {
                         ret[profileIds[i]] += 1;
                     }
                 }
             }
             return Promise.resolve(ret);
-        }
+        },
     });
 
     @cached get oncoKbEvidenceCache() {
@@ -3554,7 +4721,9 @@ export class ResultsViewPageStore {
     }
 
     @cached get discreteCNACache() {
-        return new DiscreteCNACache(this.studyToMolecularProfileDiscrete.result);
+        return new DiscreteCNACache(
+            this.studyToMolecularProfileDiscrete.result
+        );
     }
 
     @cached get cancerTypeCache() {
@@ -3570,122 +4739,129 @@ export class ResultsViewPageStore {
     }
 
     @cached get mutationDataCache() {
-        return new MutationDataCache(this.studyToMutationMolecularProfile.result,
-            this.studyToDataQueryFilter.result);
+        return new MutationDataCache(
+            this.studyToMutationMolecularProfile.result,
+            this.studyToDataQueryFilter.result
+        );
     }
 
     readonly geneMolecularDataCache = remoteData({
-        await:()=>[
-            this.molecularProfileIdToDataQueryFilter
-        ],
-        invoke: ()=>{
+        await: () => [this.molecularProfileIdToDataQueryFilter],
+        invoke: () => {
             return Promise.resolve(
                 new GeneMolecularDataCache(
                     this.molecularProfileIdToDataQueryFilter.result
                 )
             );
-        }
+        },
     });
 
-    readonly expressionProfiles = remoteData({
-        await:()=>[
-            this.molecularProfilesInStudies
-        ],
-        invoke:()=>{
-            return Promise.resolve(this.molecularProfilesInStudies.result.filter(
-                (profile:MolecularProfile)=>isRNASeqProfile(profile.molecularProfileId)
-            ));
-        }
-    },[]);
+    readonly expressionProfiles = remoteData(
+        {
+            await: () => [this.molecularProfilesInStudies],
+            invoke: () => {
+                return Promise.resolve(
+                    this.molecularProfilesInStudies.result.filter(
+                        (profile: MolecularProfile) =>
+                            isRNASeqProfile(profile.molecularProfileId)
+                    )
+                );
+            },
+        },
+        []
+    );
 
-    @memoize sortRnaSeqMolecularDataByStudy(seqData:{[profileId:string]:NumericGeneMolecularData[]}){
-        return _.keyBy(seqData,(data:NumericGeneMolecularData[])=>{
-           return data[0].studyId;
+    @memoize sortRnaSeqMolecularDataByStudy(seqData: {
+        [profileId: string]: NumericGeneMolecularData[];
+    }) {
+        return _.keyBy(seqData, (data: NumericGeneMolecularData[]) => {
+            return data[0].studyId;
         });
     }
 
     readonly genesetMolecularDataCache = remoteData({
-        await:() => [
-            this.molecularProfileIdToDataQueryFilter
-        ],
-        invoke: () => Promise.resolve(
-            new GenesetMolecularDataCache(
-                this.molecularProfileIdToDataQueryFilter.result!
-            )
-        )
+        await: () => [this.molecularProfileIdToDataQueryFilter],
+        invoke: () =>
+            Promise.resolve(
+                new GenesetMolecularDataCache(
+                    this.molecularProfileIdToDataQueryFilter.result!
+                )
+            ),
     });
 
-    public numericGenesetMolecularDataCache = new MobxPromiseCache<{genesetId:string, molecularProfileId:string}, GenesetMolecularData[]>(
-        q=>({
-            await: ()=>[
-                this.molecularProfileIdToDataQueryFilter
-            ],
-            invoke: ()=>{
-                const dqf = this.molecularProfileIdToDataQueryFilter.result![q.molecularProfileId];
-                if (dqf) {
-                    return internalClient.fetchGeneticDataItemsUsingPOST({
-                        geneticProfileId: q.molecularProfileId,
-                        genesetDataFilterCriteria: {
-                            genesetIds: [q.genesetId],
-                            ...dqf
-                        } as GenesetDataFilterCriteria
-                    });
-                } else {
-                    return Promise.resolve([]);
-                }
+    public numericGenesetMolecularDataCache = new MobxPromiseCache<
+        { genesetId: string; molecularProfileId: string },
+        GenesetMolecularData[]
+    >(q => ({
+        await: () => [this.molecularProfileIdToDataQueryFilter],
+        invoke: () => {
+            const dqf = this.molecularProfileIdToDataQueryFilter.result![
+                q.molecularProfileId
+            ];
+            if (dqf) {
+                return internalClient.fetchGeneticDataItemsUsingPOST({
+                    geneticProfileId: q.molecularProfileId,
+                    genesetDataFilterCriteria: {
+                        genesetIds: [q.genesetId],
+                        ...dqf,
+                    } as GenesetDataFilterCriteria,
+                });
+            } else {
+                return Promise.resolve([]);
             }
-        })
-    );
+        },
+    }));
 
     readonly genesetCorrelatedGeneCache = remoteData({
-        await:() => [
-            this.molecularProfileIdToDataQueryFilter
-        ],
-        invoke: () => Promise.resolve(
-            new GenesetCorrelatedGeneCache(
-                this.molecularProfileIdToDataQueryFilter.result!
-            )
-        )
+        await: () => [this.molecularProfileIdToDataQueryFilter],
+        invoke: () =>
+            Promise.resolve(
+                new GenesetCorrelatedGeneCache(
+                    this.molecularProfileIdToDataQueryFilter.result!
+                )
+            ),
     });
 
     readonly treatmentMolecularDataCache = remoteData({
-        await:() => [
-            this.molecularProfileIdToDataQueryFilter
-        ],
-        invoke: () => Promise.resolve(
-            new TreatmentMolecularDataCache(
-                this.molecularProfileIdToDataQueryFilter.result!
-            )
-        )
+        await: () => [this.molecularProfileIdToDataQueryFilter],
+        invoke: () =>
+            Promise.resolve(
+                new TreatmentMolecularDataCache(
+                    this.molecularProfileIdToDataQueryFilter.result!
+                )
+            ),
     });
 
     readonly geneCache = new GeneCache();
     readonly genesetCache = new GenesetCache();
     readonly treatmentCache = new TreatmentCache();
 
-    public numericGeneMolecularDataCache = new MobxPromiseCache<{entrezGeneId:number, molecularProfileId:string}, NumericGeneMolecularData[]>(
-        q=>({
-            await: ()=>[
-                this.molecularProfileIdToDataQueryFilter
-            ],
-            invoke: ()=>{
-                const dqf = this.molecularProfileIdToDataQueryFilter.result![q.molecularProfileId];
-                // it's possible that sampleIds is empty for a given profile
-                const hasSampleSpec = dqf && ((dqf.sampleIds && dqf.sampleIds.length) || dqf.sampleListId);
-                if (hasSampleSpec) {
-                    return client.fetchAllMolecularDataInMolecularProfileUsingPOST({
-                        molecularProfileId: q.molecularProfileId,
-                        molecularDataFilter: {
-                            entrezGeneIds: [q.entrezGeneId],
-                            ...dqf
-                        } as MolecularDataFilter
-                    });
-                } else {
-                    return Promise.resolve([]);
-                }
+    public numericGeneMolecularDataCache = new MobxPromiseCache<
+        { entrezGeneId: number; molecularProfileId: string },
+        NumericGeneMolecularData[]
+    >(q => ({
+        await: () => [this.molecularProfileIdToDataQueryFilter],
+        invoke: () => {
+            const dqf = this.molecularProfileIdToDataQueryFilter.result![
+                q.molecularProfileId
+            ];
+            // it's possible that sampleIds is empty for a given profile
+            const hasSampleSpec =
+                dqf &&
+                ((dqf.sampleIds && dqf.sampleIds.length) || dqf.sampleListId);
+            if (hasSampleSpec) {
+                return client.fetchAllMolecularDataInMolecularProfileUsingPOST({
+                    molecularProfileId: q.molecularProfileId,
+                    molecularDataFilter: {
+                        entrezGeneIds: [q.entrezGeneId],
+                        ...dqf,
+                    } as MolecularDataFilter,
+                });
+            } else {
+                return Promise.resolve([]);
             }
-        })
-    );
+        },
+    }));
 
     public clinicalDataCache = new ClinicalDataCache(
         this.samples,
@@ -3695,81 +4871,109 @@ export class ResultsViewPageStore {
         this.coverageInformation
     );
 
-    public mutationCache =
-        new MobxPromiseCache<{entrezGeneId:number}, Mutation[]>(
-            q=>({
-                await:()=>[
-                    this.studyToMutationMolecularProfile,
-                    this.studyToDataQueryFilter
-                ],
-                invoke: async()=>{
-                    return _.flatten(await Promise.all(Object.keys(this.studyToMutationMolecularProfile.result!).map(studyId=>{
-                        const molecularProfileId = this.studyToMutationMolecularProfile.result![studyId].molecularProfileId;
-                        const dqf = this.studyToDataQueryFilter.result![studyId];
+    public mutationCache = new MobxPromiseCache<
+        { entrezGeneId: number },
+        Mutation[]
+    >(q => ({
+        await: () => [
+            this.studyToMutationMolecularProfile,
+            this.studyToDataQueryFilter,
+        ],
+        invoke: async () => {
+            return _.flatten(
+                await Promise.all(
+                    Object.keys(
+                        this.studyToMutationMolecularProfile.result!
+                    ).map(studyId => {
+                        const molecularProfileId = this
+                            .studyToMutationMolecularProfile.result![studyId]
+                            .molecularProfileId;
+                        const dqf = this.studyToDataQueryFilter.result![
+                            studyId
+                        ];
                         if (dqf && molecularProfileId) {
-                            return client.fetchMutationsInMolecularProfileUsingPOST({
-                                molecularProfileId,
-                                mutationFilter: {
-                                    entrezGeneIds:[q.entrezGeneId],
-                                    ...dqf
-                                } as MutationFilter,
-                                projection:"DETAILED"
-                            });
+                            return client.fetchMutationsInMolecularProfileUsingPOST(
+                                {
+                                    molecularProfileId,
+                                    mutationFilter: {
+                                        entrezGeneIds: [q.entrezGeneId],
+                                        ...dqf,
+                                    } as MutationFilter,
+                                    projection: 'DETAILED',
+                                }
+                            );
                         } else {
                             return Promise.resolve([]);
                         }
-                    })));
-                }
-            })
-        );
+                    })
+                )
+            );
+        },
+    }));
 
     @action clearErrors() {
         this.ajaxErrors = [];
     }
 
     readonly overallSurvivalDescriptions = remoteData({
-        await:() => [
-            this.clinicalAttributes,
-            this.studyIdToStudy
-        ],
+        await: () => [this.clinicalAttributes, this.studyIdToStudy],
         invoke: () => {
             const overallSurvivalClinicalAttributeId = 'OS_STATUS';
-            const clinicalAttributeMap = _.groupBy(this.clinicalAttributes.result, "clinicalAttributeId");
-            const result : ISurvivalDescription[] = [];
-            const studyIdToStudy : {[studyId:string]:CancerStudy} = this.studyIdToStudy.result;
-            if (clinicalAttributeMap && clinicalAttributeMap[overallSurvivalClinicalAttributeId] && clinicalAttributeMap[overallSurvivalClinicalAttributeId].length > 0) {
-                clinicalAttributeMap[overallSurvivalClinicalAttributeId].forEach((attr) => {
+            const clinicalAttributeMap = _.groupBy(
+                this.clinicalAttributes.result,
+                'clinicalAttributeId'
+            );
+            const result: ISurvivalDescription[] = [];
+            const studyIdToStudy: { [studyId: string]: CancerStudy } = this
+                .studyIdToStudy.result;
+            if (
+                clinicalAttributeMap &&
+                clinicalAttributeMap[overallSurvivalClinicalAttributeId] &&
+                clinicalAttributeMap[overallSurvivalClinicalAttributeId]
+                    .length > 0
+            ) {
+                clinicalAttributeMap[
+                    overallSurvivalClinicalAttributeId
+                ].forEach(attr => {
                     result.push({
-                            studyName: studyIdToStudy[attr.studyId].name,
-                            description: attr.description
+                        studyName: studyIdToStudy[attr.studyId].name,
+                        description: attr.description,
                     } as ISurvivalDescription);
                 });
                 return Promise.resolve(result);
             }
             return Promise.resolve([]);
-        }
+        },
     });
 
     readonly diseaseFreeSurvivalDescriptions = remoteData({
-        await:() => [
-            this.clinicalAttributes,
-            this.studyIdToStudy
-        ],
+        await: () => [this.clinicalAttributes, this.studyIdToStudy],
         invoke: () => {
             const diseaseFreeSurvivalClinicalAttributeId = 'DFS_STATUS';
-            const clinicalAttributeMap = _.groupBy(this.clinicalAttributes.result, "clinicalAttributeId");
-            const result : ISurvivalDescription[] = [];
-            const studyIdToStudy : {[studyId:string]:CancerStudy} = this.studyIdToStudy.result;
-            if (clinicalAttributeMap && clinicalAttributeMap[diseaseFreeSurvivalClinicalAttributeId] && clinicalAttributeMap[diseaseFreeSurvivalClinicalAttributeId].length > 0) {
-                clinicalAttributeMap[diseaseFreeSurvivalClinicalAttributeId].forEach((attr) => {
+            const clinicalAttributeMap = _.groupBy(
+                this.clinicalAttributes.result,
+                'clinicalAttributeId'
+            );
+            const result: ISurvivalDescription[] = [];
+            const studyIdToStudy: { [studyId: string]: CancerStudy } = this
+                .studyIdToStudy.result;
+            if (
+                clinicalAttributeMap &&
+                clinicalAttributeMap[diseaseFreeSurvivalClinicalAttributeId] &&
+                clinicalAttributeMap[diseaseFreeSurvivalClinicalAttributeId]
+                    .length > 0
+            ) {
+                clinicalAttributeMap[
+                    diseaseFreeSurvivalClinicalAttributeId
+                ].forEach(attr => {
                     result.push({
-                            studyName: studyIdToStudy[attr.studyId].name,
-                            description: attr.description
+                        studyName: studyIdToStudy[attr.studyId].name,
+                        description: attr.description,
                     } as ISurvivalDescription);
                 });
                 return Promise.resolve(result);
             }
             return Promise.resolve([]);
-        }
+        },
     });
 }

--- a/src/pages/resultsView/styles.scss
+++ b/src/pages/resultsView/styles.scss
@@ -112,3 +112,9 @@
     margin-bottom:5px;
   }
 }
+
+#wideGeneBoxValidationStatus > div {
+  white-space: normal;
+  width: 100%;
+  max-width: 555px;
+}

--- a/src/pages/resultsView/styles.scss
+++ b/src/pages/resultsView/styles.scss
@@ -1,120 +1,117 @@
 .Safari {
-  // this is necessary to fix hidden scroll bars when position:absolute
-  .oncoprintjs__scroll_div {
-    position:static !important;
-  }
+    // this is necessary to fix hidden scroll bars when position:absolute
+    .oncoprintjs__scroll_div {
+        position: static !important;
+    }
 }
 
 .oncoprintjs__scroll_div {
-  // force scrollbar visible, to indicate when theres more oncoprint offscreen to scroll to
-  // source: https://gist.github.com/devinrhode2/2573411#gistcomment-2243001
-  &::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-    background-color: rgba(0,0,0,0);
-    -webkit-border-radius: 100px;
-  }
+    // force scrollbar visible, to indicate when theres more oncoprint offscreen to scroll to
+    // source: https://gist.github.com/devinrhode2/2573411#gistcomment-2243001
+    &::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+        background-color: rgba(0, 0, 0, 0);
+        -webkit-border-radius: 100px;
+    }
 
-  &::-webkit-scrollbar:hover {
-    //background-color: rgba(0, 0, 0, 0.09);
-  }
+    &::-webkit-scrollbar:hover {
+        //background-color: rgba(0, 0, 0, 0.09);
+    }
 
-  &::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.21);
-    -webkit-border-radius: 100px;
-    width: 8px;
-    height: 8px;
-  }
-  
-  &::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.30);
-  }
+    &::-webkit-scrollbar-thumb {
+        background: rgba(0, 0, 0, 0.21);
+        -webkit-border-radius: 100px;
+        width: 8px;
+        height: 8px;
+    }
 
-  &::-webkit-scrollbar-thumb:active {
-    background: rgba(0, 0, 0, 0.42);
-    -webkit-border-radius: 100px;
-  }
+    &::-webkit-scrollbar-thumb:hover {
+        background: rgba(0, 0, 0, 0.3);
+    }
+
+    &::-webkit-scrollbar-thumb:active {
+        background: rgba(0, 0, 0, 0.42);
+        -webkit-border-radius: 100px;
+    }
 }
 
 .oncoprintAddClinicalTracks {
-  > .tab-content {
-    padding:10px 0 5px 0 !important;
+    > .tab-content {
+        padding: 10px 0 5px 0 !important;
 
-    > .msk-tab {
-      padding-left:5px !important;
-      padding-right:5px !important;
+        > .msk-tab {
+            padding-left: 5px !important;
+            padding-right: 5px !important;
 
-      .ReactVirtualized__Table > * {
-        width:100% !important;
-      }
+            .ReactVirtualized__Table > * {
+                width: 100% !important;
+            }
+        }
     }
-  }
 }
 
 .oncoprintAddClinicalTracksDropdown {
-  .rc-tooltip-arrow {
-    border:none !important;
-  }
+    .rc-tooltip-arrow {
+        border: none !important;
+    }
 }
 
 .oncoprintContainer {
-  border: none !important;
-  padding: 0 !important;
+    border: none !important;
+    padding: 0 !important;
 
-  #oncoprintDiv {
+    #oncoprintDiv {
+        .oncoprintjs__track_options__toggle_btn_img {
+            border-width: 0px !important;
+            border-radius: $cornerBorderRadius;
+            position: relative;
+            top: 4px;
+            &:hover {
+                background-color: #eee;
+            }
+        }
 
-    .oncoprintjs__track_options__toggle_btn_img {
-      border-width:0px !important;
-      border-radius:$cornerBorderRadius;
-      position:relative;
-      top:4px;
-      &:hover {
-        background-color:#eee;
-      }
+        .oncoprintjs__track_options__dropdown {
+            border: 1px solid rgba(0, 0, 0, 0.15) !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+            border-radius: $cornerBorderRadius;
+            li {
+                &.oncoprintjs__track_options__separator {
+                    border-top: 1px solid #dddddd !important;
+                }
+                &:not(.oncoprintjs__track_options__separator) {
+                    border-width: 0 !important;
+                }
+                padding: 2px 5px;
+                &:hover {
+                    background: #fff !important;
+                    text-decoration: underline;
+                }
+            }
+        }
     }
-
-    .oncoprintjs__track_options__dropdown {
-      border: 1px solid rgba(0, 0, 0, 0.15) !important;
-      margin: 0 !important;
-      padding: 0 !important;
-      box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-      border-radius:$cornerBorderRadius;
-      li {
-        &.oncoprintjs__track_options__separator {
-          border-top: 1px solid #dddddd !important;
-        }
-        &:not(.oncoprintjs__track_options__separator){
-          border-width: 0 !important;
-        }
-        padding: 2px 5px;
-        &:hover {
-          background: #fff !important;
-          text-decoration: underline;
-        }
-
-      }
-    }
-
-  }
 }
 
 .oncoprintContainer {
-  opacity: 0;
-  max-width: 95vw;
-  &.fadeIn {
-    transition: opacity .75s ease-in-out;
-    opacity:1;
-  }
+    opacity: 0;
+    max-width: 95vw;
+    &.fadeIn {
+        transition: opacity 0.75s ease-in-out;
+        opacity: 1;
+    }
 }
 
 .tabMessageContainer {
-  .alert {
-    margin-bottom:5px;
-  }
+    .alert {
+        margin-bottom: 5px;
+    }
 }
 
 #wideGeneBoxValidationStatus > div {
-  white-space: normal;
-  width: 100%;
-  max-width: 555px;
+    white-space: normal;
+    width: 100%;
+    max-width: 555px;
 }

--- a/src/pages/studyView/styles.scss
+++ b/src/pages/studyView/styles.scss
@@ -66,12 +66,19 @@ $selectHeightInner: $selectHeight - 2px;
     font-size: 18px !important;
 }
 
-#geneBoxValidationStatus > div {
-    max-width: 280px;
+#geneBoxValidationStatus > div,
+#wideGeneBoxValidationStatus > div {
     white-space: normal;
     width: 100%;
 }
 
+#geneBoxValidationStatus > div {
+    max-width: 280px;
+}
+
+#wideGeneBoxValidationStatus > div {
+    max-width: 555px;
+}
 
 
 .studyFilterResult-enter-done {

--- a/src/pages/studyView/styles.scss
+++ b/src/pages/studyView/styles.scss
@@ -1,18 +1,18 @@
 $selectHeight: 30px;
 $selectHeightInner: $selectHeight - 2px;
 
-.studyViewSummaryHeader{
+.studyViewSummaryHeader {
     .Select {
         font-size: 14px;
         width: 220px;
         height: $selectHeight;
 
         .Select-control {
-            height:$selectHeightInner;
+            height: $selectHeightInner;
         }
 
         .Select-input {
-            height:$selectHeightInner;
+            height: $selectHeightInner;
             input {
                 padding: 0px 5px;
                 line-height: $selectHeightInner;
@@ -20,11 +20,11 @@ $selectHeightInner: $selectHeight - 2px;
         }
 
         .Select-value {
-          line-height: $selectHeightInner !important;
+            line-height: $selectHeightInner !important;
 
-          .Select-value-label {
-            line-height: $selectHeightInner;
-          }
+            .Select-value-label {
+                line-height: $selectHeightInner;
+            }
         }
 
         .Select-menu-outer {
@@ -39,13 +39,13 @@ $selectHeightInner: $selectHeight - 2px;
 
         .Select-menu {
             max-height: 398px; // needs to be 2 less than Select-menu-outer height to not hide border. Irrelevant
-                              //    as long as & > div > div:nth-child(2) max-height is less
-            overflow:hidden;
+            //    as long as & > div > div:nth-child(2) max-height is less
+            overflow: hidden;
 
-            & > div > div:nth-child(2){
-                max-height:350px !important;
-                overflow-x:hidden !important;
-                overflow-y:scroll !important;
+            & > div > div:nth-child(2) {
+                max-height: 350px !important;
+                overflow-x: hidden !important;
+                overflow-y: scroll !important;
             }
         }
 
@@ -60,7 +60,8 @@ $selectHeightInner: $selectHeight - 2px;
     color: white !important;
 }
 
-.mfb-component__main-icon--active, .mfb-component__main-icon--resting,
+.mfb-component__main-icon--active,
+.mfb-component__main-icon--resting,
 .mfb-component__child-icon {
     line-height: 56px !important;
     font-size: 18px !important;
@@ -79,7 +80,6 @@ $selectHeightInner: $selectHeight - 2px;
 #wideGeneBoxValidationStatus > div {
     max-width: 555px;
 }
-
 
 .studyFilterResult-enter-done {
     transform: scale(1) !important; /* Standard syntax */

--- a/src/shared/components/GeneSelectionBox/GeneSymbolValidator.tsx
+++ b/src/shared/components/GeneSelectionBox/GeneSymbolValidator.tsx
@@ -195,7 +195,9 @@ export default class GeneSymbolValidator extends React.Component<
                 errorMessageOnly={this.props.errorMessageOnly}
                 wrapTheContent={this.props.wrap}
                 replaceGene={this.replaceGene}
-            />
+            >
+                {this.props.children}
+            </GeneSymbolValidatorMessage>
         );
     }
 

--- a/src/shared/components/GeneSelectionBox/GeneSymbolValidatorMessage.tsx
+++ b/src/shared/components/GeneSelectionBox/GeneSymbolValidatorMessage.tsx
@@ -161,17 +161,22 @@ const GeneSymbolValidatorMessageChild = (
     );
 };
 
-const GeneSymbolValidatorMessage = (props: GeneSymbolValidatorMessageProps) => {
-    return (
-        <div id="geneBoxValidationStatus">
-            <GeneSymbolValidatorMessageChild {...props} />
-        </div>
-    );
-};
-
-GeneSymbolValidatorMessage.defaultProps = {
-    errorMessageOnly: false,
-    wrapTheContent: false,
+class GeneSymbolValidatorMessage extends React.Component<GeneSymbolValidatorMessageProps, {}> {
+    render () {
+        if (this.props.children) {
+            return (
+                <div id="wideGeneBoxValidationStatus">
+                    {this.props.children}
+                </div>
+            )
+        }
+    
+        return (
+            <div id="geneBoxValidationStatus">
+                <GeneSymbolValidatorMessageChild {...this.props} />
+            </div>
+        );
+    }
 };
 
 export default React.memo(GeneSymbolValidatorMessage);

--- a/src/shared/components/GeneSelectionBox/GeneSymbolValidatorMessage.tsx
+++ b/src/shared/components/GeneSelectionBox/GeneSymbolValidatorMessage.tsx
@@ -161,22 +161,25 @@ const GeneSymbolValidatorMessageChild = (
     );
 };
 
-class GeneSymbolValidatorMessage extends React.Component<GeneSymbolValidatorMessageProps, {}> {
-    render () {
+class GeneSymbolValidatorMessage extends React.Component<
+    GeneSymbolValidatorMessageProps,
+    {}
+> {
+    render() {
         if (this.props.children) {
             return (
                 <div id="wideGeneBoxValidationStatus">
                     {this.props.children}
                 </div>
-            )
+            );
         }
-    
+
         return (
             <div id="geneBoxValidationStatus">
                 <GeneSymbolValidatorMessageChild {...this.props} />
             </div>
         );
     }
-};
+}
 
 export default React.memo(GeneSymbolValidatorMessage);

--- a/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
+++ b/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
@@ -235,7 +235,7 @@ export default class OQLTextArea extends React.Component<
             : 'Click gene symbols below or enter here';
     }
 
-    render() {        
+    render() {
         return (
             <div className={styles.genesSelection}>
                 <textarea

--- a/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
+++ b/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
@@ -235,7 +235,7 @@ export default class OQLTextArea extends React.Component<
             : 'Click gene symbols below or enter here';
     }
 
-    render() {
+    render() {        
         return (
             <div className={styles.genesSelection}>
                 <textarea
@@ -264,7 +264,9 @@ export default class OQLTextArea extends React.Component<
                     errorMessageOnly={
                         this.props.location === GeneBoxType.STUDY_VIEW_PAGE
                     }
-                />
+                >
+                    {this.props.children}
+                </GeneSymbolValidator>
             </div>
         );
     }

--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -19,6 +19,8 @@ import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
 import { Gene } from 'shared/api/generated/CBioPortalAPI';
 import { bind } from 'bind-decorator';
 import GenesetsValidator from './GenesetsValidator';
+import FontAwesome from 'react-fontawesome';
+import GeneSymbolValidationError from './GeneSymbolValidationError';
 
 const styles = styles_any as {
     GeneSetSelector: string;
@@ -30,6 +32,8 @@ const styles = styles_any as {
     notEmpty: string;
     sectionSpinner: string;
     learnOql: string;
+    geneCount: string;
+    icon: string;
 };
 
 @observer
@@ -81,6 +85,29 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
         }
     }
 
+    @computed
+    get customError(): JSX.Element | null {        
+        if (this.store.isQueryLimitReached) {
+            return (
+                <div className={styles.geneCount}>
+                    <div
+                        className={""}
+                        title={`Please limit your queries to ${this.store.geneLimit} genes or fewer.`}
+                    >
+                        <FontAwesome className={styles.icon} name="exclamation-circle" />
+                        <GeneSymbolValidationError
+                            sampleCount={this.store.profiledSamplesCount.result.all}
+                            queryProductLimit={AppConfig.serverConfig.query_product_limit}
+                            email={AppConfig.serverConfig.skin_email_contact}
+                        />
+                    </div>
+                </div>
+            )
+        }
+
+        return null;
+    }
+
     render() {
         return (
             <FlexRow padded overflow className={styles.GeneSetSelector}>
@@ -126,7 +153,9 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
                             'Enter HUGO Gene Symbols, Gene Aliases, or OQL'
                         }
                         callback={this.handleOQLUpdate}
-                    />
+                    >
+                        {this.customError}
+                    </OQLTextArea>
 
                     <GenesetsValidator />
 

--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -86,23 +86,30 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
     }
 
     @computed
-    get customError(): JSX.Element | null {        
+    get customError(): JSX.Element | null {
         if (this.store.isQueryLimitReached) {
             return (
                 <div className={styles.geneCount}>
                     <div
-                        className={""}
+                        className={''}
                         title={`Please limit your queries to ${this.store.geneLimit} genes or fewer.`}
                     >
-                        <FontAwesome className={styles.icon} name="exclamation-circle" />
+                        <FontAwesome
+                            className={styles.icon}
+                            name="exclamation-circle"
+                        />
                         <GeneSymbolValidationError
-                            sampleCount={this.store.profiledSamplesCount.result.all}
-                            queryProductLimit={AppConfig.serverConfig.query_product_limit}
+                            sampleCount={
+                                this.store.profiledSamplesCount.result.all
+                            }
+                            queryProductLimit={
+                                AppConfig.serverConfig.query_product_limit
+                            }
                             email={AppConfig.serverConfig.skin_email_contact}
                         />
                     </div>
                 </div>
-            )
+            );
         }
 
         return null;

--- a/src/shared/components/query/GeneSymbolValidationError.tsx
+++ b/src/shared/components/query/GeneSymbolValidationError.tsx
@@ -1,21 +1,37 @@
-import * as React from "react";
-import { observer } from "mobx-react";
+import * as React from 'react';
+import { observer } from 'mobx-react';
 
 export type GeneSymbolValidationErrorProps = {
-    sampleCount: number,
-    queryProductLimit: number,
-    email: string,
-}
+    sampleCount: number;
+    queryProductLimit: number;
+    email: string;
+};
 
 @observer
-export default class GeneSymbolValidationError extends React.Component<GeneSymbolValidationErrorProps, {}> {
+export default class GeneSymbolValidationError extends React.Component<
+    GeneSymbolValidationErrorProps,
+    {}
+> {
     render() {
-        return <span>
-            Queries are limited by gene and sample count. The product of the query's gene and
-            sample count must be less than {this.props.queryProductLimit.toLocaleString()}.
-            You have selected {this.props.sampleCount.toLocaleString()} samples, so you can have no more
-            than {Math.floor(this.props.queryProductLimit / this.props.sampleCount).toLocaleString()} genes in your query.
-            Please <a style={{color: "#ccc"}} href={`mailto:${this.props.email}`}>let us know</a> your use case(s) if you need to query more than that.
-        </span>
+        return (
+            <span>
+                Queries are limited by gene and sample count. The product of the
+                query's gene and sample count must be less than{' '}
+                {this.props.queryProductLimit.toLocaleString()}. You have
+                selected {this.props.sampleCount.toLocaleString()} samples, so
+                you can have no more than{' '}
+                {Math.floor(
+                    this.props.queryProductLimit / this.props.sampleCount
+                ).toLocaleString()}{' '}
+                genes in your query. Please{' '}
+                <a
+                    style={{ color: '#ccc' }}
+                    href={`mailto:${this.props.email}`}
+                >
+                    let us know
+                </a>{' '}
+                your use case(s) if you need to query more than that.
+            </span>
+        );
     }
 }

--- a/src/shared/components/query/GeneSymbolValidationError.tsx
+++ b/src/shared/components/query/GeneSymbolValidationError.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { observer } from "mobx-react";
+
+export type GeneSymbolValidationErrorProps = {
+    sampleCount: number,
+    queryProductLimit: number,
+    email: string,
+}
+
+@observer
+export default class GeneSymbolValidationError extends React.Component<GeneSymbolValidationErrorProps, {}> {
+    render() {
+        return <span>
+            Queries are limited by gene and sample count. The product of the query's gene and
+            sample count must be less than {this.props.queryProductLimit.toLocaleString()}.
+            You have selected {this.props.sampleCount.toLocaleString()} samples, so you can have no more
+            than {Math.floor(this.props.queryProductLimit / this.props.sampleCount).toLocaleString()} genes in your query.
+            Please <a style={{color: "#ccc"}} href={`mailto:${this.props.email}`}>let us know</a> your use case(s) if you need to query more than that.
+        </span>
+    }
+}

--- a/src/shared/components/query/GeneSymbolValidator.tsx
+++ b/src/shared/components/query/GeneSymbolValidator.tsx
@@ -5,6 +5,7 @@ import FontAwesome from 'react-fontawesome';
 import ReactSelect from 'react-select1';
 import { GeneReplacement, QueryStoreComponent, Focus } from './QueryStore';
 import AppConfig from 'appConfig';
+import GeneSymbolValidationError from "./GeneSymbolValidationError";
 
 const styles = styles_any as {
     GeneSymbolValidator: string;
@@ -43,23 +44,14 @@ export default class GeneSymbolValidator extends QueryStoreComponent<{}, {}> {
                 <div className={styles.GeneSymbolValidator}>
                     <div
                         className={styles.invalidBubble}
-                        title="Please limit your queries to 100 genes or fewer."
+                        title={`Please limit your queries to ${this.store.geneLimit} genes or fewer.`}
                     >
-                        <FontAwesome
-                            className={styles.icon}
-                            name="exclamation-circle"
+                        <FontAwesome className={styles.icon} name="exclamation-circle" />
+                        <GeneSymbolValidationError
+                            sampleCount={this.store.profiledSamplesCount.result.all}
+                            queryProductLimit={AppConfig.serverConfig.query_product_limit}
+                            email={AppConfig.serverConfig.skin_email_contact}
                         />
-                        <span>
-                            Queries are limited to 100 genes. Please{' '}
-                            <a
-                                style={{ color: '#ccc' }}
-                                href={`mailto:${AppConfig.serverConfig.skin_email_contact}`}
-                            >
-                                let us know
-                            </a>{' '}
-                            your use case(s) if you need to query more than 100
-                            genes.
-                        </span>
                     </div>
                 </div>
             );

--- a/src/shared/components/query/GeneSymbolValidator.tsx
+++ b/src/shared/components/query/GeneSymbolValidator.tsx
@@ -5,7 +5,7 @@ import FontAwesome from 'react-fontawesome';
 import ReactSelect from 'react-select1';
 import { GeneReplacement, QueryStoreComponent, Focus } from './QueryStore';
 import AppConfig from 'appConfig';
-import GeneSymbolValidationError from "./GeneSymbolValidationError";
+import GeneSymbolValidationError from './GeneSymbolValidationError';
 
 const styles = styles_any as {
     GeneSymbolValidator: string;
@@ -46,10 +46,17 @@ export default class GeneSymbolValidator extends QueryStoreComponent<{}, {}> {
                         className={styles.invalidBubble}
                         title={`Please limit your queries to ${this.store.geneLimit} genes or fewer.`}
                     >
-                        <FontAwesome className={styles.icon} name="exclamation-circle" />
+                        <FontAwesome
+                            className={styles.icon}
+                            name="exclamation-circle"
+                        />
                         <GeneSymbolValidationError
-                            sampleCount={this.store.profiledSamplesCount.result.all}
-                            queryProductLimit={AppConfig.serverConfig.query_product_limit}
+                            sampleCount={
+                                this.store.profiledSamplesCount.result.all
+                            }
+                            queryProductLimit={
+                                AppConfig.serverConfig.query_product_limit
+                            }
                             email={AppConfig.serverConfig.skin_email_contact}
                         />
                     </div>

--- a/src/shared/components/query/GenesetsValidator.tsx
+++ b/src/shared/components/query/GenesetsValidator.tsx
@@ -20,7 +20,7 @@ const styles = styles_any as {
 @observer
 export default class GenesetsValidator extends QueryStoreComponent<{}, {}> {
     render() {
-        if (this.store.genesetIdsQuery.error)
+        if (this.store.genesetIdsQuery.error) {
             return (
                 <div className={styles.GeneSymbolValidator}>
                     <span className={styles.errorMessage}>
@@ -33,10 +33,13 @@ export default class GenesetsValidator extends QueryStoreComponent<{}, {}> {
                     </span>
                 </div>
             );
+        }
 
-        if (!this.store.genesetIdsQuery.query.length) return null;
+        if (!this.store.genesetIdsQuery.query.length) {
+            return null;
+        }
 
-        if (this.store.genesets.isError)
+        if (this.store.genesets.isError) {
             return (
                 <div className={styles.GeneSymbolValidator}>
                     <span className={styles.pendingMessage}>
@@ -44,11 +47,12 @@ export default class GenesetsValidator extends QueryStoreComponent<{}, {}> {
                     </span>
                 </div>
             );
+        }
 
         if (
             this.store.genesets.isPending &&
             this.store.genesets.result.invalid.length === 0
-        )
+        ) {
             return (
                 <div className={styles.GeneSymbolValidator}>
                     <span className={styles.pendingMessage}>
@@ -56,8 +60,9 @@ export default class GenesetsValidator extends QueryStoreComponent<{}, {}> {
                     </span>
                 </div>
             );
+        }
 
-        if (this.store.genesets.result.invalid.length)
+        if (this.store.genesets.result.invalid.length) {
             return (
                 <div className={styles.GeneSymbolValidator}>
                     <div
@@ -77,6 +82,7 @@ export default class GenesetsValidator extends QueryStoreComponent<{}, {}> {
                     )}
                 </div>
             );
+        }
 
         return (
             <div className={styles.GeneSymbolValidator}>

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1790,7 +1790,13 @@ export class QueryStore {
     }
 
     @computed get isQueryLimitReached(): boolean {
-        return this.oql.query.length > AppConfig.serverConfig.query_gene_limit;
+        return (
+            this.oql.query.length * this.profiledSamplesCount.result.all > AppConfig.serverConfig.query_product_limit
+        );
+    }
+
+    @computed get geneLimit(): number {
+        return Math.floor(AppConfig.serverConfig.query_product_limit / this.profiledSamplesCount.result.all)
     }
 
     @computed get submitError() {
@@ -1902,7 +1908,7 @@ export class QueryStore {
         }
 
         if (this.isQueryLimitReached) {
-            return 'Please limit your queries to 100 genes or fewer.';
+            return `Please limit your queries to ${this.geneLimit} genes or fewer.`;
         }
 
         if (this.genes.result.suggestions.length)

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1791,12 +1791,16 @@ export class QueryStore {
 
     @computed get isQueryLimitReached(): boolean {
         return (
-            this.oql.query.length * this.profiledSamplesCount.result.all > AppConfig.serverConfig.query_product_limit
+            this.oql.query.length * this.profiledSamplesCount.result.all >
+            AppConfig.serverConfig.query_product_limit
         );
     }
 
     @computed get geneLimit(): number {
-        return Math.floor(AppConfig.serverConfig.query_product_limit / this.profiledSamplesCount.result.all)
+        return Math.floor(
+            AppConfig.serverConfig.query_product_limit /
+                this.profiledSamplesCount.result.all
+        );
     }
 
     @computed get submitError() {

--- a/src/shared/components/query/styles/styles.module.scss
+++ b/src/shared/components/query/styles/styles.module.scss
@@ -71,6 +71,26 @@
   border: 1px solid #ddd;
   border-radius: 2px;
   box-shadow: 0 0 1px #e9e9e9;
+
+  span.icon {
+    text-align: center;
+    margin-right: 4px;
+    width: 16px;
+    height: 16px;
+    line-height: 17px;
+  }
+
+  div.geneCount {
+    color: #fff;
+    margin: 2px 2px 2px 0;
+    padding: 5px 10px;
+    border-radius: 2px;
+    span.icon {
+      color: #fff;
+      line-height: 17px;
+    }
+    background: $redError;
+  }
 }
 
 div.SelectedStudiesWindow {

--- a/src/shared/components/query/styles/styles.module.scss
+++ b/src/shared/components/query/styles/styles.module.scss
@@ -1,63 +1,57 @@
 .QueryAndDownloadTabs {
+    position: relative;
 
-  position:relative;
-
-  :global(.citationRule) {
-    position:absolute;
-    z-index:10;
-    top:10px;
-    right:20px;
-    font-size:12px;
-  }
-
+    :global(.citationRule) {
+        position: absolute;
+        z-index: 10;
+        top: 10px;
+        right: 20px;
+        font-size: 12px;
+    }
 }
 
 .QueryContainer {
-
-
-  :global(.sectionLabel) {
-    min-width:246px;
-  }
-
-  &:global(.forkedMode) {
-    //> div:nth-child(2) {
-    //  margin-top:0px !important;
-    //}
-
-    .forkedButtons {
-      margin-top:10px;
-      justify-content: center;
-      align-items: center;
-      > div {   // we have to use span to fix issue with mouseover events and disabled button controls
-
-      }
-      a {
-        pointer-events:all !important;
-        margin:0 10px;
-      }
-
+    :global(.sectionLabel) {
+        min-width: 246px;
     }
 
-  }
+    &:global(.forkedMode) {
+        //> div:nth-child(2) {
+        //  margin-top:0px !important;
+        //}
 
-  label {
-    margin-bottom: 0;
-    font-weight: normal;
-  }
+        .forkedButtons {
+            margin-top: 10px;
+            justify-content: center;
+            align-items: center;
+            > div {
+                // we have to use span to fix issue with mouseover events and disabled button controls
+            }
+            a {
+                pointer-events: all !important;
+                margin: 0 10px;
+            }
+        }
+    }
 
-  .errorMessage {
-    color: $redError;
-    font-weight: bold;
-  }
+    label {
+        margin-bottom: 0;
+        font-weight: normal;
+    }
 
-  .oqlMessage {
-    color: $brand-info;
-    font-weight: bold;
-  }
+    .errorMessage {
+        color: $redError;
+        font-weight: bold;
+    }
+
+    .oqlMessage {
+        color: $brand-info;
+        font-weight: bold;
+    }
 }
 
 .CancerStudySelector {
-  height:400px;
+    height: 400px;
 }
 
 .CancerStudySelector,
@@ -66,617 +60,613 @@
 .CaseSetSelector,
 .StudySelection,
 .GeneSetSelector {
-  background: #fff;
-  padding: 10px;
-  border: 1px solid #ddd;
-  border-radius: 2px;
-  box-shadow: 0 0 1px #e9e9e9;
-
-  span.icon {
-    text-align: center;
-    margin-right: 4px;
-    width: 16px;
-    height: 16px;
-    line-height: 17px;
-  }
-
-  div.geneCount {
-    color: #fff;
-    margin: 2px 2px 2px 0;
-    padding: 5px 10px;
+    background: #fff;
+    padding: 10px;
+    border: 1px solid #ddd;
     border-radius: 2px;
+    box-shadow: 0 0 1px #e9e9e9;
+
     span.icon {
-      color: #fff;
-      line-height: 17px;
+        text-align: center;
+        margin-right: 4px;
+        width: 16px;
+        height: 16px;
+        line-height: 17px;
     }
-    background: $redError;
-  }
+
+    div.geneCount {
+        color: #fff;
+        margin: 2px 2px 2px 0;
+        padding: 5px 10px;
+        border-radius: 2px;
+        span.icon {
+            color: #fff;
+            line-height: 17px;
+        }
+        background: $redError;
+    }
 }
 
 div.SelectedStudiesWindow {
-  div:global(.modal-dialog) {
-    width: 850px;
-  }
+    div:global(.modal-dialog) {
+        width: 850px;
+    }
 }
 
 .CancerStudySelectorHeader {
-  justify-content: space-between;
-  align-items:center;
+    justify-content: space-between;
+    align-items: center;
 
-  h2 {
-    padding: 0;
-    margin:0;
-    font-size:18px;
-  }
-  padding:0 10px 5px 10px;
+    h2 {
+        padding: 0;
+        margin: 0;
+        font-size: 18px;
+    }
+    padding: 0 10px 5px 10px;
 
-  :global(.Select-control) {
-    height: 28px;
-  }
-
-  :global(.Select-input) {
-    height: 28px;
-  }
-
-  :global(.autosuggest) {
-    width:200px;
-
-    input {
-      padding-right:20px !important;
+    :global(.Select-control) {
+        height: 28px;
     }
 
-  }
+    :global(.Select-input) {
+        height: 28px;
+    }
 
-  :global(.Select-placeholder),
-  :global(.Select--single) > :global(.Select-control .Select-value) {
-    line-height: 28px !important;
-  }
+    :global(.autosuggest) {
+        width: 200px;
 
-  border-bottom:1px solid #ddd;
+        input {
+            padding-right: 20px !important;
+        }
+    }
 
+    :global(.Select-placeholder),
+    :global(.Select--single) > :global(.Select-control .Select-value) {
+        line-height: 28px !important;
+    }
 
+    border-bottom: 1px solid #ddd;
 }
 
 .CancerStudySelector {
-  position: relative;
-  overflow: hidden;
-  user-select: none;
-  padding: 5px 0 0 0;
+    position: relative;
+    overflow: hidden;
+    user-select: none;
+    padding: 5px 0 0 0;
 
-  label {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-  }
-  a {
-    cursor: pointer;
-  }
-
-  h2 {
-    padding: 0;
-  }
-
-  .selectAll {
-    text-transform: uppercase;
-    min-width: 105px;
-    text-align: center;
-  }
-
-  .noData,
-  .selectedCount {
-    font-size: 12px;
-    text-align: right;
-    margin: 0 10px;
-
-    &.selectionsExist {
-      color: #337ab7;
-      text-decoration: underline;
-      &:hover {
+    label {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+    }
+    a {
         cursor: pointer;
-      }
     }
-  }
 
-  h3 {
-    background-color: #1982b8;
-    border-bottom: 1px solid rgb(17, 116, 167);
-    color: #fff;
-    font: normal normal 500 13px/18px 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    text-transform: uppercase;
-    margin: 0;
-    padding: 10px 15px;
+    h2 {
+        padding: 0;
+    }
 
+    .selectAll {
+        text-transform: uppercase;
+        min-width: 105px;
+        text-align: center;
+    }
+
+    .noData,
     .selectedCount {
-      float: right;
-    }
-  }
+        font-size: 12px;
+        text-align: right;
+        margin: 0 10px;
 
-  div.cancerStudySelectorBody {
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
-    flex: 1;
-  }
-
-  div.cancerTypeListContainer,
-  div.cancerStudyListContainer {
-    overflow-y: scroll;
-    overflow-x: auto;
-    height:100%;
-  }
-
-  div.cancerStudyListContainer {
-    flex:1;
-    &:only-child {
-      padding: 10px 10px 10px 10px;
-    }
-  }
-
-  ul.cancerTypeList {
-    background: $lightBlue;
-    padding: 0px;
-    margin: 0px !important;
-    width: 230px;
-
-    li {
-      cursor: pointer;
-      list-style-type: none;
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-      color: #043852;
-      border-bottom: 1px solid rgb(222, 233, 241);
-      border-top: 1px solid rgb(243, 248, 251);
-      padding: 8px 10px;
-
-      span {
-        &.cancerTypeListItemLabel {
-          flex: 1;
-          margin: 0 10px 0 0;
+        &.selectionsExist {
+            color: #337ab7;
+            text-decoration: underline;
+            &:hover {
+                cursor: pointer;
+            }
         }
+    }
 
-        &.cancerTypeListItemCount {
-          background-color: rgb(222, 233, 241);
-          border-radius: 2px;
-          box-shadow: 0px 1px 0px rgba(0,0,0,0.1);
-          font: normal normal 400 10px/19px 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          text-align: center;
-          width: 25px;
+    h3 {
+        background-color: #1982b8;
+        border-bottom: 1px solid rgb(17, 116, 167);
+        color: #fff;
+        font: normal normal 500 13px/18px 'Helvetica Neue', Helvetica, Arial,
+            sans-serif;
+        text-transform: uppercase;
+        margin: 0;
+        padding: 10px 15px;
+
+        .selectedCount {
+            float: right;
         }
-      }
     }
-  }
 
-  .selectable:hover {
-    color: #000;
-    background-color: #deeaf3;
-  }
-
-  .selectable.selected {
-    background-color: rgba(143, 189, 212, 0.42);
-  }
-
-  .matchingNodeText {
-    font-style: italic;
-  }
-
-  .nonMatchingNodeText {
-    font-style: normal;
-  }
-
-  .containsSelectedStudies {
-    color: #000;
-
-    .cancerTypeListItemCount {
-      position: relative;
-
-      &:before {
-        background: rgba(25, 130, 184, 0.5);
-        display: block;
-        position: absolute;
-        top: 0px;
-        right: 0px;
-        border-radius: 1px 2px 1px 2px;
-        content: ' ';
-        height: 5px;
-        width: 5px;
-      }
+    div.cancerStudySelectorBody {
+        border-bottom-left-radius: 2px;
+        border-bottom-right-radius: 2px;
+        flex: 1;
     }
-  }
 
-  .searchTextInput {
-    min-width: 220px;
-  }
+    div.cancerTypeListContainer,
+    div.cancerStudyListContainer {
+        overflow-y: scroll;
+        overflow-x: auto;
+        height: 100%;
+    }
+
+    div.cancerStudyListContainer {
+        flex: 1;
+        &:only-child {
+            padding: 10px 10px 10px 10px;
+        }
+    }
+
+    ul.cancerTypeList {
+        background: $lightBlue;
+        padding: 0px;
+        margin: 0px !important;
+        width: 230px;
+
+        li {
+            cursor: pointer;
+            list-style-type: none;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            color: #043852;
+            border-bottom: 1px solid rgb(222, 233, 241);
+            border-top: 1px solid rgb(243, 248, 251);
+            padding: 8px 10px;
+
+            span {
+                &.cancerTypeListItemLabel {
+                    flex: 1;
+                    margin: 0 10px 0 0;
+                }
+
+                &.cancerTypeListItemCount {
+                    background-color: rgb(222, 233, 241);
+                    border-radius: 2px;
+                    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1);
+                    font: normal normal 400 10px/19px 'Helvetica Neue',
+                        Helvetica, Arial, sans-serif;
+                    text-align: center;
+                    width: 25px;
+                }
+            }
+        }
+    }
+
+    .selectable:hover {
+        color: #000;
+        background-color: #deeaf3;
+    }
+
+    .selectable.selected {
+        background-color: rgba(143, 189, 212, 0.42);
+    }
+
+    .matchingNodeText {
+        font-style: italic;
+    }
+
+    .nonMatchingNodeText {
+        font-style: normal;
+    }
+
+    .containsSelectedStudies {
+        color: #000;
+
+        .cancerTypeListItemCount {
+            position: relative;
+
+            &:before {
+                background: rgba(25, 130, 184, 0.5);
+                display: block;
+                position: absolute;
+                top: 0px;
+                right: 0px;
+                border-radius: 1px 2px 1px 2px;
+                content: ' ';
+                height: 5px;
+                width: 5px;
+            }
+        }
+    }
+
+    .searchTextInput {
+        min-width: 220px;
+    }
 }
 
 .MolecularProfileSelector {
-  div.group {
-    display: flex;
-    flex-direction: column;
-
     div.group {
-      margin-left: 20px;
+        display: flex;
+        flex-direction: column;
+
+        div.group {
+            margin-left: 20px;
+        }
     }
-  }
 
-  div.zScore {
-    margin: 0px 0 10px 20px;
+    div.zScore {
+        margin: 0px 0 10px 20px;
 
-    input[type='text'] {
-      border: 1px solid #ddd;
-      border-radius: 2px;
-      margin: 0 5px;
-      padding: 2px 5px;
+        input[type='text'] {
+            border: 1px solid #ddd;
+            border-radius: 2px;
+            margin: 0 5px;
+            padding: 2px 5px;
+        }
     }
-  }
 
-  label {
-    display: inline;
-    cursor: pointer;
+    label {
+        display: inline;
+        cursor: pointer;
 
-    input[type='radio'],
-    input[type='checkbox'] {
-      margin-right: 8px;
+        input[type='radio'],
+        input[type='checkbox'] {
+            margin-right: 8px;
+        }
     }
-  }
 
-  span.infoIcon {
-    color: #555;
-  }
+    span.infoIcon {
+        color: #555;
+    }
 
-  span.groupName {
-  }
+    span.groupName {
+    }
 
-  span.profileName {
-    margin-right: 6px;
-  }
+    span.profileName {
+        margin-right: 6px;
+    }
 }
 
 .DataTypePrioritySelector {
-  input[type="radio"] {
-    margin: 0 6px 0 2px;
-  }
+    input[type='radio'] {
+        margin: 0 6px 0 2px;
+    }
 }
 
 .DataTypePriorityLabel {
-  line-height: 2;
-  margin: 0 10px 0 0;
+    line-height: 2;
+    margin: 0 10px 0 0;
 }
 
 .CaseSetSelector {
-  div:global(.Select) {
-    width: 555px;
-    margin-bottom:10px;
-  }
-  textarea {
-    width: 555px;
-    resize: vertical;
-    padding: 5px;
-    border: 1px solid $borderColor;
-    border-radius: 2px;
-  }
-  .radioRow {
-    div {
-      padding: 0 0 0 2px;
+    div:global(.Select) {
+        width: 555px;
+        margin-bottom: 10px;
     }
+    textarea {
+        width: 555px;
+        resize: vertical;
+        padding: 5px;
+        border: 1px solid $borderColor;
+        border-radius: 2px;
+    }
+    .radioRow {
+        div {
+            padding: 0 0 0 2px;
+        }
 
-    :global(.spinner) {
-      float: right;
+        :global(.spinner) {
+            float: right;
+        }
     }
-  }
-  input[type="radio"] {
-    margin-right: 6px;
-  }
+    input[type='radio'] {
+        margin-right: 6px;
+    }
 }
 
 .GeneSetSelector {
-  div:global(.Select) {
-    width: 555px;
-    margin-bottom:8px;
-  }
-
-  .buttonRow {
-    margin-bottom:8px;
-    justify-content:space-between;
-  }
-
-  textarea.geneSet {
-    width: 555px;
-    resize: vertical;
-    border: 1px solid #ddd;
-    border-radius: 2px;
-    padding: 5px;
-
-    &.empty {
+    div:global(.Select) {
+        width: 555px;
+        margin-bottom: 8px;
     }
-    &.notEmpty {
-      text-transform: uppercase;
+
+    .buttonRow {
+        margin-bottom: 8px;
+        justify-content: space-between;
     }
-  }
+
+    textarea.geneSet {
+        width: 555px;
+        resize: vertical;
+        border: 1px solid #ddd;
+        border-radius: 2px;
+        padding: 5px;
+
+        &.empty {
+        }
+        &.notEmpty {
+            text-transform: uppercase;
+        }
+    }
 }
 
 .GeneSymbolValidator {
-  cursor: default;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  width: 555px;
-  padding-top: 5px;
-  span.icon {
-    text-align: center;
-    margin-right: 4px;
-    width: 16px;
-    height: 16px;
-    line-height: 17px;
-  }
-  span.pendingMessage,
-  span.oqlNotice,
-  span.errorMessage {
-    font-size: small;
-  }
-  div.validBubble,
-  div.invalidBubble {
-    color: #fff;
+    cursor: default;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    margin: 2px 2px 2px 0;
-    padding: 5px 10px;
-    border-radius: 2px;
+    width: 555px;
+    padding-top: 5px;
     span.icon {
-      color: #fff;
-      line-height: 17px;
+        text-align: center;
+        margin-right: 4px;
+        width: 16px;
+        height: 16px;
+        line-height: 17px;
     }
-  }
-  div.invalidBubble {
-    background: $redError;
-  }
-  div.validBubble {
-    background: $greenSuccess;
-  }
-  div.suggestionBubble {
-    color: rgba(0, 0, 0, 0.5);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    margin: 2px;
-    padding: 5px 10px;
-    background-color: $lightGrey;
-    border-radius: 2px;
-    &:hover {
-      background-color: $mediumGrey;
+    span.pendingMessage,
+    span.oqlNotice,
+    span.errorMessage {
+        font-size: small;
     }
-    span.icon {
-      color: $darkGrey;
-      line-height: 17px;
+    div.validBubble,
+    div.invalidBubble {
+        color: #fff;
+        display: flex;
+        align-items: center;
+        margin: 2px 2px 2px 0;
+        padding: 5px 10px;
+        border-radius: 2px;
+        span.icon {
+            color: #fff;
+            line-height: 17px;
+        }
     }
-    span.noChoiceLabel {
-      font-weight: normal;
+    div.invalidBubble {
+        background: $redError;
     }
-    span.singleChoiceLabel {
-      font-weight: bold;
+    div.validBubble {
+        background: $greenSuccess;
     }
-    span.multiChoiceLabel {
-      font-weight: normal;
+    div.suggestionBubble {
+        color: rgba(0, 0, 0, 0.5);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        margin: 2px;
+        padding: 5px 10px;
+        background-color: $lightGrey;
+        border-radius: 2px;
+        &:hover {
+            background-color: $mediumGrey;
+        }
+        span.icon {
+            color: $darkGrey;
+            line-height: 17px;
+        }
+        span.noChoiceLabel {
+            font-weight: normal;
+        }
+        span.singleChoiceLabel {
+            font-weight: bold;
+        }
+        span.multiChoiceLabel {
+            font-weight: normal;
+        }
+        div:global(.Select) {
+            width: 140px;
+            margin-left: 4px;
+            float: left;
+        }
     }
-    div:global(.Select) {
-      width: 140px;
-      margin-left: 4px;
-      float: left;
-    }
-  }
 }
 
-
 div.MutSigGeneSelectorWindow {
-  div:global(.modal-dialog) {
-    width: 650px;
-  }
-
-  div.MutSigGeneSelector {
-    margin: 10px;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-
-    :global(.table) {
-      margin: 0;
-      & > thead > tr > th {
-        font-size: 13px;
-      }
-      & > tbody > tr > td {
-        vertical-align: middle;
-        padding: 6px 10px;
-        font-size: 12px;
-      }
+    div:global(.modal-dialog) {
+        width: 650px;
     }
-    div.selectionColumnHeader,
-    div.selectionColumnCell {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
 
-      label {
-        min-height: 1em !important;
-        input[type='checkbox'] {
-          margin: 4px 0 0 0;
+    div.MutSigGeneSelector {
+        margin: 10px;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+
+        :global(.table) {
+            margin: 0;
+            & > thead > tr > th {
+                font-size: 13px;
+            }
+            & > tbody > tr > td {
+                vertical-align: middle;
+                padding: 6px 10px;
+                font-size: 12px;
+            }
         }
-      }
+        div.selectionColumnHeader,
+        div.selectionColumnCell {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+
+            label {
+                min-height: 1em !important;
+                input[type='checkbox'] {
+                    margin: 4px 0 0 0;
+                }
+            }
+        }
+        button.selectButton {
+            align-self: flex-end;
+        }
     }
-    button.selectButton {
-      align-self: flex-end;
-    }
-  }
 }
 
 div.GisticGeneSelectorWindow {
-  div:global(.modal-dialog) {
-    width: 800px;
-  }
-
-  div.GisticGeneSelector {
-    margin: 10px;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-
-    div.header.amp.del {
-      float: left;
-      display: flex;
-      flex-direction: column;
-
-      span.amp {
-        color: red;
-      }
-      span.del {
-        color: blue;
-      }
+    div:global(.modal-dialog) {
+        width: 800px;
     }
 
-    div.gisticTable {
-      margin: 10px 0;
-      overflow: auto;
-      :global(.table) {
-        margin: 0;
-        & > thead > tr > th {
-          font-size: 13px;
+    div.GisticGeneSelector {
+        margin: 10px;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+
+        div.header.amp.del {
+            float: left;
+            display: flex;
+            flex-direction: column;
+
+            span.amp {
+                color: red;
+            }
+            span.del {
+                color: blue;
+            }
         }
-        & > tbody > tr > td {
-          vertical-align: middle;
-          padding: 3px 10px;
-          font-size: 12px;
 
-          .amp {
-            height: 1em;
-            background-color: red;
-          }
-          .del {
-            height: 1em;
-            background-color: blue;
-          }
+        div.gisticTable {
+            margin: 10px 0;
+            overflow: auto;
+            :global(.table) {
+                margin: 0;
+                & > thead > tr > th {
+                    font-size: 13px;
+                }
+                & > tbody > tr > td {
+                    vertical-align: middle;
+                    padding: 3px 10px;
+                    font-size: 12px;
+
+                    .amp {
+                        height: 1em;
+                        background-color: red;
+                    }
+                    .del {
+                        height: 1em;
+                        background-color: blue;
+                    }
+                }
+            }
         }
-      }
-    }
 
-    div.GisticGeneToggles {
-      width: 400px;
-    }
+        div.GisticGeneToggles {
+            width: 400px;
+        }
 
-    .someGenes,
-    .moreGenes {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-    }
+        .someGenes,
+        .moreGenes {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+        }
 
-    span.geneToggle {
-      background: rgba(0,0,0,0);
-      line-height: 16px !important;
-      padding: 3px 5px;
-      -webkit-transition: background 0.2s ease-in-out;
-      -o-transition: background 0.2s ease-in-out;
-      transition: background 0.2s ease-in-out;
+        span.geneToggle {
+            background: rgba(0, 0, 0, 0);
+            line-height: 16px !important;
+            padding: 3px 5px;
+            -webkit-transition: background 0.2s ease-in-out;
+            -o-transition: background 0.2s ease-in-out;
+            transition: background 0.2s ease-in-out;
 
-      &:not(.simulateHovered) {
-        cursor: pointer;
-      }
-      &:hover,
-      &.simulateHovered {
-        background: #dee9f1;
-        border-radius: 3px;
-      }
-      &.selected {
-        font-weight: 600;
-      }
-      &.notSelected {
-        font-weight: 400;
-      }
-    }
+            &:not(.simulateHovered) {
+                cursor: pointer;
+            }
+            &:hover,
+            &.simulateHovered {
+                background: #dee9f1;
+                border-radius: 3px;
+            }
+            &.selected {
+                font-weight: 600;
+            }
+            &.notSelected {
+                font-weight: 400;
+            }
+        }
 
-    a.showMoreLess {
-      cursor: pointer;
-      padding: 3px;
-      color: #337ab7;
-      &:hover {
-        text-decoration: underline;
-      }
-    }
+        a.showMoreLess {
+            cursor: pointer;
+            padding: 3px;
+            color: #337ab7;
+            &:hover {
+                text-decoration: underline;
+            }
+        }
 
-    button.selectButton {
-      align-self: flex-end;
+        button.selectButton {
+            align-self: flex-end;
+        }
     }
-  }
 }
 
 div.GenesetsSelectorWindow {
-  div:global(.modal-dialog) {
-     width: 800px;
-  }
-  div.GenesetsFormGroup {
-      class: "form-group";
-      display:"inline-block";
-      padding: "10px 15px";
-  }
+    div:global(.modal-dialog) {
+        width: 800px;
+    }
+    div.GenesetsFormGroup {
+        class: 'form-group';
+        display: 'inline-block';
+        padding: '10px 15px';
+    }
 }
 
 div.GenesetsVolcanoSelectorWindow {
-  div:global(.modal-dialog) {
-     width: 1200px;
-     height: 500px;
-  }
-  div.GenesetsSelectionArea {
-      padding: 10px 15px;
-  }
-  div.GenesetsFormGroup {
-      class: "form-group";
-      display:"inline-block";
-      padding: "10px 15px";
-  }
+    div:global(.modal-dialog) {
+        width: 1200px;
+        height: 500px;
+    }
+    div.GenesetsSelectionArea {
+        padding: 10px 15px;
+    }
+    div.GenesetsFormGroup {
+        class: 'form-group';
+        display: 'inline-block';
+        padding: '10px 15px';
+    }
 }
 
 span.downloadSubmitExplanation {
 }
 
 label.transposeDataMatrix {
-  input[type='checkbox'] {
-    margin-right: 6px;
-  }
+    input[type='checkbox'] {
+        margin-right: 6px;
+    }
 }
 
 div.submitRow {
+    align-items: center;
 
-  align-items:center;
-
-  button.genomeSpace {
-    border: 1px solid $darkestCream;
-    border-radius: 2px;
-  }
+    button.genomeSpace {
+        border: 1px solid $darkestCream;
+        border-radius: 2px;
+    }
 }
 
 .tooltip {
-  max-width: 300px;
+    max-width: 300px;
 }
 
 .learnOql {
-  display:inline-block;
-  margin-top:25px;
+    display: inline-block;
+    margin-top: 25px;
 }
 
 .quickSelect {
-  display:flex;
-  align-items:center;
-  button {
-    margin-left:10px;
-  }
+    display: flex;
+    align-items: center;
+    button {
+        margin-left: 10px;
+    }
 }
 
 .StudySelection {
-  align-items:center;
+    align-items: center;
 }
 
 .studyName {
-  border-right:1px dashed $borderColor;
-  padding-right:10px;
-  margin-right:10px;
-  display:inline-block;
-
+    border-right: 1px dashed $borderColor;
+    padding-right: 10px;
+    margin-right: 10px;
+    display: inline-block;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11886,6 +11886,11 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6384

Describe changes proposed in this pull request:
- Behavior
    - Previous: users cannot query more than 100 genes
    - New: users cannot make a query where `genes * samples > 1,000,000`
- Code changes
    - Changed the logic in QueryStore and ResultsViewPageStore for determining
if the query is valid
    - Changed error message to explain new restrictions
    - Changed the related config value from 100 to 1,000,000
# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)

# Any screenshots or GIFs?
![large-sample-set](https://user-images.githubusercontent.com/20069833/66502318-fd75ee80-ea92-11e9-9691-d7b674a6212e.png)
![small-sample-set](https://user-images.githubusercontent.com/20069833/66502319-fd75ee80-ea92-11e9-8809-ec1e3c7523ac.png)
![results-view](https://user-images.githubusercontent.com/20069833/66502320-fd75ee80-ea92-11e9-9f45-522ec37b2fd1.png)




