### PR TITLE
Plots Tab Selection History

### DIFF
--- a/src/pages/resultsView/plots/LastPlotsTabSelectionForDatatype.spec.ts
+++ b/src/pages/resultsView/plots/LastPlotsTabSelectionForDatatype.spec.ts
@@ -1,0 +1,211 @@
+import {assert} from 'chai';
+import LastPlotsTabSelectionForDatatype from './LastPlotsTabSelectionForDatatype';
+import { AxisMenuSelection, MutationCountBy } from './PlotsTab';
+import sinon from 'sinon';
+
+// couldn't figure out how to do this with sinon
+function createFakeCallbacks() {
+    return {
+        gene: sinon.stub(),
+        geneSet: sinon.stub(),
+        source: sinon.stub(),
+        treatment: sinon.stub(),
+    }
+}
+
+// parts of AxisMenuSelection needed to make things compile that are not
+// used in PlotsTabSelectionHistory
+const untestedSelectionFields: AxisMenuSelection = {
+    mutationCountBy: MutationCountBy.MutationType,
+    logScale: false,
+}
+
+describe("PlotsTabSelectionHistory", () => {
+    describe("horizontal updates", () => {
+        it("should update nothing when no changes have been made", () =>{
+            const subject = new LastPlotsTabSelectionForDatatype();
+            const fakes = createFakeCallbacks();
+
+            subject.runHorizontalUpdaters(
+                "foo",
+                fakes.gene,
+                fakes.geneSet,
+                fakes.source,
+                fakes.treatment,
+            )
+
+            assert.equal(fakes.gene.args.length, 0);
+            assert.equal(fakes.geneSet.args.length, 0);
+            assert.equal(fakes.source.args.length, 0);
+            assert.equal(fakes.treatment.args.length, 0);
+        });
+
+        it("should update genes when changes have been made to genes", () => {
+            const subject = new LastPlotsTabSelectionForDatatype();
+            const fakes = createFakeCallbacks();
+            const newSelection: AxisMenuSelection = {
+                dataType: "COPY_NUMBER_ALTERATION",
+                selectedGeneOption: {value: 0, label: "BRAF"},
+                ...untestedSelectionFields,
+            }
+            
+            subject.updateHorizontalFromSelection(newSelection)
+            subject.runHorizontalUpdaters(
+                "COPY_NUMBER_ALTERATION",
+                fakes.gene,
+                fakes.geneSet,
+                fakes.source,
+                fakes.treatment,
+            )
+
+            assert.equal(fakes.gene.args.length, 1);
+            assert.equal(fakes.geneSet.args.length, 0);
+            assert.equal(fakes.source.args.length, 0);
+            assert.equal(fakes.treatment.args.length, 0);
+
+            assert.deepEqual(fakes.gene.args[0], [{value: 0, label: "BRAF"}]);
+        });
+
+        it("should update genesets when changes have been made to genesets", () => {
+            const subject = new LastPlotsTabSelectionForDatatype();
+            const fakes = createFakeCallbacks();
+            const newSelection: AxisMenuSelection = {
+                dataType: "COPY_NUMBER_ALTERATION",
+                selectedGenesetOption: {value: "BRAF", label: "BRAF"},
+                ...untestedSelectionFields,
+            }
+            
+            subject.updateHorizontalFromSelection(newSelection)
+            subject.runHorizontalUpdaters(
+                "COPY_NUMBER_ALTERATION",
+                fakes.gene,
+                fakes.geneSet,
+                fakes.source,
+                fakes.treatment,
+            )
+
+            assert.equal(fakes.gene.args.length, 0);
+            assert.equal(fakes.geneSet.args.length, 1);
+            assert.equal(fakes.source.args.length, 0);
+            assert.equal(fakes.treatment.args.length, 0);
+
+            assert.deepEqual(fakes.geneSet.args[0], [{value: "BRAF", label: "BRAF"}]);
+        });
+
+        it("should update source when changes have been made to source", () => {
+            const subject = new LastPlotsTabSelectionForDatatype();
+            const fakes = createFakeCallbacks();
+            const newSelection: AxisMenuSelection = {
+                dataType: "COPY_NUMBER_ALTERATION",
+                selectedDataSourceOption: {
+                    value: "coadread_tcga_pub_gistic",
+                    label: "Putative copy-number alterations from GISTIC"
+                },
+                ...untestedSelectionFields,
+            }
+            
+            subject.updateHorizontalFromSelection(newSelection)
+            subject.runHorizontalUpdaters(
+                "COPY_NUMBER_ALTERATION",
+                fakes.gene,
+                fakes.geneSet,
+                fakes.source,
+                fakes.treatment,
+            )
+
+            assert.equal(fakes.gene.args.length, 0);
+            assert.equal(fakes.geneSet.args.length, 0);
+            assert.equal(fakes.source.args.length, 1);
+            assert.equal(fakes.treatment.args.length, 0);
+
+            assert.deepEqual(
+                fakes.source.args[0],
+                [{
+                    value: "coadread_tcga_pub_gistic",
+                    label: "Putative copy-number alterations from GISTIC"
+                }]
+            );
+        });
+
+        it("should update treatments when changes have been made to treatments", () => {
+            const subject = new LastPlotsTabSelectionForDatatype();
+            const fakes = createFakeCallbacks();
+            const newSelection: AxisMenuSelection = {
+                dataType: "COPY_NUMBER_ALTERATION",
+                selectedTreatmentOption: {
+                    value: "test value",
+                    label: "test label"
+                },
+                ...untestedSelectionFields,
+            }
+            
+            subject.updateHorizontalFromSelection(newSelection)
+            subject.runHorizontalUpdaters(
+                "COPY_NUMBER_ALTERATION",
+                fakes.gene,
+                fakes.geneSet,
+                fakes.source,
+                fakes.treatment,
+            )
+
+            assert.equal(fakes.gene.args.length, 0);
+            assert.equal(fakes.geneSet.args.length, 0);
+            assert.equal(fakes.source.args.length, 0);
+            assert.equal(fakes.treatment.args.length, 1);
+
+            assert.deepEqual(fakes.treatment.args[0], [{value: "test value", label: "test label"}]);
+        });
+    })
+
+    describe("vertical updates", () => {
+        it("should update all the vertical fields", () => {
+            const subject = new LastPlotsTabSelectionForDatatype();
+            const fakes = createFakeCallbacks();
+            const newSelection: AxisMenuSelection = {
+                dataType: "COPY_NUMBER_ALTERATION",
+                selectedGeneOption: {
+                    value: 0,
+                    label: "BRAF"
+                },
+                selectedGenesetOption: {
+                    value: "BRAF",
+                    label: "BRAF"
+                },
+                selectedDataSourceOption: {
+                    value: "coadread_tcga_pub_gistic",
+                    label: "Putative copy-number alterations from GISTIC"
+                },
+                selectedTreatmentOption: {
+                    value: "test value",
+                    label: "test label"
+                },
+                ...untestedSelectionFields,
+            }
+            
+            subject.updateHorizontalFromSelection(newSelection)
+            subject.runHorizontalUpdaters(
+                "COPY_NUMBER_ALTERATION",
+                fakes.gene,
+                fakes.geneSet,
+                fakes.source,
+                fakes.treatment,
+            )
+
+            assert.equal(fakes.gene.args.length, 1);
+            assert.equal(fakes.geneSet.args.length, 1);
+            assert.equal(fakes.source.args.length, 1);
+            assert.equal(fakes.treatment.args.length, 1);
+
+            assert.deepEqual(fakes.gene.args[0], [{value: 0, label: "BRAF"}]);
+            assert.deepEqual(fakes.geneSet.args[0], [{value: "BRAF", label: "BRAF"}]);
+            assert.deepEqual(
+                fakes.source.args[0],
+                [{
+                    value: "coadread_tcga_pub_gistic",
+                    label: "Putative copy-number alterations from GISTIC"
+                }]
+            );
+            assert.deepEqual(fakes.treatment.args[0], [{value: "test value", label: "test label"}]);
+        })
+    });
+});

--- a/src/pages/resultsView/plots/LastPlotsTabSelectionForDatatype.ts
+++ b/src/pages/resultsView/plots/LastPlotsTabSelectionForDatatype.ts
@@ -1,0 +1,105 @@
+import { AxisMenuSelection, PlotsTabGeneOption, PlotsTabOption } from "./PlotsTab";
+import autobind from "autobind-decorator";
+
+type Selection = {
+    gene?: PlotsTabGeneOption | undefined,
+    geneSet?: PlotsTabOption | undefined,
+    source?: PlotsTabOption | undefined,
+    treatment?: PlotsTabOption | undefined,
+
+}
+
+type FieldUpdater = (option: any) => void;
+
+export default class LastPlotsTabSelectionForDatatype {
+    private horizontal: Map<string, Selection> = new Map();
+    private vertical: Map<string, Selection> = new Map();
+
+    @autobind
+    public updateHorizontalFromSelection(newSelection: AxisMenuSelection): void {
+        this.updateAxisWithSelection(this.horizontal, newSelection);
+    }
+    
+    @autobind
+    public updateVerticalFromSelection(newSelection: AxisMenuSelection): void {
+        this.updateAxisWithSelection(this.vertical, newSelection);
+    }
+
+    private updateAxisWithSelection(axis: Map<string, Selection>, newSelection: AxisMenuSelection): void {
+        if (newSelection.dataType !== undefined) {
+            let selectionToUpdate = axis.get(newSelection.dataType)
+
+            if (selectionToUpdate === undefined) {
+                selectionToUpdate = {};
+            }
+
+            axis.set(newSelection.dataType, LastPlotsTabSelectionForDatatype.updateSelection(selectionToUpdate, newSelection))
+        }
+    }
+
+    private static updateSelection(selectionToUpdate: Selection, newSelection: AxisMenuSelection): Selection {
+        selectionToUpdate.gene = newSelection.selectedGeneOption;
+        selectionToUpdate.geneSet = newSelection.selectedGenesetOption;
+        selectionToUpdate.source = newSelection.selectedDataSourceOption;
+        selectionToUpdate.treatment = newSelection.selectedTreatmentOption;
+        return selectionToUpdate;
+    }
+
+    /**
+     * Finds the old selections made for dataType type on the 
+     * horizontal axis. For each selection, it runs the
+     * corresponding updater. Unused and unchanged selections
+     * are not updated. 
+     */
+    @autobind
+    public runHorizontalUpdaters(
+        type: string,
+        gene: FieldUpdater,
+        geneSet: FieldUpdater,
+        source: FieldUpdater,
+        treatment: FieldUpdater,
+    ): void {
+        LastPlotsTabSelectionForDatatype.runSelectionUpdaters(this.horizontal, type, gene, geneSet, source, treatment);
+    }
+
+    /**
+     * Finds the old selections made for dataType type on the 
+     * vertical axis. For each selection, it runs the
+     * corresponding updater. Unused and unchanged selections
+     * are not updated. 
+     */
+    @autobind
+    public runVerticalUpdaters(
+        type: string,
+        gene: FieldUpdater,
+        geneSet: FieldUpdater,
+        source: FieldUpdater,
+        treatment: FieldUpdater,
+    ): void {
+        LastPlotsTabSelectionForDatatype.runSelectionUpdaters(this.vertical, type, gene, geneSet, source, treatment);
+    }
+
+    private static runSelectionUpdaters(
+        axis: Map<string, Selection>,
+        type: string,
+        gene: FieldUpdater,
+        geneSet: FieldUpdater,
+        source: FieldUpdater,
+        treatment: FieldUpdater,
+    ) {
+        if (!axis.get(type)) {
+            return;
+        } 
+
+        const infoUpdaterPairs = [
+            {saved: axis.get(type)!.gene, updater: gene},
+            {saved: axis.get(type)!.geneSet, updater: geneSet},
+            {saved: axis.get(type)!.source, updater: source},
+            {saved: axis.get(type)!.treatment, updater: treatment},
+        ]
+
+        infoUpdaterPairs
+            .filter((tuple) => tuple.saved !== undefined)
+            .forEach((tuple) => tuple.updater(tuple.saved));
+    }
+}

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -83,6 +83,7 @@ import "./styles.scss";
 import { Treatment } from "shared/api/generated/CBioPortalAPIInternal";
 import { showWaterfallPlot } from 'pages/resultsView/plots/PlotsTabUtils';
 import AlterationFilterWarning from "../../../shared/components/banners/AlterationFilterWarning";
+import LastPlotsTabSelectionForDatatype from "./LastPlotsTabSelectionForDatatype";
 
 enum EventKey {
     horz_logScale,
@@ -141,10 +142,10 @@ export type AxisMenuSelection = {
     entrezGeneId?:number;
     genesetId?:string;
     treatmentId?:string;
-    selectedGeneOption?:{value:number, label:string}; // value is entrez id, label is hugo symbol
-    selectedDataSourceOption?:{value:string, label:string};
-    selectedGenesetOption?:{value:string, label:string};
-    selectedTreatmentOption?:{value:string, label:string};
+    selectedGeneOption?:PlotsTabGeneOption;
+    selectedDataSourceOption?:PlotsTabOption;
+    selectedGenesetOption?:PlotsTabOption;
+    selectedTreatmentOption?:PlotsTabOption;
     dataType?:string;
     dataSourceId?:string;
     mutationCountBy:MutationCountBy;
@@ -158,6 +159,15 @@ export type UtilitiesMenuSelection = {
 
 export interface IPlotsTabProps {
     store:ResultsViewPageStore;
+};
+
+export type PlotsTabOption = { value: string; label: string };
+export type PlotsTabGeneOption = {
+    value: number, // entrez id
+    label: string, // hugo symbol
+}
+export type PlotsTabDataTypeToSources = {
+    [dataType: string]: { value: string; label: string }[];
 };
 
 const searchInputTimeoutMs = 600;
@@ -193,6 +203,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
 
     private horzSelection:AxisMenuSelection;
     private vertSelection:AxisMenuSelection;
+    private selectionHistory = new LastPlotsTabSelectionForDatatype();
     private utilitiesMenuSelection:UtilitiesMenuSelection;
 
     private scrollPane:HTMLDivElement;
@@ -720,36 +731,42 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
     private onVerticalAxisGeneSelect(option:any) {
         this.vertSelection.selectedGeneOption = option;
         this.viewLimitValues = true;
+        this.selectionHistory.updateVerticalFromSelection(this.vertSelection);
     }
 
     @autobind
     private onHorizontalAxisGeneSelect(option:any) {
-        this.horzSelection.selectedGeneOption = option;
+        this.horzSelection.selectedGeneOption = option;        
         this.viewLimitValues = true;
+        this.selectionHistory.updateHorizontalFromSelection(this.horzSelection);
     }
 
     @autobind
     private onVerticalAxisGenesetSelect(option:any) {
         this.vertSelection.selectedGenesetOption = option;
         this.viewLimitValues = true;
+        this.selectionHistory.updateVerticalFromSelection(this.vertSelection);
     }
 
     @autobind
     private onHorizontalAxisGenesetSelect(option:any) {
         this.horzSelection.selectedGenesetOption = option;
         this.viewLimitValues = true;
+        this.selectionHistory.updateHorizontalFromSelection(this.horzSelection);
     }
 
     @autobind
     private onVerticalAxisTreatmentSelect(option:any) {
         this.vertSelection.selectedTreatmentOption = option;
         this.viewLimitValues = true;
+        this.selectionHistory.updateVerticalFromSelection(this.vertSelection);
     }
 
     @autobind
     private onHorizontalAxisTreatmentSelect(option:any) {
         this.horzSelection.selectedTreatmentOption = option;
         this.viewLimitValues = true;
+        this.selectionHistory.updateHorizontalFromSelection(this.horzSelection);
     }
 
     @autobind
@@ -808,14 +825,15 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
     @computed get vertGeneOptions() {
         let sameGeneOption = undefined;
         // // listen to updates of `horzGeneOptions` or the selected data type for the horzontal axis
-        // if (this.horzGeneOptions || this.horzSelection.dataType) {
             // when the data type on the horizontal axis is a gene  profile
             // add an option to select the same gene
-        if (this.horzSelection.dataType && this.showGeneSelectBox(this.horzSelection.dataType)
-            && this.horzSelection.selectedGeneOption && this.horzSelection.selectedGeneOption.value !== NONE_SELECTED_OPTION_NUMERICAL_VALUE) {
+        if (this.horzSelection.dataType &&
+            this.showGeneSelectBox(this.horzSelection.dataType) &&
+            this.horzSelection.selectedGeneOption &&
+            this.horzSelection.selectedGeneOption.value !== NONE_SELECTED_OPTION_NUMERICAL_VALUE
+        ) {
             sameGeneOption = [{ value: SAME_SELECTED_OPTION_NUMERICAL_VALUE, label: `Same gene (${this.horzSelection.selectedGeneOption.label})`}];
         }
-        // }
         return (sameGeneOption || []).concat((this.horzGeneOptions.result || []) as any[]);
     }
 
@@ -999,6 +1017,9 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
     @autobind
     @action
     private onVerticalAxisDataTypeSelect(option:any) {
+        const oldVerticalGene = this.vertSelection.selectedGeneOption;
+        const oldHorizontalGene = this.horzSelection.selectedGeneOption;
+
         this.vertSelection.dataType = option.value;
         // simultaneous selection of viewCNA and viewMutationType is not
         // supported by the waterfall plot
@@ -1006,11 +1027,30 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
             this.viewCopyNumber = false;
         }
         this.viewLimitValues = true;
+        this.selectionHistory.runVerticalUpdaters(
+            option.value,
+            this.onVerticalAxisGeneSelect,
+            this.onVerticalAxisGenesetSelect,
+            this.onVerticalAxisDataSourceSelect,
+            this.onVerticalAxisTreatmentSelect,
+        );
+
+        if (
+            this.vertSelection.dataType &&
+            !this.showGeneSelectBox(this.vertSelection.dataType) &&
+            oldHorizontalGene &&
+            oldHorizontalGene.value == SAME_SELECTED_OPTION_NUMERICAL_VALUE
+        ) {
+            this.onHorizontalAxisGeneSelect(oldVerticalGene);
+        }
     }
 
     @autobind
     @action
     public onHorizontalAxisDataTypeSelect(option:any) {
+        const oldHorizontalGene = this.horzSelection.selectedGeneOption;
+        const oldVerticalGene = this.vertSelection.selectedGeneOption;
+
         // simultaneous selection of viewCNA and viewMutationType is not
         // supported by the waterfall plot
         this.horzSelection.dataType = option.value;
@@ -1018,6 +1058,22 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
             this.viewCopyNumber = false;
         }
         this.viewLimitValues = true;
+        this.selectionHistory.runHorizontalUpdaters(
+            option.value,
+            this.onHorizontalAxisGeneSelect,
+            this.onHorizontalAxisGenesetSelect,
+            this.onHorizontalAxisDataSourceSelect,
+            this.onHorizontalAxisTreatmentSelect,
+        );
+
+        if (
+            this.horzSelection.dataType &&
+            !this.showGeneSelectBox(this.horzSelection.dataType) &&
+            oldVerticalGene &&
+            oldVerticalGene.value == SAME_SELECTED_OPTION_NUMERICAL_VALUE
+        ) {
+            this.onVerticalAxisGeneSelect(oldHorizontalGene);
+        }
     }
 
     @autobind
@@ -1025,6 +1081,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
     public onVerticalAxisDataSourceSelect(option:any) {
         this.vertSelection.selectedDataSourceOption = option;
         this.viewLimitValues = true;
+        this.selectionHistory.updateVerticalFromSelection(this.vertSelection);
     }
 
     @autobind
@@ -1032,6 +1089,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
     public onHorizontalAxisDataSourceSelect(option:any) {
         this.horzSelection.selectedDataSourceOption = option;
         this.viewLimitValues = true;
+        this.selectionHistory.updateHorizontalFromSelection(this.horzSelection);
     }
 
     @autobind
@@ -1863,6 +1921,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
         }
     });
 
+    // In case we want to handle samples differently
     /*readonly mutationProfileDuplicateSamplesReport = remoteData({
         await:()=>[
             this.horzAxisDataPromise,
@@ -2365,7 +2424,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps,{}> {
         this.plotExists = !!this.getSvg();
     }
 
-    public render() {
+    public render() {        
         return (
             <div data-test="PlotsTabEntireDiv">
                 <div className={'tabMessageContainer'}>


### PR DESCRIPTION
Describe changes proposed in this pull request:
- functionality
    - any changes made to gene, geneset, treatment, or dataSource will
    be remembered if you switch to a different data type and switch back
    - bugfix: changing gene on axis A while having gene set to same on
    axis B no longer has strange behavior if you then switch datatype A
    - bugfix: same scenario as above, swapping axes also works as
    expected
- implementation
    - created PlotsTabSelectionHistory to manage the selection history
    - it maps from each dataType selected to the sub setting selected
    for that datatype
    - when the datatype is changed, it loads the previous settings for
    the new datatype, and calls the related onChange functions
    - the map model is populated as selections are made and is empty by
    default

Fix cBioPortal/cbioportal#6724
Fix cBioPortal/cbioportal#6723


# Checks
- [x] Has tests
- [x] The commit log is comprehensible. 

# Any screenshots or GIFs?
![demo](https://user-images.githubusercontent.com/20069833/67227522-63ecfc00-f405-11e9-85b6-b626a07dc707.gif)
![demo-1](https://user-images.githubusercontent.com/20069833/67227526-664f5600-f405-11e9-8537-d9b2a08496d7.gif)

