### PR TITLE
Impl. download of OAuth2/OpenID Connect DAT tokens (triggered by backend)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:watch": "yarn run test -- --watch",
     "test:debug": "yarn run test -- --debug --browsers=Chrome_with_debugging --single-run=false",
     "prettierFixCurrentChanges": "STAGED_AND_CHANGED_FILES=$(git diff HEAD --name-only --cached --diff-filter=d) && ([ -z \"$STAGED_AND_CHANGED_FILES\" ] && echo \"Nothing to prettify\" || (yarn run prettier --write $(echo $STAGED_AND_CHANGED_FILES) && git add -f $(echo $STAGED_AND_CHANGED_FILES)))",
-    "prettierCheckCircleCI": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && CHANGED_FILES=$(git diff origin/$(echo $BRANCH_ENV) --name-only --diff-filter=d) && [ ! -z \"$CHANGED_FILES\" ] && yarn run prettier -c $(echo $CHANGED_FILES)",
+    "prettierCheckCircleCI": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && git remote add cbio-repo https://github.com/cBioPortal/cbioportal-frontend.git && git fetch cbio-repo $(echo $BRANCH_ENV) && CHANGED_FILES=$(git diff cbio-repo/$(echo $BRANCH_ENV) --name-only --diff-filter=d) && [ ! -z \"$CHANGED_FILES\" ] && yarn run prettier -c $(echo $CHANGED_FILES) && git remote remove cbio-repo",
     "prettierFixLocal": "CHANGED_FILES=$(git diff $(echo $BRANCH_ENV) --name-only --diff-filter=d) && ([ ! -z \"$CHANGED_FILES\" ] && yarn run prettier --write $(echo $CHANGED_FILES) || echo \"Nothing to prettify\")",
     "prettierAll": "yarn run prettier --write $(git ls-files | grep '\\(.js\\|.ts\\|.scss\\|.css\\)')",
     "checkIncorrectImportStatements": "./scripts/check_incorrect_import_statements.sh",

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -3,7 +3,6 @@ import { IServerConfig } from './IAppConfig';
 const ServerConfigDefaults: Partial<IServerConfig> = {
     app_version: '1.0',
     api_cache_limit: 450,
-    dat_uuid_revoke_other_tokens: true,
     dat_method: 'none',
     disabled_tabs: '',
     genomenexus_url: 'https://v1.genomenexus.org',

--- a/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
+++ b/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
@@ -75,7 +75,8 @@ export class DataAccessTokensDropdown extends React.Component<
                     AppConfig.serverConfig.authenticationMethod ===
                         'social_auth' ||
                     (AppConfig.serverConfig.dat_method !== 'uuid' &&
-                        AppConfig.serverConfig.dat_method !== 'jwt'),
+                        AppConfig.serverConfig.dat_method !== 'jwt' &&
+                        AppConfig.serverConfig.dat_method !== 'oauth2'),
             },
         ];
         const shownListItems = listItems.filter(l => {


### PR DESCRIPTION
# Background
cBioPortal provides tokens, also referred to as Data Access Tokens or DATs, that allow programmatic access the cBioPortal API. These tokens, as well as user permissions, are managed by the cBioPortal instance.

# Problem
cBioPortal can be configured to use an external Identity Provider (IDP), such as Keycloak, that handles user authentication and user authorization. This setup is not supported by current DAT implementation.

# Solution
We have extended the frontend so that cBioPortal can provide an OpenID Connect _offline token_ (=OAuth2 refresh token with scope _offline_access_) to the user. Responsibility for triggering the download of all token types (JWT/UUID/OAuth2) has been moved to the cBioPortal backend (is handled by the frontend at present).

# Details
- The backend handles the download because for OpenID Connect this involves communication in the _back channel_ between cBioPortal backend and the Identity Provider (IDP).