### PR TITLE
do not clear selected study list when click query tab

### DIFF
--- a/src/shared/components/query/QueryAndDownloadTabs.tsx
+++ b/src/shared/components/query/QueryAndDownloadTabs.tsx
@@ -90,7 +90,6 @@ export default class QueryAndDownloadTabs extends React.Component<
     @action
     onSelectTab(tabId: string) {
         this.store.forDownloadTab = tabId === DOWNLOAD;
-        this.store.selectableSelectedStudyIds = [];
         this.activeTabId = tabId;
     }
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6900

Describe changes proposed in this pull request:
- a do not clear selected study list when click query tab
![query_tab](https://user-images.githubusercontent.com/15748980/74384523-6b268400-4dbf-11ea-9b0d-30f6cd49dff9.gif)
