### PR TITLE
Fix env_vars bool checks

### DIFF
--- a/scripts/env_vars.sh
+++ b/scripts/env_vars.sh
@@ -4,11 +4,11 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 RED='\033[0;31m'
 NC='\033[0m'
 
-if [[ "$CIRCLECI" ]]; then
+if [[ "$CIRCLECI" = true ]]; then
     PR_BRANCH=$CIRCLE_BRANCH
     PR_NUMBER=$CIRCLE_PR_NUMBER
     PR_URL=$CIRCLE_PULL_REQUEST
-elif [[ "$NETLIFY" ]]; then
+elif [[ "$NETLIFY" = true ]]; then
     PR_BRANCH=$BRANCH
     PR_NUMBER=$REVIEW_ID
     if [[ "$PULL_REQUEST" = true ]]; then
@@ -16,7 +16,7 @@ elif [[ "$NETLIFY" ]]; then
     fi
 fi
 
-if [[ "$CIRCLECI" ]] || [[ "$NETLIFY" ]]; then
+if [[ "$CIRCLECI" = true ]] || [[ "$NETLIFY" = true ]]; then
     # on circle ci determine env variables based on branch or in case of PR
     # what branch the PR is pointing to
     if [[ "$PR_NUMBER" ]] && ! [[ $PR_BRANCH == "release-"* ]]; then

--- a/scripts/env_vars.sh
+++ b/scripts/env_vars.sh
@@ -19,9 +19,9 @@ fi
 if [[ "$CIRCLECI" = true ]] || [[ "$NETLIFY" = true ]]; then
     # on circle ci determine env variables based on branch or in case of PR
     # what branch the PR is pointing to
-    if [[ "$PR_NUMBER" ]] && ! [[ $PR_BRANCH == "release-"* ]] && ! [[ $PR_BRANCH == "master" ]] && ! [[ $PR_BRANCH == "rc" ]]; then
+    if [[ "$PR_NUMBER" ]] && ! [[ $PR_BRANCH == "release-"* ]]; then
         BRANCH=$(curl "https://github.com/cBioPortal/cbioportal-frontend/pull/${PR_NUMBER}" | grep -oE 'title="cBioPortal/cbioportal-frontend:[^"]*' | cut -d: -f2 | head -1)
-    elif [[ "$PR_URL" ]] && ! [[ $PR_BRANCH == "release-"* ]]  && ! [[ $PR_BRANCH == "master" ]] && ! [[ $PR_BRANCH == "rc" ]]; then
+    elif [[ "$PR_URL" ]] && ! [[ $PR_BRANCH == "release-"* ]]; then
         BRANCH=$(curl "${PR_URL}" | grep -oE 'title="cBioPortal/cbioportal-frontend:[^"]*' | cut -d: -f2 | head -1)
     else
         BRANCH=$PR_BRANCH

--- a/scripts/env_vars.sh
+++ b/scripts/env_vars.sh
@@ -19,9 +19,9 @@ fi
 if [[ "$CIRCLECI" = true ]] || [[ "$NETLIFY" = true ]]; then
     # on circle ci determine env variables based on branch or in case of PR
     # what branch the PR is pointing to
-    if [[ "$PR_NUMBER" ]] && ! [[ $PR_BRANCH == "release-"* ]]; then
+    if [[ "$PR_NUMBER" ]] && ! [[ $PR_BRANCH == "release-"* ]] && ! [[ $PR_BRANCH == "master" ]] && ! [[ $PR_BRANCH == "rc" ]]; then
         BRANCH=$(curl "https://github.com/cBioPortal/cbioportal-frontend/pull/${PR_NUMBER}" | grep -oE 'title="cBioPortal/cbioportal-frontend:[^"]*' | cut -d: -f2 | head -1)
-    elif [[ "$PR_URL" ]] && ! [[ $PR_BRANCH == "release-"* ]]; then
+    elif [[ "$PR_URL" ]] && ! [[ $PR_BRANCH == "release-"* ]]  && ! [[ $PR_BRANCH == "master" ]] && ! [[ $PR_BRANCH == "rc" ]]; then
         BRANCH=$(curl "${PR_URL}" | grep -oE 'title="cBioPortal/cbioportal-frontend:[^"]*' | cut -d: -f2 | head -1)
     else
         BRANCH=$PR_BRANCH


### PR DESCRIPTION
Change all bash bool variable checks in the env_var script. This fixes an issue for setting the BRANCH variable when running localdb e2e test on master or release branches in backend repo.