### PR TITLE
Temporary fix for private portal consumption of oncokb

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -154,20 +154,22 @@ export function getProxyUrlIfNecessary(url:any) {
 }
 
 export function getOncoKbApiUrl() {
-
-    // if (AppConfig.serverConfig.oncoKbTokenDefined) {
-    //     return buildCBioPortalAPIUrl(`proxy/oncokb`);
-    // }
+    // temporary fix uses the public portals proxy for all
+    // instances that define a token (will only be internal)
+    if (AppConfig.serverConfig.oncoKbTokenDefined) {
+        //return buildCBioPortalAPIUrl(`proxy/oncokb`);
+        return "https://www.cbioportal.org/proxy/oncokb";
+    }
     // TODO workaround for temporary backward compatibility
     //  remove this after documenting OncoKB token for all portal instances
-    //else {
+    else {
         let url = AppConfig.serverConfig.oncokb_public_api_url;
         if (typeof url === 'string') {
             return buildCBioPortalAPIUrl(`proxy/${trimProtocol(url)}`);
         } else {
             return undefined;
         }
-    //}
+    }
 }
 
 export function getGenomeNexusApiUrl() {


### PR DESCRIPTION
Temporary fix while we work out issues with proxy on private instances (probably apache related)