### PR TITLE
Change footer version logic

### DIFF
--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -78,8 +78,24 @@ export class AppStore {
         invoke:async()=>{
             const portalVersionResult = await internalClient.getInfoUsingGET({});
             if (portalVersionResult && portalVersionResult.portalVersion) {
-                let version = portalVersionResult.portalVersion.split('-')[0];
-                if (!version.startsWith("v")) {
+                let version = undefined;
+
+                // try getting version from branch name assume like release-x.y.z
+                if (portalVersionResult.gitBranch && portalVersionResult.gitBranch.startsWith("release-")) {
+                    let branchVersion = portalVersionResult.gitBranch.split('-')[1];
+                    if (branchVersion.split('.').length == 3) {
+                        version = branchVersion;
+                    }
+                }
+
+                // if branch name does not contain version name, use
+                // portalVersion
+                if (version === undefined) {
+                    version = portalVersionResult.portalVersion.split('-')[0];
+                }
+
+                // add v prefix if missing
+                if (version !== undefined && !version.startsWith("v")) {
                     version = `v${version}`;
                 }
                 return Promise.resolve(version);


### PR DESCRIPTION
Use x.y.z if the branch name is like release-x.y.z, otherwise use
portalVersion (same as latest tag). This avoids having to tag the release (or using `PROJECT_VERSION` env variable) to set the footer version. Instead it assumes that when one is building from the `release-x.y.z` branch, that the version is closer to `x.y.z` than the latest tag.