### PR TITLE
Use v1.genomenexus.org as default

### DIFF
--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -6,7 +6,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     dat_uuid_revoke_other_tokens: true,
     dat_method: 'none',
     disabled_tabs: '',
-    genomenexus_url: 'https://www.genomenexus.org',
+    genomenexus_url: 'https://v1.genomenexus.org',
     g2s_url: 'https://g2s.genomenexus.org',
     mycancergenome_show: false,
 


### PR DESCRIPTION
In case we want to change the API later on. Explicitly have v1 in the URL