### PR TITLE
Frontend should consume postData written to JSP

### DIFF
--- a/end-to-end-test/local/specs/core/resultspage.spec.js
+++ b/end-to-end-test/local/specs/core/resultspage.spec.js
@@ -1,0 +1,49 @@
+var assert = require('assert');
+var goToUrlAndSetLocalStorage = require('../../../shared/specUtils').goToUrlAndSetLocalStorage;
+var postDataToUrl = require('../../../shared/specUtils').postDataToUrl;
+var parse = require('url-parse');
+var _ = require('lodash');
+
+var useExternalFrontend = require('../../../shared/specUtils').useExternalFrontend;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, "");
+
+describe('study select page', function() {
+
+    if (useExternalFrontend) {
+
+        describe('error messaging for invalid study id(s)', function(){
+
+            it('show error alert and query form for single invalid study id',function(){
+                var url = `${CBIOPORTAL_URL}/results?localdist=true`;
+
+                const query = {"gene_list":"KRAS NRAS BRAF"
+                    ,"cancer_study_list":"coadread_tcga_pub",
+                    "case_ids":"","case_set_id":"coadread_tcga_pub_nonhypermut",
+                    "Z_SCORE_THRESHOLD":"2.0",
+                    "genetic_profile_ids_PROFILE_MUTATION_EXTENDED":"coadread_tcga_pub_mutations",
+                    "genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION":"coadread_tcga_pub_gistic"
+                };
+
+                postDataToUrl(url, query);
+
+                browser.waitUntil(()=>{
+                    var url = browser.getUrl();
+
+                    // make sure param in query is passed to url
+                    return _.every(query,(item,key)=>{
+                        return url.includes(key);
+                    });
+                });
+
+                const postData = browser.execute(()=>{
+                    return window.postData;
+                }).value;
+
+                assert(postData === null, "postData has been set to null after read");
+
+            });
+        });
+
+    }
+});

--- a/end-to-end-test/shared/specUtils.js
+++ b/end-to-end-test/shared/specUtils.js
@@ -293,6 +293,38 @@ function getOncoprintGroupHeaderOptionsElements(trackGroupIndex) {
     };
 }
 
+
+function postDataToUrl(url, data) {
+
+    browser.execute((url, data)=>{
+
+        function formSubmit(url, params) {
+            // method="smart" means submit with GET iff the URL wouldn't be too long
+
+            const form = document.createElement('form');
+            form.setAttribute('method', 'post');
+            form.setAttribute('action', url);
+            form.setAttribute('target', '_self');
+
+            for (const key of Object.keys(params)) {
+                const hiddenField = document.createElement('input');
+                hiddenField.setAttribute('type', 'hidden');
+                hiddenField.setAttribute('name', key);
+                hiddenField.setAttribute('value', params[key]);
+                form.appendChild(hiddenField);
+            }
+
+            document.body.appendChild(form);
+            form.submit();
+        }
+
+        formSubmit(url, data)
+
+    },url, data)
+
+}
+
+
 module.exports = {
     checkElementWithElementHidden: checkElementWithElementHidden,
     waitForPlotsTab: waitForPlotsTab,
@@ -332,5 +364,8 @@ module.exports = {
     getOncoprintGroupHeaderOptionsElements:getOncoprintGroupHeaderOptionsElements,
     showGsva: showGsva,
     setResultsPageSettingsMenuOpen:setResultsPageSettingsMenuOpen,
-    setDropdownOpen:setDropdownOpen
+    setDropdownOpen:setDropdownOpen,
+    postDataToUrl:postDataToUrl
 };
+
+

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -46,7 +46,7 @@ import setWindowVariable from 'shared/lib/setWindowVariable';
 import LoadingIndicator from "shared/components/loadingIndicator/LoadingIndicator";
 import onMobxPromise from "shared/lib/onMobxPromise";
 import {createQueryStore} from "shared/lib/createQueryStore";
-import {handleLegacySubmission} from "shared/lib/redirectHelpers";
+import {handleLegacySubmission, handlePostedSubmission} from "shared/lib/redirectHelpers";
 
 function initStore(appStore: AppStore, urlWrapper: ResultsViewURLWrapper) {
     const resultsViewPageStore = new ResultsViewPageStore(
@@ -102,6 +102,8 @@ export default class ResultsViewPage extends React.Component<
         this.urlWrapper = new ResultsViewURLWrapper(props.routing);
 
         handleLegacySubmission(this.urlWrapper);
+
+        handlePostedSubmission(this.urlWrapper);
 
         setWindowVariable('urlWrapper', this.urlWrapper);
 

--- a/src/shared/lib/redirectHelpers.ts
+++ b/src/shared/lib/redirectHelpers.ts
@@ -28,6 +28,15 @@ export function restoreRouteAfterRedirect(injected: { routing:ExtendedRouterStor
 
 }
 
+// harvest query data written to the page by JSP to support queries originating
+// from external posts
+export function handlePostedSubmission(urlWrapper:ResultsViewURLWrapper){
+    if (getBrowserWindow().postData) {
+        urlWrapper.updateURL(getBrowserWindow().postData, "results", true, true);
+        // we don't want this data to be around anymore once we've tranferred it to URL
+        getBrowserWindow().postData = null;
+    }
+}
 
 export function handleLegacySubmission(urlWrapper:ResultsViewURLWrapper){
     const legacySubmission = localStorage.getItem("legacyStudySubmission");


### PR DESCRIPTION
External applications may send users to portal using http post (for large queries).  JSP writes this posted data to postData variable.  Frontend needs to consume this data.