### PR TITLE
OncoKB Card improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "react-markdown": "^3.4.1",
     "react-mfb": "^0.6.0",
     "react-motion": "^0.4.7",
-    "react-mutation-mapper": "^0.5.6",
+    "react-mutation-mapper": "^0.5.7",
     "react-overlays": "0.7.4",
     "react-portal": "^4.2.0",
     "react-rangeslider": "^2.1.0",

--- a/packages/react-mutation-mapper/package.json
+++ b/packages/react-mutation-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mutation-mapper",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Generic Mutation Mapper",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbTreatmentTable.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbTreatmentTable.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import ReactTable from 'react-table';
 
 import {
+    getPositionalVariant,
     getTumorTypeName,
     levelIconClassNames,
     mergeAlterations,
@@ -115,6 +116,11 @@ export default class OncoKbTreatmentTable extends React.Component<
                             alteration.toLocaleLowerCase() ===
                             lowerCasedQueryVariant
                     );
+                    if (!matchedAlteration) {
+                        matchedAlteration = getPositionalVariant(
+                            this.props.variant
+                        );
+                    }
                     let pickedAlteration =
                         matchedAlteration === undefined
                             ? props.value[0]
@@ -205,12 +211,6 @@ export default class OncoKbTreatmentTable extends React.Component<
                 <ReactTable
                     data={this.props.treatments}
                     columns={this.columns}
-                    defaultSorted={[
-                        {
-                            id: 'level',
-                            desc: true,
-                        },
-                    ]}
                     showPagination={false}
                     pageSize={this.props.treatments.length}
                     className="-striped -highlight"

--- a/packages/react-mutation-mapper/src/util/OncoKbUtils.spec.tsx
+++ b/packages/react-mutation-mapper/src/util/OncoKbUtils.spec.tsx
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { Mutation } from '../model/Mutation';
 import {
     defaultOncoKbIndicatorFilter,
+    getPositionalVariant,
     groupOncoKbIndicatorDataByMutations,
 } from './OncoKbUtils';
 
@@ -176,6 +177,67 @@ describe('OncoKbUtils', () => {
             assert.isUndefined(
                 grouped[666],
                 'none should be picked by the indicator filter as oncogenic at position 666'
+            );
+        });
+    });
+
+    describe('getPositionalVariant', () => {
+        it('Missense with one amino acid change', () => {
+            const missenseAlteration = 'V600E';
+            const expectedPositionalVariant = 'V600';
+            assert.equal(
+                getPositionalVariant(missenseAlteration),
+                expectedPositionalVariant,
+                'V600 should be returned'
+            );
+        });
+        it('Missense with multiple amino acid changes', () => {
+            const missenseAlteration = 'VK600EI';
+            const expectedPositionalVariant = 'V600';
+            assert.equal(
+                getPositionalVariant(missenseAlteration),
+                expectedPositionalVariant,
+                'V600 should be returned'
+            );
+        });
+        it('Input is positional alteration', () => {
+            const oneAAAlteration = 'V600';
+            const twoAAAlteration = 'VK600';
+            const expectedPositionalVariant = 'V600';
+            assert.equal(
+                getPositionalVariant(oneAAAlteration),
+                expectedPositionalVariant,
+                'V600 should be returned'
+            );
+            assert.equal(
+                getPositionalVariant(twoAAAlteration),
+                expectedPositionalVariant,
+                'V600 should be returned'
+            );
+        });
+        it('Undefined returned for delins missense alteration', () => {
+            // the structure is too complex to parse, we simply skip for this scenario
+            const missenseAlteration = 'M277_D278delinsIY';
+            assert.equal(
+                getPositionalVariant(missenseAlteration),
+                undefined,
+                'undefined should be returned'
+            );
+        });
+        it('Undefined returned for other type of alteration', () => {
+            const inframeDeletion = 'N486_T491delinsK';
+            assert.equal(
+                getPositionalVariant(inframeDeletion),
+                undefined,
+                'undefined should be returned'
+            );
+        });
+        it('Undefined returned for empty string', () => {
+            const missenseAlteration = '';
+            assert.equal(
+                getPositionalVariant(missenseAlteration),
+                undefined,
+                'V600 should be returned'
             );
         });
     });

--- a/packages/react-mutation-mapper/src/util/OncoKbUtils.ts
+++ b/packages/react-mutation-mapper/src/util/OncoKbUtils.ts
@@ -261,6 +261,29 @@ export function mergeAlterations(alterations: string | string[]) {
     return regular.join(', ');
 }
 
+/**
+ * Return the positional variant of the missense mutation
+ * @param alteration The missense mutation
+ */
+export function getPositionalVariant(alteration: string) {
+    const regExp = new RegExp('^([A-Z]+)([0-9]+)([A-Z]*)$');
+    const result = regExp.exec(alteration);
+
+    // Only if the alteration is missense mutation or positional variant
+    // result[0]: matched alteration
+    // result[1]: reference alleles (there could be multiple reference alleles, we only return the first allele)
+    // result[2]: position(protein start/end)
+    // result[3]: variant alleles (empty if the alteration is positional variant already)
+    if (
+        _.isArray(result) &&
+        result.length === 4 &&
+        (!result[3] || result[1].length === result[3].length)
+    ) {
+        return `${result[1][0]}${result[2]}`;
+    }
+    return undefined;
+}
+
 export function getTumorTypeName(tumorType?: TumorType) {
     if (!tumorType) {
         return '';


### PR DESCRIPTION
- Get positional alteration matched when the exact match does not exist in alterations column in oncokb treatment table
- Do not sort oncokb card treatment table by default, use the default sorting returned from oncokb data

This fixes https://github.com/cBioPortal/cbioportal/issues/7365
