### PR TITLE
Fixed long y axis label overlapping utilities menu

### DIFF
--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -22,6 +22,7 @@ import { Popover } from "react-bootstrap";
 import * as ReactDOM from "react-dom";
 import classnames from "classnames";
 import WindowStore from "../window/WindowStore";
+import { textTruncationUtils } from "cbioportal-frontend-commons";
 
 export interface IBaseBoxScatterPlotPoint {
     value:number;
@@ -84,6 +85,7 @@ const BOTTOM_LEGEND_PADDING = 15;
 const RIGHT_PADDING_FOR_LONG_LABELS = 50;
 const HORIZONTAL_OFFSET = 8;
 const VERTICAL_OFFSET = 17;
+const UTILITIES_MENU_HEIGHT = 20;
 
 
 const BOX_STYLES = {
@@ -454,6 +456,27 @@ export default class BoxScatterPlot<D extends IBaseBoxScatterPlotPoint> extends 
             />
         );
     }
+    
+    @computed get yAxisLabel():string[] {
+        if (this.props.axisLabelY) {
+            return textTruncationUtils(
+                this.props.axisLabelY,
+                this.chartHeight - UTILITIES_MENU_HEIGHT,
+                axisTickLabelStyles.fontFamily,
+                `${axisTickLabelStyles.fontSize}px`
+            );
+        }
+        return [];
+    }
+    
+    @computed get yAxisLabelVertOffset():number {
+        if (this.props.horizontal) {
+            return -1*this.biggestCategoryLabelSize - 24;
+        } else if (this.yAxisLabel.length > 1) {
+            return -30;
+        }
+        return -50;
+    }
 
     @computed get vertAxis() {
         return (
@@ -461,12 +484,12 @@ export default class BoxScatterPlot<D extends IBaseBoxScatterPlotPoint> extends 
                 orientation="left"
                 offsetX={50}
                 crossAxis={false}
-                label={this.props.axisLabelY}
+                label={this.yAxisLabel}
                 dependentAxis={true}
                 tickValues={this.props.horizontal ? this.categoryTickValues : undefined}
                 tickCount={this.props.horizontal ? undefined : NUM_AXIS_TICKS}
                 tickFormat={this.props.horizontal ? this.formatCategoryTick : this.formatNumericalTick}
-                axisLabelComponent={<VictoryLabel dy={this.props.horizontal ? -1*this.biggestCategoryLabelSize - 24 : -50}/>}
+                axisLabelComponent={<VictoryLabel dy={this.yAxisLabelVertOffset}/>}
             />
         );
     }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6720 long y axis label overlapping utilities menu

## Changes:
- Used `textTruncationUtils` to split the long label into multiple lines

## Screenshots:
### Before:
![image](https://user-images.githubusercontent.com/10508276/67117889-b0d89480-f1b1-11e9-9536-871d2fb0289c.png)

### After:
![Screenshot from 2019-11-11 13-16-56](https://user-images.githubusercontent.com/31291004/68586756-a72b0f80-0485-11ea-8c45-a2dc7a4d76ef.png)