### PR TITLE
Fix redirect for old patients URL

### DIFF
--- a/src/shared/lib/redirectHelpers.ts
+++ b/src/shared/lib/redirectHelpers.ts
@@ -81,6 +81,23 @@ export function handleCaseDO() {
         );
     }
 
+    // Support for URLs like cbioportal.org/case.do#/patient?studyId=foo&caseId=bar
+    if (
+        routingStore.location.hash &&
+        routingStore.location.hash.startsWith('#/patient')
+    ) {
+        routingStore.location.hash = routingStore.location.hash!.replace(
+            /#\/patient\??/,
+            ''
+        );
+        // parse the url params from the hash and add them to new params
+        routingStore.location.hash
+            .split('&') // split the url params
+            .map(s => s.split('=')) // separate key value pairs
+            .forEach(pair => (newParams[pair[0]] = pair[1]));
+        routingStore.location.hash = '';
+    }
+
     (getBrowserWindow().routingStore as ExtendedRouterStore).updateRoute(
         newParams,
         '/patient',


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7167

Describe changes proposed in this pull request:
- Problem:
  - cbioportal.org/case.do#/patient?studyId=ucec_tcga_pub&caseId=TCGA-BK-A0CC
  resulted in an error page
- Solution
  - Remove the url hash, add to the urlparams
  - NB: couldn't find a way to test this


# Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.

I really tried to test this. The issue I ran into was that `routingStore` needed to be pulled out so I could mock it, but you need to call `getBrowserWindow().routingStore` at the end instead of referencing the object passed in, so you can't pull it out. 