### PR TITLE
Add separate genome nexus cache for mutation assessor

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -958,6 +958,11 @@ export default class PatientViewPage extends React.Component<
                                                             .patientViewPageStore
                                                             .genomeNexusCache
                                                     }
+                                                    genomeNexusMutationAssessorCache={
+                                                        this
+                                                            .patientViewPageStore
+                                                            .genomeNexusMutationAssessorCache
+                                                    }
                                                     genomeNexusMyVariantInfoCache={
                                                         this
                                                             .patientViewPageStore

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -31,6 +31,7 @@ import {
 import OncoKbEvidenceCache from 'shared/cache/OncoKbEvidenceCache';
 import PubMedCache from 'shared/cache/PubMedCache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';
+import GenomeNexusMutationAssessorCache from 'shared/cache/GenomeNexusMutationAssessorCache';
 import GenomeNexusMyVariantInfoCache from 'shared/cache/GenomeNexusMyVariantInfoCache';
 import { IOncoKbData } from 'shared/model/OncoKB';
 import { IHotspotIndex, indexHotspotsData } from 'react-mutation-mapper';
@@ -1389,6 +1390,10 @@ export class PatientViewPageStore {
 
     @cached get genomeNexusMyVariantInfoCache() {
         return new GenomeNexusMyVariantInfoCache();
+    }
+
+    @cached get genomeNexusMutationAssessorCache() {
+        return new GenomeNexusMutationAssessorCache();
     }
 
     @cached get pubMedCache() {

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -42,6 +42,7 @@ import { cached, labelMobxPromises, MobxPromise } from 'mobxpromise';
 import OncoKbEvidenceCache from 'shared/cache/OncoKbEvidenceCache';
 import PubMedCache from 'shared/cache/PubMedCache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';
+import GenomeNexusMutationAssessorCache from 'shared/cache/GenomeNexusMutationAssessorCache';
 import GenomeNexusMyVariantInfoCache from 'shared/cache/GenomeNexusMyVariantInfoCache';
 import CancerTypeCache from 'shared/cache/CancerTypeCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
@@ -2958,6 +2959,7 @@ export class ResultsViewPageStore {
                                         ] || [],
                                     () => this.mutationCountCache,
                                     () => this.genomeNexusCache,
+                                    () => this.genomeNexusMutationAssessorCache,
                                     () => this.genomeNexusMyVariantInfoCache,
                                     () => this.discreteCNACache,
                                     this.studyToMolecularProfileDiscrete.result!,
@@ -4868,6 +4870,10 @@ export class ResultsViewPageStore {
      */
     @cached get genomeNexusCache() {
         return new GenomeNexusCache();
+    }
+
+    @cached get genomeNexusMutationAssessorCache() {
+        return new GenomeNexusMutationAssessorCache();
     }
 
     @cached get genomeNexusMyVariantInfoCache() {

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -152,6 +152,10 @@ export default class Mutations extends React.Component<
                                 this.props.store.mutationCountCache
                             }
                             genomeNexusCache={this.props.store.genomeNexusCache}
+                            genomeNexusMutationAssessorCache={
+                                this.props.store
+                                    .genomeNexusMutationAssessorCache
+                            }
                             genomeNexusMyVariantInfoCache={
                                 this.props.store.genomeNexusMyVariantInfoCache
                             }

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -113,6 +113,9 @@ export default class ResultsViewMutationMapper extends MutationMapper<
                 pubMedCache={this.props.pubMedCache}
                 mutationCountCache={this.props.mutationCountCache}
                 genomeNexusCache={this.props.genomeNexusCache}
+                genomeNexusMutationAssessorCache={
+                    this.props.genomeNexusMutationAssessorCache
+                }
                 genomeNexusMyVariantInfoCache={
                     this.props.genomeNexusMyVariantInfoCache
                 }

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
@@ -23,6 +23,7 @@ import {
 import MutationCountCache from 'shared/cache/MutationCountCache';
 import DiscreteCNACache from 'shared/cache/DiscreteCNACache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';
+import GenomeNexusMutationAssessorCache from 'shared/cache/GenomeNexusMutationAssessorCache';
 import GenomeNexusMyVariantInfoCache from 'shared/cache/GenomeNexusMyVariantInfoCache';
 import { MutationTableDownloadDataFetcher } from 'shared/lib/MutationTableDownloadDataFetcher';
 import MutationMapperStore, {
@@ -47,6 +48,7 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
         getMutations: () => Mutation[],
         private getMutationCountCache: () => MutationCountCache,
         private getGenomeNexusCache: () => GenomeNexusCache,
+        private getGenomeNexusMutationAssessorCache: () => GenomeNexusMutationAssessorCache,
         private getGenomeNexusMyVariantInfoCache: () => GenomeNexusMyVariantInfoCache,
         private getDiscreteCNACache: () => DiscreteCNACache,
         public studyToMolecularProfileDiscrete: {
@@ -132,6 +134,7 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
             this.mutationData,
             this.studyToMolecularProfileDiscrete,
             this.getGenomeNexusCache,
+            this.getGenomeNexusMutationAssessorCache,
             this.getGenomeNexusMyVariantInfoCache,
             this.getMutationCountCache,
             this.getDiscreteCNACache

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
@@ -469,6 +469,9 @@ export default class MutationMapperTool extends React.Component<
                             }
                             downloadDataFetcher={this.store.downloadDataFetcher}
                             genomeNexusCache={this.store.genomeNexusCache}
+                            genomeNexusMutationAssessorCache={
+                                this.store.genomeNexusMutationAssessorCache
+                            }
                             genomeNexusMyVariantInfoCache={
                                 this.store.genomeNexusMyVariantInfoCache
                             }

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -42,6 +42,7 @@ import { fetchHotspotsData } from 'shared/lib/CancerHotspotsUtils';
 import OncoKbEvidenceCache from 'shared/cache/OncoKbEvidenceCache';
 import PubMedCache from 'shared/cache/PubMedCache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';
+import GenomeNexusMutationAssessorCache from 'shared/cache/GenomeNexusMutationAssessorCache';
 import GenomeNexusMyVariantInfoCache from 'shared/cache/GenomeNexusMyVariantInfoCache';
 import PdbHeaderCache from 'shared/cache/PdbHeaderCache';
 import MutationMapperStore from 'shared/components/mutationMapper/MutationMapperStore';
@@ -380,6 +381,10 @@ export default class MutationMapperToolStore {
         return new GenomeNexusCache();
     }
 
+    @cached get genomeNexusMutationAssessorCache() {
+        return new GenomeNexusMutationAssessorCache();
+    }
+
     @cached get genomeNexusMyVariantInfoCache() {
         return new GenomeNexusMyVariantInfoCache();
     }
@@ -397,6 +402,7 @@ export default class MutationMapperToolStore {
             this.mutations,
             undefined,
             () => this.genomeNexusCache,
+            () => this.genomeNexusMutationAssessorCache,
             () => this.genomeNexusMyVariantInfoCache
         );
     }

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
@@ -30,6 +30,9 @@ export default class StandaloneMutationMapper extends MutationMapper<
                     this.props.store.indexedVariantAnnotations
                 }
                 genomeNexusCache={this.props.genomeNexusCache}
+                genomeNexusMutationAssessorCache={
+                    this.props.genomeNexusMutationAssessorCache
+                }
                 genomeNexusMyVariantInfoCache={
                     this.props.genomeNexusMyVariantInfoCache
                 }

--- a/src/shared/cache/GenomeNexusMutationAssessorCache.ts
+++ b/src/shared/cache/GenomeNexusMutationAssessorCache.ts
@@ -1,12 +1,13 @@
+import * as _ from 'lodash';
 import { fetchVariantAnnotationsByMutation } from 'shared/lib/StoreUtils';
 import {
     extractGenomicLocation,
     genomicLocationString,
 } from 'shared/lib/MutationUtils';
-import { VariantAnnotation } from 'cbioportal-frontend-commons';
 import { Mutation } from 'shared/api/generated/CBioPortalAPI';
 import LazyMobXCache, { CacheData } from 'shared/lib/LazyMobXCache';
 import AppConfig from 'appConfig';
+import { VariantAnnotation } from 'cbioportal-frontend-commons';
 
 export type GenomeNexusCacheDataType = CacheData<VariantAnnotation>;
 
@@ -14,7 +15,7 @@ export function fetch(queries: Mutation[]): Promise<VariantAnnotation[]> {
     if (queries.length > 0) {
         return fetchVariantAnnotationsByMutation(
             queries,
-            ['annotation_summary'],
+            ['annotation_summary', 'mutation_assessor'],
             AppConfig.serverConfig.isoformOverrideSource
         );
     } else {
@@ -33,7 +34,7 @@ export function queryToKey(m: Mutation) {
     }
 }
 
-export default class GenomeNexusCache extends LazyMobXCache<
+export default class GenomeNexusMutationAssessorCache extends LazyMobXCache<
     VariantAnnotation,
     Mutation
 > {

--- a/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
+++ b/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
@@ -9,7 +9,7 @@ import {
 import mutationAssessorColumn from './styles/mutationAssessorColumn.module.scss';
 
 export interface IMutationAssessorProps {
-    mutationAssessor: MutationAssessorData;
+    mutationAssessor: MutationAssessorData | undefined;
 }
 
 export function hideArrow(tooltipEl: any) {
@@ -35,7 +35,7 @@ export default class MutationAssessor extends React.Component<
         if (mutationAssessorData) {
             return `impact: ${mutationAssessorData.functionalImpact}, score: ${mutationAssessorData.functionalImpactScore}`;
         } else {
-            return 'Error';
+            return 'NA';
         }
     }
 
@@ -78,102 +78,109 @@ export default class MutationAssessor extends React.Component<
     }
 
     private tooltipContent() {
-        const maData = this.props.mutationAssessor;
-        const xVarLink = MutationAssessor.maLink(
-            `http://mutationassessor.org/r3/?cm=var&p=${maData.uniprotId}&var=${maData.variant}`
-        );
-        const msaLink = MutationAssessor.maLink(maData.msaLink);
-        const pdbLink = MutationAssessor.maLink(maData.pdbLink);
+        if (this.props.mutationAssessor) {
+            const maData = this.props.mutationAssessor;
+            const xVarLink = MutationAssessor.maLink(
+                `http://mutationassessor.org/r3/?cm=var&p=${maData.uniprotId}&var=${maData.variant}`
+            );
+            const msaLink = MutationAssessor.maLink(maData.msaLink);
+            const pdbLink = MutationAssessor.maLink(maData.pdbLink);
 
-        const impact = maData.functionalImpact ? (
-            <div>
-                <table className={tooltipStyles['ma-tooltip-table']}>
-                    <tr>
-                        <td>Source</td>
-                        <td>
-                            <a href="http://mutationassessor.org/r3">
-                                MutationAssessor
-                            </a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Impact</td>
-                        <td>
-                            <span
-                                className={
-                                    mutationAssessorColumn[
-                                        `ma-${maData.functionalImpact}`
-                                    ]
-                                }
-                            >
-                                {maData.functionalImpact}
-                            </span>
-                        </td>
-                    </tr>
-                    {(maData.functionalImpactScore ||
-                        maData.functionalImpactScore === 0) && (
+            const impact = maData.functionalImpact ? (
+                <div>
+                    <table className={tooltipStyles['ma-tooltip-table']}>
                         <tr>
-                            <td>Score</td>
+                            <td>Source</td>
                             <td>
-                                <b>{maData.functionalImpactScore.toFixed(2)}</b>
+                                <a href="http://mutationassessor.org/r3">
+                                    MutationAssessor
+                                </a>
                             </td>
                         </tr>
-                    )}
-                </table>
-            </div>
-        ) : null;
+                        <tr>
+                            <td>Impact</td>
+                            <td>
+                                <span
+                                    className={
+                                        mutationAssessorColumn[
+                                            `ma-${maData.functionalImpact}`
+                                        ]
+                                    }
+                                >
+                                    {maData.functionalImpact}
+                                </span>
+                            </td>
+                        </tr>
+                        {(maData.functionalImpactScore ||
+                            maData.functionalImpactScore === 0) && (
+                            <tr>
+                                <td>Score</td>
+                                <td>
+                                    <b>
+                                        {maData.functionalImpactScore.toFixed(
+                                            2
+                                        )}
+                                    </b>
+                                </td>
+                            </tr>
+                        )}
+                    </table>
+                </div>
+            ) : null;
 
-        const xVar = xVarLink ? (
-            <div className={tooltipStyles['mutation-assessor-link']}>
-                <a href={xVarLink} target="_blank">
-                    <img
-                        height="15"
-                        width="19"
-                        src={require('./../../mutationTable/column/mutationAssessor.png')}
-                        className={tooltipStyles['mutation-assessor-main-img']}
-                        alt="Mutation Assessor"
-                    />
-                    Go to Mutation Assessor
-                </a>
-            </div>
-        ) : null;
+            const xVar = xVarLink ? (
+                <div className={tooltipStyles['mutation-assessor-link']}>
+                    <a href={xVarLink} target="_blank">
+                        <img
+                            height="15"
+                            width="19"
+                            src={require('./../../mutationTable/column/mutationAssessor.png')}
+                            className={
+                                tooltipStyles['mutation-assessor-main-img']
+                            }
+                            alt="Mutation Assessor"
+                        />
+                        Go to Mutation Assessor
+                    </a>
+                </div>
+            ) : null;
 
-        const msa = msaLink ? (
-            <div className={tooltipStyles['mutation-assessor-link']}>
-                <a href={msaLink} target="_blank">
-                    <span
-                        className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-msa-icon']}`}
-                    >
-                        msa
-                    </span>
-                    Multiple Sequence Alignment
-                </a>
-            </div>
-        ) : null;
+            const msa = msaLink ? (
+                <div className={tooltipStyles['mutation-assessor-link']}>
+                    <a href={msaLink} target="_blank">
+                        <span
+                            className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-msa-icon']}`}
+                        >
+                            msa
+                        </span>
+                        Multiple Sequence Alignment
+                    </a>
+                </div>
+            ) : null;
 
-        const pdb = pdbLink ? (
-            <div className={tooltipStyles['mutation-assessor-link']}>
-                <a href={pdbLink} target="_blank">
-                    <span
-                        className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-3d-icon']}`}
-                    >
-                        3D
-                    </span>
-                    Mutation Assessor 3D View
-                </a>
-            </div>
-        ) : null;
+            const pdb = pdbLink ? (
+                <div className={tooltipStyles['mutation-assessor-link']}>
+                    <a href={pdbLink} target="_blank">
+                        <span
+                            className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-3d-icon']}`}
+                        >
+                            3D
+                        </span>
+                        Mutation Assessor 3D View
+                    </a>
+                </div>
+            ) : null;
 
-        return (
-            <span>
-                {impact}
-                {msa}
-                {pdb}
-                {xVar}
-            </span>
-        );
+            return (
+                <span>
+                    {impact}
+                    {msa}
+                    {pdb}
+                    {xVar}
+                </span>
+            );
+        }
     }
-
     // This is mostly to make the legacy MA links work
     public static maLink(link: string | undefined) {
         let url = null;

--- a/src/shared/components/annotation/genomeNexus/PolyPhen2.tsx
+++ b/src/shared/components/annotation/genomeNexus/PolyPhen2.tsx
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 import tooltipStyles from './styles/polyPhen2Tooltip.module.scss';
 
 export interface IPolyPhen2Props {
-    polyPhenPrediction: string; // benign, possibly_damaging, probably_damging
-    polyPhenScore: number;
+    polyPhenPrediction: string | undefined; // benign, possibly_damaging, probably_damging
+    polyPhenScore: number | undefined;
 }
 
 export function hideArrow(tooltipEl: any) {
@@ -23,10 +23,14 @@ export default class PolyPhen2 extends React.Component<IPolyPhen2Props, {}> {
     }
 
     public static download(
-        polyPhenScore: number,
-        polyPhenPrediction: string
+        polyPhenScore: number | undefined,
+        polyPhenPrediction: string | undefined
     ): string {
-        return `impact: ${polyPhenPrediction}, score: ${polyPhenScore}`;
+        if (polyPhenScore || polyPhenPrediction) {
+            return `impact: ${polyPhenPrediction}, score: ${polyPhenScore}`;
+        } else {
+            return 'NA';
+        }
     }
 
     public render() {

--- a/src/shared/components/annotation/genomeNexus/Sift.tsx
+++ b/src/shared/components/annotation/genomeNexus/Sift.tsx
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 import tooltipStyles from './styles/siftTooltip.module.scss';
 
 export interface ISiftProps {
-    siftPrediction: string; // deleterious, deleterious_low_confidence, tolerated, tolerated_low_confidence
-    siftScore: number;
+    siftPrediction: string | undefined; // deleterious, deleterious_low_confidence, tolerated, tolerated_low_confidence
+    siftScore: number | undefined;
 }
 
 export function hideArrow(tooltipEl: any) {
@@ -22,8 +22,15 @@ export default class Sift extends React.Component<ISiftProps, {}> {
         this.tooltipContent = this.tooltipContent.bind(this);
     }
 
-    public static download(siftScore: number, siftPrediction: string): string {
-        return `impact: ${siftPrediction}, score: ${siftScore}`;
+    public static download(
+        siftScore: number | undefined,
+        siftPrediction: string | undefined
+    ): string {
+        if (siftScore || siftPrediction) {
+            return `impact: ${siftPrediction}, score: ${siftScore}`;
+        } else {
+            return 'NA';
+        }
     }
 
     public render() {

--- a/src/shared/components/mutationMapper/MutationMapper.tsx
+++ b/src/shared/components/mutationMapper/MutationMapper.tsx
@@ -25,6 +25,7 @@ import StructureViewerPanel from 'shared/components/structureViewer/StructureVie
 import OncoKbEvidenceCache from 'shared/cache/OncoKbEvidenceCache';
 import PubMedCache from 'shared/cache/PubMedCache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';
+import GenomeNexusMutationAssessorCache from 'shared/cache/GenomeNexusMutationAssessorCache';
 import GenomeNexusMyVariantInfoCache from 'shared/cache/GenomeNexusMyVariantInfoCache';
 import { IMyCancerGenomeData } from 'shared/model/MyCancerGenome';
 import PdbHeaderCache from 'shared/cache/PdbHeaderCache';
@@ -60,6 +61,7 @@ export interface IMutationMapperProps {
     pdbHeaderCache?: PdbHeaderCache;
     oncoKbEvidenceCache?: OncoKbEvidenceCache;
     genomeNexusCache?: GenomeNexusCache;
+    genomeNexusMutationAssessorCache?: GenomeNexusMutationAssessorCache;
     genomeNexusMyVariantInfoCache?: GenomeNexusMyVariantInfoCache;
     // server config properties
     genomeNexusUrl?: string;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -53,6 +53,7 @@ import VariantCountCache from 'shared/cache/VariantCountCache';
 import PubMedCache from 'shared/cache/PubMedCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';
+import GenomeNexusMutationAssessorCache from 'shared/cache/GenomeNexusMutationAssessorCache';
 import GenomeNexusMyVariantInfoCache from 'shared/cache/GenomeNexusMyVariantInfoCache';
 import { ILazyMobXTableApplicationDataStore } from 'shared/lib/ILazyMobXTableApplicationDataStore';
 import { ILazyMobXTableApplicationLazyDownloadDataFetcher } from 'shared/lib/ILazyMobXTableApplicationLazyDownloadDataFetcher';
@@ -88,6 +89,7 @@ export interface IMutationTableProps {
     pubMedCache?: PubMedCache;
     mutationCountCache?: MutationCountCache;
     genomeNexusCache?: GenomeNexusCache;
+    genomeNexusMutationAssessorCache?: GenomeNexusMutationAssessorCache;
     genomeNexusMyVariantInfoCache?: GenomeNexusMyVariantInfoCache;
     mutSigData?: IMutSigData;
     enableOncoKb?: boolean;
@@ -664,18 +666,27 @@ export default class MutationTable<
 
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT] = {
             name: 'Functional Impact',
-            render: (d: Mutation[]) =>
-                this.props.genomeNexusCache ? (
-                    FunctionalImpactColumnFormatter.renderFunction(
+            render: (d: Mutation[]) => {
+                if (
+                    this.props.genomeNexusCache ||
+                    this.props.genomeNexusMutationAssessorCache
+                ) {
+                    return FunctionalImpactColumnFormatter.renderFunction(
                         d,
-                        this.props.genomeNexusCache
-                    )
-                ) : (
-                    <span></span>
-                ),
+                        this.props.genomeNexusCache,
+                        this.props.genomeNexusMutationAssessorCache
+                    );
+                } else {
+                    return <span></span>;
+                }
+            },
             download: (d: Mutation[]) =>
-                FunctionalImpactColumnFormatter.download(d, this.props
-                    .genomeNexusCache as GenomeNexusCache),
+                FunctionalImpactColumnFormatter.download(
+                    d,
+                    this.props.genomeNexusCache as GenomeNexusCache,
+                    this.props
+                        .genomeNexusMutationAssessorCache as GenomeNexusMutationAssessorCache
+                ),
             headerRender: FunctionalImpactColumnFormatter.headerRender,
             visible: false,
             shouldExclude: () => !this.props.enableFunctionalImpact,


### PR DESCRIPTION
have a separate cache for mutation assessor, each column in functional impact loading separately, so can show sift and polyphen before mutation assessor was fetched completely


![image](https://user-images.githubusercontent.com/16869603/72916160-8695f600-3d0f-11ea-9854-c3c0484a88a4.png)

fix https://github.com/cBioPortal/cbioportal/issues/6867