### PR TITLE
Add pull of DockerHub image for e2e-localdb tests

### DIFF
--- a/end-to-end-test/local/docker/build_portal_image.sh
+++ b/end-to-end-test/local/docker/build_portal_image.sh
@@ -10,4 +10,6 @@ if [[ $BACKEND_IMAGE_NAME == $CUSTOM_BACKEND_IMAGE_NAME ]]; then
     docker build https://github.com/$BACKEND_PROJECT_USERNAME/cbioportal.git#$BACKEND_BRANCH \
         -f docker/web-and-data/Dockerfile \
         -t $BACKEND_IMAGE_NAME
+else
+    docker pull $BACKEND_IMAGE_NAME
 fi

--- a/end-to-end-test/local/docker/setup_docker_containers.sh
+++ b/end-to-end-test/local/docker/setup_docker_containers.sh
@@ -96,19 +96,6 @@ run_database_container() {
 
 }
 
-build_cbioportal_image() {
-
-    curdir=$PWD
-
-    if [[ $BACKEND_IMAGE_NAME == $CUSTOM_BACKEND_IMAGE_NAME ]]; then
-        docker build https://github.com/$BACKEND_PROJECT_USERNAME/cbioportal.git#$BACKEND_BRANCH \
-            -f docker/web-and-data/Dockerfile \
-            -t $BACKEND_IMAGE_NAME
-    fi
-
-    cd $curdir
-}
-
 run_cbioportal_container() {
 
     # stop cbioportal container if running


### PR DESCRIPTION
# Problem
While locally developing e2e-localdb test the most recent version of a cbioportal image from DockerHub was not used for tests.

# Fix 
- A pull of the most recent image was introduced.
- A redundant method in setup_docker_containers.sh was removed.