### PR TITLE
fix genomeBuild parsing

### DIFF
--- a/src/pages/patientView/genomicOverview/Tracks.tsx
+++ b/src/pages/patientView/genomicOverview/Tracks.tsx
@@ -25,7 +25,7 @@ interface TracksPropTypes {
     onSelectGenePanel?: (name: string) => void;
 }
 
-export const DEFAULT_GENOME_BUILD = 'GRCh37';
+export const DEFAULT_GENOME_BUILD = 'hg19';
 const noGenePanelMessage =
     'Gene panel information not found. Sample is presumed to be whole exome/genome sequenced.';
 

--- a/src/pages/patientView/genomicOverview/tracksHelper.ts
+++ b/src/pages/patientView/genomicOverview/tracksHelper.ts
@@ -91,6 +91,10 @@ export const genomeBuilds: Map<string, string> = new Map([
     ['hg38', 'GRCh38'],
     ['38', 'GRCh38'],
     ['mm10', 'GRCm38'],
+    // If the genome build is already Ensembl (e.g. VEP output), make sure the lookup doesn't fail
+    ['GRCh37', 'GRCh37'],
+    ['GRCh38', 'GRCh38'],
+    ['GRCm38', 'GRCm38'],
 ]);
 
 export type ChromosomeSizes = {

--- a/src/pages/patientView/genomicOverview/tracksHelper.ts
+++ b/src/pages/patientView/genomicOverview/tracksHelper.ts
@@ -91,7 +91,7 @@ export const genomeBuilds: Map<string, string> = new Map([
     ['hg38', 'GRCh38'],
     ['38', 'GRCh38'],
     ['mm10', 'GRCm38'],
-    // If the genome build is already Ensembl (e.g. VEP output), make sure the lookup doesn't fail
+    // If the genome build is already in correct format, make sure the lookup doesn't fail
     ['GRCh37', 'GRCh37'],
     ['GRCh38', 'GRCh38'],
     ['GRCm38', 'GRCm38'],


### PR DESCRIPTION
We noticed that the chromosome plot in the patient view was always displaying a human genome, regardless of the `portal.properties` settings. This implies it will never display mouse chromosomes when needed.

When any other reference genome build than 'GRCh37' is used, the genome is not parsed correctly. The frontend derives the genome build through the API, from the dataset itself, and translates the UCSC name into NCBI (GRC) format.
In case the genome is already in GRC format, it will fail and fallback to GRCh37. This is a problem when a non-default genome is used. 

This PR fixes that.