### PR TITLE
Add a test for forgotten package.json version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,16 @@ jobs:
           name: "Check Incorrect Package Import Statements"
           command: yarn run checkIncorrectImportStatements
 
+  check_missing_package_version_update:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /tmp/
+      # make sure that version has been updated for the packages that has changed
+      - run:
+          name: "Check Missing Package Version Update"
+          command: yarn run checkMissingPackageVersionUpdate
+
   end_to_end_tests:
     <<: *defaults
     environment:
@@ -292,6 +302,9 @@ workflows:
                 requires:
                     - install
             - check_incorrect_import_statements:
+                requires:
+                    - install
+            - check_missing_package_version_update:
                 requires:
                     - install
     nightly:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "cbioportal-frontend",
   "private": true,
-  "version": "0.0.0",
   "workspaces": {
     "packages": [
       ".",
@@ -18,6 +17,8 @@
     "watch": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && cross-env NODE_ENV=development webpack-dev-server",
     "watchSSL": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && cross-env NODE_ENV=development webpack-dev-server --https",
     "clean": "rimraf dist tsDist common-dist",
+    "checkMissingPackageVersionUpdate": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && ./scripts/check_missing_package_version_update.sh",
+    "updatePackageVersion": "lerna version --no-git-tag-version --no-push",
     "build": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && yarn run buildAll",
     "buildAll": "yarn run buildModules && yarn run buildMain",
     "buildMain": "yarn run clean && yarn run compileOqlParser && yarn run buildDLL:prod && cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 webpack",

--- a/scripts/check_missing_package_version_update.sh
+++ b/scripts/check_missing_package_version_update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# check if there is a change in any of the workspace packages,
+# but the corresponding package version (in package.json) is not updated
+
+# get the names of all changed modules
+MODULES_STR=$(lerna list --since="origin/${BRANCH_ENV}");
+
+# convert to an array
+readarray -t MODULES_ARRAY <<< "$MODULES_STR";
+
+# find packages with unchanged version field
+PACKAGES_MISSING_VERSION_UPDATE=();
+
+# for each updated module, see if package.json is also updated
+for module in ${MODULES_ARRAY[@]}
+do
+  VERSION_DIFF_COUNT=$(git diff --unified=0 origin/${BRANCH_ENV} -- $(printf "packages/%s/package.json" "${module}") | grep -c '"version":');
+  # if no line with "version": has changed, then the package version is NOT updated
+  if [[ $VERSION_DIFF_COUNT == 0 ]]; then
+    PACKAGES_MISSING_VERSION_UPDATE+=($module);
+  fi
+done
+
+# echo all the packages that needs to be updated, but not updated
+if [[ ${#PACKAGES_MISSING_VERSION_UPDATE[@]} > 0 ]]; then
+  echo $(printf '%s\n' "${PACKAGES_MISSING_VERSION_UPDATE[@]}");
+  exit 1;
+fi


### PR DESCRIPTION
- Add a test for `package.json` version field check. 
- We would like to make sure that when a public package is updated, the corresponding `package.json` version is also updated.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!