### PR TITLE
Patient view mutation table should, by default, show all mutations, n…

### DIFF
--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -102,7 +102,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
             error, please contact us at <a style="color:#FF0000" href="mailto:cbioportal-access@cbio.mskcc.org">
             cbioportal-access@cbio.mskcc.org</a>`,
 
-    skin_patientview_filter_genes_profiled_all_samples: false,
+    skin_patientview_filter_genes_profiled_all_samples: true,
 
     enable_darwin: false,
 


### PR DESCRIPTION
Change default behavior of patient view mutations table to show by default all mutations, not just mutations which are profiled in all gene panels.
https://github.com/cBioPortal/cbioportal/issues/6890