### PR TITLE
Update survival plots vocabulary

### DIFF
--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -121,7 +121,6 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
             DFS_SURVIVAL: 300,
             DSS_SURVIVAL: 250,
             PFS_SURVIVAL: 250,
-            EFS_SURVIVAL: 250,
             MUTATION_COUNT_CNA_FRACTION: 200,
             MUTATED_GENES_TABLE: 90,
             FUSION_GENES_TABLE: 85,

--- a/src/pages/resultsView/survival/SurvivalUtil.tsx
+++ b/src/pages/resultsView/survival/SurvivalUtil.tsx
@@ -40,22 +40,20 @@ export type SurvivalPlotFilters = {
 // TODO should remove this if we want to be generic
 export const survivalClinicalDataVocabulary: { [prefix: string]: string[] } = {
     OS: ['DECEASED'],
-    PFS: ['CENSORED'],
-    DFS: ['Recurred/Progressed', 'Recurred'],
-    DSS: ['DEAD WITH TUMOR'],
-    EFS: ['Censored'],
+    PFS: ['Progressed', 'Recurred/Progressed', 'PROGRESSION', 'Yes', '1'],
+    DFS: ['Recurred/Progressed', 'Recurred', 'Progressed', 'Yes', '1'],
+    DSS: ['DECEASED', 'Yes', 'DEAD OF MELANOMA', 'DEAD WITH TUMOR', '1'],
 };
 
 // TODO should remove this if we want to be generic
 export const survivalPlotTooltipxLabelWithEvent: {
     [prefix: string]: string;
 } = {
-    // TODO text for PFS DSS EFS?
+    // TODO text for PFS DSS?
     OS: 'Time of Death',
     PFS: 'Time of Death',
     DFS: 'Time of relapse',
     DSS: 'Time of Death',
-    EFS: 'Time of Death',
 };
 
 // TODO should remove this if we want to be generic
@@ -64,7 +62,6 @@ export const plotsPriority: { [prefix: string]: number } = {
     DFS: 2,
     PFS: 3,
     DSS: 4,
-    EFS: 5,
 };
 
 export const DEFAULT_SURVIVAL_PRIORITY = 999;

--- a/src/pages/studyView/StudyViewConfig.ts
+++ b/src/pages/studyView/StudyViewConfig.ts
@@ -98,7 +98,6 @@ const studyViewFrontEnd = {
         DFS_SURVIVAL: 300,
         DSS_SURVIVAL: 250,
         PFS_SURVIVAL: 250,
-        EFS_SURVIVAL: 250,
         MUTATION_COUNT_CNA_FRACTION: 200,
         MUTATED_GENES_TABLE: 90,
         FUSION_GENES_TABLE: 85,


### PR DESCRIPTION
-  Enlarge the survival plots vocabulary map to cover all possible data values in current studies.
-  remove EFS, so now we only support OS, DFS, PFS, DSS

related to:
https://github.com/cBioPortal/cbioportal/issues/7019
https://github.com/cBioPortal/cbioportal/issues/7311
