### PR TITLE
Clinical timeline: Create split heirarchy for Diagnosis subtypes

### DIFF
--- a/src/pages/patientView/timeline/legacy.js
+++ b/src/pages/patientView/timeline/legacy.js
@@ -167,6 +167,7 @@ export function buildTimeline(params, caseIds, patientInfo, clinicalDataMap, cas
     window.pvTimeline =
         window.pvTimeline
             .splitByClinicalAttributes("Treatment", ["TREATMENT_TYPE","SUBTYPE", "AGENT"])
+            .splitByClinicalAttributes("Diagnosis", ["SUBTYPE"])
             .collapseAll()
             .toggleTrackCollapse("Specimen")
             .enableTrackTooltips(false)


### PR DESCRIPTION
We want to show Diagnosis subtypes as children of Diagnosis track in clinical timeline on patient page
![image](https://user-images.githubusercontent.com/186521/71294536-ce0f1800-2346-11ea-84e0-74eca9811ad9.png)


