### PR TITLE
Fix overwriting of empty parameters on modify query (and all other updateURL calls)

### DIFF
--- a/src/shared/components/query/QueryStoreUtils.ts
+++ b/src/shared/components/query/QueryStoreUtils.ts
@@ -18,6 +18,7 @@ export type MolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
 export function currentQueryParams(store:QueryStore) {
     let nonProfileParams = nonMolecularProfileParams(store);
     let profileParams = molecularProfileParams(store);
+    debugger;
     return queryParams(nonProfileParams, profileParams);
 }
 
@@ -27,11 +28,11 @@ export function queryParams(nonMolecularProfileParams:NonMolecularProfileQueryPa
 
     // Remove params with no value, because they may cause problems.
     // For example, the server will always transpose if transpose_matrix is present, no matter the value.
-    for (let key in params) {
-        if (!(params as any)[key]) {
-            delete (params as any)[key];
-        }
-    }
+    // for (let key in params) {
+    //     if (!(params as any)[key]) {
+    //         delete (params as any)[key];
+    //     }
+    // }
 
     return {query:params};
 }

--- a/src/shared/components/query/QueryStoreUtils.ts
+++ b/src/shared/components/query/QueryStoreUtils.ts
@@ -18,21 +18,12 @@ export type MolecularProfileQueryParams = Pick<CancerStudyQueryUrlParams,
 export function currentQueryParams(store:QueryStore) {
     let nonProfileParams = nonMolecularProfileParams(store);
     let profileParams = molecularProfileParams(store);
-    debugger;
     return queryParams(nonProfileParams, profileParams);
 }
 
 export function queryParams(nonMolecularProfileParams:NonMolecularProfileQueryParams,
                             molecularProfileParams:MolecularProfileQueryParams) {
     let params:CancerStudyQueryUrlParams = Object.assign({}, nonMolecularProfileParams, molecularProfileParams);
-
-    // Remove params with no value, because they may cause problems.
-    // For example, the server will always transpose if transpose_matrix is present, no matter the value.
-    // for (let key in params) {
-    //     if (!(params as any)[key]) {
-    //         delete (params as any)[key];
-    //     }
-    // }
 
     return {query:params};
 }

--- a/src/shared/lib/ExtendedRouterStore.spec.ts
+++ b/src/shared/lib/ExtendedRouterStore.spec.ts
@@ -50,6 +50,33 @@ describe('ExtendedRouterStore', () => {
 
     });
 
+
+    it('Properties that are undefined will be removed from URL', () => {
+
+        routingStore.updateRoute({
+                                     param1: 'something1',
+                                     param2: 'something2',
+                                     param3: 'something3'
+                                 }, undefined, false);
+
+
+        assert.deepEqual(routingStore.location.query, {  param1: 'something1', param2: 'something2', param3: 'something3'},'sets params');
+
+        routingStore.updateRoute({
+                                     param3: undefined
+                                 }, undefined, false);
+
+        assert.deepEqual(routingStore.location.query, { param1: 'something1', param2: 'something2'},'removes undefined param');
+
+        routingStore.updateRoute({
+                                     param2: ''
+                                 }, undefined, false);
+
+        assert.deepEqual(routingStore.location.query, { param1: 'something1'},'removes empty string prop');
+
+
+    });
+
 });
 
 

--- a/src/shared/lib/ExtendedRouterStore.ts
+++ b/src/shared/lib/ExtendedRouterStore.ts
@@ -49,24 +49,6 @@ export function normalizeLegacySession(sessionData:any){
     return sessionData;
 }
 
-// export enum QueryParameter {
-//     GENE_LIST="gene_list",
-//     Z_SCORE_THRESHOLD="Z_SCORE_THRESHOLD",
-//     RPPA_SCORE_THRESHOLD="RPPA_SCORE_THRESHOLD",
-//     CANCER_STUDY_LIST="cancer_study_list",
-//     CASE_IDS="case_ids",
-//     CASE_SET_ID="case_set_id",
-//     GENE_SET_CHOICE="gene_set_choice",
-//     GENETIC_PROFILE_IDS="genetic_profile_ids",
-//     CANCER_STUDY_ID="cancer_study_id",
-//     DATA_PRIORITY="data_priority",
-//     GENESET_LIST="geneset_list",
-//     TREATMENT_LIST="treatment_list",
-//     TAB_INDEX="tab_index",
-//     TRANSPOSE_MATRIX="transpose_matrix",
-//     ACTION="Action"
-// }
-
 export default class ExtendedRouterStore extends RouterStore {
 
 
@@ -89,6 +71,13 @@ export default class ExtendedRouterStore extends RouterStore {
         } else {
             newQuery = newParams;
         }
+
+        // clear out any undefined props
+        _.each(newQuery, (v, k: string) => {
+            if (v === undefined || v === "") {
+                delete newQuery[k];
+            }
+        });
 
         // put a leading slash if there isn't one
         path = URL.resolve('/', path);


### PR DESCRIPTION
Prior to URLWrapper, modify query cleared all existing query params and replaced them with newly submitted.  But ULWrapper changed that to allow persisting of existing non-URL sessions.  A problem arose when we submit an empty parameter (e.g. mutation profile type).  On submit the code was stripping out empty params which had the affect of retaining the old value.  THis is fixed by accomplishing the overwrite in the routing store where we ALWAYS overwrite all the URL params.  

Fixes: https://github.com/cBioPortal/cbioportal/issues/6894

To reproduce bug, make a single study query and then modify query by updating genomic profile.  You can't update it. 
