### PR TITLE
Fix alignment of gene entry textarea and error message 

### DIFF
--- a/src/pages/resultsView/styles.scss
+++ b/src/pages/resultsView/styles.scss
@@ -137,4 +137,8 @@
     .oqlValidationContainer {
         min-height: 27px;
     }
+
+    div {
+        justify-content: left !important;
+    }
 }

--- a/src/shared/components/GeneSelectionBox/styles.module.scss
+++ b/src/shared/components/GeneSelectionBox/styles.module.scss
@@ -9,6 +9,7 @@
     display: flex;
     align-items: flex-start;
     margin-bottom: 5px;
+    justify-content: flex-end;
 }
 
 .genesSelection {


### PR DESCRIPTION
Fixes #7262. 

The gene entry textarea was not right aligned.  When error message exceed it's width, it would travel leftward.  This pins it to right edge of parent div.

![image](https://user-images.githubusercontent.com/186521/76107674-2c8f7e00-5fa7-11ea-9a94-1839ea613fbf.png)
