### PR TITLE
Adjusted buttons in Oncoprint controls

### DIFF
--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -617,7 +617,7 @@ export default class OncoprintControls extends React.Component<
             this.props.state.hideHeatmapMenu ||
             !this.props.state.heatmapProfilesPromise
         ) {
-            return <span />;
+            return null;
         }
         let menu = <LoadingIndicator isLoading={true} />;
         if (this.props.state.heatmapProfilesPromise.isComplete) {
@@ -1551,12 +1551,11 @@ export default class OncoprintControls extends React.Component<
                     <Button
                         active={this.showMinimap}
                         onClick={this.toggleShowMinimap}
-                        className="oncoprint__controls__minimap_button"
                     >
                         <img
                             src={require('./toggle-minimap.svg')}
                             alt="icon"
-                            style={{ width: 15, height: 15, margin: 2 }}
+                            style={{ width: 15, height: 15 }}
                         />
                     </Button>
                 </DefaultTooltip>

--- a/src/shared/components/oncoprint/controls/styles.scss
+++ b/src/shared/components/oncoprint/controls/styles.scss
@@ -119,10 +119,6 @@
     
   }
   
-  .oncoprint__controls__minimap_button {
-    padding: 5px 8px 6px 10px !important;
-  }
-  
   .Select {
     
     margin-right:10px;


### PR DESCRIPTION
## Changes:
- Removed custom padding and margin of minimap button to make its height the same as other buttons
- Removed the `span` between Add clinical tracks and Sort buttons when study does not contain molecular profiles

## Screenshots
### Before:
![Screenshot from 2019-10-30 14-08-41](https://user-images.githubusercontent.com/31291004/67860719-def99500-fb1e-11e9-9a5e-786c06b5a60c.png)

### After:
![Screenshot from 2019-10-30 14-06-03](https://user-images.githubusercontent.com/31291004/67860590-875b2980-fb1e-11e9-8572-05e1a98e80c0.png)
