### PR TITLE
add wait time in e2e script

### DIFF
--- a/end-to-end-test/remote/specs/core/oncoprint.spec.js
+++ b/end-to-end-test/remote/specs/core/oncoprint.spec.js
@@ -145,6 +145,9 @@ describe('oncoprint', function() {
             browser.click(mrnaElements.dropdown_selector + ' li:nth-child(1)'); // Click Cluster
             browser.pause(500); // give it time to sort
 
+            // wait for page to refresh
+            waitForOncoprint(ONCOPRINT_TIMEOUT);
+
             // Open menu again, which will have closed
             browser.click(mrnaElements.button_selector);
             browser.waitForVisible(mrnaElements.dropdown_selector, 1000); // wait for menu to appear


### PR DESCRIPTION
There is one [e2e test](https://circleci.com/gh/cBioPortal/cbioportal-frontend/58237?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) easily fail when run the tests, because after we clicked the `cluster` button, the page will refresh again. Should wait for oncoprint to showup before clicking the button.
