### PR TITLE
Fix env URL for master

### DIFF
--- a/env/master.sh
+++ b/env/master.sh
@@ -1,2 +1,2 @@
-export CBIOPORTAL_URL="https://master.cbioportal.org"
+export CBIOPORTAL_URL="https://www.cbioportal.org"
 export GENOME_NEXUS_URL="https://www.genomenexus.org"


### PR DESCRIPTION
Master env file was mistakenly pointed to master.cbioportal.org