### PR TITLE
Fix Oncoprint controls hidden while loading generic assay data

### DIFF
--- a/end-to-end-test/local/specs/treatment.spec.js
+++ b/end-to-end-test/local/specs/treatment.spec.js
@@ -140,6 +140,10 @@ describe('treatment feature', function() {
                     $('.oncoprint__controls__heatmap_menu'),
                     'IC50 values of compounds on cellular phenotype readout'
                 );
+                // wait for generic assay data loading complete
+                $(
+                    '.oncoprint__controls__heatmap_menu .generic-assay-selector'
+                ).waitForExist();
                 var treatments = getSelectCheckedOptions(
                     $(
                         '.oncoprint__controls__heatmap_menu .generic-assay-selector'
@@ -154,6 +158,10 @@ describe('treatment feature', function() {
                     $('.oncoprint__controls__heatmap_menu'),
                     'IC50 values of compounds on cellular phenotype readout'
                 );
+                // wait for generic assay data loading complete
+                $(
+                    '.oncoprint__controls__heatmap_menu .generic-assay-selector'
+                ).waitForExist();
                 var treatments = getSelectCheckedOptions(
                     $(
                         '.oncoprint__controls__heatmap_menu .generic-assay-selector'
@@ -173,6 +181,11 @@ describe('treatment feature', function() {
                     $('.oncoprint__controls__heatmap_menu'),
                     'IC50 values of compounds on cellular phenotype readout'
                 );
+                // wait for generic assay data loading complete
+                $(
+                    '.oncoprint__controls__heatmap_menu .generic-assay-selector'
+                ).waitForExist();
+
                 var searchBox = $(
                     '.oncoprint__controls__heatmap_menu .generic-assay-selector .default-checked-select'
                 ).$('input');
@@ -202,6 +215,10 @@ describe('treatment feature', function() {
                     $('.oncoprint__controls__heatmap_menu'),
                     'IC50 values of compounds on cellular phenotype readout'
                 );
+                // wait for generic assay data loading complete
+                $(
+                    '.oncoprint__controls__heatmap_menu .generic-assay-selector'
+                ).waitForExist();
 
                 var searchBox = $(
                     '.oncoprint__controls__heatmap_menu .generic-assay-selector .default-checked-select'
@@ -233,6 +250,11 @@ describe('treatment feature', function() {
                     $('.oncoprint__controls__heatmap_menu'),
                     'IC50 values of compounds on cellular phenotype readout'
                 );
+                // wait for generic assay data loading complete
+                $(
+                    '.oncoprint__controls__heatmap_menu .generic-assay-selector'
+                ).waitForExist();
+
                 assert($('div.icon*=17-AAG').isExisting());
                 var selectMenuEntry = selectCheckedOption(
                     $(

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -1538,14 +1538,6 @@ export default class ResultsViewOncoprint extends React.Component<
         if (
             this.oncoprint &&
             !this.oncoprint.webgl_unavailable &&
-            (this.genericAssayEntitiesSelectOptionsGroupByGenericAssayType
-                .isComplete ||
-                this.genericAssayEntitiesSelectOptionsGroupByGenericAssayType
-                    .isError) &&
-            (this.genericAssayEntitiesSelectOptionsGroupByMolecularProfileId
-                .isComplete ||
-                this.genericAssayEntitiesSelectOptionsGroupByMolecularProfileId
-                    .isError) &&
             this.props.store.molecularProfileIdToMolecularProfile.result
         ) {
             return (
@@ -1558,15 +1550,13 @@ export default class ResultsViewOncoprint extends React.Component<
                             this.props.store
                                 .molecularProfileIdToMolecularProfile.result
                         }
-                        genericAssayEntitiesSelectOptionsGroupByGenericAssayType={
+                        genericAssayEntitiesSelectOptionsGroupByGenericAssayTypePromise={
                             this
                                 .genericAssayEntitiesSelectOptionsGroupByGenericAssayType
-                                .result
                         }
-                        genericAssayEntitiesSelectOptionsGroupByMolecularProfileId={
+                        genericAssayEntitiesSelectOptionsGroupByMolecularProfileIdPromise={
                             this
                                 .genericAssayEntitiesSelectOptionsGroupByMolecularProfileId
-                                .result
                         }
                         selectedGenericAssayEntitiesGroupByGenericAssayTypeFromUrl={
                             this


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7427

Describe changes proposed in this pull request:
- a do not wait for generic assay data when rendering oncoprint control
- b shows a loading icon and disable the button click when waiting for data loading.

![image](https://user-images.githubusercontent.com/15748980/80262086-5b96a780-865a-11ea-8952-8a4b1aa089a3.png)
