### PR TITLE
In README Docs, removed reference to API URL and .env;  closes #7095

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example pages:
  - http://localhost:3000/
  - http://localhost:3000/patient?studyId=lgg_ucsf_2014&caseId=P04
 
-To run unit/integration tests (need to have API URL defined in `.env`)
+To run unit/integration tests
 ```
 yarn run test
 ```


### PR DESCRIPTION
Fixes cBioPortal/cbioportal#7095

Describe changes proposed in this pull request:
- Modified the README:  removed reference to API URL and .env, as @inodb says these are no longer needed;  I also confirmed locally that these are no longer needed.

# Notify reviewers
@inodb 