### PR TITLE
Add Software acknowledgment page

### DIFF
--- a/src/appShell/App/PortalFooter.tsx
+++ b/src/appShell/App/PortalFooter.tsx
@@ -182,6 +182,9 @@ export default class PortalFooter extends React.Component<
                                 <h3>DEV</h3>
                                 <ul>
                                     <li>
+                                        <Link to="/software">Software</Link>
+                                    </li>
+                                    <li>
                                         <a
                                             target="_blank"
                                             href="https://github.com/cBioPortal/"

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -57,6 +57,7 @@ export interface IServerConfig {
     show_civic: boolean;
     show_genomenexus: boolean;
     skin_documentation_about: string | null;
+    skin_documentation_software: string | null;
     skin_documentation_baseurl: string | null;
     skin_blurb: string | null;
     skin_custom_header_tabs: string | null;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -44,6 +44,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     skin_authorization_message:
         'Access to this portal is only available to authorized users.',
     skin_documentation_about: 'About-Us.md',
+    skin_documentation_software: 'Software-Acknowledgments.md',
     skin_documentation_baseurl:
         'https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/',
     skin_documentation_markdown: true,

--- a/src/pages/staticPages/software/Software.tsx
+++ b/src/pages/staticPages/software/Software.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
+import './styles.scss';
+import AppConfig from 'appConfig';
+import StaticContent from '../../../shared/components/staticContent/StaticContent';
+import Helmet from 'react-helmet';
+
+export default class Software extends React.Component<{}, {}> {
+    public render() {
+        return (
+            <PageLayout className={'whiteBackground staticPage'}>
+                <Helmet>
+                    <title>{'cBioPortal for Cancer Genomics::Software'}</title>
+                </Helmet>
+                <StaticContent
+                    sourceUrl={
+                        AppConfig.serverConfig.skin_documentation_software!
+                    }
+                    title={'Software'}
+                />
+            </PageLayout>
+        );
+    }
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -37,6 +37,7 @@ import RMATLAB from 'bundle-loader?lazy!babel-loader!./pages/staticPages/rmatlab
 import Tutorials from 'bundle-loader?lazy!babel-loader!./pages/staticPages/tutorials/Tutorials';
 import Visualize from 'bundle-loader?lazy!babel-loader!./pages/staticPages/visualize/Visualize';
 import AboutUs from 'bundle-loader?lazy!babel-loader!./pages/staticPages/aboutus/AboutUs';
+import Software from 'bundle-loader?lazy!babel-loader!./pages/staticPages/software/Software';
 import News from 'bundle-loader?lazy!babel-loader!./pages/staticPages/news/News';
 import FAQ from 'bundle-loader?lazy!babel-loader!./pages/staticPages/faq/FAQ';
 import OQL from 'bundle-loader?lazy!babel-loader!./pages/staticPages/oql/OQL';
@@ -248,6 +249,13 @@ export const makeRoutes = routing => {
                     $(document).scrollTop(0);
                 }}
                 getComponent={lazyLoadComponent(AboutUs)}
+            />
+            <Route
+                path="/software"
+                onEnter={() => {
+                    $(document).scrollTop(0);
+                }}
+                getComponent={lazyLoadComponent(Software)}
             />
             <Route
                 path="/news"


### PR DESCRIPTION
# Fixes cBioPortal/cbioportal#5667

- Added new software acknowledgment page/component.
- Added new property: ` skin_documentation_software`.
- Added new ` /software` router.
- Added link to `/software` within the footer.

> Note:  the actual content of the software page is a markdown page, which now exists within the back-end repo, and not part of this PR.  See:  https://github.com/cBioPortal/cbioportal/blob/master/docs/Software-Acknowledgments.md

# Any screenshots or GIFs?
- Not applicable

# Notify reviewers
@alisman @inodb or @jjgao 