### PR TITLE
improve footer version logic

### DIFF
--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -80,7 +80,7 @@ export class AppStore {
             const portalVersionResult = await internalClient.getInfoUsingGET({});
             if (portalVersionResult && portalVersionResult.portalVersion) {
                 let version = portalVersionResult.portalVersion.split('-')[0];
-                if (!version.startsWith("v") {
+                if (!version.startsWith("v")) {
                     version = `v${version}`;
                 }
                 return Promise.resolve(version);

--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -79,7 +79,11 @@ export class AppStore {
         invoke:async()=>{
             const portalVersionResult = await internalClient.getInfoUsingGET({});
             if (portalVersionResult && portalVersionResult.portalVersion) {
-                return Promise.resolve("v" + portalVersionResult.portalVersion.split('-')[0]);
+                let version = portalVersionResult.portalVersion.split('-')[0];
+                if (!version.startsWith("v") {
+                    version = `v${version}`;
+                }
+                return Promise.resolve(version);
             }
             return undefined;
         }


### PR DESCRIPTION
Only add v prefix if the API does not return the v prefix

Avoids getting things like `vv3.1.8` in the footer