### PR TITLE
Store trial matches by match type

### DIFF
--- a/src/pages/patientView/trialMatch/TrialMatchTableUtils.spec.ts
+++ b/src/pages/patientView/trialMatch/TrialMatchTableUtils.spec.ts
@@ -12,93 +12,125 @@ describe("TrialMatchTableUtils", () => {
                     "positive": [ "Non-Small Cell Lung Cancer" ],
                     "negative": []
                 },
-                "matches": [],
-                "notMatches": [
-                    {
-                        "genomicAlteration": "EGFR !E709_T710delinsD",
-                        "matches": [
-                            {
-                                "trueHugoSymbol": null,
-                                "trueProteinChange": null,
-                                "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
-                            }
-                        ]
-                    },
-                    {
-                        "genomicAlteration": "EGFR !E709K",
-                        "matches": [
-                            {
-                                "trueHugoSymbol": null,
-                                "trueProteinChange": null,
-                                "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
-                            }
-                        ]
-                    },
-                    {
-                        "genomicAlteration": "EGFR !L833V",
-                        "matches": [
-                            {
-                                "trueHugoSymbol": null,
-                                "trueProteinChange": null,
-                                "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
-                            }
-                        ]
-                    }
-                ]
+                "matches": {
+                    "MUTATION": [],
+                    "MSI": [],
+                    "CNA": [],
+                    "WILDTYPE": []
+                },
+                "notMatches": {
+                    "MUTATION": [
+                        {
+                            "genomicAlteration": "EGFR !E709_T710delinsD",
+                            "matches": [
+                                {
+                                    "trueHugoSymbol": null,
+                                    "trueProteinChange": null,
+                                    "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
+                                }
+                            ]
+                        },
+                        {
+                            "genomicAlteration": "EGFR !E709K",
+                            "matches": [
+                                {
+                                    "trueHugoSymbol": null,
+                                    "trueProteinChange": null,
+                                    "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
+                                }
+                            ]
+                        },
+                        {
+                            "genomicAlteration": "EGFR !L833V",
+                            "matches": [
+                                {
+                                    "trueHugoSymbol": null,
+                                    "trueProteinChange": null,
+                                    "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
+                                }
+                            ]
+                        }
+                    ],
+                    "MSI": [],
+                    "CNA": [],
+                    "WILDTYPE": []
+                }
             }, {
                 "trialAgeNumerical": ">=18",
                 "trialOncotreePrimaryDiagnosis": {
                     "positive": [ "Non-Small Cell Lung Cancer" ],
                     "negative": []
                 },
-                "matches": [
-                    {
-                        "genomicAlteration": "EGFR 729_761del",
-                        "matches": [
-                            {
-                                "trueHugoSymbol": "EGFR",
-                                "trueProteinChange": "L747_P753delinsS",
-                                "sampleIds": [ "P-0000628-T01-IM3" ]
-                            }
-                        ]
-                    }
-                ],
-                "notMatches": [
-                    {
-                        "genomicAlteration": "EGFR !T790M",
-                        "matches": [
-                            {
-                                "trueHugoSymbol": null,
-                                "trueProteinChange": null,
-                                "sampleIds": [ "P-0000628-T01-IM3" ]
-                            }
-                        ]
-                    }
-                ]
+                "matches": {
+                    "MUTATION": [
+                        {
+                            "genomicAlteration": "EGFR 729_761del",
+                            "matches": [
+                                {
+                                    "trueHugoSymbol": "EGFR",
+                                    "trueProteinChange": "L747_P753delinsS",
+                                    "sampleIds": [ "P-0000628-T01-IM3" ]
+                                }
+                            ]
+                        }
+                    ],
+                    "MSI": [],
+                    "CNA": [],
+                    "WILDTYPE": []
+                },
+                "notMatches": {
+                    "MUTATION": [
+                        {
+                            "genomicAlteration": "EGFR !T790M",
+                            "matches": [
+                                {
+                                    "trueHugoSymbol": null,
+                                    "trueProteinChange": null,
+                                    "sampleIds": [ "P-0000628-T01-IM3" ]
+                                }
+                            ]
+                        }
+                    ],
+                    "MSI": [],
+                    "CNA": [],
+                    "WILDTYPE": []
+
+                }
             }, {
                 "trialAgeNumerical": ">18",
                 "trialOncotreePrimaryDiagnosis": {
                     "positive": [ "Lung Adenocarcinoma" ],
                     "negative": []
                 },
-                "matches": [
-                    {
-                        "genomicAlteration": "EGFR Oncogenic Mutations",
-                        "matches": [
-                            {
-                                "trueHugoSymbol": "EGFR",
-                                "trueProteinChange": "L747_P753delinsS",
-                                "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
-                            },
-                            {
-                                "trueHugoSymbol": "EGFR",
-                                "trueProteinChange": "T790M",
-                                "sampleIds": [ "P-0000628-T02-IM5" ]
-                            }
-                        ]
-                    }
-                ],
-                "notMatches": []
+                "matches": {
+                    "MUTATION": [
+                        {
+                            "genomicAlteration": "EGFR Oncogenic Mutations",
+                            "matches": [
+                                {
+                                    "trueHugoSymbol": "EGFR",
+                                    "trueProteinChange": "L747_P753delinsS",
+                                    "sampleIds": [ "P-0000628-T01-IM3", "P-0000628-T02-IM5" ]
+                                },
+                                {
+                                    "trueHugoSymbol": "EGFR",
+                                    "trueProteinChange": "T790M",
+                                    "sampleIds": [ "P-0000628-T02-IM5" ]
+                                }
+                            ]
+                        }
+                    ],
+                    "MSI": [],
+                    "CNA": [],
+                    "WILDTYPE": []
+
+                },
+                "notMatches": {
+                    "MUTATION": [],
+                    "MSI": [],
+                    "CNA": [],
+                    "WILDTYPE": []
+                }
             }];
         const expectedResult = [2, 1, 0];
         _.forEach(clinicalMatchGroup, (item: any, index: number) => {

--- a/src/pages/patientView/trialMatch/TrialMatchTableUtils.ts
+++ b/src/pages/patientView/trialMatch/TrialMatchTableUtils.ts
@@ -1,6 +1,6 @@
 import {
     IArmMatch, IClinicalGroupMatch, IDetailedTrialMatch, IGenomicGroupMatch, IGenomicMatch, ITrial,
-    ITrialMatch, IArm, IDrug
+    ITrialMatch, IArm, IDrug, IGenomicMatchType
 } from "../../../shared/model/MatchMiner";
 import * as _ from 'lodash';
 
@@ -65,8 +65,18 @@ export function groupTrialMatchesByAgeNumerical(armGroup: ITrialMatch[]): IClini
                 positive: positiveCancerTypes,
                 negative: negativeCancerTypes
             },
-            matches: [],
-            notMatches: []
+            matches: {
+                MUTATION: [],
+                CNA: [],
+                MSI: [],
+                WILDTYPE: []
+            },
+            notMatches: {
+                MUTATION: [],
+                CNA: [],
+                MSI: [],
+                WILDTYPE: []
+            }
         };
         const positiveAndNegativeMatches = groupTrialMatchesByGenomicAlteration(matchesGroupedByAge[age]);
         clinicalGroupMatch.matches = positiveAndNegativeMatches.matches;
@@ -78,16 +88,26 @@ export function groupTrialMatchesByAgeNumerical(armGroup: ITrialMatch[]): IClini
 
 export function groupTrialMatchesByGenomicAlteration(ageGroup: ITrialMatch[]) {
     const matchesGroupedByGenomicAlteration = _.groupBy(ageGroup, (trial: ITrialMatch) => trial.genomicAlteration);
-    const matches: IGenomicGroupMatch[] = []; // positive matches
-    const notMatches: IGenomicGroupMatch[] = []; // negative matches
+    // positive matches
+    const matches: IGenomicMatchType = {
+        MUTATION: [],
+        CNA: [],
+        MSI: [],
+        WILDTYPE: []
+    };
+    // negative matches
+    const notMatches: IGenomicMatchType = {
+        MUTATION: [],
+        CNA: [],
+        MSI: [],
+        WILDTYPE: []
+    };
     _.forEach(matchesGroupedByGenomicAlteration, (genomicAlterationGroup, genomicAlteration) => {
         const genomicGroupMatch = formatTrialMatchesByMatchType(genomicAlterationGroup, genomicAlteration);
-        // If a genomic alteration(i.e. BRAF V600E) contains a "!",
-        // it means this trial cannot be used for the genomic alteration, which is a "NOT" match.
         if(genomicAlteration.includes('!')) {
-            notMatches.push(genomicGroupMatch);
+            notMatches[genomicAlterationGroup[ 0 ][ 'matchType' ]].push(genomicGroupMatch);
         } else {
-            matches.push(genomicGroupMatch);
+            matches[genomicAlterationGroup[ 0 ][ 'matchType' ]].push(genomicGroupMatch);
         }
     });
     return { notMatches: notMatches, matches: matches };
@@ -140,13 +160,20 @@ export function calculateTrialPriority(armMatches: IArmMatch[]): number {
 export function getMatchPriority(clinicalGroupMatch: IClinicalGroupMatch): number {
     // In trial match tab, positive matches should always display before negative matches(notMatches).
     // The highest and default priority is 0. The priority the higher, the display order the lower.
-    if (clinicalGroupMatch.notMatches.length > 0) {
-        if (clinicalGroupMatch.matches.length === 0) {
+    const matchesLength = getMatchesLength(clinicalGroupMatch.matches);
+    const notMatchesLength = getMatchesLength(clinicalGroupMatch.notMatches);
+    if (notMatchesLength > 0) {
+        if ( matchesLength === 0) {
             return 2; // A trial only has negative matches.
         }
         return 1; // A trial has both positive matches and negative matches.
     }
     return 0; // A trial only has positive matches.
+}
+
+export function getMatchesLength(genomicMatchType: IGenomicMatchType): number {
+    return _.sum([genomicMatchType.MUTATION.length, genomicMatchType.CNA.length,
+        genomicMatchType.MSI.length, genomicMatchType.WILDTYPE.length]);
 }
 
 export function excludeControlArms(trialMatches: ITrialMatch[]): ITrialMatch[] {

--- a/src/pages/patientView/trialMatch/style/trialMatch.module.scss
+++ b/src/pages/patientView/trialMatch/style/trialMatch.module.scss
@@ -6,7 +6,7 @@
   border-top-color: rgb(221, 221, 221) !important;
 }
 .alterationUl{
-  margin-bottom: 0 !important;
+  margin-bottom: -20px !important;
   list-style-type: none;
   padding-left: 15px;
 }
@@ -17,6 +17,9 @@
   maxHeight: 400px;
   maxWidth: 600px;
   overflow: auto;
+}
+.commentIcon {
+  color: #3786C2;
 }
 .criteriaContainer {
   display: flex;

--- a/src/shared/model/MatchMiner.ts
+++ b/src/shared/model/MatchMiner.ts
@@ -78,7 +78,11 @@ export interface IClinicalGroupMatch {
 }
 
 export interface IGenomicMatchType {
-    [key: keyof MatchType]: IGenomicGroupMatch[]
+    MUTATION: IGenomicGroupMatch[],
+    CNA: IGenomicGroupMatch[],
+    MSI: IGenomicGroupMatch[],
+    WILDTYPE: IGenomicGroupMatch[],
+    [key: string]: IGenomicGroupMatch[]
 }
 
 export interface IGenomicGroupMatch {

--- a/src/shared/model/MatchMiner.ts
+++ b/src/shared/model/MatchMiner.ts
@@ -1,3 +1,10 @@
+enum MatchType {
+    MUTATION = 'MUTATION',
+    CNA = 'CNA',
+    MSI = 'MSI',
+    WILDTYPE = 'WILDTYPE'
+}
+
 export interface ITrial {
     id: string;
     nctId: string | '';
@@ -66,9 +73,14 @@ export interface IClinicalGroupMatch {
         positive: string[], // trialOncotreePrimaryDiagnosis not includes '!'
         negative: string[] // trialOncotreePrimaryDiagnosis includes '!'
     };
-    matches: IGenomicGroupMatch[];
-    notMatches: IGenomicGroupMatch[];
+    matches: IGenomicMatchType;
+    notMatches: IGenomicMatchType;
 }
+
+export interface IGenomicMatchType {
+    [key: keyof MatchType]: IGenomicGroupMatch[]
+}
+
 export interface IGenomicGroupMatch {
     genomicAlteration: string;
     matchType: string;


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Group trial matches by match type
- Use comment icon to replace hover link

![image](https://user-images.githubusercontent.com/14971266/67686479-24766080-f96d-11e9-8e1d-533b31ea577b.png)
