### PR TITLE
Persist url params in ResultsView after update of query parameters

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -29,7 +29,7 @@ export interface IResultsViewPageProps {
     routing: any;
 }
 
-export function createQueryStore(currentQuery?:any) {
+export function createQueryStore(currentQuery?:any, clear:boolean = true) {
 
     const win:any = window;
 
@@ -41,7 +41,7 @@ export function createQueryStore(currentQuery?:any) {
         query.cancer_study_list = query.cancer_study_list || query.cancer_study_id;
         delete query.cancer_study_id;
 
-        win.routingStore.updateRoute(query, "results", true);
+        win.routingStore.updateRoute(query, "results", clear);
 
     };
 

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -29,7 +29,7 @@ export interface IResultsViewPageProps {
     routing: any;
 }
 
-export function createQueryStore(currentQuery?:any, clear:boolean = true) {
+export function createQueryStore(currentQuery?:any, clearQueryOnSubmit:boolean = true) {
 
     const win:any = window;
 
@@ -41,7 +41,7 @@ export function createQueryStore(currentQuery?:any, clear:boolean = true) {
         query.cancer_study_list = query.cancer_study_list || query.cancer_study_id;
         delete query.cancer_study_id;
 
-        win.routingStore.updateRoute(query, "results", clear);
+        win.routingStore.updateRoute(query, "results", clearQueryOnSubmit);
 
     };
 

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import $ from 'jquery';
 import URL from 'url';
 import { inject, observer } from 'mobx-react';
-import { computed, observable, reaction, runInAction } from 'mobx';
+import { computed, observable, reaction, runInAction, action } from 'mobx';
 import { ResultsViewPageStore } from './ResultsViewPageStore';
 import CancerSummaryContainer from 'pages/resultsView/cancerSummary/CancerSummaryContainer';
 import Mutations from './mutation/Mutations';
@@ -177,11 +177,22 @@ export default class ResultsViewPage extends React.Component<
 
         this.resultsViewPageStore = initStore(props.appStore);
 
+        this.props.routing
+
         getBrowserWindow().resultsViewPageStore = this.resultsViewPageStore;
     }
 
     private handleTabChange(id: string, replace?: boolean) {
         this.props.routing.updateRoute({}, `results/${id}`, false, replace);
+    }
+
+    @autobind
+    private handleSilentUrlUpdate(url:string) {
+    // private handleSilentUrlUpdate(params:{[name:string]:any}) {
+        // this.props.routing.updateRoute(params, undefined, false, true);
+        if (this.props.routing) {
+            this.props.routing.history.replace(url);
+        }
     }
 
     @autobind
@@ -219,6 +230,7 @@ export default class ResultsViewPage extends React.Component<
                         >
                             <ResultsViewOncoprint
                                 divId={'oncoprintDiv'}
+                                replaceRoutingHistoryCallback={this.handleSilentUrlUpdate}
                                 store={store}
                                 key={store.hugoGeneSymbols.join(',')}
                                 routing={this.props.routing}

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -577,7 +577,7 @@ export default class ResultsViewPage extends React.Component<
                         showDownloadTab={false}
                         showAlerts={true}
                         getQueryStore={() =>
-                            createQueryStore(this.props.routing.query)
+                            createQueryStore(this.props.routing.query, false)
                         }
                     />
                 </div>

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -188,8 +188,6 @@ export default class ResultsViewPage extends React.Component<
 
     @autobind
     private handleSilentUrlUpdate(url:string) {
-    // private handleSilentUrlUpdate(params:{[name:string]:any}) {
-        // this.props.routing.updateRoute(params, undefined, false, true);
         if (this.props.routing) {
             this.props.routing.history.replace(url);
         }

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -162,7 +162,7 @@ export default class QuerySummary extends React.Component<{ routingStore:Extende
                                   showDownloadTab={false}
                                   showAlerts={true}
                                   modifyQueryParams={this.props.store.modifyQueryParams}
-                                  getQueryStore={()=>createQueryStore(getBrowserWindow().routingStore.query)}
+                                  getQueryStore={()=>createQueryStore(getBrowserWindow().routingStore.query, false)}
             />
         </div>
     }

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -46,7 +46,6 @@ interface IResultsViewOncoprintProps {
     store:ResultsViewPageStore;
     routing:any;
     addOnBecomeVisibleListener?:(callback:()=>void)=>void;
-    // replaceRoutingHistoryCallback?:(params:{[name:string]:any}) => void;
     replaceRoutingHistoryCallback?:(url:string) => void;
 }
 
@@ -247,9 +246,6 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                             break;
                     }
                     url += '&' + ONCOPRINT_SORTBY_URL_PARAM + '=' + value;
-                    // const params:{[name:string]:any} = {};
-                    // params[ONCOPRINT_SORTBY_URL_PARAM] = value;
-                    // this.props.replaceRoutingHistoryCallback!(params);
                     this.props.replaceRoutingHistoryCallback!(url);
                 }
             );

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -139,6 +139,7 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
     @observable.ref private oncoprint:OncoprintJS;
 
     private urlParamsReaction:IReactionDisposer;
+    private silentUrlParamsReaction:IReactionDisposer;
 
     constructor(props:IResultsViewOncoprintProps) {
         super(props);
@@ -221,6 +222,30 @@ export default class ResultsViewOncoprint extends React.Component<IResultsViewOn
                     newParams[TREATMENT_LIST_URL_PARAM] = this.treatmentsUrlParam;
                 }
                 getBrowserWindow().globalStores.routing.updateRoute(newParams, undefined, true, true);
+            }
+        );
+
+        this.silentUrlParamsReaction = reaction(
+            ()=>[
+                this.sortMode
+            ],
+            ()=>{
+                const regex = new RegExp('&' + ONCOPRINT_SORTBY_URL_PARAM + '=[^&]*');
+                let url = (window.location.href).replace(regex, '');
+                let value:SortByUrlParamValue;
+                switch (this.sortMode.type) {
+                    case 'alphabetical':
+                        value = SortByUrlParamValue.CASE_ID;
+                        break;
+                    case 'caseList':
+                        value = SortByUrlParamValue.CASE_LIST;
+                        break;
+                    default:
+                        value = SortByUrlParamValue.NONE;
+                        break;
+                }
+                url += '&' + ONCOPRINT_SORTBY_URL_PARAM + '=' + value;
+                window.history.replaceState({}, "", url);
             }
         );
 


### PR DESCRIPTION
# Why
1. The default configuration of certain components in ResultsView (e.g. sort order of oncoprint) can be controlled by setting a URL param. When modifying the query these params are lost from the url.
2. The oncoprint_sortby url param controls the default sort order of the oncoprint when it is loaded. At present this param is not updated when the sort order is updated by the user via the UI (Sort menu in OncoprintControls).

# Fix
This PR will:
1. persist all url params that were set by any component in ResultsView. URL params are no longer erased when the user modifies the query.
2. update the url param _oncoprint_sortby_ when the user changes the sort order via the UI. 

Important: the update of the query params  will not trigger a page reload, but will re-render the oncoprint component. A way should be investigated that prevents this from happening.
