### PR TITLE
Group matched trials by patient genomic info instead of genomic alterations.

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -626,6 +626,7 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
                     {
                         this.shouldShowTrialMatch(this.patientViewPageStore) && (
                             <MSKTab key={7} id="trialMatchTab" linkText="Matched Trials">
+                                <p style={{marginBottom: '0'}}>Curated genomic and clinical criteria from open clinical trials at Memorial Sloan Kettering. Please <a href="mailto:team@oncokb.org">contact us</a> if you have any questions.</p>
                                 <TrialMatchTable
                                     sampleManager={sampleManager}
                                     detailedTrialMatches={this.patientViewPageStore.detailedTrialMatches.result}

--- a/src/pages/patientView/trialMatch/TrialMatchTableUtils.spec.ts
+++ b/src/pages/patientView/trialMatch/TrialMatchTableUtils.spec.ts
@@ -336,18 +336,18 @@ describe("TrialMatchTableUtils", () => {
                 matches: {
                     MUTATION: [
                         {
-                            genomicAlteration: "NTRK3 Fusions",
-                            matchType: "MUTATION",
-                            matches: [
-                                {
-                                    trueHugoSymbol: "NTRK3",
-                                    trueProteinChange: "NTRK3-ETV6 fusion - Archer"
-                                },
-                                {
-                                    trueHugoSymbol: "NTRK3",
-                                    trueProteinChange: "ETV6-NTRK3 fusion"
-                                }
-                            ]
+                            genomicAlteration: ["NTRK3 Fusions"],
+                            patientGenomic: {
+                                trueHugoSymbol: "NTRK3",
+                                trueProteinChange: "NTRK3-ETV6 fusion - Archer"
+                            }
+                        },
+                        {
+                            genomicAlteration: ["NTRK3 Fusions"],
+                            patientGenomic: {
+                                trueHugoSymbol: "NTRK3",
+                                trueProteinChange: "ETV6-NTRK3 fusion"
+                            }
                         }
                     ],
                     CNA: [],
@@ -376,18 +376,18 @@ describe("TrialMatchTableUtils", () => {
                 matches: {
                     MUTATION: [
                         {
-                            genomicAlteration: "NTRK3 Fusions",
-                            matchType: "MUTATION",
-                            matches: [
-                                {
-                                    trueHugoSymbol: "NTRK3",
-                                    trueProteinChange: "NTRK3-ETV6 fusion - Archer"
-                                },
-                                {
-                                    trueHugoSymbol: "NTRK3",
-                                    trueProteinChange: "ETV6-NTRK3 fusion"
-                                }
-                            ]
+                            genomicAlteration: ["NTRK3 Fusions"],
+                            patientGenomic: {
+                                trueHugoSymbol: "NTRK3",
+                                trueProteinChange: "NTRK3-ETV6 fusion - Archer"
+                            }
+                        },
+                        {
+                            genomicAlteration: ["NTRK3 Fusions"],
+                            patientGenomic: {
+                                trueHugoSymbol: "NTRK3",
+                                trueProteinChange: "ETV6-NTRK3 fusion"
+                            }
                         }
                     ],
                     CNA: [],
@@ -419,18 +419,18 @@ describe("TrialMatchTableUtils", () => {
                 matches: {
                     MUTATION: [
                         {
-                            genomicAlteration: "NTRK3 Fusions",
-                            matchType: "MUTATION",
-                            matches: [
-                                {
-                                    trueHugoSymbol: "NTRK3",
-                                    trueProteinChange: "NTRK3-ETV6 fusion - Archer"
-                                },
-                                {
-                                    trueHugoSymbol: "NTRK3",
-                                    trueProteinChange: "ETV6-NTRK3 fusion"
-                                }
-                            ]
+                            genomicAlteration: ["NTRK3 Fusions"],
+                            patientGenomic: {
+                                trueHugoSymbol: "NTRK3",
+                                trueProteinChange: "NTRK3-ETV6 fusion - Archer"
+                            }
+                        },
+                        {
+                            genomicAlteration: ["NTRK3 Fusions"],
+                            patientGenomic: {
+                                trueHugoSymbol: "NTRK3",
+                                trueProteinChange: "ETV6-NTRK3 fusion"
+                            }
                         }
                     ],
                     CNA: [],

--- a/src/pages/patientView/trialMatch/TrialMatchTableUtils.ts
+++ b/src/pages/patientView/trialMatch/TrialMatchTableUtils.ts
@@ -61,28 +61,25 @@ export function groupTrialMatchesByAgeNumerical(armGroup: ITrialMatch[]): IClini
                 }
             }
         });
-        let clinicalGroupMatch: IClinicalGroupMatch = {
+        const clinicalGroupMatch: IClinicalGroupMatch = {
             trialAgeNumerical: [age],
             trialOncotreePrimaryDiagnosis: {
                 positive: positiveCancerTypes,
                 negative: negativeCancerTypes
-            },
-            matches: {
-                MUTATION: [],
-                CNA: [],
-                MSI: [],
-                WILDTYPE: []
-            },
-            notMatches: {
-                MUTATION: [],
-                CNA: [],
-                MSI: [],
-                WILDTYPE: []
             }
         };
-        const positiveAndNegativeMatches = groupTrialMatchesByGenomicAlteration(matchesGroupedByAge[age]);
-        clinicalGroupMatch.matches = positiveAndNegativeMatches.matches;
-        clinicalGroupMatch.notMatches = positiveAndNegativeMatches.notMatches;
+        const positiveTrialMatches = _.filter(matchesGroupedByAge[age], (trialMatch:ITrialMatch) => {
+            if (!_.isUndefined(trialMatch.genomicAlteration)) return !trialMatch.genomicAlteration.includes('!')
+        });
+        const negativeTrialMatches = _.filter(matchesGroupedByAge[age], (trialMatch:ITrialMatch) => {
+            if (!_.isUndefined(trialMatch.genomicAlteration)) return trialMatch.genomicAlteration.includes('!')
+        });
+        if (positiveTrialMatches.length > 0) {
+            clinicalGroupMatch.matches = groupPositiveTrialMatchesByMatchType(positiveTrialMatches);
+        }
+        if (negativeTrialMatches.length > 0) {
+            clinicalGroupMatch.notMatches = groupNegativeTrialMatchesByMatchType(negativeTrialMatches);
+        }
         return clinicalGroupMatch;
     });
     if (matches.length > 1) {
@@ -106,62 +103,52 @@ export function mergeClinicalGroupMatchByAge(clinicalGroupMatch: IClinicalGroupM
     return mergedClinicalGroupMatch;
 }
 
-export function groupTrialMatchesByGenomicAlteration(ageGroup: ITrialMatch[]) {
-    const matchesGroupedByGenomicAlteration = _.groupBy(ageGroup, (trial: ITrialMatch) => trial.genomicAlteration);
-    // positive matches
+export function groupPositiveTrialMatchesByMatchType(trialMatches: ITrialMatch[]) {
+    const matchesGroupedByMatchType = _.groupBy(trialMatches, (trial: ITrialMatch) => trial.matchType);
     const matches: IGenomicMatchType = {
         MUTATION: [],
         CNA: [],
         MSI: [],
         WILDTYPE: []
     };
-    // negative matches
-    const notMatches: IGenomicMatchType = {
+    _.forEach(matchesGroupedByMatchType, (matchTypeGroup: ITrialMatch[], matchType: string) => {
+        if (matchType === 'MUTATION') {
+            const matchesGroupedByPatientGenomic = _.groupBy( matchTypeGroup, ( trial: ITrialMatch ) => trial.trueHugoSymbol! + trial.trueProteinChange!);
+            _.forEach(matchesGroupedByPatientGenomic, (patientGenomicGroup: ITrialMatch[]) => {
+                const mutationGroupMatch: IGenomicGroupMatch = {
+                    genomicAlteration: _.uniq(patientGenomicGroup.map((trialMatch: ITrialMatch) => trialMatch.genomicAlteration!)),
+                    patientGenomic: {
+                        trueHugoSymbol: patientGenomicGroup[0].trueHugoSymbol!,
+                        trueProteinChange: patientGenomicGroup[0].trueProteinChange!
+                    }
+                };
+                matches.MUTATION.push(mutationGroupMatch);
+            });
+        } else {
+            const genomicGroupMatch: IGenomicGroupMatch = {
+                genomicAlteration: _.uniq(matchTypeGroup.map((trialMatch: ITrialMatch) => trialMatch.genomicAlteration!))
+            };
+            matches[matchType].push(genomicGroupMatch);
+        }
+    });
+    return matches;
+}
+
+export function groupNegativeTrialMatchesByMatchType(trialMatches: ITrialMatch[]) {
+    const matchesGroupedByMatchType = _.groupBy(trialMatches, (trial: ITrialMatch) => trial.matchType);
+    const matches: IGenomicMatchType = {
         MUTATION: [],
         CNA: [],
         MSI: [],
         WILDTYPE: []
     };
-    _.forEach(matchesGroupedByGenomicAlteration, (genomicAlterationGroup, genomicAlteration) => {
-        const genomicGroupMatch = formatTrialMatchesByMatchType(genomicAlterationGroup, genomicAlteration);
-        if(genomicAlteration.includes('!')) {
-            notMatches[genomicAlterationGroup[ 0 ][ 'matchType' ]].push(genomicGroupMatch);
-        } else {
-            matches[genomicAlterationGroup[ 0 ][ 'matchType' ]].push(genomicGroupMatch);
-        }
-    });
-    return { notMatches: notMatches, matches: matches };
-}
-
-function formatTrialMatchesByMatchType(genomicAlterationGroup: ITrialMatch[], genomicAlteration: string) {
-    const matchType = genomicAlterationGroup[ 0 ][ 'matchType' ];
-    if (matchType === 'MUTATION') {
-        return groupTrialMatchesByPatientGenomic(genomicAlterationGroup, genomicAlteration, matchType);
-    } else {
+    _.forEach(matchesGroupedByMatchType, (matchTypeGroup: ITrialMatch[], matchType: string) => {
         const genomicGroupMatch: IGenomicGroupMatch = {
-            genomicAlteration: genomicAlteration,
-            matchType: matchType,
-            matches: []
+            genomicAlteration: _.uniq(matchTypeGroup.map((trialMatch: ITrialMatch) => trialMatch.genomicAlteration!))
         };
-        return genomicGroupMatch;
-    }
-}
-
-export function groupTrialMatchesByPatientGenomic(genomicAlterationGroup: ITrialMatch[], genomicAlteration: string, matchType: string): IGenomicGroupMatch {
-    const matchesGroupedByPatientGenomic = _.groupBy( genomicAlterationGroup, ( trial: ITrialMatch ) => trial.trueHugoSymbol! + trial.trueProteinChange! );
-    const genomicGroupMatch: IGenomicGroupMatch = {
-        genomicAlteration: genomicAlteration,
-        matchType: matchType,
-        matches: []
-    };
-    genomicGroupMatch.matches = _.map(matchesGroupedByPatientGenomic, (patientGenomicGroup: ITrialMatch[]) => {
-        const genomicMatch: IGenomicMatch = {
-            trueHugoSymbol: patientGenomicGroup[0].trueHugoSymbol!,
-            trueProteinChange: patientGenomicGroup[0].trueProteinChange!
-        };
-        return genomicMatch;
+        matches[matchType].push(genomicGroupMatch);
     });
-    return genomicGroupMatch;
+    return matches;
 }
 
 export function calculateTrialPriority(armMatches: IArmMatch[]): number {
@@ -177,8 +164,14 @@ export function calculateTrialPriority(armMatches: IArmMatch[]): number {
 export function getMatchPriority(clinicalGroupMatch: IClinicalGroupMatch): number {
     // In trial match tab, positive matches should always display before negative matches(notMatches).
     // The highest and default priority is 0. The priority the higher, the display order the lower.
-    const matchesLength = getMatchesLength(clinicalGroupMatch.matches);
-    const notMatchesLength = getMatchesLength(clinicalGroupMatch.notMatches);
+    let matchesLength = 0;
+    let notMatchesLength = 0;
+    if (!_.isUndefined(clinicalGroupMatch.matches)) {
+        matchesLength = getMatchesLength(clinicalGroupMatch.matches);
+    }
+    if (!_.isUndefined(clinicalGroupMatch.notMatches)) {
+        notMatchesLength = getMatchesLength(clinicalGroupMatch.notMatches);
+    }
     if (notMatchesLength > 0) {
         if ( matchesLength === 0) {
             return 2; // A trial only has negative matches.

--- a/src/pages/patientView/trialMatch/style/trialMatch.module.scss
+++ b/src/pages/patientView/trialMatch/style/trialMatch.module.scss
@@ -83,3 +83,10 @@
   text-align: right;
   font-size: 13px;
 }
+.statusButton {
+  margin: 20% 0 20% 0;
+
+  a:hover {
+    text-decoration: none;
+  }
+}

--- a/src/shared/model/MatchMiner.ts
+++ b/src/shared/model/MatchMiner.ts
@@ -70,8 +70,13 @@ export interface ITrialQuery {
 }
 
 export interface IGenomicMatch {
-    trueHugoSymbol?: string;
-    trueProteinChange?: string;
+    trueHugoSymbol: string;
+    trueProteinChange: string;
+}
+
+export interface IPatientGenomic {
+    trueHugoSymbol: string;
+    trueProteinChange: string;
 }
 
 export interface IClinicalGroupMatch {
@@ -80,8 +85,8 @@ export interface IClinicalGroupMatch {
         positive: string[], // trialOncotreePrimaryDiagnosis not includes '!'
         negative: string[] // trialOncotreePrimaryDiagnosis includes '!'
     };
-    matches: IGenomicMatchType;
-    notMatches: IGenomicMatchType;
+    matches?: IGenomicMatchType;
+    notMatches?: IGenomicMatchType;
 }
 
 export interface IGenomicMatchType {
@@ -93,9 +98,8 @@ export interface IGenomicMatchType {
 }
 
 export interface IGenomicGroupMatch {
-    genomicAlteration: string;
-    matchType: string;
-    matches: IGenomicMatch[];
+    genomicAlteration: string[];
+    patientGenomic?: IPatientGenomic;
 }
 
 export interface IArmMatch {


### PR DESCRIPTION
Fix some issues of https://github.com/oncokb/oncokb/issues/1816

Group matched trials by patient genomic info instead of genomic alterations. In current approach, it may have some duplicates since trials are grouped by genomic alterations. We just decided to group trials by patient genomic info (hugo symbol + protein change) first if a patient has.