### PR TITLE
Refactoring of end-to-end-test-draft-pr requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
           command: |
               source $PORTAL_SOURCE_DIR/env/custom.sh || true && \
               cd $TEST_HOME/local/runtime-config && \
-              ./setup_environment.sh && ./setup_environment.sh >> $BASH_ENV
+              ./setup_environment.sh -d && ./setup_environment.sh >> $BASH_ENV
       - run:
           name: Generate checksum of data that populates the test database
           command: |         

--- a/end-to-end-test/local/runtime-config/setup_environment.sh
+++ b/end-to-end-test/local/runtime-config/setup_environment.sh
@@ -2,6 +2,22 @@
 
 set -e
 
+DRAFT_PR_REQUIRED=false
+
+usage() {
+    echo "-d: git PR must be in draft state in order for tests to run" 
+    exit 1
+}
+
+while getopts "d" opt; do
+    case "${opt}" in
+        d) DRAFT_PR_REQUIRED=true
+           ;;
+        \?) usage
+            ;;
+    esac
+done
+
 # -+-+-+-+-+-+-+ ENVIRONMENTAL VARIABLES +-+-+-+-+-+-+-
 
 echo export E2E_CBIOPORTAL_HOST_NAME=cbioportal
@@ -50,7 +66,7 @@ if [[ "$CIRCLECI" = true ]]; then
         # Only allow committing a BACKEND variable in custom.sh if the PR is in
         # draft state. We do allow setting custom.sh programmatically on CI (as
         # is done in the backend repo), which is why we use `git show`.
-        if git show HEAD:env/custom.sh | grep -q BACKEND && [[ $PULL_REQUEST_STATE != "draft" ]]; then
+        if git show HEAD:env/custom.sh | grep -q BACKEND && [ "$DRAFT_PR_REQUIRED" = true ] && [[ $PULL_REQUEST_STATE != "draft" ]]; then
             echo "Error: BACKEND variable defined in custom.sh, but pull request state is not 'draft'"
             echo "Remove BACKEND variable from custom.sh or change the pull request into a draft pull request."
             exit 1


### PR DESCRIPTION
For compatibility with end-to-end-tests running on backend PR.  This update loosens the requirement of PR needing to be in draft state when BACKEND is defined in custom.sh.

With this PR, the condition is only required for frontend PRs.