### PR TITLE
Always proxy oncokb request

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -133,17 +133,20 @@ export function getOncoQueryDocUrl() {
     return buildCBioPortalPageUrl("/oql");
 }
 
+export function trimProtocol(url:string) {
+    // we need to support legacy configuration values
+    url = url.replace(/^http[s]?:\/\//,''); // get rid of protocol
+    url = url.replace(/\/$/,""); // get rid of trailing slashes
+    url = url.replace(/^\/+/,""); // get rid of leading slashes
+    return url;
+}
 export function getProxyUrlIfNecessary(url:any) {
     if (typeof url === 'string') {
         // use url if https, otherwise use proxy
         if (url.startsWith('https://')) {
             return url
         } else {
-            // we need to support legacy configuration values
-            url = url.replace(/^http[s]?:\/\//,''); // get rid of protocol
-            url = url.replace(/\/$/,""); // get rid of trailing slashes
-            url = url.replace(/^\/+/,""); // get rid of leading slashes
-
+            url = trimProtocol(url);
             return buildCBioPortalAPIUrl(`proxy/${url}`)
         }
     } else {
@@ -153,8 +156,13 @@ export function getProxyUrlIfNecessary(url:any) {
 
 export function getOncoKbApiUrl() {
     let url = AppConfig.serverConfig.oncokb_public_api_url;
-    return getProxyUrlIfNecessary(url);
+    if (typeof url === 'string') {
+        return buildCBioPortalAPIUrl(`proxy/${trimProtocol(url)}`);
+    } else {
+        return undefined;
+    }
 }
+
 export function getGenomeNexusApiUrl() {
     let url = AppConfig.serverConfig.genomenexus_url;
     return getProxyUrlIfNecessary(url);


### PR DESCRIPTION
The coming up new OncoKB website is no longer allowing cross domain requests. All requests need to be proxied and attached the auth header

