### PR TITLE
Persistent API Cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "git-revision-webpack-plugin": "^3.0.3",
     "html-webpack-plugin": "3.2.0",
     "igv": "2.3.5",
+    "idb-keyval": "~3.2.0",
     "imports-loader": "^0.8.0",
     "jStat": "^1.7.0",
     "javascript-natural-sort": "^0.7.1",

--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "autobind-decorator": "^2.1.0",
     "classnames": "^2.2.5",
+    "idb-keyval": "~3.2.0",
     "jquery": "^3.2.1",
     "lodash": "^4.17.11",
     "measure-text": "0.0.4",

--- a/packages/cbioportal-frontend-commons/src/lib/apiClientCache.ts
+++ b/packages/cbioportal-frontend-commons/src/lib/apiClientCache.ts
@@ -14,7 +14,7 @@ function hash(str: string) {
     return hash;
 }
 
-function getHash(obj: any) {
+export function getHash(obj: any) {
     return hash(JSON.stringify(obj));
 }
 

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -52,6 +52,7 @@ export interface IServerConfig {
     pubmed_url: string | null;
     priority_studies: string | null;
     api_cache_limit: number;
+    enable_persistent_cache: boolean;
     show_hotspot: boolean | undefined;
     show_oncokb: boolean;
     show_civic: boolean;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -3,6 +3,7 @@ import { IServerConfig } from './IAppConfig';
 const ServerConfigDefaults: Partial<IServerConfig> = {
     app_version: '1.0',
     api_cache_limit: 450,
+    enable_persistent_cache: false,
     dat_uuid_revoke_other_tokens: true,
     dat_method: 'none',
     disabled_tabs: '',

--- a/src/shared/api/persistentApiClientCache.spec.ts
+++ b/src/shared/api/persistentApiClientCache.spec.ts
@@ -1,0 +1,405 @@
+import sinon from 'sinon';
+import request from 'superagent';
+import { assert } from 'chai';
+import { get } from 'idb-keyval';
+import { set } from 'idb-keyval';
+import { keys } from 'idb-keyval';
+import { clear } from 'idb-keyval';
+
+import {
+    PERSISTENT_CACHE_PREFIX,
+    cacheMethods,
+    clearPersistentCache,
+} from './persistentApiClientCache';
+import { sleep } from '../lib/TimeUtils';
+import client from './cbioportalInternalClientInstance';
+import { getHash } from 'cbioportal-frontend-commons';
+
+class FakeAPIClass {}
+
+function createFakeOkResponse() {
+    return createFakeResponse(true);
+}
+
+function createFakeFailingResponse() {
+    return createFakeResponse(false);
+}
+
+function createFakeResponse(ok: boolean): Promise<request.Response> {
+    return new Promise<request.Response>(resolve => {
+        resolve({ ok } as any);
+    });
+}
+
+function createFakeRejectingResponse(): Promise<request.Response> {
+    return new Promise<request.Response>((resolve, reject) => {
+        reject({ ok: false } as any);
+    });
+}
+
+async function waitForKeyCount(count: number) {
+    let cached = await keys();
+    while (cached.length != count) {
+        await sleep(25);
+        cached = await keys();
+    }
+}
+
+describe('cacheGetMethods cache invalidation', () => {
+    beforeEach('clear the cache', async () => {
+        await clear();
+    });
+
+    afterEach(() => {
+        (client.getAllTimestampsUsingGET as sinon.SinonStub).restore();
+    });
+
+    it('should invalidate an out of date cached endpoint', async () => {
+        sinon
+            .stub(client, 'getAllTimestampsUsingGET')
+            .returns({ table: '9999-12-31 23:59:59' });
+        const response = {
+            ok: true,
+            timestamp: new Date('2015-10-21 00:00:00'),
+        } as any;
+        const originalEndpoint = sinon.stub().returns(createFakeOkResponse());
+        const api = FakeAPIClass as any;
+
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+        await set(
+            PERSISTENT_CACHE_PREFIX + 'endpointGETWithHttpInfo?' + getHash({}),
+            response
+        );
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo({});
+
+        const actual: any = await get(
+            PERSISTENT_CACHE_PREFIX + 'endpointGETWithHttpInfo?' + getHash({})
+        );
+        assert.isTrue(actual.timestamp > new Date('2015-10-21 00:00:00'));
+        assert.deepEqual(originalEndpoint.args, [[{}]]);
+    });
+
+    it('should invalidate with one out of date table and one up to date table', async () => {
+        sinon.stub(client, 'getAllTimestampsUsingGET').returns({
+            upToDateTable: '1977-09-20 00:00:00',
+            outOfDateTable: '9999-12-31 23:59:59',
+        });
+        const response = {
+            ok: true,
+            timestamp: new Date('2018-10-28'),
+        } as any;
+        const url = '/url/for/endpoint';
+        const originalEndpoint = sinon.stub().returns(createFakeOkResponse());
+        const api = FakeAPIClass as any;
+
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+        api.prototype.endpointGETURL = (_: any) => url;
+        await set(PERSISTENT_CACHE_PREFIX + url, response);
+
+        cacheMethods(api, [
+            {
+                tables: ['upToDateTable', 'outOfDateTable'],
+                endpoint: 'endpointGETWithHttpInfo',
+            },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo({});
+
+        const actual: any = await get(PERSISTENT_CACHE_PREFIX + url);
+        assert.isTrue(actual.timestamp > new Date('2015-10-21 00:00:00'));
+        assert.deepEqual(originalEndpoint.args, [[{}]]);
+    });
+
+    it('should not invalidate an not out of date cached endpoint', async () => {
+        sinon
+            .stub(client, 'getAllTimestampsUsingGET')
+            .returns({ table: '1453-10-19 00:00:00' });
+        const response = {
+            ok: true,
+            timestamp: new Date('2015-10-21 00:00:00'),
+        } as any;
+        const originalEndpoint = sinon.stub().returns(createFakeOkResponse());
+        const api = FakeAPIClass as any;
+
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+        await set(
+            PERSISTENT_CACHE_PREFIX + 'endpointGETWithHttpInfo?' + getHash({}),
+            response
+        );
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo({});
+
+        const actual: any = await get(
+            PERSISTENT_CACHE_PREFIX + 'endpointGETWithHttpInfo?' + getHash({})
+        );
+        assert.deepEqual(actual.timestamp, new Date('2015-10-21 00:00:00'));
+        assert.deepEqual(originalEndpoint.args, []);
+    });
+});
+
+describe('cacheGetMethods', () => {
+    beforeEach('clear the cache', async () => {
+        sinon
+            .stub(client, 'getAllTimestampsUsingGET')
+            .returns({ table: '1993-04-06 00:00:00' });
+        await clear();
+    });
+
+    afterEach(() => {
+        (client.getAllTimestampsUsingGET as sinon.SinonStub).restore();
+    });
+
+    it('should create a cache enabled method for an endpoint listed', async () => {
+        const originalEndpoint = sinon.stub().returns(createFakeOkResponse());
+        const api = FakeAPIClass as any;
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo('foo');
+        // the method was replaced
+        assert.notEqual(
+            api.prototype.endpointGETWithHttpInfo,
+            originalEndpoint
+        );
+    });
+
+    it('should not create a cache enable method for an endpoint not listed', () => {
+        const originalEndpoint = sinon.stub().returns(createFakeOkResponse());
+        const api = FakeAPIClass as any;
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+
+        cacheMethods(api, []);
+        api.prototype.endpointGETWithHttpInfo('foo');
+
+        // the method was not replaced
+        assert.equal(api.prototype.endpointGETWithHttpInfo, originalEndpoint);
+    });
+
+    it('should used the cached response when it exists', async () => {
+        const originalEndpoint = sinon.stub().returns(createFakeOkResponse());
+        const api = FakeAPIClass as any;
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo({ foo: 'bar' });
+        await waitForKeyCount(1);
+
+        await api.prototype.endpointGETWithHttpInfo({ foo: 'bar' });
+
+        assert.deepEqual(originalEndpoint.args, [[{ foo: 'bar' }]]);
+    });
+
+    it('should not cache a response if it is not ok', async () => {
+        const originalEndpoint = sinon
+            .stub()
+            .returns(createFakeFailingResponse());
+        const api = FakeAPIClass as any;
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo({ foo: 'bar' });
+
+        //wait for caching to happen
+        await sleep(25);
+        await api.prototype.endpointGETWithHttpInfo({ foo: 'bar' });
+
+        // wait for caching to happen again
+        await sleep(25);
+
+        // we expect two calls to the original method because the non ok response
+        // does not get cached
+        assert.deepEqual(originalEndpoint.args, [
+            [{ foo: 'bar' }],
+            [{ foo: 'bar' }],
+        ]);
+        const cached = await keys();
+        assert.deepEqual(cached, []);
+    });
+
+    it('should cache one response but not the other', async () => {
+        const endpointToBeCached = sinon.stub().returns(createFakeOkResponse());
+        const endpointToBeUncached = sinon
+            .stub()
+            .returns(createFakeOkResponse());
+
+        const api = FakeAPIClass as any;
+        api.prototype.cacheMeGETWithHttpInfo = endpointToBeCached;
+        api.prototype.doNotCacheGETWithHttpInfo = endpointToBeUncached;
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'cacheMeGETWithHttpInfo' },
+        ]);
+        await api.prototype.doNotCacheGETWithHttpInfo({ foo: 'bar' });
+        await api.prototype.cacheMeGETWithHttpInfo({ foo: 'bar' });
+
+        await sleep(25);
+
+        await api.prototype.doNotCacheGETWithHttpInfo({ foo: 'bar' });
+        await api.prototype.cacheMeGETWithHttpInfo({ foo: 'bar' });
+
+        assert.deepEqual(endpointToBeCached.args, [[{ foo: 'bar' }]]);
+        assert.deepEqual(endpointToBeUncached.args, [
+            [{ foo: 'bar' }],
+            [{ foo: 'bar' }],
+        ]);
+    });
+
+    it('should complain if you tell it to cache a method of the wrong type', async () => {
+        const log = sinon.stub();
+        const api = FakeAPIClass as any;
+        const endpointToBeCached = sinon.stub().returns(createFakeOkResponse());
+        api.prototype.endpointGET = endpointToBeCached;
+
+        cacheMethods(
+            api,
+            [{ tables: ['table'], endpoint: 'endpointGET' }],
+            log
+        );
+
+        await api.prototype.endpointGET({ foo: 'bar' });
+
+        await sleep(25);
+
+        const cached = await keys();
+        assert.deepEqual(cached, []);
+        assert.deepEqual(endpointToBeCached.args, [[{ foo: 'bar' }]]);
+        assert.deepEqual(log.args, [
+            ["Attempt to cache method that does not end in 'WithHttpInfo'"],
+            ['Method: endpointGET'],
+            ['This method will not be cached.'],
+        ]);
+    });
+});
+
+async function callExpodingRequest(request: any, args: any): Promise<void> {
+    try {
+        await request(args);
+        assert.isTrue(false);
+    } catch (err) {
+        assert.deepEqual(err, { ok: false });
+    }
+}
+
+describe('error support', () => {
+    beforeEach('clear the cache', async () => {
+        sinon
+            .stub(client, 'getAllTimestampsUsingGET')
+            .returns({ table: '1993-04-06 00:00:00' });
+        await clear();
+    });
+
+    afterEach(() => {
+        (client.getAllTimestampsUsingGET as sinon.SinonStub).restore();
+    });
+
+    it('should let error handeling logic work', async () => {
+        const originalEndpoint = sinon
+            .stub()
+            .returns(createFakeRejectingResponse());
+        const api = FakeAPIClass as any;
+        api.prototype.endpointGETWithHttpInfo = originalEndpoint;
+
+        // first call to failing endpoint, then give chance for response to be cached
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+        ]);
+        callExpodingRequest(api.prototype.endpointGETWithHttpInfo, {
+            foo: 'bar',
+        });
+        await sleep(25);
+
+        // now that cache is warm, call again
+        callExpodingRequest(api.prototype.endpointGETWithHttpInfo, {
+            foo: 'bar',
+        });
+
+        // expect empty cache, as errors are not cached
+        const cached = await keys();
+        assert.deepEqual(cached, []);
+        // expect two actual method calls, as the method was called twice and never cached
+        assert.deepEqual(originalEndpoint.args, [
+            [{ foo: 'bar' }],
+            [{ foo: 'bar' }],
+        ]);
+    });
+});
+
+describe('clear', () => {
+    beforeEach('clear the cache', async () => {
+        sinon
+            .stub(client, 'getAllTimestampsUsingGET')
+            .returns({ table: '1993-04-06 00:00:00' });
+        await clear();
+    });
+
+    afterEach(() => {
+        (client.getAllTimestampsUsingGET as sinon.SinonStub).restore();
+    });
+
+    it('should clear the entire cache', async () => {
+        const api = FakeAPIClass as any;
+        const endpointGETWithHttpInfo = sinon
+            .stub()
+            .returns(createFakeOkResponse());
+        const endpointBGETWithHttpInfo = sinon
+            .stub()
+            .returns(createFakeOkResponse());
+        api.prototype.endpointGETWithHttpInfo = endpointGETWithHttpInfo;
+        api.prototype.endpointBGETWithHttpInfo = endpointBGETWithHttpInfo;
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+            { tables: ['table'], endpoint: 'endpointBGETWithHttpInfo' },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo({ foo: 'bar' });
+        await api.prototype.endpointBGETWithHttpInfo({ foo: 'bar' });
+        waitForKeyCount(2);
+
+        await clearPersistentCache();
+
+        waitForKeyCount(0);
+        const allKeys = await keys();
+        assert.deepEqual(allKeys, []);
+    });
+
+    it('should clear just the specified domain of the cache', async () => {
+        const api = FakeAPIClass as any;
+        const endpointGETWithHttpInfo = sinon
+            .stub()
+            .returns(createFakeOkResponse());
+        const endpointBGETWithHttpInfo = sinon
+            .stub()
+            .returns(createFakeOkResponse());
+        api.prototype.endpointGETWithHttpInfo = endpointGETWithHttpInfo;
+        api.prototype.endpointBGETWithHttpInfo = endpointBGETWithHttpInfo;
+
+        cacheMethods(api, [
+            { tables: ['table'], endpoint: 'endpointGETWithHttpInfo' },
+            { tables: ['table'], endpoint: 'endpointBGETWithHttpInfo' },
+        ]);
+        await api.prototype.endpointGETWithHttpInfo({ foo: 'bar' });
+        await api.prototype.endpointBGETWithHttpInfo({ foo: 'bar' });
+        await waitForKeyCount(2);
+
+        await clearPersistentCache('endpointB');
+
+        waitForKeyCount(1);
+        const allKeys = await keys();
+        assert.deepEqual(allKeys, [
+            'persistent-cache-endpointGETWithHttpInfo?' +
+                getHash({ foo: 'bar' }),
+        ]);
+    });
+});

--- a/src/shared/api/persistentApiClientCache.ts
+++ b/src/shared/api/persistentApiClientCache.ts
@@ -1,0 +1,153 @@
+import { set, get, keys, del } from 'idb-keyval';
+import request from 'superagent';
+import internalClient from './cbioportalInternalClientInstance';
+import { getHash } from 'cbioportal-frontend-commons';
+
+export type EndpointUpdateInfo = {
+    tables: string[];
+    endpoint: string;
+    timestamp?: Date;
+};
+type TimestampedReponse = { timestamp: Date } & request.Response;
+type Log = (message: string) => void;
+
+export const PERSISTENT_CACHE_PREFIX = 'persistent-cache-'; // prefix to namespace keys from anything else in store
+var endpointUpdateTimes: Map<string, EndpointUpdateInfo> | Promise<void>;
+
+function createCacheCheckingVersionOfGet(
+    name: string,
+    api: any,
+    log: Log
+): void {
+    const oldMethod = api[name];
+    const method = async function(parameters: any): Promise<request.Response> {
+        // Wait for timestamps to finish loading to avoid race condition
+        // where the persistent cache would sometimes be ignored
+        if (endpointUpdateTimes instanceof Promise) {
+            await endpointUpdateTimes;
+        }
+
+        // for every GET in the api, there is a corresponding
+        // GETURL function that returns the url as a string
+        if (!name.endsWith('WithHttpInfo')) {
+            log("Attempt to cache method that does not end in 'WithHttpInfo'");
+            log('Method: ' + name);
+            log('This method will not be cached.');
+            return await oldMethod.apply(this, [parameters]);
+        }
+        const url = name + '?' + getHash(parameters);
+        // check the cache for a matching url
+        var response: TimestampedReponse = await get(
+            PERSISTENT_CACHE_PREFIX + url
+        );
+
+        // if not in cache, fetch a response and cache it
+        if (!response || cachedResponseOutdated(response, name, log)) {
+            response = (await oldMethod.apply(this, [
+                parameters,
+            ])) as TimestampedReponse;
+            response.timestamp = new Date();
+
+            if (response.ok) {
+                set(PERSISTENT_CACHE_PREFIX + url, response);
+            }
+        }
+
+        return response;
+    };
+
+    api[name] = method;
+}
+
+function cachedResponseOutdated(
+    response: TimestampedReponse,
+    methodName: string,
+    log: Log
+): boolean {
+    const updateTime = (endpointUpdateTimes as Map<
+        string,
+        EndpointUpdateInfo
+    >).get(methodName);
+
+    const ret =
+        updateTime == undefined ||
+        updateTime.timestamp == undefined ||
+        updateTime.timestamp > response.timestamp;
+
+    if (ret) {
+        log(
+            `The resource for ${methodName} has been updated since last request.`
+        );
+        log('The persistent cache entry will be updated.');
+    }
+
+    return ret;
+}
+
+async function populateUpdateTimes(
+    endpoints: EndpointUpdateInfo[]
+): Promise<void> {
+    const timeStamps: any = await internalClient.getAllTimestampsUsingGET({});
+
+    endpointUpdateTimes = new Map(
+        endpoints.map(i => [i.endpoint, i] as [string, EndpointUpdateInfo])
+    );
+    endpoints.forEach(endpointInfo => {
+        endpointInfo.timestamp = endpointInfo.tables
+            .map(table => new Date(timeStamps[table]))
+            .reduce((a, b) => (a > b ? a : b));
+    });
+}
+
+/**
+ * Clears the persistant cache. If a domain is specified, only cache
+ * items matching that domain will be cleared.
+ *
+ * @param prefix The prefix to clear. If not specified, the entire
+ * cache will be cleared
+ */
+export async function clearPersistentCache(
+    prefix: string = ''
+): Promise<void[]> {
+    const allKeys = await keys();
+    const promises = allKeys
+        .filter((key: string) =>
+            key.startsWith(PERSISTENT_CACHE_PREFIX + prefix)
+        )
+        .map((key: string) => del(key));
+    return Promise.all(promises);
+}
+
+/**
+ * Pass an api and a list of methods on that API into this method
+ * to persistently cache those methods. The persistent cache will persist indefinitely
+ * provided the browser does not clear it and it does not become invalidated.
+ * If you would like to clear the cache, see {@link persistantApiClientCache#clear}
+ *
+ * @param api an API classname, such as {@link CBioPortalAPI}
+ * @param methodNames the methods to cache
+ * @param log logs errors if not null.
+ */
+export function cacheMethods(
+    api: any,
+    methodNames: EndpointUpdateInfo[],
+    log?: Log
+): void {
+    if (!window.indexedDB) {
+        return;
+    }
+
+    const monadicLog = (message: string): void => {
+        if (log) {
+            log(message);
+        }
+    };
+
+    Object.getOwnPropertyNames(api.prototype)
+        .filter(name => methodNames.find(names => names.endpoint === name))
+        .forEach(name =>
+            createCacheCheckingVersionOfGet(name, api.prototype, monadicLog)
+        );
+
+    endpointUpdateTimes = populateUpdateTimes(methodNames);
+}

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -198,12 +198,6 @@ export async function fetchAllReferenceGenomeGenes(
     genomeName: string,
     client: CBioPortalAPI = defaultClient
 ) {
-    if (AppConfig.serverConfig.app_name === 'public-portal') {
-        // this is temporary
-        return $.get(
-            getFrontendAssetUrl('reactapp/reference_genome_hg19.json')
-        );
-    }
     if (genomeName) {
         return await client.getAllReferenceGenomeGenesUsingGET({
             genomeName: genomeName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11562,6 +11562,11 @@ icss-utils@^4.1.0:
   dependencies:
     postcss "^7.0.14"
 
+idb-keyval@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-3.2.0.tgz#cbbf354deb5684b6cdc84376294fc05932845bd6"
+  integrity sha512-slx8Q6oywCCSfKgPgL0sEsXtPVnSbTLWpyiDcu6msHOyKOLari1TD1qocXVCft80umnkk3/Qqh3lwoFt8T/BPQ==
+
 ieee754@^1.1.12, ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"


### PR DESCRIPTION
Fix #6635

Describe changes proposed in this pull request:
- Persistently cache endpoints that
    - Are relatively static
    - Are either expensive, or have a large response
- Added new dependency that abstracts IndexedDB into a key value store
- The persistent cache works the same way the existing cache works, replacing the existing methods with ones that check the persistent cache before doing a request
- Invalidation