### PR TITLE
Updated treatment selection in heatmap menu

### DIFF
--- a/end-to-end-test/local/specs/treatment.spec.js
+++ b/end-to-end-test/local/specs/treatment.spec.js
@@ -106,6 +106,33 @@ describe('treatment feature', function() {
                 searchBox.setValue('17-AAG');
                 var treatments = $('.oncoprint__controls__heatmap_menu .treatment-selector').$$('.checked-select-option');
                 assert.equal(treatments.length, 1);
+                
+                // test if add all button displays number of filtered treatments
+                var addAllButton = $('.oncoprint__controls__heatmap_menu .treatment-selector .default-checked-select button');
+                assert.equal(addAllButton.getText(), 'Select all (1)');
+                
+                // test if add all button only adds filtered treatments
+                addAllButton.click();
+                var selectedTreatments = $('.icon-area.treatment-textarea').$$('div.icon');
+                assert.equal(selectedTreatments.length, 1);
+            });
+            
+            it('keeps the filtered treatments list open after selecting an option', () => {
+                openHeatmapMenu();
+                selectReactSelectOption( $('.oncoprint__controls__heatmap_menu'), 'IC50 values of compounds on cellular phenotype readout');
+               
+                var searchBox = $('.oncoprint__controls__heatmap_menu .treatment-selector .default-checked-select').$('input');
+                searchBox.setValue('AZ');
+                var treatments = $('.oncoprint__controls__heatmap_menu .treatment-selector').$$('.checked-select-option');
+                assert.equal(treatments.length, 2);
+                
+                var treatment = treatments[0];
+                var treatmentName = treatment.getText();
+                treatmentName = treatmentName.replace(/.*\((.*)\).*/, "$1");
+                treatment.$('..').click();
+                $('div.icon*='+treatmentName).waitForExist();
+                assert( $('div.icon*='+treatmentName) );
+                assert.equal(treatments.length, 2);
             });
 
             it('initializes from `treatment_list` URL parameter', () => {

--- a/src/public-lib/components/checkedSelect/CheckedSelect.tsx
+++ b/src/public-lib/components/checkedSelect/CheckedSelect.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import ReactSelect from "react-select";
 import autobind from "autobind-decorator";
-import {computed} from "mobx";
+import {computed, observable, action} from "mobx";
 import {observer} from "mobx-react";
 
 import {CheckBoxType, getOptionLabel, getSelectedValuesMap, Option} from "./CheckedSelectUtils";
@@ -23,6 +23,8 @@ type CheckedSelectProps = {
     clearAllLabel?: string | JSX.Element;
     showControls?: boolean;
     height?:number;
+    onInputChange?: (input:string) => void;
+    inputValue?:string;
 };
 
 @observer
@@ -35,7 +37,9 @@ export default class CheckedSelect extends React.Component<CheckedSelectProps, {
         showControls: true,
         checkBoxType: CheckBoxType.STRING
     };
-
+    
+    @observable defaultInputValue = '';
+    
     @computed
     get selectedValues() {
         return getSelectedValuesMap(this.props.value);
@@ -85,6 +89,21 @@ export default class CheckedSelect extends React.Component<CheckedSelectProps, {
     private getOptionLabel(option: Option): JSX.Element
     {
         return getOptionLabel(option, this.selectedValues, this.props.checkBoxType);
+    }
+    
+    @computed get inputValue() {
+        return this.props.inputValue || this.defaultInputValue;
+    }
+    
+    @autobind
+    @action defaultOnInputChange(input:string, options:{action:string}) {
+        // The input value (which is a blank string in the case of action === 'set-value')
+        // will be passed to `this.props.onInputChange` by default without the `if` condition.
+        // This leads to undesirable behaviour so adding the if condition will prevent that.
+        if (options.action !== "set-value") {
+            if (this.props.onInputChange) this.props.onInputChange(input);
+            this.defaultInputValue = input;
+        }
     }
 
     @autobind
@@ -179,6 +198,9 @@ export default class CheckedSelect extends React.Component<CheckedSelectProps, {
                     getOptionLabel={this.getOptionLabel}
                     value={this.props.value}
                     labelKey="label"
+                    onInputChange={this.defaultOnInputChange}
+                    inputValue={this.inputValue}
+                    backspaceRemovesValue={false}
                 />
             </div>
         );

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -207,6 +207,7 @@ export default class OncoprintControls extends React.Component<
     @observable heatmapGenesReady = false;
     @observable private _selectedTreatmentIds: string[] = [];
     private textareaTreatmentText = '';
+    @observable treatmentFilter = '';
 
     constructor(props: IOncoprintControlsProps) {
         super(props);
@@ -568,9 +569,40 @@ export default class OncoprintControls extends React.Component<
         }));
     }
     
+    @computed get filteredTreatmentOptions() {
+        if (this.treatmentFilter && this.props.treatmentSelectOptions) {
+            const regex = new RegExp(this.treatmentFilter, 'i');
+            return this.props.treatmentSelectOptions.filter(
+                option => regex.test(option.label) || regex.test(option.value)
+            );
+        }
+        return this.props.treatmentSelectOptions;
+    }
+
+    @autobind
+    @action
+    onInputChange(input: string) {
+        this.treatmentFilter = input;
+    }
+
+    @autobind onAddAllTreatments() {
+        if (this.filteredTreatmentOptions) {
+            // merge the current selected options with all the filtered ones and remove duplicates
+            this.onSelectTreatments(
+                _.uniqBy(
+                    [
+                        ...this.selectedTreatmentsJS,
+                        ...this.filteredTreatmentOptions,
+                    ],
+                    option => option.value
+                )
+            );
+        }
+    }
+
     @computed get addAllLabel() {
-        if (this.props.treatmentSelectOptions) {
-            return `Select all (${this.props.treatmentSelectOptions.length})`;
+        if (this.filteredTreatmentOptions) {
+            return `Select all (${this.filteredTreatmentOptions.length})`;
         }
         return 'Select all';
     }
@@ -665,6 +697,7 @@ export default class OncoprintControls extends React.Component<
                                         this.onChangeTreatmentTextArea
                                     }
                                     onIconClicked={this.onTreatmentRemoved}
+                                    classNames={['treatment-textarea']}
                                 />,
                                 <div
                                     className={classNames('treatment-selector')}
@@ -672,10 +705,13 @@ export default class OncoprintControls extends React.Component<
                                     <CheckedSelect
                                         name="treatment-select"
                                         placeholder="Search for Treatments..."
-                                        options={this.props.treatmentSelectOptions}
+                                        options={this.filteredTreatmentOptions}
                                         onChange={this.onSelectTreatments}
-                                        value={this.selectedTreatments}
+                                        value={this.selectedTreatmentsJS}
+                                        onInputChange={this.onInputChange}
                                         addAllLabel={this.addAllLabel}
+                                        onAddAll={this.onAddAllTreatments}
+                                        inputValue={this.treatmentFilter}
                                     />
                                 </div>,
                                 <button

--- a/src/shared/components/oncoprint/controls/styles.scss
+++ b/src/shared/components/oncoprint/controls/styles.scss
@@ -44,6 +44,10 @@
       min-height:50px;
       border:1px solid $borderColor;
       resize: vertical;
+      
+      &.treatment-textarea {
+        border-radius: 2px;
+      }
     }
     > *, button {
       margin-bottom:10px;


### PR DESCRIPTION
## Changes:
- Added border-radius to treatment textarea to make it consistent with gene selection textarea;
- Updated CheckedSelect component in OncoprintControls to fix issue [#6717](https://github.com/cBioPortal/cbioportal/issues/6717): "Select all" button should only add the filtered treatments;
- Prevented clearing the search value to keep the filtered treatments list open after selecting an option;
- Added local e2e tests

## GIF:
![treatment-selection](https://user-images.githubusercontent.com/31291004/67481868-fc33ec80-f662-11e9-9593-c5273fad151c.gif)
