### PR TITLE
Update circleci build cache key to take packages folder into account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       # key. If there are no changes to src/ and yarn.lock, no need to rebuild
       - run:
           name: "Concatenate all source files to use as hash key for caching dist folder"
-          command: "cat yarn.lock $(find src/ -type f | sort) webpack.config.js vendor-bundles.webpack.config.js > has_source_changed"
+          command: "cat yarn.lock $(find src/ -type f | sort) $(find packages/ -type f | sort) webpack.config.js vendor-bundles.webpack.config.js > has_source_changed"
       - restore_cache:
           keys:
           - v2-dependencies-plus-dist-{{ checksum "has_source_changed" }}


### PR DESCRIPTION
With monorepo we know have src files in /packages folder in addition to /src.  We need to take these into account when generating cache key in circleCI to ensure that it evicts cache appropriately