### PR TITLE
Show hidden axis (BoxScatterPlot)

### DIFF
--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -401,6 +401,9 @@ export default class BoxScatterPlot<D extends IBaseBoxScatterPlotPoint> extends 
         //  this axis is for numbers, not categories
         return (
             <VictoryAxis
+                style={{
+                    grid: {strokeOpacity: 1}
+                }}
                 orientation="bottom"
                 offsetY={50}
                 crossAxis={false}


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6727

Describe changes proposed in this pull request:
- a add style in axis for BoxScatterPlot forcing to show all the lines (lines for first category will be hide automatically)
![image](https://user-images.githubusercontent.com/15748980/67784738-9a003080-fa42-11e9-8095-9135b4222729.png)
