### PR TITLE
[react-mutation-mapper] display error message when no transcript available

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "react-markdown": "^3.4.1",
     "react-mfb": "^0.6.0",
     "react-motion": "^0.4.7",
-    "react-mutation-mapper": "^0.4.2",
+    "react-mutation-mapper": "^0.4.3",
     "react-overlays": "0.7.4",
     "react-portal": "^4.2.0",
     "react-rangeslider": "^2.1.0",

--- a/packages/react-mutation-mapper/package.json
+++ b/packages/react-mutation-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mutation-mapper",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Generic Mutation Mapper",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -562,7 +562,12 @@ export default class LollipopMutationPlot extends React.Component<LollipopMutati
                     />
                 </div>
             );
-        } else {
+        }
+        else if (this.props.store.canonicalTranscript.isComplete &&
+            this.props.store.canonicalTranscript.result === undefined) {
+            return <span><i className="fa fa-exclamation-triangle text-danger"/> No Transcript found for {this.hugoGeneSymbol}</span>;
+        }
+        else {
             return this.props.loadingIndicator || <i className="fa fa-spinner fa-pulse fa-2x" />;
         }
     }


### PR DESCRIPTION
Related to cBioPortal/cbioportal/issues/1378

For a proper fix, we need to make sure that we have at least one transcript for every hugo symbol.

![no_transcript_found](https://user-images.githubusercontent.com/3604198/72577035-52e64680-389f-11ea-9cdd-f1901d374aa0.png)


# Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!