### PR TITLE
Add scrollbar in metadata tags tooltip

### DIFF
--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.scss
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.scss
@@ -15,6 +15,9 @@
  **/
 
  .studyTagsTooltip{
+    max-height: 45vh;
+    overflow: auto; 
+  
     .json-to-table table {
         width: 100%;
         border-collapse: collapse;


### PR DESCRIPTION
Add scrollbar in metadata tags tooltip

# Screenshots
### Before:
![Screenshot from 2019-10-16 10-24-25](https://user-images.githubusercontent.com/31291004/66901667-67e0de80-efff-11e9-8d2e-59ee61c18f4b.png)

### After:
![Screenshot from 2019-10-16 10-20-40](https://user-images.githubusercontent.com/31291004/66901352-d6716c80-effe-11e9-95c3-0a8ab8c8e50b.png)