### PR TITLE
results view oncoprint - fix wrapping behavior in tooltip

### DIFF
--- a/src/shared/components/oncoprint/TooltipUtils.spec.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.spec.ts
@@ -947,11 +947,11 @@ describe("Oncoprint TooltipUtils", () => {
             });
             it("should show the correct output for a single value", () => {
                 const tooltipResult = tooltip([{ attr_val_counts: { "a": 1 }, attr_val: "a", sample: "sampleID" }]);
-                assert.isTrue(tooltipResult.html().indexOf(`label1234: <span style="white-space:nowrap"><b>a</b></span>`) > -1);
+                assert.isTrue(tooltipResult.html().indexOf(`label1234: <span style="white-space:nowrap; display:inline-block;"><b>a</b></span>`) > -1);
             });
             it("should show the correct output for multiple values", () => {
                 const tooltipResult = tooltip([{ attr_val_counts: { "a": 1, "b": 3 }, attr_val: "a", sample: "sampleID" }]);
-                assert.isTrue(tooltipResult.html().indexOf(`label1234:<br><span style="white-space:nowrap"><b>a</b>: 1 sample</span><br><span style="white-space:nowrap"><b>b</b>: 3 samples</span>`) > -1);
+                assert.isTrue(tooltipResult.html().indexOf(`label1234:<br><span style="white-space:nowrap; display:inline-block;"><b>a</b>: 1 sample</span><br><span style="white-space:nowrap; display:inline-block;"><b>b</b>: 3 samples</span>`) > -1);
             });
             it("should show the correct output for multiple data, single value", () => {
                 const tooltipResult = tooltip([
@@ -959,7 +959,7 @@ describe("Oncoprint TooltipUtils", () => {
                     { attr_val_counts: { "a": 1 }, attr_val: "a", patient: "patientID" },
                     { attr_val_counts: { "a": 2 }, attr_val: "a", patient: "patientID" }
                 ]);
-                assert.isTrue(tooltipResult.html().indexOf(`label1234: <span style="white-space:nowrap"><b>a</b> (4 samples)</span><br>`) > -1);
+                assert.isTrue(tooltipResult.html().indexOf(`label1234: <span style="white-space:nowrap; display:inline-block;"><b>a</b> (4 samples)</span><br>`) > -1);
             });
             it("should show the correct output for multiple data, multiple values", () => {
                 const tooltip = makeClinicalTrackTooltip(trackSpec, false);
@@ -969,7 +969,7 @@ describe("Oncoprint TooltipUtils", () => {
                     { attr_val_counts: { "a": 2, "b": 1, "c": 1 }, attr_val: "a", patient: "patientID" }
                 ]);
                 assert.isTrue(tooltipResult.html().indexOf(
-                    `label1234:<br><span style="white-space:nowrap"><b>a</b>: 4 samples</span><br><span style="white-space:nowrap"><b>b</b>: 6 samples</span><br><span style="white-space:nowrap"><b>c</b>: 1 sample</span>`
+                    `label1234:<br><span style="white-space:nowrap; display:inline-block;"><b>a</b>: 4 samples</span><br><span style="white-space:nowrap; display:inline-block;"><b>b</b>: 6 samples</span><br><span style="white-space:nowrap; display:inline-block;"><b>c</b>: 1 sample</span>`
                 ) > -1);
             });
         });

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -34,7 +34,7 @@ function patientViewAnchorTag(study_id:string, patient_id:string) {
 };
 
 function makeGenePanelPopupLink(gene_panel_id:string, profiled:boolean, numSamples?:number) {
-    let anchor = $(`<span style="white-space:nowrap"><a href="#" ${!profiled ? 'style="color:red;"': ""} oncontextmenu="return false;">${gene_panel_id}</a>${numSamples ? ` (${numSamples})` : ""}</span>`);
+    let anchor = $(`<span style="white-space:nowrap; display:inline-block;"><a href="#" ${!profiled ? 'style="color:red;"': ""} oncontextmenu="return false;">${gene_panel_id}</a>${numSamples ? ` (${numSamples})` : ""}</span>`);
     anchor.ready(()=>{
         anchor.click(function() {
             client.getGenePanelUsingGET({ genePanelId: gene_panel_id }).then((panel:GenePanel)=>{
@@ -98,17 +98,17 @@ export function makeClinicalTrackTooltip(track:ClinicalTrackSpec, link_id?:boole
                 if (displayVal.substring(displayVal.length-3) === ".00") {
                     displayVal = displayVal.substring(0, displayVal.length-3);
                 }
-                ret += track.label+': <span style="white-space:nowrap"><b>' + displayVal + `${count > 1 ? ` (average of ${count} values)`:""}</b></span><br>`;
+                ret += track.label+': <span style="white-space:nowrap; display:inline-block;"><b>' + displayVal + `${count > 1 ? ` (average of ${count} values)`:""}</b></span><br>`;
             } else {
                 if (attr_vals.length > 1) {
                     ret += track.label+':<br>';
                     for (let i = 0; i < attr_vals.length; i++) {
                         const val = attr_vals[i];
-                        ret += '<span style="white-space:nowrap"><b>' + val + '</b>: ' + attr_val_counts[val] + ` sample${attr_val_counts[val] === 1 ? "" : "s"}</span><br>`;
+                        ret += '<span style="white-space:nowrap; display:inline-block;"><b>' + val + '</b>: ' + attr_val_counts[val] + ` sample${attr_val_counts[val] === 1 ? "" : "s"}</span><br>`;
                     }
                 } else if (attr_vals.length === 1) {
                     let displayVal = attr_vals[0];
-                    ret += track.label+': <span style="white-space:nowrap"><b>' + displayVal + `</b>${dataUnderMouse.length > 1 ? ` (${attr_val_counts[attr_vals[0]]} samples)` : ""}</span><br>`;
+                    ret += track.label+': <span style="white-space:nowrap; display:inline-block;"><b>' + displayVal + `</b>${dataUnderMouse.length > 1 ? ` (${attr_val_counts[attr_vals[0]]} samples)` : ""}</span><br>`;
                 }
             }
         }
@@ -304,7 +304,10 @@ export function makeGeneticTrackTooltip(
             oncokb_oncogenic, driver_filter, driver_filter_annotation,
                 driver_tiers_filter, driver_tiers_filter_annotation, germline],
             value:count})=>{
-            var ret = $('<span>').css("white-space", "nowrap");
+            var ret = $('<span>').css({
+                "white-space":"nowrap",
+                "display":"inline-block"
+            });
             ret.append(`<b>${hugo_gene_symbol} ${amino_acid_change}</b>`);
             if (cancer_hotspots_hotspot) {
                 ret.append(`<img src="${hotspotsImg}" title="Hotspot" style="height:11px; width:11px; margin-left:3px"/>`);


### PR DESCRIPTION
this PR just adds "display:inline-block" to spans that are "white-space:nowrap" to make them wrap as blocks

![image](https://user-images.githubusercontent.com/636232/69579193-03228780-0fa0-11ea-83a5-0c9eee50d45e.png)
