### PR TITLE
Refine global/local http error handling

### DIFF
--- a/packages/cbioportal-frontend-commons/src/api/remoteData.ts
+++ b/packages/cbioportal-frontend-commons/src/api/remoteData.ts
@@ -6,14 +6,6 @@ import {
     hasObservers,
 } from 'mobxpromise';
 
-type errorHandler = (error: Error) => void;
-
-let errorHandlers: errorHandler[] = [];
-
-export function addServiceErrorHandler(handler: errorHandler) {
-    errorHandlers.push(handler);
-}
-
 (MobxPromise as any).prototype.toJSON = function() {
     return JSON.stringify(this.result);
 };
@@ -38,10 +30,6 @@ export const remoteData: MobxPromiseFactory = function<R>(
         onError: error => {
             if (onError) {
                 onError(error);
-            } else if (!hasObservers(mobxPromise, 'error')) {
-                errorHandlers.forEach(handler => {
-                    handler(error);
-                });
             }
         },
     });

--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -23,7 +23,11 @@ export class AppStore {
                 sendSentryMessage('ERRORHANDLER:' + error);
             } catch (ex) {}
 
-            if (error.status && /400|500|403/.test(error.status)) {
+            if (
+                error.status &&
+                parseInt(error.status) &&
+                parseInt(error.status) >= 400
+            ) {
                 sendSentryMessage('ERROR DIALOG SHOWN:' + error);
                 this.siteErrors.push({ errorObj: error, dismissed: false });
             }

--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -110,6 +110,7 @@ superagent.Request.prototype.end = function(callback) {
         if (redirecting) {
             return;
         }
+
         if (response && response.statusCode === 401) {
             var storageKey = `redirect${Math.floor(
                 Math.random() * 1000000000000
@@ -131,6 +132,8 @@ superagent.Request.prototype.end = function(callback) {
         } else {
             callback(error, response);
         }
+
+        return this;
     });
 };
 

--- a/src/appShell/App/Container.tsx
+++ b/src/appShell/App/Container.tsx
@@ -17,6 +17,8 @@ import {
 import { buildCBioPortalPageUrl } from 'shared/api/urls';
 import ErrorScreen from 'shared/components/errorScreen/ErrorScreen';
 import { ServerConfigHelpers } from 'config/config';
+import { AppStore } from 'AppStore';
+import { Modal } from 'react-bootstrap';
 
 interface IContainerProps {
     location: Location;
@@ -104,37 +106,33 @@ export default class Container extends React.Component<IContainerProps, {}> {
                         <PortalHeader appStore={this.appStore} />
                     </div>
                 </div>
-                <If condition={this.appStore.isErrorCondition}>
-                    <Then>
-                        <div className="contentWrapper">
-                            <ErrorScreen
-                                title={
-                                    formatErrorTitle(
-                                        this.appStore.undismissedSiteErrors
-                                    ) ||
-                                    'Oops. There was an error retrieving data.'
-                                }
-                                body={
-                                    <a href={buildCBioPortalPageUrl('/')}>
-                                        Return to homepage
-                                    </a>
-                                }
-                                errorLog={formatErrorLog(
-                                    this.appStore.undismissedSiteErrors
-                                )}
-                                errorMessages={formatErrorMessages(
-                                    this.appStore.undismissedSiteErrors
-                                )}
-                            />
-                        </div>
-                    </Then>
-                    <Else>
-                        <div className="contentWrapper">
-                            {this.props.children}
-                        </div>
-                    </Else>
-                </If>
+                <div className="contentWrapper">
+                    <If condition={this.appStore.isErrorCondition}>
+                        <Then>{showSiteErrors(this.appStore)}</Then>
+                        <Else>
+                            <>
+                                {this.appStore.isDialogErrorCondition &&
+                                    showSiteErrors(this.appStore)}
+                                {this.props.children}
+                            </>
+                        </Else>
+                    </If>
+                </div>
             </div>
         );
+    }
+}
+
+function showSiteErrors(appStore: AppStore) {
+    if (appStore.isErrorCondition) {
+        return (
+            <ErrorScreen
+                title={'Oops. There was an error retrieving data.'}
+                errors={appStore.undismissedSiteErrors}
+                errorLog={formatErrorLog(appStore.undismissedSiteErrors)}
+            />
+        );
+    } else {
+        return null;
     }
 }

--- a/src/pages/groupComparison/ClinicalData.tsx
+++ b/src/pages/groupComparison/ClinicalData.tsx
@@ -267,17 +267,19 @@ export default class ClinicalData extends React.Component<
                         })
                 );
 
-                let clinicalData = await client.fetchClinicalDataUsingPOST({
-                    clinicalDataType: attribute.patientAttribute
-                        ? 'PATIENT'
-                        : 'SAMPLE',
-                    clinicalDataMultiStudyFilter: {
-                        attributeIds: [attribute.clinicalAttributeId],
-                        identifiers: attribute.patientAttribute
-                            ? patientidentifiers
-                            : sampleIdentifiers,
-                    },
-                });
+                let clinicalData = await client
+                    .handleErrorsGlobally()
+                    .fetchClinicalDataUsingPOST({
+                        clinicalDataType: attribute.patientAttribute
+                            ? 'PATIENT'
+                            : 'SAMPLE',
+                        clinicalDataMultiStudyFilter: {
+                            attributeIds: [attribute.clinicalAttributeId],
+                            identifiers: attribute.patientAttribute
+                                ? patientidentifiers
+                                : sampleIdentifiers,
+                        },
+                    });
 
                 const shouldParseFloat =
                     attribute.datatype.toLowerCase() === 'number';

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -313,7 +313,7 @@ export default class GroupComparisonStore extends ComparisonStore {
                     }
                 }
             }
-            return client.fetchSamplesUsingPOST({
+            return client.handleErrorsGlobally().fetchSamplesUsingPOST({
                 sampleFilter: {
                     sampleIdentifiers,
                 } as SampleFilter,
@@ -327,7 +327,7 @@ export default class GroupComparisonStore extends ComparisonStore {
             await: () => [this._session],
             invoke: () => {
                 const studyIds = getStudyIds(this._session.result!.groups);
-                return client.fetchStudiesUsingPOST({
+                return client.handleErrorsGlobally().fetchStudiesUsingPOST({
                     studyIds,
                     projection: 'DETAILED',
                 });

--- a/src/shared/api/cbioportalClientInstance.ts
+++ b/src/shared/api/cbioportalClientInstance.ts
@@ -1,5 +1,10 @@
 import CBioPortalAPI from './generated/CBioPortalAPI';
+import { AppStore, SiteError } from 'AppStore';
+import { getBrowserWindow } from 'cbioportal-frontend-commons';
+import { extendCBioPortalAPI } from 'shared/lib/extendCBioPortalAPI';
 
-const client = new CBioPortalAPI();
+const ExtendedCBioPortalAPI = extendCBioPortalAPI(CBioPortalAPI);
+
+const client = new ExtendedCBioPortalAPI();
 
 export default client;

--- a/src/shared/api/cbioportalInternalClientInstance.ts
+++ b/src/shared/api/cbioportalInternalClientInstance.ts
@@ -1,5 +1,8 @@
 import CBioPortalAPIInternal from './generated/CBioPortalAPIInternal';
+import { extendCBioPortalAPI } from 'shared/lib/extendCBioPortalAPI';
 
-const internalClient = new CBioPortalAPIInternal();
+const ExtendedCBioPortalAPI = extendCBioPortalAPI(CBioPortalAPIInternal);
+
+const internalClient = new ExtendedCBioPortalAPI();
 
 export default internalClient;

--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -53,7 +53,9 @@ class StudyInfoOverlay extends React.Component<
 > {
     @observable readonly studyMetadata = remoteData({
         invoke: async () => {
-            return client.getTagsUsingGET({ studyId: this.props.studyId });
+            return client
+                .handleErrorsGlobally({ mode: 'dialog' })
+                .getTagsUsingGET({ studyId: this.props.studyId });
         },
         onError: error => {
             console.error('Error on getting study tags.', error);

--- a/src/shared/lib/MobxPromiseCache.ts
+++ b/src/shared/lib/MobxPromiseCache.ts
@@ -1,5 +1,6 @@
 import { MobxPromise, MobxPromiseInputParams } from 'mobxpromise';
 import { logicalAnd } from './LogicUtils';
+import { remoteData } from 'cbioportal-frontend-commons';
 
 export function stringifyObjectUnique(obj: { [k: string]: any }) {
     const keys = Object.keys(obj);
@@ -31,7 +32,7 @@ export default class MobxPromiseCache<Query, Result> {
     public get(q: Query): MobxPromise<Result> {
         const key = this.queryToKey(q);
         if (!this.cache[key]) {
-            this.cache[key] = new MobxPromise<Result>(
+            this.cache[key] = remoteData<Result>(
                 this.queryToMobxPromiseInput(q)
             );
         }

--- a/src/shared/lib/SuperAgentWrapped.ts
+++ b/src/shared/lib/SuperAgentWrapped.ts
@@ -1,0 +1,39 @@
+import { Request } from 'superagent';
+import request from 'superagent';
+import { SiteError } from 'AppStore';
+import { getBrowserWindow } from 'cbioportal-frontend-commons';
+
+class SuperAgentClient {
+    handleErrorsGlobally(errorConfig: Partial<SiteError> = {}) {
+        // @ts-ignore end does in fact exist)
+        const oldEnd = Request.prototype.end;
+
+        const restoreEnd = function() {
+            // @ts-ignore end does in fact exist)
+            Request.prototype.end = oldEnd;
+        };
+
+        // @ts-ignore end does in fact exist)
+        Request.prototype.end = function(fn) {
+            const callback = function(err: any) {
+                if (err) {
+                    errorConfig.errorObj = err;
+                    getBrowserWindow().globalStores.appStore.handleServiceError(
+                        errorConfig as SiteError
+                    );
+                }
+                fn.apply(this, arguments);
+            };
+            oldEnd.call(this, callback);
+            restoreEnd();
+        };
+
+        return request;
+    }
+
+    handleErrorsLocally() {
+        return request;
+    }
+}
+
+export default new SuperAgentClient();

--- a/src/shared/lib/extendCBioPortalAPI.ts
+++ b/src/shared/lib/extendCBioPortalAPI.ts
@@ -1,0 +1,50 @@
+import CBioPortalAPI from 'shared/api/generated/CBioPortalAPI';
+import { SiteError } from 'AppStore';
+import { getBrowserWindow } from 'cbioportal-frontend-commons';
+
+type Constructor<T> = new (...args: any[]) => T;
+
+export function extendCBioPortalAPI<T extends Constructor<{}>>(Base: T) {
+    return class extends Base {
+        handleErrorsGlobally(errorConfig: Partial<SiteError> = {}) {
+            const self = this;
+
+            // @ts-ignore (it's private, but we CAN access it)
+            const proxiedRequest = this.request;
+
+            function restoreRequest() {
+                // @ts-ignore (it's private, but we CAN access it)
+                self.request = proxiedRequest;
+            }
+
+            // @ts-ignore (it's private, but we CAN access it)
+            self.request = function() {
+                const args = Array.from(arguments);
+                if (args.length >= 9) {
+                    args[8] = args[8].concat([
+                        function(error: any) {
+                            errorConfig.errorObj = error;
+                            getBrowserWindow().globalStores.appStore.handleServiceError(
+                                errorConfig as SiteError
+                            );
+                        },
+                    ]);
+                }
+                // @ts-ignore
+                const res = proxiedRequest(...args);
+                restoreRequest();
+            };
+            return self;
+        }
+
+        handleErrorsLocally() {
+            return this;
+        }
+
+        constructor(...args: any[]) {
+            super(...args);
+        }
+    };
+}
+
+class Nada {}

--- a/src/shared/lib/oql/oql-parser.js
+++ b/src/shared/lib/oql/oql-parser.js
@@ -4,3031 +4,2561 @@
  * http://pegjs.org/
  */
 
-'use strict';
+"use strict";
 
 function peg$subclass(child, parent) {
-    function ctor() {
-        this.constructor = child;
-    }
-    ctor.prototype = parent.prototype;
-    child.prototype = new ctor();
+  function ctor() { this.constructor = child; }
+  ctor.prototype = parent.prototype;
+  child.prototype = new ctor();
 }
 
 function peg$SyntaxError(message, expected, found, location) {
-    this.message = message;
-    this.expected = expected;
-    this.found = found;
-    this.location = location;
-    this.name = 'SyntaxError';
+  this.message  = message;
+  this.expected = expected;
+  this.found    = found;
+  this.location = location;
+  this.name     = "SyntaxError";
 
-    if (typeof Error.captureStackTrace === 'function') {
-        Error.captureStackTrace(this, peg$SyntaxError);
-    }
+  if (typeof Error.captureStackTrace === "function") {
+    Error.captureStackTrace(this, peg$SyntaxError);
+  }
 }
 
 peg$subclass(peg$SyntaxError, Error);
 
 peg$SyntaxError.buildMessage = function(expected, found) {
-    var DESCRIBE_EXPECTATION_FNS = {
+  var DESCRIBE_EXPECTATION_FNS = {
         literal: function(expectation) {
-            return '"' + literalEscape(expectation.text) + '"';
+          return "\"" + literalEscape(expectation.text) + "\"";
         },
 
-        class: function(expectation) {
-            var escapedParts = '',
-                i;
+        "class": function(expectation) {
+          var escapedParts = "",
+              i;
 
-            for (i = 0; i < expectation.parts.length; i++) {
-                escapedParts +=
-                    expectation.parts[i] instanceof Array
-                        ? classEscape(expectation.parts[i][0]) +
-                          '-' +
-                          classEscape(expectation.parts[i][1])
-                        : classEscape(expectation.parts[i]);
-            }
+          for (i = 0; i < expectation.parts.length; i++) {
+            escapedParts += expectation.parts[i] instanceof Array
+              ? classEscape(expectation.parts[i][0]) + "-" + classEscape(expectation.parts[i][1])
+              : classEscape(expectation.parts[i]);
+          }
 
-            return '[' + (expectation.inverted ? '^' : '') + escapedParts + ']';
+          return "[" + (expectation.inverted ? "^" : "") + escapedParts + "]";
         },
 
         any: function(expectation) {
-            return 'any character';
+          return "any character";
         },
 
         end: function(expectation) {
-            return 'end of input';
+          return "end of input";
         },
 
         other: function(expectation) {
-            return expectation.description;
-        },
-    };
-
-    function hex(ch) {
-        return ch
-            .charCodeAt(0)
-            .toString(16)
-            .toUpperCase();
-    }
-
-    function literalEscape(s) {
-        return s
-            .replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/\0/g, '\\0')
-            .replace(/\t/g, '\\t')
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/[\x00-\x0F]/g, function(ch) {
-                return '\\x0' + hex(ch);
-            })
-            .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) {
-                return '\\x' + hex(ch);
-            });
-    }
-
-    function classEscape(s) {
-        return s
-            .replace(/\\/g, '\\\\')
-            .replace(/\]/g, '\\]')
-            .replace(/\^/g, '\\^')
-            .replace(/-/g, '\\-')
-            .replace(/\0/g, '\\0')
-            .replace(/\t/g, '\\t')
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/[\x00-\x0F]/g, function(ch) {
-                return '\\x0' + hex(ch);
-            })
-            .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) {
-                return '\\x' + hex(ch);
-            });
-    }
-
-    function describeExpectation(expectation) {
-        return DESCRIBE_EXPECTATION_FNS[expectation.type](expectation);
-    }
-
-    function describeExpected(expected) {
-        var descriptions = new Array(expected.length),
-            i,
-            j;
-
-        for (i = 0; i < expected.length; i++) {
-            descriptions[i] = describeExpectation(expected[i]);
+          return expectation.description;
         }
+      };
 
-        descriptions.sort();
+  function hex(ch) {
+    return ch.charCodeAt(0).toString(16).toUpperCase();
+  }
 
-        if (descriptions.length > 0) {
-            for (i = 1, j = 1; i < descriptions.length; i++) {
-                if (descriptions[i - 1] !== descriptions[i]) {
-                    descriptions[j] = descriptions[i];
-                    j++;
-                }
-            }
-            descriptions.length = j;
-        }
+  function literalEscape(s) {
+    return s
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g,  '\\"')
+      .replace(/\0/g, '\\0')
+      .replace(/\t/g, '\\t')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/[\x00-\x0F]/g,          function(ch) { return '\\x0' + hex(ch); })
+      .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) { return '\\x'  + hex(ch); });
+  }
 
-        switch (descriptions.length) {
-            case 1:
-                return descriptions[0];
+  function classEscape(s) {
+    return s
+      .replace(/\\/g, '\\\\')
+      .replace(/\]/g, '\\]')
+      .replace(/\^/g, '\\^')
+      .replace(/-/g,  '\\-')
+      .replace(/\0/g, '\\0')
+      .replace(/\t/g, '\\t')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/[\x00-\x0F]/g,          function(ch) { return '\\x0' + hex(ch); })
+      .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) { return '\\x'  + hex(ch); });
+  }
 
-            case 2:
-                return descriptions[0] + ' or ' + descriptions[1];
+  function describeExpectation(expectation) {
+    return DESCRIBE_EXPECTATION_FNS[expectation.type](expectation);
+  }
 
-            default:
-                return (
-                    descriptions.slice(0, -1).join(', ') +
-                    ', or ' +
-                    descriptions[descriptions.length - 1]
-                );
-        }
+  function describeExpected(expected) {
+    var descriptions = new Array(expected.length),
+        i, j;
+
+    for (i = 0; i < expected.length; i++) {
+      descriptions[i] = describeExpectation(expected[i]);
     }
 
-    function describeFound(found) {
-        return found ? '"' + literalEscape(found) + '"' : 'end of input';
+    descriptions.sort();
+
+    if (descriptions.length > 0) {
+      for (i = 1, j = 1; i < descriptions.length; i++) {
+        if (descriptions[i - 1] !== descriptions[i]) {
+          descriptions[j] = descriptions[i];
+          j++;
+        }
+      }
+      descriptions.length = j;
     }
 
-    return (
-        'Expected ' +
-        describeExpected(expected) +
-        ' but ' +
-        describeFound(found) +
-        ' found.'
-    );
+    switch (descriptions.length) {
+      case 1:
+        return descriptions[0];
+
+      case 2:
+        return descriptions[0] + " or " + descriptions[1];
+
+      default:
+        return descriptions.slice(0, -1).join(", ")
+          + ", or "
+          + descriptions[descriptions.length - 1];
+    }
+  }
+
+  function describeFound(found) {
+    return found ? "\"" + literalEscape(found) + "\"" : "end of input";
+  }
+
+  return "Expected " + describeExpected(expected) + " but " + describeFound(found) + " found.";
 };
 
 function peg$parse(input, options) {
-    options = options !== void 0 ? options : {};
+  options = options !== void 0 ? options : {};
 
-    var peg$FAILED = {},
-        peg$startRuleFunctions = { start: peg$parsestart },
-        peg$startRuleFunction = peg$parsestart,
-        peg$c0 = function() {
-            return false;
-        },
-        peg$c1 = /^[0-9]/,
-        peg$c2 = peg$classExpectation([['0', '9']], false, false),
-        peg$c3 = function(number) {
-            return number.join('');
-        },
-        peg$c4 = '-',
-        peg$c5 = peg$literalExpectation('-', false),
-        peg$c6 = function(number) {
-            return '-' + number;
-        },
-        peg$c7 = '.',
-        peg$c8 = peg$literalExpectation('.', false),
-        peg$c9 = function(whole_part, decimal_part) {
-            return whole_part + '.' + decimal_part;
-        },
-        peg$c10 = function(decimal_part) {
-            return '.' + decimal_part;
-        },
-        peg$c11 = function(whole_part) {
-            return whole_part;
-        },
-        peg$c12 = /^[\-_.@\/a-zA-Z0-9*]/,
-        peg$c13 = peg$classExpectation(
-            ['-', '_', '.', '@', '/', ['a', 'z'], ['A', 'Z'], ['0', '9'], '*'],
-            false,
-            false
-        ),
-        peg$c14 = function(word) {
-            return word.join('');
-        },
-        peg$c15 = /^[\-_.\/a-zA-Z0-9*]/,
-        peg$c16 = peg$classExpectation(
-            ['-', '_', '.', '/', ['a', 'z'], ['A', 'Z'], ['0', '9'], '*'],
-            false,
-            false
-        ),
-        peg$c17 = function(char) {
-            return char;
-        },
-        peg$c18 = /^[GPAVLIMCFYWHKRQNEDST]/,
-        peg$c19 = peg$classExpectation(
-            [
-                'G',
-                'P',
-                'A',
-                'V',
-                'L',
-                'I',
-                'M',
-                'C',
-                'F',
-                'Y',
-                'W',
-                'H',
-                'K',
-                'R',
-                'Q',
-                'N',
-                'E',
-                'D',
-                'S',
-                'T',
-            ],
-            false,
-            false
-        ),
-        peg$c20 = function(letter) {
-            return letter;
-        },
-        peg$c21 = /^[^"]/,
-        peg$c22 = peg$classExpectation(['"'], true, false),
-        peg$c23 = function(stringExceptQuotes) {
-            return stringExceptQuotes.join('');
-        },
-        peg$c24 = /^[ \t\r]/,
-        peg$c25 = peg$classExpectation([' ', '\t', '\r'], false, false),
-        peg$c26 = /^[,; \t\r\n]/,
-        peg$c27 = peg$classExpectation(
-            [',', ';', ' ', '\t', '\r', '\n'],
-            false,
-            false
-        ),
-        peg$c28 = '[',
-        peg$c29 = peg$literalExpectation('[', false),
-        peg$c30 = '"',
-        peg$c31 = peg$literalExpectation('"', false),
-        peg$c32 = function(label) {
-            return { label: label, list: [] };
-        },
-        peg$c33 = function() {
-            return { label: undefined, list: [] };
-        },
-        peg$c34 = 'amp',
-        peg$c35 = peg$literalExpectation('AMP', true),
-        peg$c36 = 'homdel',
-        peg$c37 = peg$literalExpectation('HOMDEL', true),
-        peg$c38 = 'gain',
-        peg$c39 = peg$literalExpectation('GAIN', true),
-        peg$c40 = 'hetloss',
-        peg$c41 = peg$literalExpectation('HETLOSS', true),
-        peg$c42 = 'mut',
-        peg$c43 = peg$literalExpectation('MUT', true),
-        peg$c44 = 'exp',
-        peg$c45 = peg$literalExpectation('EXP', true),
-        peg$c46 = 'prot',
-        peg$c47 = peg$literalExpectation('PROT', true),
-        peg$c48 = function(mqr, sqr) {
-            return mqr.concat(sqr);
-        },
-        peg$c49 = function(qr, sqr) {
-            return qr.concat(sqr);
-        },
-        peg$c50 = function(mqr) {
-            return mqr;
-        },
-        peg$c51 = function(qr) {
-            return qr;
-        },
-        peg$c52 = ']',
-        peg$c53 = peg$literalExpectation(']', false),
-        peg$c54 = function(mergedGenes, qr, mqr) {
-            mergedGenes.list = qr;
-            return [mergedGenes].concat(mqr);
-        },
-        peg$c55 = function(mergedGenes, qr) {
-            mergedGenes.list = qr;
-            return [mergedGenes];
-        },
-        peg$c56 = function(first, rest) {
-            return [first].concat(rest);
-        },
-        peg$c57 = function(first) {
-            return [first];
-        },
-        peg$c58 = ':',
-        peg$c59 = peg$literalExpectation(':', false),
-        peg$c60 = function(geneName, alts) {
-            return { gene: geneName, alterations: alts };
-        },
-        peg$c61 = function(geneName) {
-            return { gene: geneName, alterations: false };
-        },
-        peg$c62 = function(a1, a2) {
-            return [a1].concat(a2);
-        },
-        peg$c63 = function(a1) {
-            return [a1];
-        },
-        peg$c64 = function(cmd) {
-            return cmd;
-        },
-        peg$c65 = '_',
-        peg$c66 = peg$literalExpectation('_', false),
-        peg$c67 = function(d) {
-            return { alteration_type: 'any', modifiers: [d] };
-        },
-        peg$c68 = function() {
-            return 'AMP';
-        },
-        peg$c69 = function() {
-            return 'HOMDEL';
-        },
-        peg$c70 = function() {
-            return 'GAIN';
-        },
-        peg$c71 = function() {
-            return 'HETLOSS';
-        },
-        peg$c72 = 'cna',
-        peg$c73 = peg$literalExpectation('CNA', true),
-        peg$c74 = function(op, constrval) {
-            return {
-                alteration_type: 'cna',
-                constr_rel: op,
-                constr_val: constrval,
-                modifiers: [],
-            };
-        },
-        peg$c75 = 'CNA_',
-        peg$c76 = peg$literalExpectation('CNA_', false),
-        peg$c77 = function(mod) {
-            return { alteration_type: 'cna', modifiers: [mod] };
-        },
-        peg$c78 = function(constrval, mod) {
-            return {
-                alteration_type: 'cna',
-                constr_rel: '=',
-                constr_val: constrval,
-                modifiers: [mod],
-            };
-        },
-        peg$c79 = '_CNA',
-        peg$c80 = peg$literalExpectation('_CNA', false),
-        peg$c81 = function(mod, constrval) {
-            return {
-                alteration_type: 'cna',
-                constr_rel: '=',
-                constr_val: constrval,
-                modifiers: [mod],
-            };
-        },
-        peg$c82 = function(constrval) {
-            return {
-                alteration_type: 'cna',
-                constr_rel: '=',
-                constr_val: constrval,
-                modifiers: [],
-            };
-        },
-        peg$c83 = 'MUT',
-        peg$c84 = peg$literalExpectation('MUT', false),
-        peg$c85 = '=',
-        peg$c86 = peg$literalExpectation('=', false),
-        peg$c87 = function(mutation) {
-            return {
-                alteration_type: 'mut',
-                constr_rel: '=',
-                constr_type: mutation.type,
-                constr_val: mutation.value,
-                info: mutation.info,
-                modifiers: mutation.modifiers,
-            };
-        },
-        peg$c88 = '!=',
-        peg$c89 = peg$literalExpectation('!=', false),
-        peg$c90 = function(mutation) {
-            return {
-                alteration_type: 'mut',
-                constr_rel: '!=',
-                constr_type: mutation.type,
-                constr_val: mutation.value,
-                info: mutation.info,
-                modifiers: mutation.modifiers,
-            };
-        },
-        peg$c91 = function(mutation) {
-            if (mutation.type) {
-                return {
-                    alteration_type: 'mut',
-                    constr_rel: '=',
-                    constr_type: mutation.type,
-                    constr_val: mutation.value,
-                    info: mutation.info,
-                    modifiers: mutation.modifiers,
-                };
-            } else {
-                return {
-                    alteration_type: 'mut',
-                    info: {},
-                    modifiers: mutation.modifiers,
-                };
-            }
-        },
-        peg$c92 = 'EXP',
-        peg$c93 = peg$literalExpectation('EXP', false),
-        peg$c94 = function(op, constrval) {
-            return {
-                alteration_type: 'exp',
-                constr_rel: op,
-                constr_val: parseFloat(constrval),
-            };
-        },
-        peg$c95 = 'fusion',
-        peg$c96 = peg$literalExpectation('FUSION', true),
-        peg$c97 = function(mod) {
-            return { alteration_type: 'fusion', modifiers: [mod] };
-        },
-        peg$c98 = '_fusion',
-        peg$c99 = peg$literalExpectation('_FUSION', true),
-        peg$c100 = function() {
-            return { alteration_type: 'fusion', modifiers: [] };
-        },
-        peg$c101 = 'PROT',
-        peg$c102 = peg$literalExpectation('PROT', false),
-        peg$c103 = function(op, constrval) {
-            return {
-                alteration_type: 'prot',
-                constr_rel: op,
-                constr_val: parseFloat(constrval),
-            };
-        },
-        peg$c104 = '>=',
-        peg$c105 = peg$literalExpectation('>=', false),
-        peg$c106 = function() {
-            return '>=';
-        },
-        peg$c107 = '<=',
-        peg$c108 = peg$literalExpectation('<=', false),
-        peg$c109 = function() {
-            return '<=';
-        },
-        peg$c110 = '>',
-        peg$c111 = peg$literalExpectation('>', false),
-        peg$c112 = function() {
-            return '>';
-        },
-        peg$c113 = '<',
-        peg$c114 = peg$literalExpectation('<', false),
-        peg$c115 = function() {
-            return '<';
-        },
-        peg$c116 = function(modifier, mutationWithModifiers) {
-            mutationWithModifiers.modifiers.unshift(modifier);
-            return mutationWithModifiers;
-        },
-        peg$c117 = function(mutation, modifiers) {
-            mutation.modifiers = modifiers;
-            return mutation;
-        },
-        peg$c118 = function(modifier) {
-            return { info: {}, modifiers: [modifier] };
-        },
-        peg$c119 = function(mutation) {
-            mutation.modifiers = [];
-            return mutation;
-        },
-        peg$c120 = function(modifier, more) {
-            return [modifier].concat(more);
-        },
-        peg$c121 = function(modifier) {
-            return [modifier];
-        },
-        peg$c122 = function() {
-            return { info: {} };
-        },
-        peg$c123 = 'missense',
-        peg$c124 = peg$literalExpectation('MISSENSE', true),
-        peg$c125 = function() {
-            return { type: 'class', value: 'MISSENSE', info: {} };
-        },
-        peg$c126 = 'nonsense',
-        peg$c127 = peg$literalExpectation('NONSENSE', true),
-        peg$c128 = function() {
-            return { type: 'class', value: 'NONSENSE', info: {} };
-        },
-        peg$c129 = 'nonstart',
-        peg$c130 = peg$literalExpectation('NONSTART', true),
-        peg$c131 = function() {
-            return { type: 'class', value: 'NONSTART', info: {} };
-        },
-        peg$c132 = 'nonstop',
-        peg$c133 = peg$literalExpectation('NONSTOP', true),
-        peg$c134 = function() {
-            return { type: 'class', value: 'NONSTOP', info: {} };
-        },
-        peg$c135 = 'frameshift',
-        peg$c136 = peg$literalExpectation('FRAMESHIFT', true),
-        peg$c137 = function() {
-            return { type: 'class', value: 'FRAMESHIFT', info: {} };
-        },
-        peg$c138 = 'inframe',
-        peg$c139 = peg$literalExpectation('INFRAME', true),
-        peg$c140 = function() {
-            return { type: 'class', value: 'INFRAME', info: {} };
-        },
-        peg$c141 = 'splice',
-        peg$c142 = peg$literalExpectation('SPLICE', true),
-        peg$c143 = function() {
-            return { type: 'class', value: 'SPLICE', info: {} };
-        },
-        peg$c144 = 'trunc',
-        peg$c145 = peg$literalExpectation('TRUNC', true),
-        peg$c146 = function() {
-            return { type: 'class', value: 'TRUNC', info: {} };
-        },
-        peg$c147 = 'promoter',
-        peg$c148 = peg$literalExpectation('PROMOTER', true),
-        peg$c149 = function() {
-            return { type: 'class', value: 'PROMOTER', info: {} };
-        },
-        peg$c150 = function(letter, position, string) {
-            return {
-                type: 'name',
-                value: letter + position + string,
-                info: {},
-            };
-        },
-        peg$c151 = function(letter, position) {
-            return {
-                type: 'position',
-                value: parseInt(position),
-                info: { amino_acid: letter.toUpperCase() },
-            };
-        },
-        peg$c152 = function(mutation_name) {
-            return {
-                type: 'name',
-                value: mutation_name,
-                info: { unrecognized: true },
-            };
-        },
-        peg$c153 = function(firstChar, rest) {
-            return firstChar + rest;
-        },
-        peg$c154 = function(lastChar) {
-            return lastChar;
-        },
-        peg$c155 = function(mod) {
-            return mod;
-        },
-        peg$c156 = 'germline',
-        peg$c157 = peg$literalExpectation('GERMLINE', true),
-        peg$c158 = function() {
-            return 'GERMLINE';
-        },
-        peg$c159 = 'somatic',
-        peg$c160 = peg$literalExpectation('SOMATIC', true),
-        peg$c161 = function() {
-            return 'SOMATIC';
-        },
-        peg$c162 = function(d) {
-            return d;
-        },
-        peg$c163 = 'driver',
-        peg$c164 = peg$literalExpectation('DRIVER', true),
-        peg$c165 = function() {
-            return 'DRIVER';
-        },
-        peg$currPos = 0,
-        peg$savedPos = 0,
-        peg$posDetailsCache = [{ line: 1, column: 1 }],
-        peg$maxFailPos = 0,
-        peg$maxFailExpected = [],
-        peg$silentFails = 0,
-        peg$result;
+  var peg$FAILED = {},
 
-    if ('startRule' in options) {
-        if (!(options.startRule in peg$startRuleFunctions)) {
-            throw new Error(
-                'Can\'t start parsing from rule "' + options.startRule + '".'
-            );
-        }
+      peg$startRuleFunctions = { start: peg$parsestart },
+      peg$startRuleFunction  = peg$parsestart,
 
-        peg$startRuleFunction = peg$startRuleFunctions[options.startRule];
+      peg$c0 = function() { return false; },
+      peg$c1 = /^[0-9]/,
+      peg$c2 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c3 = function(number) { return number.join("");},
+      peg$c4 = "-",
+      peg$c5 = peg$literalExpectation("-", false),
+      peg$c6 = function(number) { return "-"+number;},
+      peg$c7 = ".",
+      peg$c8 = peg$literalExpectation(".", false),
+      peg$c9 = function(whole_part, decimal_part) { return whole_part + "." + decimal_part;},
+      peg$c10 = function(decimal_part) { return "."+decimal_part;},
+      peg$c11 = function(whole_part) {return whole_part;},
+      peg$c12 = /^[\-_.@\/a-zA-Z0-9*]/,
+      peg$c13 = peg$classExpectation(["-", "_", ".", "@", "/", ["a", "z"], ["A", "Z"], ["0", "9"], "*"], false, false),
+      peg$c14 = function(word) { return word.join("") },
+      peg$c15 = /^[\-_.\/a-zA-Z0-9*]/,
+      peg$c16 = peg$classExpectation(["-", "_", ".", "/", ["a", "z"], ["A", "Z"], ["0", "9"], "*"], false, false),
+      peg$c17 = function(char) { return char; },
+      peg$c18 = /^[GPAVLIMCFYWHKRQNEDST]/,
+      peg$c19 = peg$classExpectation(["G", "P", "A", "V", "L", "I", "M", "C", "F", "Y", "W", "H", "K", "R", "Q", "N", "E", "D", "S", "T"], false, false),
+      peg$c20 = function(letter) { return letter; },
+      peg$c21 = /^[^"]/,
+      peg$c22 = peg$classExpectation(["\""], true, false),
+      peg$c23 = function(stringExceptQuotes) { return stringExceptQuotes.join("") },
+      peg$c24 = /^[ \t\r]/,
+      peg$c25 = peg$classExpectation([" ", "\t", "\r"], false, false),
+      peg$c26 = /^[,; \t\r\n]/,
+      peg$c27 = peg$classExpectation([",", ";", " ", "\t", "\r", "\n"], false, false),
+      peg$c28 = "[",
+      peg$c29 = peg$literalExpectation("[", false),
+      peg$c30 = "\"",
+      peg$c31 = peg$literalExpectation("\"", false),
+      peg$c32 = function(label) {return {"label": label, "list":[]};},
+      peg$c33 = function() {return {"label": undefined, "list":[]};},
+      peg$c34 = "amp",
+      peg$c35 = peg$literalExpectation("AMP", true),
+      peg$c36 = "homdel",
+      peg$c37 = peg$literalExpectation("HOMDEL", true),
+      peg$c38 = "gain",
+      peg$c39 = peg$literalExpectation("GAIN", true),
+      peg$c40 = "hetloss",
+      peg$c41 = peg$literalExpectation("HETLOSS", true),
+      peg$c42 = "mut",
+      peg$c43 = peg$literalExpectation("MUT", true),
+      peg$c44 = "exp",
+      peg$c45 = peg$literalExpectation("EXP", true),
+      peg$c46 = "prot",
+      peg$c47 = peg$literalExpectation("PROT", true),
+      peg$c48 = function(mqr, sqr) {return mqr.concat(sqr);},
+      peg$c49 = function(qr, sqr) {return qr.concat(sqr);},
+      peg$c50 = function(mqr) {return mqr;},
+      peg$c51 = function(qr) {return qr; },
+      peg$c52 = "]",
+      peg$c53 = peg$literalExpectation("]", false),
+      peg$c54 = function(mergedGenes, qr, mqr) { mergedGenes.list = qr; return [mergedGenes].concat(mqr);; },
+      peg$c55 = function(mergedGenes, qr) { mergedGenes.list = qr; return [mergedGenes]; },
+      peg$c56 = function(first, rest) { return [first].concat(rest); },
+      peg$c57 = function(first) { return [first]; },
+      peg$c58 = ":",
+      peg$c59 = peg$literalExpectation(":", false),
+      peg$c60 = function(geneName, alts) { return {"gene": geneName, "alterations": alts}; },
+      peg$c61 = function(geneName) { return {"gene": geneName, "alterations":false}; },
+      peg$c62 = function(a1, a2) { return [a1].concat(a2);},
+      peg$c63 = function(a1) { return [a1]; },
+      peg$c64 = function(cmd) { return cmd; },
+      peg$c65 = "_",
+      peg$c66 = peg$literalExpectation("_", false),
+      peg$c67 = function(d) { return {"alteration_type":"any", modifiers:[d]}; },
+      peg$c68 = function() { return "AMP"; },
+      peg$c69 = function() { return "HOMDEL"; },
+      peg$c70 = function() { return "GAIN"; },
+      peg$c71 = function() { return "HETLOSS"; },
+      peg$c72 = "cna",
+      peg$c73 = peg$literalExpectation("CNA", true),
+      peg$c74 = function(op, constrval) { return {"alteration_type":"cna", "constr_rel":op, "constr_val":constrval, modifiers:[]}; },
+      peg$c75 = "CNA_",
+      peg$c76 = peg$literalExpectation("CNA_", false),
+      peg$c77 = function(mod) { return {"alteration_type":"cna", modifiers:[mod]}; },
+      peg$c78 = function(constrval, mod) { return {"alteration_type":"cna", "constr_rel":"=", "constr_val":constrval, modifiers:[mod]}; },
+      peg$c79 = "_CNA",
+      peg$c80 = peg$literalExpectation("_CNA", false),
+      peg$c81 = function(mod, constrval) { return {"alteration_type":"cna", "constr_rel":"=", "constr_val":constrval, modifiers:[mod]}; },
+      peg$c82 = function(constrval) { return {"alteration_type":"cna", "constr_rel":"=", "constr_val":constrval, modifiers:[]}; },
+      peg$c83 = "MUT",
+      peg$c84 = peg$literalExpectation("MUT", false),
+      peg$c85 = "=",
+      peg$c86 = peg$literalExpectation("=", false),
+      peg$c87 = function(mutation) { return {"alteration_type":"mut", "constr_rel": "=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info, modifiers: mutation.modifiers}; },
+      peg$c88 = "!=",
+      peg$c89 = peg$literalExpectation("!=", false),
+      peg$c90 = function(mutation) { return {"alteration_type":"mut", "constr_rel": "!=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info, modifiers: mutation.modifiers}; },
+      peg$c91 = function(mutation) {
+      	        if (mutation.type) {
+      	            return {"alteration_type":"mut", "constr_rel": "=", "constr_type":mutation.type, "constr_val":mutation.value, "info":mutation.info, modifiers: mutation.modifiers};
+                  } else {
+                      return {"alteration_type":"mut", "info":{}, "modifiers": mutation.modifiers};
+                  }
+              },
+      peg$c92 = "EXP",
+      peg$c93 = peg$literalExpectation("EXP", false),
+      peg$c94 = function(op, constrval) { return {"alteration_type":"exp", "constr_rel":op, "constr_val":parseFloat(constrval)}; },
+      peg$c95 = "fusion",
+      peg$c96 = peg$literalExpectation("FUSION", true),
+      peg$c97 = function(mod) { return {"alteration_type":"fusion", modifiers: [mod] }; },
+      peg$c98 = "_fusion",
+      peg$c99 = peg$literalExpectation("_FUSION", true),
+      peg$c100 = function() { return {"alteration_type":"fusion", modifiers:[]}; },
+      peg$c101 = "PROT",
+      peg$c102 = peg$literalExpectation("PROT", false),
+      peg$c103 = function(op, constrval) { return {"alteration_type":"prot", "constr_rel":op, "constr_val":parseFloat(constrval)}; },
+      peg$c104 = ">=",
+      peg$c105 = peg$literalExpectation(">=", false),
+      peg$c106 = function() { return ">="; },
+      peg$c107 = "<=",
+      peg$c108 = peg$literalExpectation("<=", false),
+      peg$c109 = function() { return "<="; },
+      peg$c110 = ">",
+      peg$c111 = peg$literalExpectation(">", false),
+      peg$c112 = function() { return ">"; },
+      peg$c113 = "<",
+      peg$c114 = peg$literalExpectation("<", false),
+      peg$c115 = function() { return "<"; },
+      peg$c116 = function(modifier, mutationWithModifiers) { mutationWithModifiers.modifiers.unshift(modifier); return mutationWithModifiers; },
+      peg$c117 = function(mutation, modifiers) { mutation.modifiers = modifiers; return mutation; },
+      peg$c118 = function(modifier) { return { info: {}, modifiers: [modifier] }; },
+      peg$c119 = function(mutation) { mutation.modifiers = []; return mutation; },
+      peg$c120 = function(modifier, more) { return [modifier].concat(more); },
+      peg$c121 = function(modifier) { return [modifier]; },
+      peg$c122 = function() { return {"info":{}}; },
+      peg$c123 = "missense",
+      peg$c124 = peg$literalExpectation("MISSENSE", true),
+      peg$c125 = function() { return {"type":"class", "value":"MISSENSE", "info":{}}; },
+      peg$c126 = "nonsense",
+      peg$c127 = peg$literalExpectation("NONSENSE", true),
+      peg$c128 = function() { return {"type":"class", "value":"NONSENSE", "info":{}}; },
+      peg$c129 = "nonstart",
+      peg$c130 = peg$literalExpectation("NONSTART", true),
+      peg$c131 = function() { return {"type":"class", "value":"NONSTART", "info":{}}; },
+      peg$c132 = "nonstop",
+      peg$c133 = peg$literalExpectation("NONSTOP", true),
+      peg$c134 = function() { return {"type":"class", "value":"NONSTOP", "info":{}}; },
+      peg$c135 = "frameshift",
+      peg$c136 = peg$literalExpectation("FRAMESHIFT", true),
+      peg$c137 = function() { return {"type":"class", "value":"FRAMESHIFT", "info":{}}; },
+      peg$c138 = "inframe",
+      peg$c139 = peg$literalExpectation("INFRAME", true),
+      peg$c140 = function() { return {"type":"class", "value":"INFRAME", "info":{}}; },
+      peg$c141 = "splice",
+      peg$c142 = peg$literalExpectation("SPLICE", true),
+      peg$c143 = function() { return {"type":"class", "value":"SPLICE", "info":{}}; },
+      peg$c144 = "trunc",
+      peg$c145 = peg$literalExpectation("TRUNC", true),
+      peg$c146 = function() { return {"type":"class", "value":"TRUNC", "info":{}}; },
+      peg$c147 = "promoter",
+      peg$c148 = peg$literalExpectation("PROMOTER", true),
+      peg$c149 = function() { return {"type":"class", "value":"PROMOTER", "info":{}}; },
+      peg$c150 = function(letter, position, string) { return {"type":"name" , "value":(letter+position+string), "info":{}};},
+      peg$c151 = function(letter, position) { return {"type":"position", "value":parseInt(position), "info":{"amino_acid":letter.toUpperCase()}}; },
+      peg$c152 = function(mutation_name) { return {"type":"name", "value":mutation_name, "info":{"unrecognized":true}}; },
+      peg$c153 = function(firstChar, rest) { return firstChar + rest; },
+      peg$c154 = function(lastChar) { return lastChar; },
+      peg$c155 = function(mod) { return mod; },
+      peg$c156 = "germline",
+      peg$c157 = peg$literalExpectation("GERMLINE", true),
+      peg$c158 = function() { return "GERMLINE";},
+      peg$c159 = "somatic",
+      peg$c160 = peg$literalExpectation("SOMATIC", true),
+      peg$c161 = function() { return "SOMATIC";},
+      peg$c162 = function(d) { return d; },
+      peg$c163 = "driver",
+      peg$c164 = peg$literalExpectation("DRIVER", true),
+      peg$c165 = function() { return "DRIVER";},
+
+      peg$currPos          = 0,
+      peg$savedPos         = 0,
+      peg$posDetailsCache  = [{ line: 1, column: 1 }],
+      peg$maxFailPos       = 0,
+      peg$maxFailExpected  = [],
+      peg$silentFails      = 0,
+
+      peg$result;
+
+  if ("startRule" in options) {
+    if (!(options.startRule in peg$startRuleFunctions)) {
+      throw new Error("Can't start parsing from rule \"" + options.startRule + "\".");
     }
 
-    function text() {
-        return input.substring(peg$savedPos, peg$currPos);
-    }
+    peg$startRuleFunction = peg$startRuleFunctions[options.startRule];
+  }
 
-    function location() {
-        return peg$computeLocation(peg$savedPos, peg$currPos);
-    }
+  function text() {
+    return input.substring(peg$savedPos, peg$currPos);
+  }
 
-    function expected(description, location) {
-        location =
-            location !== void 0
-                ? location
-                : peg$computeLocation(peg$savedPos, peg$currPos);
+  function location() {
+    return peg$computeLocation(peg$savedPos, peg$currPos);
+  }
 
-        throw peg$buildStructuredError(
-            [peg$otherExpectation(description)],
-            input.substring(peg$savedPos, peg$currPos),
-            location
-        );
-    }
+  function expected(description, location) {
+    location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos)
 
-    function error(message, location) {
-        location =
-            location !== void 0
-                ? location
-                : peg$computeLocation(peg$savedPos, peg$currPos);
+    throw peg$buildStructuredError(
+      [peg$otherExpectation(description)],
+      input.substring(peg$savedPos, peg$currPos),
+      location
+    );
+  }
 
-        throw peg$buildSimpleError(message, location);
-    }
+  function error(message, location) {
+    location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos)
 
-    function peg$literalExpectation(text, ignoreCase) {
-        return { type: 'literal', text: text, ignoreCase: ignoreCase };
-    }
+    throw peg$buildSimpleError(message, location);
+  }
 
-    function peg$classExpectation(parts, inverted, ignoreCase) {
-        return {
-            type: 'class',
-            parts: parts,
-            inverted: inverted,
-            ignoreCase: ignoreCase,
-        };
-    }
+  function peg$literalExpectation(text, ignoreCase) {
+    return { type: "literal", text: text, ignoreCase: ignoreCase };
+  }
 
-    function peg$anyExpectation() {
-        return { type: 'any' };
-    }
+  function peg$classExpectation(parts, inverted, ignoreCase) {
+    return { type: "class", parts: parts, inverted: inverted, ignoreCase: ignoreCase };
+  }
 
-    function peg$endExpectation() {
-        return { type: 'end' };
-    }
+  function peg$anyExpectation() {
+    return { type: "any" };
+  }
 
-    function peg$otherExpectation(description) {
-        return { type: 'other', description: description };
-    }
+  function peg$endExpectation() {
+    return { type: "end" };
+  }
 
-    function peg$computePosDetails(pos) {
-        var details = peg$posDetailsCache[pos],
-            p;
+  function peg$otherExpectation(description) {
+    return { type: "other", description: description };
+  }
 
-        if (details) {
-            return details;
+  function peg$computePosDetails(pos) {
+    var details = peg$posDetailsCache[pos], p;
+
+    if (details) {
+      return details;
+    } else {
+      p = pos - 1;
+      while (!peg$posDetailsCache[p]) {
+        p--;
+      }
+
+      details = peg$posDetailsCache[p];
+      details = {
+        line:   details.line,
+        column: details.column
+      };
+
+      while (p < pos) {
+        if (input.charCodeAt(p) === 10) {
+          details.line++;
+          details.column = 1;
         } else {
-            p = pos - 1;
-            while (!peg$posDetailsCache[p]) {
-                p--;
-            }
-
-            details = peg$posDetailsCache[p];
-            details = {
-                line: details.line,
-                column: details.column,
-            };
-
-            while (p < pos) {
-                if (input.charCodeAt(p) === 10) {
-                    details.line++;
-                    details.column = 1;
-                } else {
-                    details.column++;
-                }
-
-                p++;
-            }
-
-            peg$posDetailsCache[pos] = details;
-            return details;
-        }
-    }
-
-    function peg$computeLocation(startPos, endPos) {
-        var startPosDetails = peg$computePosDetails(startPos),
-            endPosDetails = peg$computePosDetails(endPos);
-
-        return {
-            start: {
-                offset: startPos,
-                line: startPosDetails.line,
-                column: startPosDetails.column,
-            },
-            end: {
-                offset: endPos,
-                line: endPosDetails.line,
-                column: endPosDetails.column,
-            },
-        };
-    }
-
-    function peg$fail(expected) {
-        if (peg$currPos < peg$maxFailPos) {
-            return;
+          details.column++;
         }
 
-        if (peg$currPos > peg$maxFailPos) {
-            peg$maxFailPos = peg$currPos;
-            peg$maxFailExpected = [];
-        }
+        p++;
+      }
 
-        peg$maxFailExpected.push(expected);
+      peg$posDetailsCache[pos] = details;
+      return details;
+    }
+  }
+
+  function peg$computeLocation(startPos, endPos) {
+    var startPosDetails = peg$computePosDetails(startPos),
+        endPosDetails   = peg$computePosDetails(endPos);
+
+    return {
+      start: {
+        offset: startPos,
+        line:   startPosDetails.line,
+        column: startPosDetails.column
+      },
+      end: {
+        offset: endPos,
+        line:   endPosDetails.line,
+        column: endPosDetails.column
+      }
+    };
+  }
+
+  function peg$fail(expected) {
+    if (peg$currPos < peg$maxFailPos) { return; }
+
+    if (peg$currPos > peg$maxFailPos) {
+      peg$maxFailPos = peg$currPos;
+      peg$maxFailExpected = [];
     }
 
-    function peg$buildSimpleError(message, location) {
-        return new peg$SyntaxError(message, null, null, location);
+    peg$maxFailExpected.push(expected);
+  }
+
+  function peg$buildSimpleError(message, location) {
+    return new peg$SyntaxError(message, null, null, location);
+  }
+
+  function peg$buildStructuredError(expected, found, location) {
+    return new peg$SyntaxError(
+      peg$SyntaxError.buildMessage(expected, found),
+      expected,
+      found,
+      location
+    );
+  }
+
+  function peg$parsestart() {
+    var s0, s1;
+
+    s0 = peg$parseQuery();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parsesp();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c0();
+      }
+      s0 = s1;
     }
 
-    function peg$buildStructuredError(expected, found, location) {
-        return new peg$SyntaxError(
-            peg$SyntaxError.buildMessage(expected, found),
-            expected,
-            found,
-            location
-        );
+    return s0;
+  }
+
+  function peg$parseNaturalNumber() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (peg$c1.test(input.charAt(peg$currPos))) {
+      s2 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c2); }
     }
-
-    function peg$parsestart() {
-        var s0, s1;
-
-        s0 = peg$parseQuery();
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parsesp();
-            if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c0();
-            }
-            s0 = s1;
-        }
-
-        return s0;
-    }
-
-    function peg$parseNaturalNumber() {
-        var s0, s1, s2;
-
-        s0 = peg$currPos;
-        s1 = [];
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
         if (peg$c1.test(input.charAt(peg$currPos))) {
-            s2 = input.charAt(peg$currPos);
-            peg$currPos++;
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
         } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c2);
-            }
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c2); }
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c3(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseNumber() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 45) {
+      s1 = peg$c4;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c5); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseNumber();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c6(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseNaturalNumber();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s2 = peg$c7;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c8); }
         }
         if (s2 !== peg$FAILED) {
-            while (s2 !== peg$FAILED) {
-                s1.push(s2);
-                if (peg$c1.test(input.charAt(peg$currPos))) {
-                    s2 = input.charAt(peg$currPos);
-                    peg$currPos++;
-                } else {
-                    s2 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c2);
-                    }
-                }
-            }
-        } else {
-            s1 = peg$FAILED;
-        }
-        if (s1 !== peg$FAILED) {
+          s3 = peg$parseNaturalNumber();
+          if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c3(s1);
-        }
-        s0 = s1;
-
-        return s0;
-    }
-
-    function peg$parseNumber() {
-        var s0, s1, s2, s3;
-
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 45) {
-            s1 = peg$c4;
-            peg$currPos++;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c5);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parseNumber();
-            if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c6(s2);
-                s0 = s1;
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
+            s1 = peg$c9(s1, s3);
+            s0 = s1;
+          } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s1 = peg$c7;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c8); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseNaturalNumber();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c10(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
         if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseNaturalNumber();
-            if (s1 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 46) {
-                    s2 = peg$c7;
-                    peg$currPos++;
-                } else {
-                    s2 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c8);
-                    }
-                }
-                if (s2 !== peg$FAILED) {
-                    s3 = peg$parseNaturalNumber();
-                    if (s3 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c9(s1, s3);
-                        s0 = s1;
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                if (input.charCodeAt(peg$currPos) === 46) {
-                    s1 = peg$c7;
-                    peg$currPos++;
-                } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c8);
-                    }
-                }
-                if (s1 !== peg$FAILED) {
-                    s2 = peg$parseNaturalNumber();
-                    if (s2 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c10(s2);
-                        s0 = s1;
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-                if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    s1 = peg$parseNaturalNumber();
-                    if (s1 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c11(s1);
-                    }
-                    s0 = s1;
-                }
-            }
+          s0 = peg$currPos;
+          s1 = peg$parseNaturalNumber();
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c11(s1);
+          }
+          s0 = s1;
         }
-
-        return s0;
+      }
     }
 
-    function peg$parseString() {
-        var s0, s1, s2;
+    return s0;
+  }
 
-        s0 = peg$currPos;
-        s1 = [];
+  function peg$parseString() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (peg$c12.test(input.charAt(peg$currPos))) {
+      s2 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c13); }
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
         if (peg$c12.test(input.charAt(peg$currPos))) {
-            s2 = input.charAt(peg$currPos);
-            peg$currPos++;
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
         } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c13);
-            }
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c13); }
         }
-        if (s2 !== peg$FAILED) {
-            while (s2 !== peg$FAILED) {
-                s1.push(s2);
-                if (peg$c12.test(input.charAt(peg$currPos))) {
-                    s2 = input.charAt(peg$currPos);
-                    peg$currPos++;
-                } else {
-                    s2 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c13);
-                    }
-                }
-            }
-        } else {
-            s1 = peg$FAILED;
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c14(s1);
-        }
-        s0 = s1;
-
-        return s0;
+      }
+    } else {
+      s1 = peg$FAILED;
     }
-
-    function peg$parseMutationProteinChangeCodeChar() {
-        var s0, s1;
-
-        s0 = peg$currPos;
-        if (peg$c15.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
-            peg$currPos++;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c16);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c17(s1);
-        }
-        s0 = s1;
-
-        return s0;
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c14(s1);
     }
+    s0 = s1;
 
-    function peg$parseAminoAcid() {
-        var s0, s1;
+    return s0;
+  }
 
-        s0 = peg$currPos;
-        if (peg$c18.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
-            peg$currPos++;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c19);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c20(s1);
-        }
-        s0 = s1;
+  function peg$parseMutationProteinChangeCodeChar() {
+    var s0, s1;
 
-        return s0;
+    s0 = peg$currPos;
+    if (peg$c15.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c16); }
     }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c17(s1);
+    }
+    s0 = s1;
 
-    function peg$parseStringExceptQuotes() {
-        var s0, s1, s2;
+    return s0;
+  }
 
-        s0 = peg$currPos;
-        s1 = [];
+  function peg$parseAminoAcid() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (peg$c18.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c19); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c20(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseStringExceptQuotes() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (peg$c21.test(input.charAt(peg$currPos))) {
+      s2 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c22); }
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
         if (peg$c21.test(input.charAt(peg$currPos))) {
-            s2 = input.charAt(peg$currPos);
-            peg$currPos++;
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
         } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c22);
-            }
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c22); }
         }
-        if (s2 !== peg$FAILED) {
-            while (s2 !== peg$FAILED) {
-                s1.push(s2);
-                if (peg$c21.test(input.charAt(peg$currPos))) {
-                    s2 = input.charAt(peg$currPos);
-                    peg$currPos++;
-                } else {
-                    s2 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c22);
-                    }
-                }
-            }
-        } else {
-            s1 = peg$FAILED;
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c23(s1);
-        }
-        s0 = s1;
-
-        return s0;
+      }
+    } else {
+      s1 = peg$FAILED;
     }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c23(s1);
+    }
+    s0 = s1;
 
-    function peg$parsesp() {
-        var s0, s1;
+    return s0;
+  }
 
-        s0 = [];
+  function peg$parsesp() {
+    var s0, s1;
+
+    s0 = [];
+    if (peg$c24.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+    }
+    if (s1 !== peg$FAILED) {
+      while (s1 !== peg$FAILED) {
+        s0.push(s1);
         if (peg$c24.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
-            peg$currPos++;
+          s1 = input.charAt(peg$currPos);
+          peg$currPos++;
         } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c25);
-            }
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
-        if (s1 !== peg$FAILED) {
-            while (s1 !== peg$FAILED) {
-                s0.push(s1);
-                if (peg$c24.test(input.charAt(peg$currPos))) {
-                    s1 = input.charAt(peg$currPos);
-                    peg$currPos++;
-                } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c25);
-                    }
-                }
-            }
-        } else {
-            s0 = peg$FAILED;
-        }
-
-        return s0;
+      }
+    } else {
+      s0 = peg$FAILED;
     }
 
-    function peg$parsemsp() {
-        var s0, s1;
+    return s0;
+  }
 
-        s0 = [];
-        if (peg$c24.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
-            peg$currPos++;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c25);
-            }
-        }
-        while (s1 !== peg$FAILED) {
-            s0.push(s1);
-            if (peg$c24.test(input.charAt(peg$currPos))) {
-                s1 = input.charAt(peg$currPos);
-                peg$currPos++;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c25);
-                }
-            }
-        }
+  function peg$parsemsp() {
+    var s0, s1;
 
-        return s0;
+    s0 = [];
+    if (peg$c24.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+    }
+    while (s1 !== peg$FAILED) {
+      s0.push(s1);
+      if (peg$c24.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+      }
     }
 
-    function peg$parsezmbs() {
-        var s0, s1;
+    return s0;
+  }
 
-        s0 = [];
+  function peg$parsezmbs() {
+    var s0, s1;
+
+    s0 = [];
+    if (peg$c26.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c27); }
+    }
+    while (s1 !== peg$FAILED) {
+      s0.push(s1);
+      if (peg$c26.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c27); }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseombs() {
+    var s0, s1;
+
+    s0 = [];
+    if (peg$c26.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c27); }
+    }
+    if (s1 !== peg$FAILED) {
+      while (s1 !== peg$FAILED) {
+        s0.push(s1);
         if (peg$c26.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
-            peg$currPos++;
+          s1 = input.charAt(peg$currPos);
+          peg$currPos++;
         } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c27);
-            }
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c27); }
         }
-        while (s1 !== peg$FAILED) {
-            s0.push(s1);
-            if (peg$c26.test(input.charAt(peg$currPos))) {
-                s1 = input.charAt(peg$currPos);
-                peg$currPos++;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c27);
-                }
-            }
-        }
-
-        return s0;
+      }
+    } else {
+      s0 = peg$FAILED;
     }
 
-    function peg$parseombs() {
-        var s0, s1;
+    return s0;
+  }
 
-        s0 = [];
-        if (peg$c26.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
-            peg$currPos++;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c27);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            while (s1 !== peg$FAILED) {
-                s0.push(s1);
-                if (peg$c26.test(input.charAt(peg$currPos))) {
-                    s1 = input.charAt(peg$currPos);
-                    peg$currPos++;
-                } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c27);
-                    }
-                }
-            }
-        } else {
-            s0 = peg$FAILED;
-        }
+  function peg$parseStartMergedGenes() {
+    var s0, s1, s2, s3, s4, s5;
 
-        return s0;
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 91) {
+      s1 = peg$c28;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c29); }
     }
-
-    function peg$parseStartMergedGenes() {
-        var s0, s1, s2, s3, s4, s5;
-
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c28;
-            peg$currPos++;
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsezmbs();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 34) {
+          s3 = peg$c30;
+          peg$currPos++;
         } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c29);
-            }
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parsezmbs();
-            if (s2 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 34) {
-                    s3 = peg$c30;
-                    peg$currPos++;
-                } else {
-                    s3 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c31);
-                    }
-                }
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parseStringExceptQuotes();
-                    if (s4 !== peg$FAILED) {
-                        if (input.charCodeAt(peg$currPos) === 34) {
-                            s5 = peg$c30;
-                            peg$currPos++;
-                        } else {
-                            s5 = peg$FAILED;
-                            if (peg$silentFails === 0) {
-                                peg$fail(peg$c31);
-                            }
-                        }
-                        if (s5 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c32(s4);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseStringExceptQuotes();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 34) {
+              s5 = peg$c30;
+              peg$currPos++;
             } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c31); }
             }
-        } else {
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c32(s4);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.charCodeAt(peg$currPos) === 91) {
-                s1 = peg$c28;
-                peg$currPos++;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c29);
-                }
-            }
-            if (s1 !== peg$FAILED) {
-                s2 = peg$parsezmbs();
-                if (s2 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c33();
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseAMP() {
-        var s0;
-
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c34) {
-            s0 = input.substr(peg$currPos, 3);
-            peg$currPos += 3;
+          }
         } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c35);
-            }
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-
-        return s0;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-
-    function peg$parseHOMDEL() {
-        var s0;
-
-        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c36) {
-            s0 = input.substr(peg$currPos, 6);
-            peg$currPos += 6;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 91) {
+        s1 = peg$c28;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsezmbs();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c33();
+          s0 = s1;
         } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c37);
-            }
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-
-        return s0;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
-    function peg$parseGAIN() {
-        var s0;
+    return s0;
+  }
 
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
-            s0 = input.substr(peg$currPos, 4);
-            peg$currPos += 4;
+  function peg$parseAMP() {
+    var s0;
+
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c34) {
+      s0 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseHOMDEL() {
+    var s0;
+
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c36) {
+      s0 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c37); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseGAIN() {
+    var s0;
+
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
+      s0 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseHETLOSS() {
+    var s0;
+
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c40) {
+      s0 = input.substr(peg$currPos, 7);
+      peg$currPos += 7;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseMUT() {
+    var s0;
+
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c42) {
+      s0 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseEXP() {
+    var s0;
+
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c44) {
+      s0 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c45); }
+    }
+
+    return s0;
+  }
+
+  function peg$parsePROT() {
+    var s0;
+
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c46) {
+      s0 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseQuery() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseMergedQuery();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseombs();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseQuery();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c48(s1, s3);
+          s0 = s1;
         } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c39);
-            }
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-
-        return s0;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-
-    function peg$parseHETLOSS() {
-        var s0;
-
-        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c40) {
-            s0 = input.substr(peg$currPos, 7);
-            peg$currPos += 7;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseStandardQuery();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseombs();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseQuery();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c49(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c41);
-            }
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-
-        return s0;
-    }
-
-    function peg$parseMUT() {
-        var s0;
-
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c42) {
-            s0 = input.substr(peg$currPos, 3);
-            peg$currPos += 3;
-        } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c43);
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseEXP() {
-        var s0;
-
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c44) {
-            s0 = input.substr(peg$currPos, 3);
-            peg$currPos += 3;
-        } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c45);
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parsePROT() {
-        var s0;
-
-        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c46) {
-            s0 = input.substr(peg$currPos, 4);
-            peg$currPos += 4;
-        } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c47);
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseQuery() {
-        var s0, s1, s2, s3;
-
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         s1 = peg$parseMergedQuery();
         if (s1 !== peg$FAILED) {
-            s2 = peg$parseombs();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseQuery();
-                if (s3 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c48(s1, s3);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseStandardQuery();
-            if (s1 !== peg$FAILED) {
-                s2 = peg$parseombs();
-                if (s2 !== peg$FAILED) {
-                    s3 = peg$parseQuery();
-                    if (s3 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c49(s1, s3);
-                        s0 = s1;
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseMergedQuery();
-                if (s1 !== peg$FAILED) {
-                    s2 = peg$parsezmbs();
-                    if (s2 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c50(s1);
-                        s0 = s1;
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-                if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    s1 = peg$parseStandardQuery();
-                    if (s1 !== peg$FAILED) {
-                        s2 = peg$parsezmbs();
-                        if (s2 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c51(s1);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                }
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseMergedQuery() {
-        var s0, s1, s2, s3, s4, s5, s6, s7;
-
-        s0 = peg$currPos;
-        s1 = peg$parsezmbs();
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parseStartMergedGenes();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseStandardQuery();
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parsezmbs();
-                    if (s4 !== peg$FAILED) {
-                        if (input.charCodeAt(peg$currPos) === 93) {
-                            s5 = peg$c52;
-                            peg$currPos++;
-                        } else {
-                            s5 = peg$FAILED;
-                            if (peg$silentFails === 0) {
-                                peg$fail(peg$c53);
-                            }
-                        }
-                        if (s5 !== peg$FAILED) {
-                            s6 = peg$parsezmbs();
-                            if (s6 !== peg$FAILED) {
-                                s7 = peg$parseMergedQuery();
-                                if (s7 !== peg$FAILED) {
-                                    peg$savedPos = s0;
-                                    s1 = peg$c54(s2, s3, s7);
-                                    s0 = s1;
-                                } else {
-                                    peg$currPos = s0;
-                                    s0 = peg$FAILED;
-                                }
-                            } else {
-                                peg$currPos = s0;
-                                s0 = peg$FAILED;
-                            }
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parsezmbs();
-            if (s1 !== peg$FAILED) {
-                s2 = peg$parseStartMergedGenes();
-                if (s2 !== peg$FAILED) {
-                    s3 = peg$parseStandardQuery();
-                    if (s3 !== peg$FAILED) {
-                        s4 = peg$parsezmbs();
-                        if (s4 !== peg$FAILED) {
-                            if (input.charCodeAt(peg$currPos) === 93) {
-                                s5 = peg$c52;
-                                peg$currPos++;
-                            } else {
-                                s5 = peg$FAILED;
-                                if (peg$silentFails === 0) {
-                                    peg$fail(peg$c53);
-                                }
-                            }
-                            if (s5 !== peg$FAILED) {
-                                peg$savedPos = s0;
-                                s1 = peg$c55(s2, s3);
-                                s0 = s1;
-                            } else {
-                                peg$currPos = s0;
-                                s0 = peg$FAILED;
-                            }
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseStandardQuery() {
-        var s0, s1, s2, s3, s4;
-
-        s0 = peg$currPos;
-        s1 = peg$parsezmbs();
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parseSingleGeneQuery();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseombs();
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parseStandardQuery();
-                    if (s4 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c56(s2, s4);
-                        s0 = s1;
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parsezmbs();
-            if (s1 !== peg$FAILED) {
-                s2 = peg$parseSingleGeneQuery();
-                if (s2 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c57(s2);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseSingleGeneQuery() {
-        var s0, s1, s2, s3, s4, s5;
-
-        s0 = peg$currPos;
-        s1 = peg$parseString();
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parsemsp();
-            if (s2 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 58) {
-                    s3 = peg$c58;
-                    peg$currPos++;
-                } else {
-                    s3 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c59);
-                    }
-                }
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parsemsp();
-                    if (s4 !== peg$FAILED) {
-                        s5 = peg$parseAlterations();
-                        if (s5 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c60(s1, s5);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseString();
-            if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c61(s1);
-            }
+          s2 = peg$parsezmbs();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c50(s1);
             s0 = s1;
-        }
-
-        return s0;
-    }
-
-    function peg$parseAlterations() {
-        var s0, s1, s2, s3;
-
-        s0 = peg$currPos;
-        s1 = peg$parseAlteration();
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parsesp();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseAlterations();
-                if (s3 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c62(s1, s3);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
+          } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
         if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseAlteration();
-            if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c63(s1);
+          s0 = peg$currPos;
+          s1 = peg$parseStandardQuery();
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsezmbs();
+            if (s2 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c51(s1);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
             }
-            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         }
-
-        return s0;
+      }
     }
 
-    function peg$parseAlteration() {
-        var s0, s1;
+    return s0;
+  }
 
+  function peg$parseMergedQuery() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parsezmbs();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseStartMergedGenes();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseStandardQuery();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsezmbs();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s5 = peg$c52;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parsezmbs();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseMergedQuery();
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c54(s2, s3, s7);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parsezmbs();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseStartMergedGenes();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseStandardQuery();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parsezmbs();
+            if (s4 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 93) {
+                s5 = peg$c52;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c53); }
+              }
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c55(s2, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseStandardQuery() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parsezmbs();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseSingleGeneQuery();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseombs();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseStandardQuery();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c56(s2, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parsezmbs();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseSingleGeneQuery();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c57(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSingleGeneQuery() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parseString();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsemsp();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c58;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsemsp();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseAlterations();
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c60(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseString();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c61(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAlterations() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseAlteration();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsesp();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseAlterations();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c62(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseAlteration();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c63(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAlteration() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseAnyTypeWithModifiersCommand();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c64(s1);
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseCNACommand();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c64(s1);
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseAnyTypeWithModifiersCommand();
+        s1 = peg$parseEXPCommand();
         if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c64(s1);
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsePROTCommand();
+          if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
             s1 = peg$c64(s1);
-        }
-        s0 = s1;
-        if (s0 === peg$FAILED) {
+          }
+          s0 = s1;
+          if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parseCNACommand();
+            s1 = peg$parseFUSIONCommand();
             if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c64(s1);
+            }
+            s0 = s1;
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parseMUTCommand();
+              if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
                 s1 = peg$c64(s1);
+              }
+              s0 = s1;
             }
-            s0 = s1;
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseEXPCommand();
-                if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c64(s1);
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    s1 = peg$parsePROTCommand();
-                    if (s1 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c64(s1);
-                    }
-                    s0 = s1;
-                    if (s0 === peg$FAILED) {
-                        s0 = peg$currPos;
-                        s1 = peg$parseFUSIONCommand();
-                        if (s1 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c64(s1);
-                        }
-                        s0 = s1;
-                        if (s0 === peg$FAILED) {
-                            s0 = peg$currPos;
-                            s1 = peg$parseMUTCommand();
-                            if (s1 !== peg$FAILED) {
-                                peg$savedPos = s0;
-                                s1 = peg$c64(s1);
-                            }
-                            s0 = s1;
-                        }
-                    }
-                }
-            }
+          }
         }
-
-        return s0;
+      }
     }
 
-    function peg$parseAnyTypeWithModifiersCommand() {
-        var s0, s1, s2, s3;
+    return s0;
+  }
 
-        s0 = peg$currPos;
-        s1 = peg$parseDriverModifier();
-        if (s1 !== peg$FAILED) {
-            s2 = peg$currPos;
-            peg$silentFails++;
-            if (input.charCodeAt(peg$currPos) === 95) {
-                s3 = peg$c65;
-                peg$currPos++;
-            } else {
-                s3 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c66);
-                }
-            }
-            peg$silentFails--;
-            if (s3 === peg$FAILED) {
-                s2 = void 0;
-            } else {
-                peg$currPos = s2;
-                s2 = peg$FAILED;
-            }
-            if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c67(s1);
-                s0 = s1;
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
+  function peg$parseAnyTypeWithModifiersCommand() {
+    var s0, s1, s2, s3;
 
-        return s0;
+    s0 = peg$currPos;
+    s1 = peg$parseDriverModifier();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      if (input.charCodeAt(peg$currPos) === 95) {
+        s3 = peg$c65;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      }
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c67(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
-    function peg$parseCNAType() {
-        var s0, s1;
+    return s0;
+  }
 
+  function peg$parseCNAType() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c34) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c68();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c36) {
+        s1 = input.substr(peg$currPos, 6);
+        peg$currPos += 6;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c69();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c34) {
-            s1 = input.substr(peg$currPos, 3);
-            peg$currPos += 3;
+        if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
+          s1 = input.substr(peg$currPos, 4);
+          peg$currPos += 4;
         } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c35);
-            }
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
         if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c68();
+          peg$savedPos = s0;
+          s1 = peg$c70();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 6).toLowerCase() === peg$c36) {
-                s1 = input.substr(peg$currPos, 6);
-                peg$currPos += 6;
+          s0 = peg$currPos;
+          if (input.substr(peg$currPos, 7).toLowerCase() === peg$c40) {
+            s1 = input.substr(peg$currPos, 7);
+            peg$currPos += 7;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          }
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c71();
+          }
+          s0 = s1;
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseCNACommand() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c72) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c73); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsemsp();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseComparisonOp();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsemsp();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseCNAType();
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c74(s3, s5);
+              s0 = s1;
             } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c37);
-                }
+              peg$currPos = s0;
+              s0 = peg$FAILED;
             }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4) === peg$c75) {
+        s1 = peg$c75;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseCNAModifier();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c77(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseCNAType();
+        if (s1 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 95) {
+            s2 = peg$c65;
+            peg$currPos++;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          }
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parseCNAModifier();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c78(s1, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parseCNAModifier();
+          if (s1 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 4) === peg$c79) {
+              s2 = peg$c79;
+              peg$currPos += 4;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            }
+            if (s2 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c77(s1);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseCNAModifier();
             if (s1 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 95) {
+                s2 = peg$c65;
+                peg$currPos++;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c66); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseCNAType();
+                if (s3 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c81(s1, s3);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parseCNAType();
+              if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c69();
+                s1 = peg$c82(s1);
+              }
+              s0 = s1;
             }
-            s0 = s1;
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
-                    s1 = input.substr(peg$currPos, 4);
-                    peg$currPos += 4;
-                } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c39);
-                    }
-                }
-                if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c70();
-                }
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseMUTCommand() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c83) {
+      s1 = peg$c83;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsemsp();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 61) {
+          s3 = peg$c85;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsemsp();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseMutationWithModifiers();
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c87(s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 3) === peg$c83) {
+        s1 = peg$c83;
+        peg$currPos += 3;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsemsp();
+        if (s2 !== peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c88) {
+            s3 = peg$c88;
+            peg$currPos += 2;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c89); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parsemsp();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseMutationWithModifiers();
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c90(s5);
                 s0 = s1;
-                if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    if (
-                        input.substr(peg$currPos, 7).toLowerCase() === peg$c40
-                    ) {
-                        s1 = input.substr(peg$currPos, 7);
-                        peg$currPos += 7;
-                    } else {
-                        s1 = peg$FAILED;
-                        if (peg$silentFails === 0) {
-                            peg$fail(peg$c41);
-                        }
-                    }
-                    if (s1 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c71();
-                    }
-                    s0 = s1;
-                }
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseCNACommand() {
-        var s0, s1, s2, s3, s4, s5;
-
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c72) {
-            s1 = input.substr(peg$currPos, 3);
-            peg$currPos += 3;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c73);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parsemsp();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseComparisonOp();
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parsemsp();
-                    if (s4 !== peg$FAILED) {
-                        s5 = peg$parseCNAType();
-                        if (s5 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c74(s3, s5);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
+              } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
             }
-        } else {
+          } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 4) === peg$c75) {
-                s1 = peg$c75;
-                peg$currPos += 4;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c76);
-                }
-            }
-            if (s1 !== peg$FAILED) {
-                s2 = peg$parseCNAModifier();
-                if (s2 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c77(s2);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseCNAType();
-                if (s1 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 95) {
-                        s2 = peg$c65;
-                        peg$currPos++;
-                    } else {
-                        s2 = peg$FAILED;
-                        if (peg$silentFails === 0) {
-                            peg$fail(peg$c66);
-                        }
-                    }
-                    if (s2 !== peg$FAILED) {
-                        s3 = peg$parseCNAModifier();
-                        if (s3 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c78(s1, s3);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-                if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    s1 = peg$parseCNAModifier();
-                    if (s1 !== peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c79) {
-                            s2 = peg$c79;
-                            peg$currPos += 4;
-                        } else {
-                            s2 = peg$FAILED;
-                            if (peg$silentFails === 0) {
-                                peg$fail(peg$c80);
-                            }
-                        }
-                        if (s2 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c77(s1);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                    if (s0 === peg$FAILED) {
-                        s0 = peg$currPos;
-                        s1 = peg$parseCNAModifier();
-                        if (s1 !== peg$FAILED) {
-                            if (input.charCodeAt(peg$currPos) === 95) {
-                                s2 = peg$c65;
-                                peg$currPos++;
-                            } else {
-                                s2 = peg$FAILED;
-                                if (peg$silentFails === 0) {
-                                    peg$fail(peg$c66);
-                                }
-                            }
-                            if (s2 !== peg$FAILED) {
-                                s3 = peg$parseCNAType();
-                                if (s3 !== peg$FAILED) {
-                                    peg$savedPos = s0;
-                                    s1 = peg$c81(s1, s3);
-                                    s0 = s1;
-                                } else {
-                                    peg$currPos = s0;
-                                    s0 = peg$FAILED;
-                                }
-                            } else {
-                                peg$currPos = s0;
-                                s0 = peg$FAILED;
-                            }
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                        if (s0 === peg$FAILED) {
-                            s0 = peg$currPos;
-                            s1 = peg$parseCNAType();
-                            if (s1 !== peg$FAILED) {
-                                peg$savedPos = s0;
-                                s1 = peg$c82(s1);
-                            }
-                            s0 = s1;
-                        }
-                    }
-                }
-            }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseMutationWithModifiers();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c91(s1);
         }
-
-        return s0;
+        s0 = s1;
+      }
     }
 
-    function peg$parseMUTCommand() {
-        var s0, s1, s2, s3, s4, s5;
+    return s0;
+  }
 
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3) === peg$c83) {
-            s1 = peg$c83;
-            peg$currPos += 3;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c84);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parsemsp();
-            if (s2 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 61) {
-                    s3 = peg$c85;
-                    peg$currPos++;
-                } else {
-                    s3 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c86);
-                    }
-                }
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parsemsp();
-                    if (s4 !== peg$FAILED) {
-                        s5 = peg$parseMutationWithModifiers();
-                        if (s5 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c87(s5);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
+  function peg$parseEXPCommand() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c92) {
+      s1 = peg$c92;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c93); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsemsp();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseComparisonOp();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsemsp();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseNumber();
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c94(s3, s5);
+              s0 = s1;
             } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
+              peg$currPos = s0;
+              s0 = peg$FAILED;
             }
-        } else {
+          } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 3) === peg$c83) {
-                s1 = peg$c83;
-                peg$currPos += 3;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c84);
-                }
-            }
-            if (s1 !== peg$FAILED) {
-                s2 = peg$parsemsp();
-                if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c88) {
-                        s3 = peg$c88;
-                        peg$currPos += 2;
-                    } else {
-                        s3 = peg$FAILED;
-                        if (peg$silentFails === 0) {
-                            peg$fail(peg$c89);
-                        }
-                    }
-                    if (s3 !== peg$FAILED) {
-                        s4 = peg$parsemsp();
-                        if (s4 !== peg$FAILED) {
-                            s5 = peg$parseMutationWithModifiers();
-                            if (s5 !== peg$FAILED) {
-                                peg$savedPos = s0;
-                                s1 = peg$c90(s5);
-                                s0 = s1;
-                            } else {
-                                peg$currPos = s0;
-                                s0 = peg$FAILED;
-                            }
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseMutationWithModifiers();
-                if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c91(s1);
-                }
-                s0 = s1;
-            }
-        }
-
-        return s0;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
-    function peg$parseEXPCommand() {
-        var s0, s1, s2, s3, s4, s5;
+    return s0;
+  }
 
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3) === peg$c92) {
-            s1 = peg$c92;
-            peg$currPos += 3;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c93);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parsemsp();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseComparisonOp();
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parsemsp();
-                    if (s4 !== peg$FAILED) {
-                        s5 = peg$parseNumber();
-                        if (s5 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c94(s3, s5);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
+  function peg$parseFUSIONCommand() {
+    var s0, s1, s2, s3;
 
-        return s0;
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c95) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
-
-    function peg$parseFUSIONCommand() {
-        var s0, s1, s2, s3;
-
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 95) {
+        s2 = peg$c65;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseFusionModifier();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c97(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseFusionModifier();
+      if (s1 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 7).toLowerCase() === peg$c98) {
+          s2 = input.substr(peg$currPos, 7);
+          peg$currPos += 7;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c97(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.substr(peg$currPos, 6).toLowerCase() === peg$c95) {
-            s1 = input.substr(peg$currPos, 6);
-            peg$currPos += 6;
+          s1 = input.substr(peg$currPos, 6);
+          peg$currPos += 6;
         } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c96);
-            }
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c96); }
         }
         if (s1 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 95) {
-                s2 = peg$c65;
-                peg$currPos++;
+          peg$savedPos = s0;
+          s1 = peg$c100();
+        }
+        s0 = s1;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parsePROTCommand() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c101) {
+      s1 = peg$c101;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsemsp();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseComparisonOp();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsemsp();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseNumber();
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c103(s3, s5);
+              s0 = s1;
             } else {
-                s2 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c66);
-                }
+              peg$currPos = s0;
+              s0 = peg$FAILED;
             }
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseFusionModifier();
-                if (s3 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c97(s3);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
+          } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseComparisonOp() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c104) {
+      s1 = peg$c104;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c106();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c107) {
+        s1 = peg$c107;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c109();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 62) {
+          s1 = peg$c110;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c112();
+        }
+        s0 = s1;
         if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 60) {
+            s1 = peg$c113;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
+          }
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c115();
+          }
+          s0 = s1;
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseMutationWithModifiers() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseMutationModifier();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 95) {
+        s2 = peg$c65;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseMutationWithModifiers();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c116(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseMutation();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 95) {
+          s2 = peg$c65;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseMutationModifiers();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c117(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseMutationModifier();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c118(s1);
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parseMutation();
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c119(s1);
+          }
+          s0 = s1;
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseMutationModifiers() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseMutationModifier();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 95) {
+        s2 = peg$c65;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseMutationModifiers();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c120(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseMutationModifier();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c121(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseMutation() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c42) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c122();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 8).toLowerCase() === peg$c123) {
+        s1 = input.substr(peg$currPos, 8);
+        peg$currPos += 8;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c124); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c125();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 8).toLowerCase() === peg$c126) {
+          s1 = input.substr(peg$currPos, 8);
+          peg$currPos += 8;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c127); }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c128();
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.substr(peg$currPos, 8).toLowerCase() === peg$c129) {
+            s1 = input.substr(peg$currPos, 8);
+            peg$currPos += 8;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
+          }
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c131();
+          }
+          s0 = s1;
+          if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parseFusionModifier();
-            if (s1 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 7).toLowerCase() === peg$c98) {
-                    s2 = input.substr(peg$currPos, 7);
-                    peg$currPos += 7;
-                } else {
-                    s2 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c99);
-                    }
-                }
-                if (s2 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c97(s1);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
+            if (input.substr(peg$currPos, 7).toLowerCase() === peg$c132) {
+              s1 = input.substr(peg$currPos, 7);
+              peg$currPos += 7;
             } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c134();
+            }
+            s0 = s1;
             if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              if (input.substr(peg$currPos, 10).toLowerCase() === peg$c135) {
+                s1 = input.substr(peg$currPos, 10);
+                peg$currPos += 10;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c136); }
+              }
+              if (s1 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c137();
+              }
+              s0 = s1;
+              if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 6).toLowerCase() === peg$c95) {
+                if (input.substr(peg$currPos, 7).toLowerCase() === peg$c138) {
+                  s1 = input.substr(peg$currPos, 7);
+                  peg$currPos += 7;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c139); }
+                }
+                if (s1 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c140();
+                }
+                s0 = s1;
+                if (s0 === peg$FAILED) {
+                  s0 = peg$currPos;
+                  if (input.substr(peg$currPos, 6).toLowerCase() === peg$c141) {
                     s1 = input.substr(peg$currPos, 6);
                     peg$currPos += 6;
-                } else {
+                  } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c96);
-                    }
-                }
-                if (s1 !== peg$FAILED) {
+                    if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                  }
+                  if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c100();
-                }
-                s0 = s1;
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parsePROTCommand() {
-        var s0, s1, s2, s3, s4, s5;
-
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c101) {
-            s1 = peg$c101;
-            peg$currPos += 4;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c102);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parsemsp();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseComparisonOp();
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parsemsp();
-                    if (s4 !== peg$FAILED) {
-                        s5 = peg$parseNumber();
-                        if (s5 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c103(s3, s5);
-                            s0 = s1;
-                        } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                        }
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-
-        return s0;
-    }
-
-    function peg$parseComparisonOp() {
-        var s0, s1;
-
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c104) {
-            s1 = peg$c104;
-            peg$currPos += 2;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c105);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c106();
-        }
-        s0 = s1;
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c107) {
-                s1 = peg$c107;
-                peg$currPos += 2;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c108);
-                }
-            }
-            if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c109();
-            }
-            s0 = s1;
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                if (input.charCodeAt(peg$currPos) === 62) {
-                    s1 = peg$c110;
-                    peg$currPos++;
-                } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c111);
-                    }
-                }
-                if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c112();
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
+                    s1 = peg$c143();
+                  }
+                  s0 = s1;
+                  if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.charCodeAt(peg$currPos) === 60) {
-                        s1 = peg$c113;
-                        peg$currPos++;
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c144) {
+                      s1 = input.substr(peg$currPos, 5);
+                      peg$currPos += 5;
                     } else {
-                        s1 = peg$FAILED;
-                        if (peg$silentFails === 0) {
-                            peg$fail(peg$c114);
-                        }
+                      s1 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c145); }
                     }
                     if (s1 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c115();
-                    }
-                    s0 = s1;
-                }
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseMutationWithModifiers() {
-        var s0, s1, s2, s3;
-
-        s0 = peg$currPos;
-        s1 = peg$parseMutationModifier();
-        if (s1 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 95) {
-                s2 = peg$c65;
-                peg$currPos++;
-            } else {
-                s2 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c66);
-                }
-            }
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseMutationWithModifiers();
-                if (s3 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c116(s1, s3);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseMutation();
-            if (s1 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 95) {
-                    s2 = peg$c65;
-                    peg$currPos++;
-                } else {
-                    s2 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c66);
-                    }
-                }
-                if (s2 !== peg$FAILED) {
-                    s3 = peg$parseMutationModifiers();
-                    if (s3 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c117(s1, s3);
-                        s0 = s1;
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseMutationModifier();
-                if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c118(s1);
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    s1 = peg$parseMutation();
-                    if (s1 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c119(s1);
-                    }
-                    s0 = s1;
-                }
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseMutationModifiers() {
-        var s0, s1, s2, s3;
-
-        s0 = peg$currPos;
-        s1 = peg$parseMutationModifier();
-        if (s1 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 95) {
-                s2 = peg$c65;
-                peg$currPos++;
-            } else {
-                s2 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c66);
-                }
-            }
-            if (s2 !== peg$FAILED) {
-                s3 = peg$parseMutationModifiers();
-                if (s3 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c120(s1, s3);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseMutationModifier();
-            if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c121(s1);
-            }
-            s0 = s1;
-        }
-
-        return s0;
-    }
-
-    function peg$parseMutation() {
-        var s0, s1, s2, s3;
-
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3).toLowerCase() === peg$c42) {
-            s1 = input.substr(peg$currPos, 3);
-            peg$currPos += 3;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c43);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c122();
-        }
-        s0 = s1;
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 8).toLowerCase() === peg$c123) {
-                s1 = input.substr(peg$currPos, 8);
-                peg$currPos += 8;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c124);
-                }
-            }
-            if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c125();
-            }
-            s0 = s1;
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                if (input.substr(peg$currPos, 8).toLowerCase() === peg$c126) {
-                    s1 = input.substr(peg$currPos, 8);
-                    peg$currPos += 8;
-                } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) {
-                        peg$fail(peg$c127);
-                    }
-                }
-                if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c128();
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    if (
-                        input.substr(peg$currPos, 8).toLowerCase() === peg$c129
-                    ) {
-                        s1 = input.substr(peg$currPos, 8);
-                        peg$currPos += 8;
-                    } else {
-                        s1 = peg$FAILED;
-                        if (peg$silentFails === 0) {
-                            peg$fail(peg$c130);
-                        }
-                    }
-                    if (s1 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c131();
+                      peg$savedPos = s0;
+                      s1 = peg$c146();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
+                      s0 = peg$currPos;
+                      if (input.substr(peg$currPos, 8).toLowerCase() === peg$c147) {
+                        s1 = input.substr(peg$currPos, 8);
+                        peg$currPos += 8;
+                      } else {
+                        s1 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+                      }
+                      if (s1 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c149();
+                      }
+                      s0 = s1;
+                      if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        if (
-                            input.substr(peg$currPos, 7).toLowerCase() ===
-                            peg$c132
-                        ) {
-                            s1 = input.substr(peg$currPos, 7);
-                            peg$currPos += 7;
-                        } else {
-                            s1 = peg$FAILED;
-                            if (peg$silentFails === 0) {
-                                peg$fail(peg$c133);
-                            }
-                        }
+                        s1 = peg$parseAminoAcid();
                         if (s1 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c134();
-                        }
-                        s0 = s1;
-                        if (s0 === peg$FAILED) {
-                            s0 = peg$currPos;
-                            if (
-                                input.substr(peg$currPos, 10).toLowerCase() ===
-                                peg$c135
-                            ) {
-                                s1 = input.substr(peg$currPos, 10);
-                                peg$currPos += 10;
+                          s2 = peg$parseNaturalNumber();
+                          if (s2 !== peg$FAILED) {
+                            s3 = peg$parseMutationProteinChangeCode();
+                            if (s3 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c150(s1, s2, s3);
+                              s0 = s1;
                             } else {
-                                s1 = peg$FAILED;
-                                if (peg$silentFails === 0) {
-                                    peg$fail(peg$c136);
-                                }
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
                             }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$currPos;
+                          s1 = peg$parseAminoAcid();
+                          if (s1 !== peg$FAILED) {
+                            s2 = peg$parseNaturalNumber();
+                            if (s2 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c151(s1, s2);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$currPos;
+                            s1 = peg$parseMutationProteinChangeCode();
                             if (s1 !== peg$FAILED) {
-                                peg$savedPos = s0;
-                                s1 = peg$c137();
+                              peg$savedPos = s0;
+                              s1 = peg$c152(s1);
                             }
                             s0 = s1;
-                            if (s0 === peg$FAILED) {
-                                s0 = peg$currPos;
-                                if (
-                                    input
-                                        .substr(peg$currPos, 7)
-                                        .toLowerCase() === peg$c138
-                                ) {
-                                    s1 = input.substr(peg$currPos, 7);
-                                    peg$currPos += 7;
-                                } else {
-                                    s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) {
-                                        peg$fail(peg$c139);
-                                    }
-                                }
-                                if (s1 !== peg$FAILED) {
-                                    peg$savedPos = s0;
-                                    s1 = peg$c140();
-                                }
-                                s0 = s1;
-                                if (s0 === peg$FAILED) {
-                                    s0 = peg$currPos;
-                                    if (
-                                        input
-                                            .substr(peg$currPos, 6)
-                                            .toLowerCase() === peg$c141
-                                    ) {
-                                        s1 = input.substr(peg$currPos, 6);
-                                        peg$currPos += 6;
-                                    } else {
-                                        s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) {
-                                            peg$fail(peg$c142);
-                                        }
-                                    }
-                                    if (s1 !== peg$FAILED) {
-                                        peg$savedPos = s0;
-                                        s1 = peg$c143();
-                                    }
-                                    s0 = s1;
-                                    if (s0 === peg$FAILED) {
-                                        s0 = peg$currPos;
-                                        if (
-                                            input
-                                                .substr(peg$currPos, 5)
-                                                .toLowerCase() === peg$c144
-                                        ) {
-                                            s1 = input.substr(peg$currPos, 5);
-                                            peg$currPos += 5;
-                                        } else {
-                                            s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) {
-                                                peg$fail(peg$c145);
-                                            }
-                                        }
-                                        if (s1 !== peg$FAILED) {
-                                            peg$savedPos = s0;
-                                            s1 = peg$c146();
-                                        }
-                                        s0 = s1;
-                                        if (s0 === peg$FAILED) {
-                                            s0 = peg$currPos;
-                                            if (
-                                                input
-                                                    .substr(peg$currPos, 8)
-                                                    .toLowerCase() === peg$c147
-                                            ) {
-                                                s1 = input.substr(
-                                                    peg$currPos,
-                                                    8
-                                                );
-                                                peg$currPos += 8;
-                                            } else {
-                                                s1 = peg$FAILED;
-                                                if (peg$silentFails === 0) {
-                                                    peg$fail(peg$c148);
-                                                }
-                                            }
-                                            if (s1 !== peg$FAILED) {
-                                                peg$savedPos = s0;
-                                                s1 = peg$c149();
-                                            }
-                                            s0 = s1;
-                                            if (s0 === peg$FAILED) {
-                                                s0 = peg$currPos;
-                                                s1 = peg$parseAminoAcid();
-                                                if (s1 !== peg$FAILED) {
-                                                    s2 = peg$parseNaturalNumber();
-                                                    if (s2 !== peg$FAILED) {
-                                                        s3 = peg$parseMutationProteinChangeCode();
-                                                        if (s3 !== peg$FAILED) {
-                                                            peg$savedPos = s0;
-                                                            s1 = peg$c150(
-                                                                s1,
-                                                                s2,
-                                                                s3
-                                                            );
-                                                            s0 = s1;
-                                                        } else {
-                                                            peg$currPos = s0;
-                                                            s0 = peg$FAILED;
-                                                        }
-                                                    } else {
-                                                        peg$currPos = s0;
-                                                        s0 = peg$FAILED;
-                                                    }
-                                                } else {
-                                                    peg$currPos = s0;
-                                                    s0 = peg$FAILED;
-                                                }
-                                                if (s0 === peg$FAILED) {
-                                                    s0 = peg$currPos;
-                                                    s1 = peg$parseAminoAcid();
-                                                    if (s1 !== peg$FAILED) {
-                                                        s2 = peg$parseNaturalNumber();
-                                                        if (s2 !== peg$FAILED) {
-                                                            peg$savedPos = s0;
-                                                            s1 = peg$c151(
-                                                                s1,
-                                                                s2
-                                                            );
-                                                            s0 = s1;
-                                                        } else {
-                                                            peg$currPos = s0;
-                                                            s0 = peg$FAILED;
-                                                        }
-                                                    } else {
-                                                        peg$currPos = s0;
-                                                        s0 = peg$FAILED;
-                                                    }
-                                                    if (s0 === peg$FAILED) {
-                                                        s0 = peg$currPos;
-                                                        s1 = peg$parseMutationProteinChangeCode();
-                                                        if (s1 !== peg$FAILED) {
-                                                            peg$savedPos = s0;
-                                                            s1 = peg$c152(s1);
-                                                        }
-                                                        s0 = s1;
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                          }
                         }
+                      }
                     }
+                  }
                 }
+              }
             }
+          }
         }
-
-        return s0;
+      }
     }
 
-    function peg$parseMutationProteinChangeCode() {
-        var s0, s1, s2, s3, s4;
+    return s0;
+  }
 
-        s0 = peg$currPos;
-        s1 = peg$currPos;
-        peg$silentFails++;
-        s2 = peg$parseTrailingMutationModifier();
-        peg$silentFails--;
-        if (s2 === peg$FAILED) {
-            s1 = void 0;
-        } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
-        }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parseMutationProteinChangeCodeChar();
-            if (s2 !== peg$FAILED) {
-                s3 = peg$currPos;
-                peg$silentFails++;
-                s4 = peg$parseTrailingMutationModifier();
-                peg$silentFails--;
-                if (s4 === peg$FAILED) {
-                    s3 = void 0;
-                } else {
-                    peg$currPos = s3;
-                    s3 = peg$FAILED;
-                }
-                if (s3 !== peg$FAILED) {
-                    s4 = peg$parseMutationProteinChangeCode();
-                    if (s4 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c153(s2, s4);
-                        s0 = s1;
-                    } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                    }
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$currPos;
-            peg$silentFails++;
-            s2 = peg$parseTrailingMutationModifier();
-            peg$silentFails--;
-            if (s2 === peg$FAILED) {
-                s1 = void 0;
-            } else {
-                peg$currPos = s1;
-                s1 = peg$FAILED;
-            }
-            if (s1 !== peg$FAILED) {
-                s2 = peg$parseMutationProteinChangeCodeChar();
-                if (s2 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c154(s2);
-                    s0 = s1;
-                } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                }
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        }
+  function peg$parseMutationProteinChangeCode() {
+    var s0, s1, s2, s3, s4;
 
-        return s0;
-    }
-
-    function peg$parseTrailingMutationModifier() {
-        var s0, s1, s2;
-
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 95) {
-            s1 = peg$c65;
-            peg$currPos++;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c66);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            s2 = peg$parseMutationModifier();
-            if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c155(s2);
-                s0 = s1;
-            } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-            }
-        } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-        }
-
-        return s0;
-    }
-
-    function peg$parseMutationModifier() {
-        var s0, s1;
-
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 8).toLowerCase() === peg$c156) {
-            s1 = input.substr(peg$currPos, 8);
-            peg$currPos += 8;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c157);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c158();
-        }
-        s0 = s1;
-        if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 7).toLowerCase() === peg$c159) {
-                s1 = input.substr(peg$currPos, 7);
-                peg$currPos += 7;
-            } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) {
-                    peg$fail(peg$c160);
-                }
-            }
-            if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c161();
-            }
-            s0 = s1;
-            if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseDriverModifier();
-                if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c155(s1);
-                }
-                s0 = s1;
-            }
-        }
-
-        return s0;
-    }
-
-    function peg$parseCNAModifier() {
-        var s0, s1;
-
-        s0 = peg$currPos;
-        s1 = peg$parseDriverModifier();
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c162(s1);
-        }
-        s0 = s1;
-
-        return s0;
-    }
-
-    function peg$parseFusionModifier() {
-        var s0, s1;
-
-        s0 = peg$currPos;
-        s1 = peg$parseDriverModifier();
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c162(s1);
-        }
-        s0 = s1;
-
-        return s0;
-    }
-
-    function peg$parseDriverModifier() {
-        var s0, s1;
-
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 6).toLowerCase() === peg$c163) {
-            s1 = input.substr(peg$currPos, 6);
-            peg$currPos += 6;
-        } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) {
-                peg$fail(peg$c164);
-            }
-        }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c165();
-        }
-        s0 = s1;
-
-        return s0;
-    }
-
-    peg$result = peg$startRuleFunction();
-
-    if (peg$result !== peg$FAILED && peg$currPos === input.length) {
-        return peg$result;
+    s0 = peg$currPos;
+    s1 = peg$currPos;
+    peg$silentFails++;
+    s2 = peg$parseTrailingMutationModifier();
+    peg$silentFails--;
+    if (s2 === peg$FAILED) {
+      s1 = void 0;
     } else {
-        if (peg$result !== peg$FAILED && peg$currPos < input.length) {
-            peg$fail(peg$endExpectation());
-        }
-
-        throw peg$buildStructuredError(
-            peg$maxFailExpected,
-            peg$maxFailPos < input.length ? input.charAt(peg$maxFailPos) : null,
-            peg$maxFailPos < input.length
-                ? peg$computeLocation(peg$maxFailPos, peg$maxFailPos + 1)
-                : peg$computeLocation(peg$maxFailPos, peg$maxFailPos)
-        );
+      peg$currPos = s1;
+      s1 = peg$FAILED;
     }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseMutationProteinChangeCodeChar();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$currPos;
+        peg$silentFails++;
+        s4 = peg$parseTrailingMutationModifier();
+        peg$silentFails--;
+        if (s4 === peg$FAILED) {
+          s3 = void 0;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseMutationProteinChangeCode();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c153(s2, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$currPos;
+      peg$silentFails++;
+      s2 = peg$parseTrailingMutationModifier();
+      peg$silentFails--;
+      if (s2 === peg$FAILED) {
+        s1 = void 0;
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseMutationProteinChangeCodeChar();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c154(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseTrailingMutationModifier() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 95) {
+      s1 = peg$c65;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c66); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseMutationModifier();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c155(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseMutationModifier() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c156) {
+      s1 = input.substr(peg$currPos, 8);
+      peg$currPos += 8;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c158();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c159) {
+        s1 = input.substr(peg$currPos, 7);
+        peg$currPos += 7;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c160); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c161();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseDriverModifier();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c155(s1);
+        }
+        s0 = s1;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseCNAModifier() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDriverModifier();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c162(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseFusionModifier() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDriverModifier();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c162(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseDriverModifier() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c163) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c165();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  peg$result = peg$startRuleFunction();
+
+  if (peg$result !== peg$FAILED && peg$currPos === input.length) {
+    return peg$result;
+  } else {
+    if (peg$result !== peg$FAILED && peg$currPos < input.length) {
+      peg$fail(peg$endExpectation());
+    }
+
+    throw peg$buildStructuredError(
+      peg$maxFailExpected,
+      peg$maxFailPos < input.length ? input.charAt(peg$maxFailPos) : null,
+      peg$maxFailPos < input.length
+        ? peg$computeLocation(peg$maxFailPos, peg$maxFailPos + 1)
+        : peg$computeLocation(peg$maxFailPos, peg$maxFailPos)
+    );
+  }
 }
 
 module.exports = {
-    SyntaxError: peg$SyntaxError,
-    parse: peg$parse,
+  SyntaxError: peg$SyntaxError,
+  parse:       peg$parse
 };


### PR DESCRIPTION
We have thus far handled errors in mobxpromise.  This works well only if the developer does in fact handle the error condition in UI.  It doesn't work well for global error handling.  This PR forces developer to choose when actually calling the API client or using http client (superagent) directly.  

There are three ways of error handling:
1. local: errors fail silently unless dealt with in UI (e.g. annotation services we show error icon in table cell)
2. global: dialog.  We have an error which is serious but not catastrophic and we still want to show normal UI but with a dimissiable error dialog (or alert?).
3. global: screen.  We want to hide the site entirely and render only an error screen 