### PR TITLE
(download tab) show all molecular profiles by default

### DIFF
--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -13,7 +13,7 @@ import {default as CaseAlterationTable, ICaseAlteration} from "./CaseAlterationT
 import {
     generateCaseAlterationData, generateCnaData, generateDownloadData, generateGeneAlterationData, generateMrnaData,
     generateMutationData, generateMutationDownloadData,
-    generateProteinData, hasValidData, hasValidMutationData, stringify2DArray, generateOtherMolecularProfileData, generateOtherMolecularProfileDownloadData, DOWNLOAD_TABLE_DEFAULT_ROW_LIMIT
+    generateProteinData, hasValidData, hasValidMutationData, stringify2DArray, generateOtherMolecularProfileData, generateOtherMolecularProfileDownloadData
 } from "./DownloadUtils";
 
 import styles from "./styles.module.scss";
@@ -57,8 +57,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
         this.handleProteinDownload = this.handleProteinDownload.bind(this);
         this.handleTransposedProteinDownload = this.handleTransposedProteinDownload.bind(this);
     }
-
-    @observable showAllRows: boolean = false;
 
     readonly geneAlterationData = remoteData<IGeneAlteration[]>({
         await: ()=>[
@@ -343,13 +341,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
                                     {(this.props.store.doNonSelectedMolecularProfilesExist) && this.nonSelectedProfileDownloadRow(this.props.store.nonSelectedMolecularProfilesGroupByName.result!)}
                                 </tbody>
                             </table>
-                            {
-                                this.shouldShowMoreButtonAppear(_.size(this.props.store.nonSelectedMolecularProfilesGroupByName.result!), this.props.store.selectedMolecularProfiles.result!.length) && (
-                                    <div className={classNames(styles.showMoreButtonContainer)}>
-                                        <button className={classNames("btn", "btn-primary", "btn-sm", styles.showMoreButton)} onClick={this.toggleShowAll}>{this.showAllRows ? "Show less" : "Show more"}</button>
-                                    </div>
-                                )
-                            }
                         </div>
                         <hr/>
                         <div className={styles["tables-container"]} data-test="dataDownloadGeneAlterationTable">
@@ -442,10 +433,8 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
             }
             return {"name": profileName}
         });
-
-        const filteredProfileOptions = allProfileOptions.slice(0, Math.min(DOWNLOAD_TABLE_DEFAULT_ROW_LIMIT - this.props.store.selectedMolecularProfiles.result!.length, allProfileOptions.length));
         
-        return _.map(this.showAllRows ? allProfileOptions : filteredProfileOptions, (option) => 
+        return _.map(allProfileOptions, (option) => 
             (
                 <tr>
                     <td style={{width: 500}}>
@@ -572,16 +561,6 @@ export default class DownloadTab extends React.Component<IDownloadTabProps, {}>
                                             handleDownload,
                                             "sample_matrix.txt"));
     };
-
-    private shouldShowMoreButtonAppear(nonSelectedProfilesCount: number, selectedProfilesCount: number): boolean {
-        return nonSelectedProfilesCount > DOWNLOAD_TABLE_DEFAULT_ROW_LIMIT - selectedProfilesCount;
-    }
-
-    @autobind
-    @action
-    private toggleShowAll() {
-        this.showAllRows = !this.showAllRows;
-    }
 
     private handleMutationDownload()
     {

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -22,8 +22,6 @@ export interface IDownloadFileRow {
     alterationData: {[gene: string]: string[]};
 }
 
-export const DOWNLOAD_TABLE_DEFAULT_ROW_LIMIT = 7;
-
 export function generateOqlData(datum: GeneticTrackDatum,
                                 geneAlterationDataByGene?: {[gene: string]: IGeneAlteration},
                                 molecularProfileIdToMolecularProfile?: {[molecularProfileId:string]:MolecularProfile}): IOqlData

--- a/src/pages/resultsView/download/styles.module.scss
+++ b/src/pages/resultsView/download/styles.module.scss
@@ -24,16 +24,6 @@
     font-weight: bold;
 }
 
-.showMoreButtonContainer {
-  display: flex;
-  justify-content: center;
-}
-
-.showMoreButton {
-  // margin-left: 10px !important;
-  width: 200px;
-}
-
 .tooltip {
   max-width: 300px;
 }


### PR DESCRIPTION
@alisman @jjgao Based on today's discussion on the planning meeting, we agreed to remove the `show more` button and show all profiles by default. Please feel free to open a issue and discuss more about how to improve this download tab.

Change proposed in this pull request:
- a we can show all the molecular profiles by default
![image](https://user-images.githubusercontent.com/15748980/66435847-c00e5400-e9f3-11e9-9881-81e06af1947a.png)