### PR TITLE
Set width as 100% of clinical cretieria container when the trial is matc…

### DIFF
--- a/src/pages/patientView/trialMatch/TrialMatchTable.tsx
+++ b/src/pages/patientView/trialMatch/TrialMatchTable.tsx
@@ -96,10 +96,12 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                                 <div>
                                     {armMatch.matches.map((clinicalGroupMatch: IClinicalGroupMatch, cgIndex:number) => (
                                         <div className={styles.criteriaContainer}>
-                                            <div className={styles.firstLeft}>
-                                                {clinicalGroupMatch.matches && this.getGenomicMatch(clinicalGroupMatch.matches)}
-                                                {clinicalGroupMatch.notMatches && this.getGenomicNotMatch(clinicalGroupMatch.notMatches)}
-                                            </div>
+                                            <If condition={clinicalGroupMatch.matches || clinicalGroupMatch.notMatches}>
+                                                <div className={styles.firstLeft}>
+                                                    {clinicalGroupMatch.matches && this.getGenomicMatch(clinicalGroupMatch.matches)}
+                                                    {clinicalGroupMatch.notMatches && this.getGenomicNotMatch(clinicalGroupMatch.notMatches)}
+                                                </div>
+                                            </If>
                                             {this.getClinicalMatch(clinicalGroupMatch)}
                                             <If condition={cgIndex < armMatch.matches.length - 1}><hr className={styles.criteriaHr}/></If>
                                         </div>
@@ -163,7 +165,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
 
     public getClinicalMatch(clinicalGroupMatch: IClinicalGroupMatch) {
         return (
-            <div className={styles.firstRight}>
+            <div className={styles.firstRight} style={(clinicalGroupMatch.matches || clinicalGroupMatch.notMatches) ? {} : {width: "100%"}}>
                 <span className={styles.secondLeft}>{getAgeRangeDisplay(clinicalGroupMatch.trialAgeNumerical)}</span>
                 <span className={styles.secondRight}>
                     {clinicalGroupMatch.trialOncotreePrimaryDiagnosis.positive.join(', ')}

--- a/src/pages/patientView/trialMatch/TrialMatchTableUtils.ts
+++ b/src/pages/patientView/trialMatch/TrialMatchTableUtils.ts
@@ -69,10 +69,10 @@ export function groupTrialMatchesByAgeNumerical(armGroup: ITrialMatch[]): IClini
             }
         };
         const positiveTrialMatches = _.filter(matchesGroupedByAge[age], (trialMatch:ITrialMatch) => {
-            if (!_.isUndefined(trialMatch.genomicAlteration)) return !trialMatch.genomicAlteration.includes('!')
+            if (!_.isUndefined(trialMatch.genomicAlteration) && trialMatch.genomicAlteration !== '') return !trialMatch.genomicAlteration.includes('!')
         });
         const negativeTrialMatches = _.filter(matchesGroupedByAge[age], (trialMatch:ITrialMatch) => {
-            if (!_.isUndefined(trialMatch.genomicAlteration)) return trialMatch.genomicAlteration.includes('!')
+            if (!_.isUndefined(trialMatch.genomicAlteration) && trialMatch.genomicAlteration !== '') return trialMatch.genomicAlteration.includes('!')
         });
         if (positiveTrialMatches.length > 0) {
             clinicalGroupMatch.matches = groupPositiveTrialMatchesByMatchType(positiveTrialMatches);

--- a/src/pages/patientView/trialMatch/style/trialMatch.module.scss
+++ b/src/pages/patientView/trialMatch/style/trialMatch.module.scss
@@ -64,7 +64,7 @@
   .firstRight{
     display:flex;
     flex: 0 0 auto;
-    width: 300px;
+    width: 50%;
     justify-content: space-between;
 
     .secondLeft {


### PR DESCRIPTION
Fix https://github.com/oncokb/oncokb/issues/1891

Most trials are matched based on both clinical and genomic criteria. However, some of them can be matched only by clinical criteria. I changed the width to 100% instead of 50%  for that case.

<img width="635" alt="Screen Shot 2020-01-10 at 4 38 16 PM" src="https://user-images.githubusercontent.com/14971266/72188319-0777f800-33c8-11ea-95b5-313393108b17.png">
