### PR TITLE
Load pathway mapper dynamically to avoid IE11 crash

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -52,6 +52,7 @@ import OQLTextArea, {
     GeneBoxType,
 } from 'shared/components/GeneSelectionBox/OQLTextArea';
 import SurvivalTransitionTab from './survival/SurvivalTransitionTab';
+import browser from 'bowser';
 
 export function initStore(
     appStore: AppStore,
@@ -399,6 +400,7 @@ export default class ResultsViewPage extends React.Component<
             {
                 id: ResultsViewTab.PATHWAY_MAPPER,
                 hide: () =>
+                    browser.name === 'Internet Explorer' ||
                     !AppConfig.serverConfig.show_pathway_mapper ||
                     !this.resultsViewPageStore.studies.isComplete,
                 getTab: () => {

--- a/src/pages/resultsView/pathwayMapper/ResultsViewPathwayMapper.tsx
+++ b/src/pages/resultsView/pathwayMapper/ResultsViewPathwayMapper.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import _ from 'lodash';
 import { ResultsViewPageStore } from '../ResultsViewPageStore';
 import { addGenesToQuery, ResultsViewTab } from '../ResultsViewPageHelpers';
-import PathwayMapper, { ICBioData } from 'pathway-mapper';
 import 'pathway-mapper/dist/base.css';
 import PathwayMapperTable, { IPathwayMapperTable } from './PathwayMapperTable';
 import { observer } from 'mobx-react';
@@ -30,6 +29,7 @@ import 'cytoscape-panzoom/cytoscape.js-panzoom.css';
 import 'cytoscape-navigator/cytoscape.js-navigator.css';
 import 'react-toastify/dist/ReactToastify.css';
 import styles from './pathwayMapper.module.scss';
+import PathwayMapper, { ICBioData } from 'pathway-mapper';
 
 interface IResultsViewPathwayMapperProps {
     store: ResultsViewPageStore;
@@ -96,7 +96,19 @@ export default class ResultsViewPathwayMapper extends React.Component<
             },
             { fireImmediately: true }
         );
+
+        // @ts-ignore
+        import(/* webpackChunkName: "pathway-mapper" */ 'pathway-mapper').then(
+            (module: any) => {
+                this.PathwayMapperComponent = (module as any)
+                    .default as PathwayMapper;
+            }
+        );
     }
+
+    @observable.ref PathwayMapperComponent:
+        | PathwayMapper
+        | undefined = undefined;
 
     @computed get alterationFrequencyData(): ICBioData[] {
         return this.alterationFrequencyDataForQueryGenes.concat(
@@ -187,6 +199,10 @@ export default class ResultsViewPathwayMapper extends React.Component<
             this.dismissActiveToasts();
         }
 
+        if (!this.PathwayMapperComponent) {
+            return null;
+        }
+
         return (
             <div className="pathwayMapper">
                 <div
@@ -201,8 +217,9 @@ export default class ResultsViewPathwayMapper extends React.Component<
                                 store={this.props.store}
                                 tabReflectsOql={true}
                             />
-
-                            <PathwayMapper
+                            {/*
+                                  // @ts-ignore */}
+                            <this.PathwayMapperComponent
                                 isCBioPortal={true}
                                 isCollaborative={false}
                                 genes={this.props.store.genes.result as any}

--- a/vendor-bundles.webpack.config.js
+++ b/vendor-bundles.webpack.config.js
@@ -26,7 +26,6 @@ const config = {
             'd3',
             'datatables.net',
             'webpack-raphael',
-            'pathway-mapper',
             'pluralize',
             'react-if',
             'react-select1',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -194,6 +194,8 @@ var config = {
                                 '@babel/preset-env',
                                 '@babel/preset-react',
                             ],
+                            plugins: ['syntax-dynamic-import'],
+
                             cacheDirectory: babelCacheFolder,
                         },
                     },


### PR DESCRIPTION
Pathway mapper library is not compatible with IE11.  Merely loading into browswer breaks portal.  This PR loads pathway mapper library dynamically and only when we are not in internet explorer (any version).