### PR TITLE
Cancer Summary Page has single study links in tool tip

### DIFF
--- a/src/pages/resultsView/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryContainer.tsx
@@ -27,11 +27,12 @@ interface ICancerSummaryContainerProps {
     store:ResultsViewPageStore;
 };
 
+export const CANCER_SUMMARY_ALL_GENES = 'all';
 
 @observer
 export default class CancerSummaryContainer extends React.Component<ICancerSummaryContainerProps, {}> {
 
-    @observable private activeTab: string = "all";
+    @observable private activeTab: string = CANCER_SUMMARY_ALL_GENES;
     @observable private resultsViewPageWidth: number = 1150;
     @observable private groupAlterationsBy_userSelection: keyof ExtendedSample;
 
@@ -49,7 +50,7 @@ export default class CancerSummaryContainer extends React.Component<ICancerSumma
     }
 
     private get defaultTabId(): string {
-        return 'all';
+        return CANCER_SUMMARY_ALL_GENES;
     }
 
     public pivotData(str: keyof ExtendedSample){
@@ -125,8 +126,8 @@ export default class CancerSummaryContainer extends React.Component<ICancerSumma
                 this.groupAlterationsBy,
                 this.props.store.selectedMolecularProfileIdsByAlterationType.result!,
                 this.props.store.coverageInformation.result!);
-            geneTabs.unshift(<MSKTab key="all" id="allGenes" linkText="All Queried Genes">
-                <CancerSummaryContent gene={'all'}
+            geneTabs.unshift(<MSKTab key={CANCER_SUMMARY_ALL_GENES} id="allGenes" linkText="All Queried Genes">
+                <CancerSummaryContent gene={CANCER_SUMMARY_ALL_GENES}
                                       width={this.resultsViewPageWidth}
                                       groupedAlterationData={groupedAlterationDataForAllGenes}
                                       handlePivotChange={this.pivotData}
@@ -167,7 +168,8 @@ export default class CancerSummaryContainer extends React.Component<ICancerSumma
                              unmountOnHide={true}
                              arrowStyle={{'line-height': .8}}
                              tabButtonStyle="pills"
-                             activeTabId={this.activeTab} className="pillTabs">
+                             activeTabId={this.activeTab}
+                             className="pillTabs">
                         {this.tabs}
                     </MSKTabs>
                 </div>

--- a/src/pages/resultsView/cancerSummary/CancerSummaryContent.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryContent.tsx
@@ -350,6 +350,19 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
         return this.altCasesValue > 0;
     }
 
+    /**
+     * Only show the links in the tool tip of the plot if:
+     * 1. The plot is displaying studies
+     * 2. The plot is displaying more than 1 study
+     */
+    @computed
+    private get showStudyTooltipLinks(): boolean {
+        return (
+            this.props.groupAlterationsBy === "studyId" &&
+            this.chartData.labels.length > 1
+        );
+    }
+
     private transformLabel(str: string) {
         if (this.props.labelTransformer) {
             return this.props.labelTransformer(str);
@@ -431,10 +444,6 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
     private handleTotalSliderChangeComplete() {
         this.totalCasesValue = this.tempTotalCasesValue;
     }
-
-    // private toggleShowControls() {
-    //     this.showControls = !this.showControls;
-    // }
 
     @action
     private initializeSliderValue() {
@@ -563,11 +572,6 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
                             </ButtonGroup>
                         </div>
 
-                        {/*<div role="group" className="hidden btn-group cancer-summary--chart-buttons">*/}
-                            {/*<button onClick={this.toggleShowControls} className="btn btn-default btn-xs">Customize <i*/}
-                                {/*className="fa fa-cog" aria-hidden="true"></i></button>*/}
-                        {/*</div>*/}
-
                         <div className={classnames("inlineBlock",{hidden: !this.showControls}, 'cancer-summary-secondary-options')}>
                             {/*<button type="button" onClick={this.toggleShowControls} className="close">×</button>*/}
                             {this.controls}
@@ -578,18 +582,20 @@ export class CancerSummaryContent extends React.Component<ICancerSummaryContentP
                                 {`${this.chartData.labels.length} of ${this.groupKeysSorted.length} categories (${_.keyBy(GroupByOptions, "value")[this.props.groupAlterationsBy].label}) are shown based on filtering.`}
                             </span>
                         </div>
-
-                        <CancerSummaryChart key={Date.now()}
-                                        data={this.chartData.data}
-                                        alterationTypeDataCounts={this.chartData.alterationTypeDataCounts}
-                                        ref={(el:any)=>this.chartComponent = el}
-                                        countsByGroup={this.countsData}
-                                        representedAlterations={this.chartData.representedAlterations}
-                                        alterationTypes={OrderedAlterationLabelMap}
-                                        isPercentage={(this.yAxis === "alt-freq")}
-                                        colors={alterationToColor}
-                                        hideGenomicAlterations={this.hideGenomicAlterations}
-                                        xLabels={this.chartData.labels}/>
+                        <CancerSummaryChart
+                            gene={this.props.gene}
+                            key={Date.now()}
+                            data={this.chartData.data}
+                            alterationTypeDataCounts={this.chartData.alterationTypeDataCounts}
+                            ref={(el:any)=>this.chartComponent = el}
+                            countsByGroup={this.countsData}
+                            representedAlterations={this.chartData.representedAlterations}
+                            alterationTypes={OrderedAlterationLabelMap}
+                            isPercentage={(this.yAxis === "alt-freq")}
+                            showLinks={this.showStudyTooltipLinks}
+                            colors={alterationToColor}
+                            hideGenomicAlterations={this.hideGenomicAlterations}
+                            xLabels={this.chartData.labels}/>
 
                     </div>
                 </Then>

--- a/src/pages/resultsView/plots/QuickPlots.ts
+++ b/src/pages/resultsView/plots/QuickPlots.ts
@@ -526,9 +526,6 @@ export function generateQuickPlots(
     horizontal: TypeSourcePair,
     vertical: TypeSourcePair,
 ): ButtonInfo[] {
-    console.log(dataSources);
-    console.log(dataTypes);
-    
     return quickPlots
         .filter((plot) => plot.isApplicableToQuery(dataTypes, dataSources, cancerTypes, mutationCount))
         .map((plot) => plot.toButtonInfo(vertical, horizontal, dataTypes, dataSources));

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -5,6 +5,7 @@ import * as _ from 'lodash';
 import {GroupComparisonLoadingParams} from "../../pages/groupComparison/GroupComparisonLoading";
 import {BuildUrlParams} from "../../public-lib/lib/urls";
 import {GroupComparisonURLQuery} from "../../pages/groupComparison/GroupComparisonURLWrapper";
+import { PagePath } from "shared/enums/PagePaths";
 
 export function trimTrailingSlash(str:string){
    return str.replace(/\/$/g,"");
@@ -81,7 +82,7 @@ export function getStudySummaryUrl(studyIds:string | ReadonlyArray<string>) {
 }
 export function redirectToStudyView(studyIds: string | ReadonlyArray<string>) {
     const params = getStudySummaryUrlParams(studyIds);
-    (window as any).routingStore.updateRoute(params.query,"study", true);
+    (window as any).routingStore.updateRoute(params.query, PagePath.Study, true);
 }
 export function getSampleViewUrl(studyId:string, sampleId:string, navIds?:{patientId:string, studyId:string}[]) {
     let hash:any = undefined;

--- a/src/shared/components/query/quickSearch/QuickSearch.tsx
+++ b/src/shared/components/query/quickSearch/QuickSearch.tsx
@@ -9,14 +9,14 @@ import getBrowserWindow from 'public-lib/lib/getBrowserWindow';
 import { sleep } from 'shared/lib/TimeUtils';
 import { Label } from 'react-bootstrap';
 import * as moduleStyles from './styles.module.scss';
-import { action, computed, observable, runInAction } from 'mobx';
+import { action, computed, observable, } from 'mobx';
 import { remoteData } from 'public-lib/api/remoteData';
 import Pluralize from 'pluralize';
 import AppConfig from 'appConfig';
 import { ServerConfigHelpers } from 'config/config';
 import sessionServiceClient from 'shared/api/sessionServiceInstance';
 import { trackEvent } from 'shared/lib/tracking';
-import { PagePath } from 'shared/enums/PagePaths';
+import { PagePath } from "shared/enums/PagePaths";
 
 export const SHOW_MORE_SIZE: number = 20;
 const DEFAULT_PAGE_SIZE: number = 3;
@@ -331,8 +331,8 @@ export default class QuickSearch extends React.Component {
         let route;
         if (newOption.type === OptionType.STUDY) {
             parameters = { id: newOption.studyId };
-            route = 'study';
-            this.trackClick('study', this.inputValue);
+            route = PagePath.Study;
+            this.trackClick(PagePath.Study, this.inputValue);
         } else if (newOption.type === OptionType.GENE) {
             const studyList =
                 this.geneStudyQuery.isComplete &&

--- a/src/shared/enums/PagePaths.ts
+++ b/src/shared/enums/PagePaths.ts
@@ -1,3 +1,4 @@
 export enum PagePath {
     Patient = 'patient',
+    Study = 'study',
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6594
Describe changes proposed in this pull request:

- Made tooltip stay visible when moused over
- Changed tooltip movement logic so you don't have to chase it to mouse
over
- Deleted some commented out code
- Added two links to the tool tip
    - Link to the study you are mousing over
    - Link to the query on just the study you are mousing over

# Any screenshots or GIFs?
![study-links](https://user-images.githubusercontent.com/20069833/67789096-c9ff0200-fa49-11e9-9589-cd49c3022932.gif)
