### PR TITLE
Do not attach mutation type when it is not available

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "bootstrap-sass": "3.3.7",
     "bowser": "^1.7.1",
     "bundle-loader": "^0.5.4",
-    "cbioportal-frontend-commons": "0.2.0",
+    "cbioportal-frontend-commons": "0.2.1",
     "chart.js": "^2.6.0",
     "classnames": "^2.2.5",
     "clinical-timeline": "0.0.19",

--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cbioportal-frontend-commons",
   "description": "cBioPortal Frontend Modules",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",

--- a/packages/cbioportal-frontend-commons/src/lib/oncokb/OncoKbUtils.ts
+++ b/packages/cbioportal-frontend-commons/src/lib/oncokb/OncoKbUtils.ts
@@ -151,7 +151,7 @@ export function generateCopyNumberAlterationQuery(
     evidenceTypes?: EvidenceType[]
 ): AnnotateCopyNumberAlterationQuery {
     return {
-        id: generateQueryVariantId(entrezGeneId, tumorType, alteration, 'cna'),
+        id: generateQueryVariantId(entrezGeneId, tumorType, alteration),
         copyNameAlterationType: alteration!.toUpperCase(),
         gene: {
             entrezGeneId: entrezGeneId,


### PR DESCRIPTION
The query id does not need mutation type for CNA
This fixes https://github.com/cBioPortal/cbioportal/issues/7208