### PR TITLE
Fix long runtimes for e2e-localdb tests

### DIFF
--- a/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
+++ b/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
@@ -7,7 +7,7 @@ set -o pipefail
 DIR=$PWD
 
 cd $TEST_HOME/local/docker
-./build_portal_image.sh
+./build_portal_image.sh &> /dev/null
 MD5_ES_0=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'find /cbioportal/core/src/test/scripts/test_data/study_es_0/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//"')
 MD5_TEST_STUDIES=$(find $TEST_HOME/local/studies/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//")
 MD5_MIGRATION_SQL=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'md5sum /cbioportal/db-scripts/src/main/resources/migration.sql | sed "s/\s.*$//"')


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6844

This PR corrects long running times for e2e-localdb tests. Cause was output of docker pull command being part of the database contents hash.