### PR TITLE
Add deprecation message to top of web API page

### DIFF
--- a/src/pages/staticPages/webAPI/WebAPIPage.tsx
+++ b/src/pages/staticPages/webAPI/WebAPIPage.tsx
@@ -112,11 +112,17 @@ export default class WebAPIPage extends React.Component<{}, {}> {
     }
 
     public render() {
+        let apiLink = AppConfig.apiRoot + 'api';
         return (
             <PageLayout className={'whiteBackground staticPage'}>
                 <Helmet>
                     <title>{'cBioPortal for Cancer Genomics::Helmet'}</title>
                 </Helmet>
+
+                <div className="alert alert-danger">
+                    This Web API will soon be deprecated. Please consider
+                    transitioning to our <a href={apiLink}>New API</a> instead!
+                </div>
 
                 <h1>Web API</h1>
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#2967

- Add deprecation message to top of web API page, along with a link to the new API.
- The message is embedded in a bootstrap info box (suggested by @alisman).

## Any screenshots or GIFs?
![image](https://user-images.githubusercontent.com/1009066/75770348-c17b4880-5d15-11ea-92df-079c500b275c.png)

## Notify reviewers
@inodb @jjgao 