### PR TITLE
Make language clearer for negative matches

### DIFF
--- a/src/pages/patientView/trialMatch/TrialMatchTable.tsx
+++ b/src/pages/patientView/trialMatch/TrialMatchTable.tsx
@@ -473,8 +473,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                             {this.getDescriptionForNotMatches(
                                 mutationAndCnagenemicAlterations,
                                 3,
-                                'Negative for alterations in',
-                                ''
+                                'mutation'
                             )}
                         </span>
                         <DefaultTooltip
@@ -503,8 +502,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                             {this.getDescriptionForNotMatches(
                                 notMatches.WILDTYPE[0].genomicAlteration,
                                 3,
-                                "Tumor doesn't have",
-                                'defined by the trial'
+                                'wildtype'
                             )}
                         </span>
                         <DefaultTooltip
@@ -577,19 +575,36 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
     public getDescriptionForNotMatches(
         genomicAlteration: string[],
         threshold: number,
-        preContent: string,
-        postContent: string
+        type: string
     ) {
         const hugoSymbolSet = new Set(
             [...genomicAlteration].map((s: string) => s.split(' ')[0])
         );
         let genomicAlterationContent = '';
-        if (hugoSymbolSet.size <= threshold) {
-            genomicAlterationContent = [...hugoSymbolSet].join(', ');
-        } else {
-            genomicAlterationContent = `${hugoSymbolSet.size} genes`;
+        if (type === 'mutation') {
+            if (hugoSymbolSet.size === 1) {
+                genomicAlterationContent =
+                    [...hugoSymbolSet].join(', ') +
+                    ' ' +
+                    [...genomicAlteration]
+                        .map((s: string) => s.split(' ')[1].replace(/!/g, ''))
+                        .join(', ');
+                return `Negative for ${genomicAlterationContent}`;
+            } else if (hugoSymbolSet.size <= threshold) {
+                genomicAlterationContent = [...hugoSymbolSet].join(', ');
+            } else {
+                genomicAlterationContent = `${hugoSymbolSet.size} genes`;
+            }
+            return `Negative for alterations in ${genomicAlterationContent}`;
+        } else if (type === 'wildtype') {
+            if (hugoSymbolSet.size <= threshold) {
+                genomicAlterationContent = [...hugoSymbolSet].join(', ');
+            } else {
+                genomicAlterationContent = `${hugoSymbolSet.size} genes`;
+            }
+            return `Tumor doesn't have ${genomicAlterationContent} defined by the trial`;
         }
-        return `${preContent} ${genomicAlterationContent} ${postContent}`;
+        return '';
     }
 
     render() {

--- a/src/pages/patientView/trialMatch/TrialMatchTable.tsx
+++ b/src/pages/patientView/trialMatch/TrialMatchTable.tsx
@@ -44,6 +44,13 @@ enum ColumnWidth {
     STATUS = 140,
 }
 
+enum AlterationType {
+    MUTATION = 'Mutation',
+    CNA = 'Copy Number Alteration',
+    MSI = 'Microsatellite Instability',
+    WILDTYPE = 'Wildtype',
+}
+
 class TrialMatchTableComponent extends LazyMobXTable<IDetailedTrialMatch> {}
 
 @observer
@@ -473,7 +480,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                             {this.getDescriptionForNotMatches(
                                 mutationAndCnagenemicAlterations,
                                 3,
-                                'mutation'
+                                AlterationType.MUTATION
                             )}
                         </span>
                         <DefaultTooltip
@@ -502,7 +509,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                             {this.getDescriptionForNotMatches(
                                 notMatches.WILDTYPE[0].genomicAlteration,
                                 3,
-                                'wildtype'
+                                AlterationType.WILDTYPE
                             )}
                         </span>
                         <DefaultTooltip
@@ -581,7 +588,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
             [...genomicAlteration].map((s: string) => s.split(' ')[0])
         );
         let genomicAlterationContent = '';
-        if (type === 'mutation') {
+        if (type === AlterationType.MUTATION) {
             if (hugoSymbolSet.size === 1) {
                 genomicAlterationContent =
                     [...hugoSymbolSet].join(', ') +
@@ -596,7 +603,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                 genomicAlterationContent = `${hugoSymbolSet.size} genes`;
             }
             return `Negative for alterations in ${genomicAlterationContent}`;
-        } else if (type === 'wildtype') {
+        } else if (type === AlterationType.WILDTYPE) {
             if (hugoSymbolSet.size <= threshold) {
                 genomicAlterationContent = [...hugoSymbolSet].join(', ');
             } else {


### PR DESCRIPTION
Fix https://github.com/oncokb/oncokb/issues/1900

The language for negative trial matches is not clear. The old one is `Negative for alterations in BRAF` which is changed to the new one `Negative for BRAF V600`

![Screen Shot 2020-04-07 at 9 03 46 PM](https://user-images.githubusercontent.com/14971266/78733447-7c00fb00-7913-11ea-99f2-9edb68fee2fe.png)
