### PR TITLE
On circleCI do not run buildModules twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,6 @@ jobs:
           - v2-dependencies-{{ checksum "yarn.lock" }}
       # Download and cache dependencies
       - run: yarn
-      - run: yarn buildModules
       - run:
           name: "Make sure lock file is still the same"
           command: 'git diff --exit-code yarn.lock > /dev/null || (echo -e "New package lock file at $(cat yarn.lock | curl -F c=@- https://ptpb.pw | grep url) (include this file in your PR to fix this test)"; git diff --exit-code yarn.lock; exit 1)'


### PR DESCRIPTION
We already run `yarn build` which includes `buildModules`