### PR TITLE
Fix oncokb icon in ie11

### DIFF
--- a/src/rootImages/oncokb-oncogenic-1.svg
+++ b/src/rootImages/oncokb-oncogenic-1.svg
@@ -1,10 +1,19 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg">
- <g>
-  <title>Layer 1</title>
-  <g id="svg_4">
-   <ellipse ry="174" rx="174.5" id="svg_1" cy="200" cx="200.5" stroke-width="50" stroke="#007fff" fill="none"/>
-   <ellipse id="svg_2" ry="97.44" rx="99.14772" cy="200" cx="201.49147" stroke-width="50" stroke="#007fff" fill="none"/>
-   <ellipse id="svg_3" ry="52.2" rx="53.04403" cy="198.50857" cx="200.00426" stroke-width="0" stroke="#007fff" fill="#007fff"/>
-  </g>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+     width="400" height="400" viewBox="0 0 194.000000 194.000000"
+     preserveAspectRatio="xMidYMid meet">
+ <metadata>
+  Created by potrace 1.10, written by Peter Selinger 2001-2011
+ </metadata>
+ <g transform="translate(0.000000,194.000000) scale(0.050000,-0.050000)"
+    fill="#366bcc" stroke="none">
+  <path d="M1746 3858 c-1605 -149 -2312 -2135 -1168 -3280 1212 -1212 3285
+-353 3285 1362 0 1149 -967 2025 -2117 1918z m490 -489 c922 -187 1427 -1211
+1014 -2059 -538 -1105 -2082 -1105 -2620 0 -526 1080 424 2298 1606 2059z"/>
+  <path d="M1670 3111 c-181 -54 -199 -60 -325 -129 -676 -366 -805 -1336 -252
+-1889 552 -553 1524 -424 1889 252 318 590 116 1333 -447 1637 -264 142 -631
+197 -865 129z m543 -494 c162 -60 343 -241 407 -407 285 -735 -635 -1339
+-1192 -782 -561 561 38 1468 785 1189z"/>
+  <path d="M1820 2402 c-532 -174 -435 -931 120 -931 499 0 657 664 212 893 -86
+44 -255 64 -332 38z"/>
  </g>
 </svg>


### PR DESCRIPTION
Old SVG image was not compatible with IE11 for unknown reason.