### PR TITLE
Display genes in one column on copy/download

### DIFF
--- a/src/pages/patientView/PatientViewGenePanelModal/GenesList.tsx
+++ b/src/pages/patientView/PatientViewGenePanelModal/GenesList.tsx
@@ -71,7 +71,7 @@ export default class GenesList extends React.Component<
     };
 
     getDownloadData = () => {
-        const downloadData = [['Genes'], ...this.genesDividedToRows(this.props.genePanel.genes)];
+        const downloadData = [['Genes'], ...this.props.genePanel.genes.map(gene => [gene.hugoGeneSymbol])];
         return serializeData(downloadData);
     };
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6889

Describe changes proposed in this pull request:
- Keeping genes in a single column on copy/download

# GIF
![gene-panel-modal-download](https://user-images.githubusercontent.com/31291004/70424662-06257980-1a70-11ea-82cc-7d9f57f19471.gif)