### PR TITLE
Set licenses to SPDX Identifier of AGPL-3.0-or-later

### DIFF
--- a/end-to-end-test/package.json
+++ b/end-to-end-test/package.json
@@ -11,7 +11,7 @@
     "clear": "rm -rf remote/screenshots/screen/; rm -rf remote/screenshots/error/; rm -rf remote/screenshots/diff/; rm -rf remote/screenshots/junit/; rm -rf local/screenshots/screen/; rm -rf local/screenshots/diff/; rm -rf local/screenshots/error/; rm -rf local/screenshots/junit/;"
   },
   "author": "",
-  "license": "",
+  "license": "AGPL-3.0-or-later",
   "dependencies": {
     "browserstack-local": "1.3.0",
     "clipboardy": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "yarn": "1.21.1"
   },
   "author": "",
-  "license": "",
+  "license": "AGPL-3.0-or-later",
   "dependencies": {
     "3dmol": "^1.3.7",
     "@babel/core": "7.4.4",

--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -15,7 +15,7 @@
     "dist"
   ],
   "author": "cBioPortal",
-  "license": "GNU Affero General Public License v3.0",
+  "license": "AGPL-3.0-or-later",
   "repository": "cBioPortal/cbioportal-frontend",
   "scripts": {
     "build": "cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 yarn run rollup",

--- a/packages/react-mutation-mapper/package.json
+++ b/packages/react-mutation-mapper/package.json
@@ -15,7 +15,7 @@
     "dist"
   ],
   "author": "cBioPortal",
-  "license": "GNU Affero General Public License v3.0",
+  "license": "AGPL-3.0-or-later",
   "repository": "cBioPortal/cbioportal-frontend",
   "scripts": {
       "build": "cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 yarn run rollup",


### PR DESCRIPTION
# Fixes cBioPortal/cbioportal#7127
- Within all the package.json files, I set license to SPDX Identifier of:  AGPL-3.0-or-later.

# Checks
- Verified that the warning message below no longer shows up multiple times:
`warning package.json: License should be a valid SPDX license expression.`
- Verified that `yarn run start` still works.
- Verified that `yarn test` still works.

# Any screenshots or GIFs?
- Not applicable

# Notify reviewers
@inodb 