### PR TITLE
update svg2pdf to custom version (fix gradient shows up as solid block)

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "styled-components": "^4.2.1",
     "superagent": "^3.8.3",
     "superagent-cache": "^3.0.1",
-    "svg2pdf.js": "^1.3.3",
+    "svg2pdf.js": "github:cbioportal/svg2pdf.js#v1.3.3-cbio",
     "svgsaver": "0.9.0",
     "swagger-client": "^3.8.22",
     "ts-loader": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21308,6 +21308,12 @@ svg2pdf.js@^1.3.3:
   dependencies:
     jspdf-yworks "^2.0.1"
 
+"svg2pdf.js@github:cbioportal/svg2pdf.js#v1.3.3-cbio":
+  version "1.3.3"
+  resolved "https://codeload.github.com/cbioportal/svg2pdf.js/tar.gz/37db750e7ba9e87de29a24df73c43e768837f734"
+  dependencies:
+    jspdf-yworks "^2.0.1"
+
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6765

Try to update `svg2pdf` to the latest version, but after updated to the latest version, the `jspdf-yworks` library throw error (not a constructor), didn't have luck to make it work. 
Tried two different ways to solve the issue:
1. Update `svg2pdf.js` to version from `1.3.3` to `1.3.4`, but still use the older `jspdf-yworks` version. That fixed the fill gradient issue found in oncoprint, but introduced in other issue in study view (some charts will shrink to 1/4). 
2. Created a fork of `svg2pdf.js` library and cherry-pick the commit fixed the issue. Then use that as the package.
Describe changes proposed in this pull request:
- a fix gradient shows up as solid block
![image](https://user-images.githubusercontent.com/15748980/70256930-673f0b80-1757-11ea-88e8-7db25a35fcf8.png)