### PR TITLE
Updated README to fix #7133

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Note: you can always check the version of the live instance by checking the vari
 Make sure you have installed the node version and yarn version specified in
 [package.json](https://github.com/cBioPortal/cbioportal-frontend/blob/master/package.json).
 
-**Tip:**  You might want to use [nvm:  Node Version Manager](https://github.com/nvm-sh/nvm) and [yvm:  Yarn Version Manager](https://yvm.js.org/docs/overview) to switch between versions more easily.
+> **Tip:**  We recommend that you use [nvm:  Node Version Manager](https://github.com/nvm-sh/nvm) and [yvm:  Yarn Version Manager](https://yvm.js.org/docs/overview) to switch between versions more easily.
 
-Remove old compiled `node_modules` if exists
+> **Windows Tip:** If you are developing on Windows, we recommend that you use [Ubuntu / Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+
+Remove old compiled `node_modules` if it exists
 
 ```
 rm -rf node_modules
@@ -35,7 +37,7 @@ To build DLLs in common-dist folder (must be done prior to start of dev server)
 yarn run buildDLL:dev
 ```
 
-To start dev server with hot reload enabled
+To start the dev server with hot reload enabled
 ```
 # set the environment variables you want based on what branch you're branching
 # from
@@ -53,7 +55,7 @@ To run unit/integration tests
 yarn run test
 ```
 
-**Tip:** There is a known solved hiccup running the tests on Ubuntu via Windows Subsystem for Linux (WSL): [#7096](https://github.com/cBioPortal/cbioportal/issues/7096)
+> **Windows Tip:** There is a known solved hiccup running the tests on Ubuntu via Windows Subsystem for Linux (WSL): [#7096](https://github.com/cBioPortal/cbioportal/issues/7096)
 
 To run unit/integration tests in watch mode
 ```
@@ -124,13 +126,13 @@ Change `x` to the number of your pull request.
 
 ## Run e2e-tests
 
-E2e-tests can be run against public cbioportal instances or against a local dockerized backend. These two e2e-tests types are referred to as `remote` and `local` types of e2e-tests.
+End-to-end tests can be run against public cbioportal instances or against a local dockerized backend. These two e2e-tests types are referred to as `remote` and `local` types of e2e-tests.
 
 ## Run of `remote e2e-tests`
 
-Install webdriver-manager, which manages standalone Selenium installation:
+First, install webdriver-manager, which manages standalone Selenium installation:
 ```
-yarn install -g webdriver-manager
+yarn global add webdriver-manager
 ```
 Run updater to get necessary binaries
 ```
@@ -138,29 +140,36 @@ webdriver-manager update
 ```
 Start the webdriver-manager
 ```
-webdriver-manager start # ...or `startSSL` (see below)
+webdriver-manager start
 ```
-In one terminal run frontend (this will get mounted inside whatever
-`CBIOPORTAL_URL` is pointing to)
+
+> **Tip:** To verify that your webdriver-manager is running, go to:  http://127.0.0.1:4444/wd/hub/static/resource/hub.html.
+
+> **Windows Tip:** If you are developing on Ubuntu under Windows Subsystem for Linux (WSL), we recommend that you install and run webdriver-manager via Powershell/Windows.  If you install and run webdriver-manager via Ubuntu, webdriver-manager has a hard time finding the Chrome browser, and this will cause all the end-to-end tests to fail.
+
+In a second terminal, run the frontend
 ```bash
-# set the environment variables you want based on what branch you're branching
-# from
+# set the environment variables for your branch
 export BRANCH_ENV=master # or rc if branching from rc
 # export any custom external API URLs by editing env/custom.sh
 yarn run start
 ```
-In another terminal run the e2e tests
+> **Tip:** Before going to the next step, verify that your front end code is running by going to: https://localhost:3000/.
+
+In a third terminal, run the e2e tests
 ```bash
-# set the environment variables you want based on what branch you're branching
-# from
 export SPEC_FILE_PATTERN=./remote/specs/**/*.spec.js
 export SCREENSHOT_DIRECTORY=./remote/screenshots
 export BRANCH_ENV=master # or rc if branching from rc
 # export any custom external API URLs in env/custom.sh
 cd end-to-end-test
 yarn install
-yarn run test-webdriver-manager # use `test-webdriver-manager-debug` for debugging of tests
+yarn run test-webdriver-manager
+# use `test-webdriver-manager-debug` for debugging of tests
 ```
+If all goes well, you will soon seen the end-to-end tests running via your Chrome browser.
+
+> **Tip:** If you want to run just one end-to-end test, you can modify `SPEC_FILE_PATTERN` accordingly.  For example, if you want to only run the `genomicEvolution.spec.js` test, you can use:  `export SPEC_FILE_PATTERN=./remote/specs/core/genomicEvolution.spec.js`.
 
 ### Mount of frontend onto HTTPS backend
 A custom frontend can be tested against any backend in the web browser using a local node server (command `yarn run start`) and the `localdev` flag passed to th e browser (see section 'Check in cBioPortal context'). For remote backends that communicate over a HTTP over SSL (https) connection (e.g., cbioportal.org or rc.cbioportal.org), the frontend has to be served over SSL as well. In this case run `yarn run startSSL` in stead of `yarn run start`.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ In a second terminal, run the frontend
 # set the environment variables for your branch
 export BRANCH_ENV=master # or rc if branching from rc
 # export any custom external API URLs by editing env/custom.sh
-yarn run start
+yarn run startSSL
 ```
 > **Tip:** Before going to the next step, verify that your front end code is running by going to: https://localhost:3000/.
 


### PR DESCRIPTION
# Fixes cBioPortal/cbioportal#7133

Describe changes proposed in this pull request:
- Changed all tips to blockquotes, to make them stand out a bit more
- In end-to-end test section, changed `yarn start` to `yarn startSSL`, as `yarn start` does not actually work.
- Added several Windows/WSL tips.
- Made a few small language tweaks in the end-to-end section.
- Added a tip on how to run just one end-to-end test.

# Any screenshots or GIFs?
- Not applicable

# Notify reviewers
@inodb @alisman 