### PR TITLE
Gene query limit supports case sets

### DIFF
--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -100,7 +100,7 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
                         />
                         <GeneSymbolValidationError
                             sampleCount={
-                                this.store.profiledSamplesCount.result.all
+                                this.store.approxSampleCount
                             }
                             queryProductLimit={
                                 AppConfig.serverConfig.query_product_limit

--- a/src/shared/components/query/GeneSymbolValidator.tsx
+++ b/src/shared/components/query/GeneSymbolValidator.tsx
@@ -51,9 +51,7 @@ export default class GeneSymbolValidator extends QueryStoreComponent<{}, {}> {
                             name="exclamation-circle"
                         />
                         <GeneSymbolValidationError
-                            sampleCount={
-                                this.store.profiledSamplesCount.result.all
-                            }
+                            sampleCount={this.store.approxSampleCount}
                             queryProductLimit={
                                 AppConfig.serverConfig.query_product_limit
                             }


### PR DESCRIPTION

Fix cBioPortal/cbioportal#6898

Describe changes proposed in this pull request:
- Issue:
  - Case sets were ignored when determining if a gene query
  was over the limit
  - This caused case sets that are a proper subset of their
  studies to limit the number of genes too strictly
- Solution:
  - Consider all the ways the user could be restricting
  their sample set when creating a query

