### PR TITLE
Restore loading animation for study summary fetch on results page

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -525,50 +525,53 @@ export default class ResultsViewPage extends React.Component<
                             />
                         </div>
                     )}
-                    {this.resultsViewPageStore.studies.isComplete && (
-                        <Helmet>
-                            <title>
-                                {buildResultsViewPageTitle(
-                                    this.resultsViewPageStore.hugoGeneSymbols,
-                                    this.resultsViewPageStore.studies.result
-                                )}
-                            </title>
-                        </Helmet>
+                    {this.resultsViewPageStore.studies.isPending && (
+                        <LoadingIndicator isLoading={true} center={true} size={"big"}></LoadingIndicator>
                     )}
                     {this.resultsViewPageStore.studies.isComplete && (
-                        <div>
-                            <div className={'headBlock'}>
-                                <QuerySummary
-                                    routingStore={this.props.routing}
-                                    store={this.resultsViewPageStore}
-                                    onToggleQueryFormVisiblity={visible => {
-                                        this.showTabs = visible;
-                                    }}
-                                />
-                            </div>
+                        <>
+                            <Helmet>
+                                <title>
+                                    {buildResultsViewPageTitle(
+                                        this.resultsViewPageStore.hugoGeneSymbols,
+                                        this.resultsViewPageStore.studies.result
+                                    )}
+                                </title>
+                            </Helmet>
+                            <div>
+                                <div className={'headBlock'}>
+                                    <QuerySummary
+                                        routingStore={this.props.routing}
+                                        store={this.resultsViewPageStore}
+                                        onToggleQueryFormVisiblity={visible => {
+                                            this.showTabs = visible;
+                                        }}
+                                    />
+                                </div>
 
-                            {// we don't show the result tabs if we don't have valid query
-                            this.showTabs &&
-                                !this.resultsViewPageStore.genesInvalid &&
-                                !this.resultsViewPageStore.isQueryInvalid && (
-                                    <MSKTabs
-                                        key={
-                                            this.urlWrapper.hash
-                                        }
-                                        activeTabId={
-                                            this.resultsViewPageStore.tabId
-                                        }
-                                        unmountOnHide={false}
-                                        onTabClick={(id: string) =>
-                                            this.handleTabChange(id)
-                                        }
-                                        className="mainTabs"
-                                        getTabHref={this.getTabHref}
-                                    >
-                                        {this.tabs}
-                                    </MSKTabs>
-                                )}
-                        </div>
+                                {// we don't show the result tabs if we don't have valid query
+                                this.showTabs &&
+                                    !this.resultsViewPageStore.genesInvalid &&
+                                    !this.resultsViewPageStore.isQueryInvalid && (
+                                        <MSKTabs
+                                            key={
+                                                this.urlWrapper.hash
+                                            }
+                                            activeTabId={
+                                                this.resultsViewPageStore.tabId
+                                            }
+                                            unmountOnHide={false}
+                                            onTabClick={(id: string) =>
+                                                this.handleTabChange(id)
+                                            }
+                                            className="mainTabs"
+                                            getTabHref={this.getTabHref}
+                                        >
+                                            {this.tabs}
+                                        </MSKTabs>
+                                    )}
+                            </div>
+                        </>
                     )}
                 </>
             );


### PR DESCRIPTION
At some point the loading animation was lost for load of study summary data on results page.  We should show animation. 