### PR TITLE
OQL editor box: right justify only when inside right panel

### DIFF
--- a/src/pages/studyView/studyPageHeader/styles.module.scss
+++ b/src/pages/studyView/studyPageHeader/styles.module.scss
@@ -7,6 +7,10 @@
         width: 280px !important;
         margin: 0 !important;
     }
+
+    div {
+        justify-content: flex-end;
+    }
 }
 
 .summary {

--- a/src/shared/components/GeneSelectionBox/styles.module.scss
+++ b/src/shared/components/GeneSelectionBox/styles.module.scss
@@ -9,7 +9,6 @@
     display: flex;
     align-items: flex-start;
     margin-bottom: 5px;
-    justify-content: flex-end;
 }
 
 .genesSelection {


### PR DESCRIPTION
When we applied right justification, we mistakenly caught instance on homepage, which should not be right justified
![image](https://user-images.githubusercontent.com/186521/76254922-a16eec00-6223-11ea-8105-396690c90f31.png)
