### PR TITLE
Add quick oql edit feature to results view page next to current gene list

### DIFF
--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -23,13 +23,20 @@ import ResultsPageSettings from "../settings/ResultsPageSettings";
 import {createQueryStore} from "shared/lib/createQueryStore";
 import _ from "lodash";
 
+interface QuerySummaryProps {
+    routingStore:ExtendedRouterStore;
+    store: ResultsViewPageStore;
+    onToggleQueryFormVisibility:(visible:boolean)=>void;
+    onToggleOQLEditUIVisibility:()=>void;
+}
+
 @observer
-export default class QuerySummary extends React.Component<{ routingStore:ExtendedRouterStore, store: ResultsViewPageStore, onToggleQueryFormVisiblity:(visible:boolean)=>void }, {}> {
+export default class QuerySummary extends React.Component<QuerySummaryProps, {}> {
 
     @autobind
     @action
     private toggleQueryFormVisibility() {
-        this.props.onToggleQueryFormVisiblity(this.props.store.queryFormVisible);
+        this.props.onToggleQueryFormVisibility(this.props.store.queryFormVisible);
         // if clicked the query button in the download tab and want to close the query form, clear the selected sample ids
         if (this.props.store.modifyQueryParams && this.props.store.queryFormVisible === true) {
             this.props.store.modifyQueryParams = undefined;
@@ -80,6 +87,12 @@ export default class QuerySummary extends React.Component<{ routingStore:Extende
 
                     &nbsp;-&nbsp;
                     {getGeneSummary(this.props.store.hugoGeneSymbols)}
+                    &nbsp;
+                    <DefaultTooltip overlay={'Edit genes or OQL'}>
+                        <a onClick={this.props.onToggleOQLEditUIVisibility}>
+                            <i className={'fa fa-pencil'}></i>
+                        </a>
+                    </DefaultTooltip>
                 </div>
             );
         }

--- a/src/pages/resultsView/styles.scss
+++ b/src/pages/resultsView/styles.scss
@@ -125,3 +125,14 @@
     width: 100%;
     max-width: 555px;
 }
+
+.quick_oql_edit {
+    display:flex;
+    margin-top:10px;
+    align-items: flex-start;
+
+    .oqlValidationContainer {
+        min-height:27px;
+    }
+
+}

--- a/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
+++ b/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
@@ -30,6 +30,7 @@ export interface IGeneSelectionBoxProps {
     validateInputGeneQuery?: boolean;
     location?: GeneBoxType;
     textBoxPrompt?: string;
+    submitButton?:JSX.Element;
     callback?: (
         oql: {
             query: SingleGeneQuery[];
@@ -264,7 +265,7 @@ export default class OQLTextArea extends React.Component<
     render() {
         return (
             <div className={styles.genesSelection}>
-
+                <div className={styles.topRow}>
                 <textarea
                     ref={this.textAreaRef as any}
                     onFocus={this.onFocus}
@@ -279,7 +280,11 @@ export default class OQLTextArea extends React.Component<
                     data-test="geneSet"
                 />
 
-                <div className={classnames({ [styles.minWidthContainer]: (this.props.location === GeneBoxType.DEFAULT) })}>
+                {
+                    (this.props.submitButton) && this.props.submitButton
+                }
+                </div>
+                <div className={'oqlValidationContainer'}>
                 <GeneSymbolValidator
                     focus={this.props.focus}
                     geneQuery={this.queryToBeValidated}

--- a/src/shared/components/GeneSelectionBox/styles.module.scss
+++ b/src/shared/components/GeneSelectionBox/styles.module.scss
@@ -2,13 +2,18 @@
 	margin: 0px 5px 3px 0;
 	padding: 2px 5px;
 	border-radius: $border-radius-base;
+	font-size:.8rem;
 }
 
-.minWidthContainer {
-	min-height:25px;
+.topRow {
+	display:flex;
+	align-items: flex-start;
+	margin-bottom:5px;
 }
+
 
 .genesSelection {
+
 	textarea.default {
 		width: 555px;
 		resize: vertical;

--- a/src/shared/components/query/styles/styles.module.scss
+++ b/src/shared/components/query/styles/styles.module.scss
@@ -368,6 +368,10 @@ div.SelectedStudiesWindow {
         margin-bottom: 8px;
     }
 
+    :global(.oqlValidationContainer) {
+        min-height:27px;
+    }
+
     .buttonRow {
         margin-bottom: 8px;
         justify-content: space-between;


### PR DESCRIPTION
Add a pencil button near gene list in results page which opens interface for quickly modifying the oql of the query.

![image](https://user-images.githubusercontent.com/186521/72630145-b617bd80-391f-11ea-85c1-5211b8dd5087.png)
