### PR TITLE
Fix #6697 colored samples by copy number alteration with treatment data

### DIFF
--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -479,7 +479,7 @@ function scatterPlotCnaLegendData(
         })
         .sortBy((v:number)=>-v) // sorted descending
         .value();
-
+        
     const legendData:any[] = uniqueDispCna.map(v=>{
         const appearance = cnaToAppearance[v as -2|-1|0|1|2];
         return {
@@ -1793,6 +1793,11 @@ export function getCnaQueries(
     }
     if (vertSelection.dataType !== CLIN_ATTR_DATA_TYPE
         && horzSelection.dataType !== AlterationTypeConstants.GENERIC_ASSAY
+        && vertSelection.entrezGeneId !== undefined) {
+        queries.push({entrezGeneId: vertSelection.entrezGeneId});
+    }
+    if (vertSelection.dataType === AlterationTypeConstants.COPY_NUMBER_ALTERATION
+        && horzSelection.dataType === AlterationTypeConstants.GENERIC_ASSAY
         && vertSelection.entrezGeneId !== undefined) {
         queries.push({entrezGeneId: vertSelection.entrezGeneId});
     }


### PR DESCRIPTION
## Fix cBioPortal/cbioportal#6697 Colors of samples by copy number alteration in horizontal box plot

### Changes:
- Updated the getCnaQueries function to cover the case where horizontal selection data type is "GENERIC_ASSAY" and vertical selection data type is "COPY_NUMBER_ALTERATION".

### Screenshot after the fix:
![Screenshot from 2019-10-23 14-44-34](https://user-images.githubusercontent.com/31291004/67394021-d1369380-f5a3-11e9-8c20-c5557058e795.png)
