### PR TITLE
revert PR #3036

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -883,9 +883,10 @@ export default class PatientViewPage extends React.Component<
                                         this.patientViewPageStore
                                             .sampleToMutationGenePanelId
                                             .isComplete &&
-                                        this.patientViewPageStore
-                                            .genePanelIdToEntrezGeneIds
-                                            .isComplete &&
+                                        // TODO re-enable after fixing PatientViewPageStore issues
+                                        // this.patientViewPageStore
+                                        //     .genePanelIdToEntrezGeneIds
+                                        //     .isComplete &&
                                         !!sampleManager && (
                                             <div data-test="patientview-mutation-table">
                                                 <PatientViewMutationTable
@@ -1101,9 +1102,10 @@ export default class PatientViewPage extends React.Component<
 
                                     {this.patientViewPageStore.studyIdToStudy
                                         .isComplete &&
-                                        this.patientViewPageStore
-                                            .genePanelIdToEntrezGeneIds
-                                            .isComplete &&
+                                        // TODO re-enable after fixing PatientViewPageStore issues
+                                        // this.patientViewPageStore
+                                        //     .genePanelIdToEntrezGeneIds
+                                        //     .isComplete &&
                                         this.patientViewPageStore.referenceGenes
                                             .isComplete && (
                                             <div data-test="patientview-copynumber-table">


### PR DESCRIPTION
Waiting for gene panel data may cause the whole patient view page crash. Disabling for now, we need to fix `PatientViewPageStore` before re-enabling this.

# Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
