### PR TITLE
Fix filter menu disappearing on CNA table

### DIFF
--- a/end-to-end-test/local/specs/core/patientview.spec.js
+++ b/end-to-end-test/local/specs/core/patientview.spec.js
@@ -13,7 +13,7 @@ describe('patient view page', function() {
     if (useExternalFrontend) {
 
         describe('gene panel information', () => {
-            
+
             before(()=>{
                 goToUrlAndSetLocalStorage(patienViewUrl);
                 waitForPatientView();
@@ -21,23 +21,23 @@ describe('patient view page', function() {
 
             const p = 'sample-icon';
             const n = 'not-profiled-icon';
-            
+
             it('mutation table shows correct sample icons, non-profiled icons and invisible icons',() => {
-                
+
                 const sampleIcon = {
                     ERBB2:  [n, n, n, p, p],
                     ABLIM1: [p, p, n, p, p],
                     PIEZO1: [n, n, p, p, p],
                     CADM2:  [p, p, p, p, p]
                 }
-                
+
                 const sampleVisibility = {
                     ERBB2:  [true , true, true, true , false],
                     ABLIM1: [true , true, true, false, false],
                     PIEZO1: [true , true, true, false, false],
                     CADM2:  [false, true, true, false, false]
                 }
-                
+
                 const genes = _.keys(sampleIcon);
                 genes.forEach((gene)=>{
                     testSampleIcon(gene, 'patientview-mutation-table', sampleIcon[gene], sampleVisibility[gene]);
@@ -52,7 +52,7 @@ describe('patient view page', function() {
                     CADM2:  [p, p, p, p, p],
                     PIEZO1: [n, p, p, p, n]
                 }
-                
+
                 const sampleVisibility = {
                     ERBB2:  [true , true, false, true , true],
                     CADM2:  [false, true, false, false, true],
@@ -60,7 +60,7 @@ describe('patient view page', function() {
                 }
 
                 const genes = _.keys(sampleIcon);
-                
+
                 genes.forEach((gene)=>{
                     testSampleIcon(gene, 'patientview-copynumber-table', sampleIcon[gene], sampleVisibility[gene]);
                 })
@@ -70,7 +70,7 @@ describe('patient view page', function() {
         });
 
         describe('filtering of mutation table', () => {
-            
+
             let selectMenu;
             let filterIcon;
 
@@ -120,6 +120,57 @@ describe('patient view page', function() {
             });
         });
 
+        describe('filtering of CNA table', () => {
+
+            let selectMenu;
+            let filterIcon;
+
+            before(() => {
+                goToUrlAndSetLocalStorage(patienViewUrl);
+                waitForPatientView();
+            });
+
+            it('filter menu icon is shown when gene panels are used', () => {
+                filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
+                assert(filterIcon.isVisible());
+            });
+
+            it('opens selection menu when filter icon clicked', () => {
+                filterIcon.click();
+                selectMenu = $('.rc-tooltip');
+                assert(selectMenu.isVisible());
+            });
+
+            it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
+                const allGenesRadio = selectMenu.$('input[value=allSamples]');
+                allGenesRadio.click();
+                const geneEntries = $$('[data-test=mutation-table-gene-column]');
+                assert.equal(geneEntries.length, 1);
+                const geneName = geneEntries[0].getText();
+                assert.equal(geneName, "CADM2");
+            });
+
+            it('re-adds genes when `any genes` option selected', () => {
+                const anyGenesRadio = selectMenu.$('input[value=anySample]');
+                anyGenesRadio.click();
+                const geneEntries = $$('[data-test=mutation-table-gene-column]');
+                assert.equal(geneEntries.length, 3);
+            });
+
+            it('closes selection menu when filter icon clicked again', () => {
+                filterIcon.click();
+                selectMenu = $('.rc-tooltip');
+                assert(!selectMenu.isVisible());
+            });
+
+            it('filter menu icon is not shown when gene panels are not used', () => {
+                goToUrlAndSetLocalStorage(CBIOPORTAL_URL+'/patient?studyId=study_es_0&caseId=TCGA-A2-A04U');
+                waitForPatientView();
+                var filterIcon = $('div[data-test=patientview-copynumber-table]').$('i[data-test=gene-filter-icon]');
+                assert(! filterIcon.isVisible());
+            });
+        });
+
         describe('genomic tracks', () => {
 
             before(()=>{
@@ -131,7 +182,7 @@ describe('patient view page', function() {
                 assert($('[data-test=cna-track-genepanel-icon-0]').isExisting());
                 assert($('[data-test=mut-track-genepanel-icon-5]').isExisting());
             });
-            
+
             it('shows mouse-over tooltip for gene panel icons with gene panel id', () => {
                 // Tooltip elements are created when hovering the gene panel icon.
                 // Control logic below is needed to access the last one after it
@@ -143,7 +194,7 @@ describe('patient view page', function() {
                 var text = toolTips[toolTips.length-1].getText();
                 assert.equal(text, 'Gene panel: TESTPANEL1');
             });
-            
+
             it('shows mouse-over tooltip for gene panel icons with NA for whole-genome analyzed sample', () => {
                 // Tooltip elements are created when hovering the gene panel icon.
                 // Control logic below is needed to access the last one after it
@@ -171,7 +222,7 @@ function testSampleIcon(geneSymbol, tableTag, sampleIconTypes, sampleVisibilitie
     const geneCell = $('div[data-test='+tableTag+'] table').$('span='+geneSymbol);
     const samplesCell = geneCell.$('..').$('..').$('div[data-test=samples-cell] ul');
     const icons = samplesCell.$$("li");
-    
+
     sampleIconTypes.forEach((desiredDataType, i) => {
         const isExpectedIcon = icons[i].$('svg[data-test='+desiredDataType+']').isExisting();
         assert.equal(isExpectedIcon, true, "Gene "+geneSymbol+": icon type at position "+i+" is not `"+desiredDataType+"`");

--- a/end-to-end-test/local/specs/core/patientview.spec.js
+++ b/end-to-end-test/local/specs/core/patientview.spec.js
@@ -144,7 +144,7 @@ describe('patient view page', function() {
             it('removes genes profiles profiled in some samples then `all genes` option selected', () => {
                 const allGenesRadio = selectMenu.$('input[value=allSamples]');
                 allGenesRadio.click();
-                const geneEntries = $$('[data-test=mutation-table-gene-column]');
+                const geneEntries = $$('[data-test=cna-table-gene-column]');
                 assert.equal(geneEntries.length, 1);
                 const geneName = geneEntries[0].getText();
                 assert.equal(geneName, "CADM2");
@@ -153,7 +153,7 @@ describe('patient view page', function() {
             it('re-adds genes when `any genes` option selected', () => {
                 const anyGenesRadio = selectMenu.$('input[value=anySample]');
                 anyGenesRadio.click();
-                const geneEntries = $$('[data-test=mutation-table-gene-column]');
+                const geneEntries = $$('[data-test=cna-table-gene-column]');
                 assert.equal(geneEntries.length, 3);
             });
 

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -262,7 +262,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
     }
 
     cnaTableShowGeneFilterMenu(sampleIds:string[]):boolean {
-        const entrezGeneIds:number[] = _.uniq(_.map(patientViewPageStore.mergedDiscreteCNADataFilteredByGene, alterations => alterations[0].entrezGeneId));
+        const entrezGeneIds:number[] = _.uniq(_.map(patientViewPageStore.mergedDiscreteCNAData, alterations => alterations[0].entrezGeneId));
         return sampleIds.length > 1
             && checkNonProfiledGenesExist(  sampleIds,
                                             entrezGeneIds,

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -97,7 +97,7 @@ export default class CopyNumberTableWrapper extends React.Component<ICopyNumberT
 
         columns.push({
             name: "Gene",
-            render: (d:DiscreteCopyNumberData[])=><span>{d[0].gene.hugoGeneSymbol}</span>,
+            render: (d:DiscreteCopyNumberData[])=><span data-test="cna-table-gene-column">{d[0].gene.hugoGeneSymbol}</span>,
             filter: (d:DiscreteCopyNumberData[], filterString:string, filterStringUpper:string)=>{
                 return d[0].gene.hugoGeneSymbol.indexOf(filterStringUpper) > -1;
             },


### PR DESCRIPTION
# Problem
When the mutation filter menu is used in some cases the filter icon that activates the menu disappears. Also, no e2e-tests were present that check gene filter functionality in patient view.

# Fix
- The logic that controlled the appearance worked on the wrong data structure. This PR keeps the menu icon showing when applicable.
- e2e-localdb tests were added.