### PR TITLE
Use SAMPLE_ACQUISITION track for sample order

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -306,7 +306,10 @@ export default class PatientViewPage extends React.Component<IPatientViewPagePro
             studyName = <StudyLink studyId={study.studyId}>{study.name}</StudyLink>;
         }
 
-        if (this.patientViewPageStore.patientViewData.isComplete && this.patientViewPageStore.studyMetaData.isComplete && sampleManager !== null) {
+        if (this.patientViewPageStore.patientViewData.isComplete &&
+            this.patientViewPageStore.studyMetaData.isComplete &&
+            this.patientViewPageStore.clinicalEvents.isComplete &&
+            sampleManager !== null) {
 
             sampleHeader = _.map(sampleManager!.samples, (sample: ClinicalDataBySampleId) => {
                 const isPDX:boolean = (sampleManager &&

--- a/src/pages/patientView/SampleManager.tsx
+++ b/src/pages/patientView/SampleManager.tsx
@@ -25,7 +25,12 @@ export function sortSamples(samples: Array<ClinicalDataBySampleId>,
     // based on sample collection data (timeline event)
     let collectionDayMap: {[s:string]:number} = {};
     if (events) {
-        const specimenEvents = events.filter((e: ClinicalEvent) => (e.eventType === 'SPECIMEN'));
+        // use SPECIMEN or SAMPLE_ACQUISITION track on timeline to get timeline
+        // event
+        // TODO: SAMPLE_ACQUISITION is specific to genie_bpc_test study. We
+        // should probably have some config to allow people to choose what
+        // timeline tracks get labels
+        const specimenEvents = events.filter((e: ClinicalEvent) => (e.eventType === 'SPECIMEN' || 'SAMPLE_ACQUISITION'));
 
         collectionDayMap = specimenEvents.reduce((map:{[s:string]:number}, specimenEvent: ClinicalEvent) => {
             let sampleAttr = _.find(specimenEvent.attributes, (attr: ClinicalEventData) => {


### PR DESCRIPTION
This is part of prototype for the GENIE BPC study. Order the labels of
the samples on the patient view by whatever the order is in the
SAMPLE_ACQUISITION track. Wait for timeline events, such that the sample
labels aren't shown before they are properly calculated using the
timeline event info.

Related to https://github.com/cBioPortal/cbioportal/issues/6982