### PR TITLE
Add variant type column to mutation tables

### DIFF
--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -64,6 +64,7 @@ export default class PatientViewMutationTable extends MutationTable<
             MutationTableColumnType.CHROMOSOME,
             MutationTableColumnType.PROTEIN_CHANGE,
             MutationTableColumnType.MUTATION_TYPE,
+            MutationTableColumnType.VARIANT_TYPE,
             MutationTableColumnType.FUNCTIONAL_IMPACT,
             MutationTableColumnType.COSMIC,
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
@@ -237,6 +238,7 @@ export default class PatientViewMutationTable extends MutationTable<
         this._columns[MutationTableColumnType.MUTATION_STATUS].order = 90;
         this._columns[MutationTableColumnType.VALIDATION_STATUS].order = 100;
         this._columns[MutationTableColumnType.MUTATION_TYPE].order = 110;
+        this._columns[MutationTableColumnType.VARIANT_TYPE].order = 115;
         this._columns[MutationTableColumnType.CENTER].order = 120;
         this._columns[MutationTableColumnType.TUMOR_ALLELE_FREQ].order = 130;
         this._columns[MutationTableColumnType.VAR_READS].order = 140;

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -47,6 +47,7 @@ export default class ResultsViewMutationTable extends MutationTable<
             MutationTableColumnType.CHROMOSOME,
             MutationTableColumnType.PROTEIN_CHANGE,
             MutationTableColumnType.MUTATION_TYPE,
+            MutationTableColumnType.VARIANT_TYPE,
             MutationTableColumnType.COSMIC,
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
             MutationTableColumnType.NORMAL_ALLELE_FREQ,
@@ -96,6 +97,7 @@ export default class ResultsViewMutationTable extends MutationTable<
         this._columns[MutationTableColumnType.HGVSG].order = 35;
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;
         this._columns[MutationTableColumnType.MUTATION_TYPE].order = 40;
+        this._columns[MutationTableColumnType.VARIANT_TYPE].order = 45;
         this._columns[MutationTableColumnType.COPY_NUM].order = 50;
         this._columns[MutationTableColumnType.COSMIC].order = 60;
         this._columns[MutationTableColumnType.MUTATION_STATUS].order = 70;

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationTable.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationTable.tsx
@@ -42,6 +42,7 @@ export default class StandaloneMutationTable extends MutationTable<
             MutationTableColumnType.CHROMOSOME,
             MutationTableColumnType.PROTEIN_CHANGE,
             MutationTableColumnType.MUTATION_TYPE,
+            MutationTableColumnType.VARIANT_TYPE,
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
             MutationTableColumnType.NORMAL_ALLELE_FREQ,
             MutationTableColumnType.EXON,
@@ -82,6 +83,7 @@ export default class StandaloneMutationTable extends MutationTable<
         this._columns[MutationTableColumnType.HGVSG].order = 35;
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;
         this._columns[MutationTableColumnType.MUTATION_TYPE].order = 40;
+        this._columns[MutationTableColumnType.VARIANT_TYPE].order = 45;
         //this._columns[MutationTableColumnType.COPY_NUM].order = 50;
         //this._columns[MutationTableColumnType.COSMIC].order = 60;
         this._columns[MutationTableColumnType.MUTATION_STATUS].order = 70;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -23,6 +23,7 @@ import GeneColumnFormatter from './column/GeneColumnFormatter';
 import ChromosomeColumnFormatter from './column/ChromosomeColumnFormatter';
 import ProteinChangeColumnFormatter from './column/ProteinChangeColumnFormatter';
 import MutationTypeColumnFormatter from './column/MutationTypeColumnFormatter';
+import VariantTypeColumnFormatter from './column/VariantTypeColumnFormatter';
 import FunctionalImpactColumnFormatter from './column/FunctionalImpactColumnFormatter';
 import CosmicColumnFormatter from './column/CosmicColumnFormatter';
 import MutationCountColumnFormatter from './column/MutationCountColumnFormatter';
@@ -135,6 +136,7 @@ export enum MutationTableColumnType {
     MUTATION_STATUS,
     VALIDATION_STATUS,
     MUTATION_TYPE,
+    VARIANT_TYPE,
     CENTER,
     TUMOR_ALLELE_FREQ,
     NORMAL_ALLELE_FREQ,
@@ -201,9 +203,7 @@ export function defaultFilter(
         return data.reduce((match: boolean, next: Mutation) => {
             const val = (next as any)[dataField];
             if (val) {
-                return (
-                    match || val.toUpperCase().indexOf(filterStringUpper) > -1
-                );
+                return match || val.toUpperCase().includes(filterStringUpper);
             } else {
                 return match;
             }
@@ -607,7 +607,7 @@ export default class MutationTable<
             ) =>
                 GeneColumnFormatter.getTextValue(d)
                     .toUpperCase()
-                    .indexOf(filterStringUpper) > -1,
+                    .includes(filterStringUpper),
         };
 
         this._columns[MutationTableColumnType.CHROMOSOME] = {
@@ -628,7 +628,7 @@ export default class MutationTable<
             ) =>
                 (ChromosomeColumnFormatter.getData(d) + '')
                     .toUpperCase()
-                    .indexOf(filterStringUpper) > -1,
+                    .includes(filterStringUpper),
             visible: false,
             align: 'right',
         };
@@ -655,7 +655,24 @@ export default class MutationTable<
             ) =>
                 MutationTypeColumnFormatter.getDisplayValue(d)
                     .toUpperCase()
-                    .indexOf(filterStringUpper) > -1,
+                    .includes(filterStringUpper),
+        };
+
+        this._columns[MutationTableColumnType.VARIANT_TYPE] = {
+            name: 'Variant Type',
+            render: VariantTypeColumnFormatter.renderFunction,
+            download: VariantTypeColumnFormatter.getTextValue,
+            sortBy: (d: Mutation[]) =>
+                VariantTypeColumnFormatter.getDisplayValue(d),
+            filter: (
+                d: Mutation[],
+                filterString: string,
+                filterStringUpper: string
+            ) =>
+                VariantTypeColumnFormatter.getDisplayValue(d)
+                    .toUpperCase()
+                    .includes(filterStringUpper),
+            visible: false,
         };
 
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT] = {

--- a/src/shared/components/mutationTable/column/CategoricalColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CategoricalColumnFormatter.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { DefaultTooltip } from 'cbioportal-frontend-commons';
+
+export interface ICategoricalColumn {
+    displayValue?: string;
+    toolTip?: string;
+    className: string;
+}
+
+export function createToolTip(content: JSX.Element, toolTip: string) {
+    content = (
+        <DefaultTooltip overlay={<span>{toolTip}</span>} placement="left">
+            {content}
+        </DefaultTooltip>
+    );
+    return content;
+}

--- a/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.tsx
@@ -108,12 +108,12 @@ describe('MutationTypeColumnFormatter', () => {
         value: string
     ) {
         assert.isTrue(
-            component.find(`span.${styles[className]}`).exists(),
+            component.find(`span.${className}`).exists(),
             `Span has the correct class name for ${mutationType}`
         );
         assert.isTrue(
             component
-                .find(`span.${styles[className]}`)
+                .find(`span.${className}`)
                 .text()
                 .indexOf(value) > -1,
             `Display value is correct for ${mutationType}`
@@ -124,49 +124,55 @@ describe('MutationTypeColumnFormatter', () => {
         testRenderedValues(
             msVarComponent,
             'Missense_Variant',
-            'missense-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.missense
+                .className,
             'Missense'
         );
         testRenderedValues(
             msMutComponent,
             'Missense_mutation',
-            'missense-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.missense
+                .className,
             'Missense'
         );
         testRenderedValues(
             stopgainSnvComponent,
             'stopgain_SNV',
-            'trunc-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.nonsense
+                .className,
             'Nonsense'
         );
         testRenderedValues(
             nonFsDelComponent,
             'NonFrameShift_deletion',
-            'inframe-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.inframe
+                .className,
             'IF'
         );
         testRenderedValues(
             spliceComponent,
             'Splice Site',
-            'trunc-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.splice_site
+                .className,
             'Splice'
         );
         testRenderedValues(
             fsDelComponent,
             'FrameShift_Deletion',
-            'trunc-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.frame_shift_del
+                .className,
             'FS del'
         );
         testRenderedValues(
             unknownMutComponent,
             'a_strange_type_of_mutation',
-            'other-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.other.className,
             'Other'
         );
         testRenderedValues(
             otherMutComponent,
             'other',
-            'other-mutation',
+            MutationTypeColumnFormatter.MAIN_MUTATION_TYPE_MAP.other.className,
             'Other'
         );
     });

--- a/src/shared/components/mutationTable/column/VariantTypeColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/VariantTypeColumnFormatter.spec.tsx
@@ -1,0 +1,114 @@
+import VariantTypeColumnFormatter from './VariantTypeColumnFormatter';
+import { Mutation } from 'shared/api/generated/CBioPortalAPI';
+import { initMutation } from 'test/MutationMockUtils';
+import React from 'react';
+import { assert } from 'chai';
+import { shallow, mount, ReactWrapper } from 'enzyme';
+import sinon from 'sinon';
+
+describe('VariantTypeColumnFormatter', () => {
+    const snpVariant = initMutation({
+        variantType: 'SNP',
+    });
+
+    const snpLowerCaseVariant = initMutation({
+        variantType: 'snp',
+    });
+
+    const dnpVariant = initMutation({
+        variantType: 'DNP',
+    });
+
+    const insVariant = initMutation({
+        variantType: 'INS',
+    });
+
+    const delVariant = initMutation({
+        variantType: 'DEL',
+    });
+
+    const otherVariant = initMutation({
+        variantType: 'other_unknown',
+    });
+
+    it('test display value', () => {
+        let mutationList = [snpVariant];
+        let displayValue = VariantTypeColumnFormatter.getDisplayValue(
+            mutationList
+        );
+        assert.equal(displayValue, 'SNP');
+
+        //  snp should be changed to SNP
+        mutationList = [snpLowerCaseVariant];
+        displayValue = VariantTypeColumnFormatter.getDisplayValue(mutationList);
+        assert.equal(displayValue, 'SNP');
+
+        mutationList = [insVariant];
+        displayValue = VariantTypeColumnFormatter.getDisplayValue(mutationList);
+        assert.equal(displayValue, 'INS');
+
+        // if we have a non-standard variant type, it should be displayed as is
+        // but as upper-case
+        mutationList = [otherVariant];
+        displayValue = VariantTypeColumnFormatter.getDisplayValue(mutationList);
+        assert.equal(displayValue, 'OTHER_UNKNOWN');
+    });
+
+    it('test tooltip content', () => {
+        let mutationList = [snpVariant];
+        let toolTip = VariantTypeColumnFormatter.getTooltip(mutationList);
+        assert.equal(
+            toolTip,
+            VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP.SNP.toolTip
+        );
+
+        mutationList = [snpLowerCaseVariant];
+        toolTip = VariantTypeColumnFormatter.getTooltip(mutationList);
+        assert.equal(
+            toolTip,
+            VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP.SNP.toolTip
+        );
+
+        mutationList = [insVariant];
+        toolTip = VariantTypeColumnFormatter.getTooltip(mutationList);
+        assert.equal(
+            toolTip,
+            VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP.INS.toolTip
+        );
+
+        //  non-standard variant types do not have tooltips
+        mutationList = [otherVariant];
+        toolTip = VariantTypeColumnFormatter.getTooltip(mutationList);
+        assert.equal(toolTip, undefined);
+    });
+
+    it('test style classes', () => {
+        let mutationList = [snpVariant];
+        let className = VariantTypeColumnFormatter.getClassName(mutationList);
+        assert.equal(
+            className,
+            VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP.SNP.className
+        );
+
+        mutationList = [snpLowerCaseVariant];
+        className = VariantTypeColumnFormatter.getClassName(mutationList);
+        assert.equal(
+            className,
+            VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP.SNP.className
+        );
+
+        mutationList = [insVariant];
+        className = VariantTypeColumnFormatter.getClassName(mutationList);
+        assert.equal(
+            className,
+            VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP.INS.className
+        );
+
+        mutationList = [otherVariant];
+        className = VariantTypeColumnFormatter.getClassName(mutationList);
+        assert.equal(
+            className,
+            VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP.OTHER.className
+        );
+    });
+});

--- a/src/shared/components/mutationTable/column/VariantTypeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/VariantTypeColumnFormatter.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import { Mutation } from 'shared/api/generated/CBioPortalAPI';
+import {
+    ICategoricalColumn,
+    createToolTip,
+} from './CategoricalColumnFormatter';
+import styles from './variantType.module.scss';
+
+/**
+ * Variant Type Column Formatter.
+ *
+ * This class follows the official GDC MAF Variant Type List:
+ * https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/
+ *
+ * Possible variant type values include:
+ * SNP, DNP, TNP, ONP, INS, DEL, or Consolidated.
+ */
+export default class VariantTypeColumnFormatter {
+    public static get MAIN_VARIANT_TYPE_MAP(): {
+        [key: string]: ICategoricalColumn;
+    } {
+        return {
+            SNP: {
+                toolTip: 'Single Nucleotide Polymorphism',
+                className: styles.variantTypeSnp,
+            },
+            DNP: {
+                toolTip: 'Di-Nucleotide Polymorphism',
+                className: styles.variantTypeSnp,
+            },
+            TNP: {
+                toolTip: 'Tri-Nucleotide Polymorphism',
+                className: styles.variantTypeSnp,
+            },
+            ONP: {
+                toolTip: 'Oligo-Nucleotide Polymorphism',
+                className: styles.variantTypeSnp,
+            },
+            INS: {
+                toolTip: 'Insertion',
+                className: styles.variantTypeIns,
+            },
+            DEL: {
+                toolTip: 'Deletion',
+                className: styles.variantTypeDel,
+            },
+            CONSOLIDATED: {
+                className: styles.variantTypeOther,
+            },
+            OTHER: {
+                className: styles.variantTypeOther,
+            },
+        };
+    }
+
+    /**
+     * Gets the display value.
+     */
+    public static getDisplayValue(data: Mutation[]): string {
+        return VariantTypeColumnFormatter.getTextValue(data);
+    }
+
+    /**
+     * Gets the Text Value.
+     */
+    public static getTextValue(data: Mutation[]): string {
+        let textValue: string = '';
+        const dataValue = VariantTypeColumnFormatter.getData(data);
+
+        if (dataValue) {
+            textValue = dataValue.toString().toUpperCase();
+        }
+
+        return textValue;
+    }
+
+    /**
+     * Gets the actual data.
+     */
+    public static getData(data: Mutation[]) {
+        if (data.length > 0) {
+            return data[0].variantType;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the Map Entry.
+     */
+    public static getMapEntry(data: Mutation[]) {
+        const variantType = VariantTypeColumnFormatter.getData(data);
+
+        if (variantType) {
+            return VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP[
+                variantType.toUpperCase()
+            ];
+        } else {
+            return undefined;
+        }
+    }
+
+    /**
+     * Gets the associated tooltip.
+     */
+    public static getTooltip(data: Mutation[]) {
+        const value:
+            | ICategoricalColumn
+            | undefined = VariantTypeColumnFormatter.getMapEntry(data);
+        if (value && value.toolTip) {
+            return value.toolTip;
+        } else {
+            return undefined;
+        }
+    }
+
+    /**
+     * Gets the CSS Class Name.
+     */
+    public static getClassName(data: Mutation[]): string {
+        const value:
+            | ICategoricalColumn
+            | undefined = VariantTypeColumnFormatter.getMapEntry(data);
+
+        if (value && value.className) {
+            return value.className;
+        }
+        // for unmapped values, use the "OTHER" style
+        else {
+            return VariantTypeColumnFormatter.MAIN_VARIANT_TYPE_MAP['OTHER']
+                .className;
+        }
+    }
+
+    public static renderFunction(data: Mutation[]) {
+        // use text for all purposes (display, sort, filter)
+        const text: string = VariantTypeColumnFormatter.getDisplayValue(data);
+        const className: string = VariantTypeColumnFormatter.getClassName(data);
+
+        // extract the tooltip, if available
+        const toolTip = VariantTypeColumnFormatter.getTooltip(data);
+        let content = <span className={className}>{text}</span>;
+
+        if (toolTip) {
+            content = createToolTip(content, toolTip);
+        }
+        return content;
+    }
+}

--- a/src/shared/components/mutationTable/column/mutationType.module.scss
+++ b/src/shared/components/mutationTable/column/mutationType.module.scss
@@ -1,20 +1,24 @@
-.missense-mutation {
+.missenseMutation {
     color: #008000;
     font-weight: bold;
 }
-.trunc-mutation {
+.truncMutation {
     color: #000000;
     font-weight: bold;
 }
-.inframe-mutation {
+.inframeMutation {
     color: #8b4513;
     font-weight: bold;
 }
-.other-mutation {
+.otherMutation {
     color: #8b00c9;
     font-weight: bold;
 }
-.default-mutation {
+.defaultMutation {
     color: #bb0000;
+    font-weight: bold;
+}
+.fusion {
+    color: #0000bb;
     font-weight: bold;
 }

--- a/src/shared/components/mutationTable/column/variantType.module.scss
+++ b/src/shared/components/mutationTable/column/variantType.module.scss
@@ -1,0 +1,16 @@
+.variantTypeSnp {
+    color: #008000;
+    font-weight: bold;
+}
+.variantTypeIns {
+    color: #8b4513;
+    font-weight: bold;
+}
+.variantTypeDel {
+    color: #8b00c9;
+    font-weight: bold;
+}
+.variantTypeOther {
+    color: #000000;
+    font-weight: bold;
+}


### PR DESCRIPTION
# Overview 

Added variant type to the mutation tables.  This PR fixes cBioPortal/cbioportal#3694.

- Added a new variant type column formatter and associated unit test.
- Refactored the existing mutation type column formatter to remove legacy attributes that are no longer used (based on discussion with @onursumer).

## Checks
- [X] Yes, I have included a unit test for the variant type column formatter.
- [X] Yes, I have just one commit (thanks to @onursumer for that feedback).

## Screenshot
![screencast](https://p15.f3.n0.cdn.getcloudapp.com/items/xQugvgzo/Screen+Recording+2020-02-22+at+07.16.28.74+PM.gif?v=73bf4c82dbaa4c1509079866987a3580)

## Notify reviewers
@onursumer @inodb 