### PR TITLE
Allow cbioportal use oncokb biological data without token

### DIFF
--- a/packages/react-mutation-mapper/src/component/column/Annotation.tsx
+++ b/packages/react-mutation-mapper/src/component/column/Annotation.tsx
@@ -29,6 +29,7 @@ import OncoKB, { sortValue as oncoKbSortValue } from '../oncokb/OncoKB';
 import HotspotAnnotation, {
     sortValue as hotspotSortValue,
 } from './HotspotAnnotation';
+import { USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB } from '../../util/DataFetcherUtils';
 
 export type AnnotationProps = {
     mutation?: Mutation;
@@ -39,6 +40,7 @@ export type AnnotationProps = {
     hotspotData?: RemoteData<IHotspotIndex | undefined>;
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
     oncoKbCancerGenes?: RemoteData<CancerGene[] | Error | undefined>;
+    usingPublicOncoKbInstance: boolean;
     pubMedCache?: MobxCache;
     resolveEntrezGeneId?: (mutation: Mutation) => number;
     resolveTumorType?: (mutation: Mutation) => string;
@@ -66,6 +68,7 @@ export interface IAnnotation {
     oncoKbStatus: 'pending' | 'error' | 'complete';
     oncoKbGeneExist: boolean;
     isOncoKbCancerGene: boolean;
+    usingPublicOncoKbInstance: boolean;
     myCancerGenomeLinks: string[];
     civicEntry?: ICivicEntry | null;
     civicStatus: 'pending' | 'error' | 'complete';
@@ -77,6 +80,7 @@ export const DEFAULT_ANNOTATION_DATA: IAnnotation = {
     oncoKbStatus: 'complete',
     oncoKbGeneExist: false,
     isOncoKbCancerGene: false,
+    usingPublicOncoKbInstance: false,
     isHotspot: false,
     is3dHotspot: false,
     hotspotStatus: 'complete',
@@ -100,6 +104,7 @@ export function getAnnotationData(
     hotspotData?: RemoteData<IHotspotIndex | undefined>,
     myCancerGenomeData?: IMyCancerGenomeData,
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>,
+    usingPublicOncoKbInstance?: boolean,
     civicGenes?: RemoteData<ICivicGene | undefined>,
     civicVariants?: RemoteData<ICivicVariant | undefined>,
     resolveTumorType: (mutation: Mutation) => string = getDefaultTumorType,
@@ -136,6 +141,9 @@ export function getAnnotationData(
             hugoGeneSymbol,
             oncoKbGeneExist,
             isOncoKbCancerGene,
+            usingPublicOncoKbInstance: usingPublicOncoKbInstance
+                ? usingPublicOncoKbInstance
+                : USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
             civicEntry:
                 civicGenes &&
                 civicGenes.result &&
@@ -245,6 +253,9 @@ export function GenericAnnotation(props: GenericAnnotationProps): JSX.Element {
         <span style={{ display: 'flex', minWidth: 100 }}>
             {enableOncoKb && (
                 <OncoKB
+                    usingPublicOncoKbInstance={
+                        annotation.usingPublicOncoKbInstance
+                    }
                     hugoGeneSymbol={annotation.hugoGeneSymbol}
                     geneNotExist={!annotation.oncoKbGeneExist}
                     isCancerGene={annotation.isOncoKbCancerGene}
@@ -290,6 +301,7 @@ export default class Annotation extends React.Component<AnnotationProps, {}> {
             hotspotData,
             myCancerGenomeData,
             oncoKbData,
+            usingPublicOncoKbInstance,
             resolveEntrezGeneId,
             resolveTumorType,
             civicGenes,
@@ -302,6 +314,7 @@ export default class Annotation extends React.Component<AnnotationProps, {}> {
             hotspotData,
             myCancerGenomeData,
             oncoKbData,
+            usingPublicOncoKbInstance,
             civicGenes,
             civicVariants,
             resolveTumorType,

--- a/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
@@ -280,6 +280,9 @@ export default class MutationMapper<
                     reactTableProps={this.props.customMutationTableProps}
                     hotspotData={this.store.indexedHotspotData}
                     oncoKbData={this.store.oncoKbData}
+                    usingPublicOncoKbInstance={
+                        this.store.usingPublicOncoKbInstance
+                    }
                     oncoKbCancerGenes={this.store.oncoKbCancerGenes}
                     myCancerGenomeData={this.store.myCancerGenomeData}
                     enableCivic={this.props.enableCivic}

--- a/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
@@ -36,6 +36,7 @@ export type DefaultMutationTableProps = {
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
     myCancerGenomeData?: IMyCancerGenomeData;
     oncoKbCancerGenes?: RemoteData<CancerGene[] | Error | undefined>;
+    usingPublicOncoKbInstance: boolean;
     indexedMyVariantInfoAnnotations?: RemoteData<
         { [genomicLocation: string]: MyVariantInfo } | undefined
     >;
@@ -96,6 +97,7 @@ export default class DefaultMutationTable extends React.Component<
                       this.props.hotspotData,
                       this.props.myCancerGenomeData,
                       this.props.oncoKbData,
+                      this.props.usingPublicOncoKbInstance,
                       this.props.civicGenes,
                       this.props.civicVariants
                   );
@@ -143,6 +145,9 @@ export default class DefaultMutationTable extends React.Component<
                         hotspotData={this.props.hotspotData}
                         oncoKbData={this.props.oncoKbData}
                         oncoKbCancerGenes={this.props.oncoKbCancerGenes}
+                        usingPublicOncoKbInstance={
+                            this.props.usingPublicOncoKbInstance
+                        }
                         pubMedCache={this.props.pubMedCache}
                         civicGenes={this.props.civicGenes}
                         civicVariants={this.props.civicVariants}

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKB.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKB.tsx
@@ -24,6 +24,7 @@ export interface IOncoKbProps {
     status: 'pending' | 'error' | 'complete';
     indicator?: IndicatorQueryResp;
     pubMedCache?: MobxCache;
+    usingPublicOncoKbInstance: boolean;
     isCancerGene: boolean;
     geneNotExist: boolean;
     hugoGeneSymbol: string;
@@ -84,6 +85,7 @@ export default class OncoKB extends React.Component<IOncoKbProps, {}> {
                 <span className={`${annotationStyles['annotation-item']}`}>
                     <i
                         className={annotationIconClassNames(
+                            this.props.usingPublicOncoKbInstance,
                             this.props.indicator
                         )}
                         data-test="oncogenic-icon-image"
@@ -131,6 +133,7 @@ export default class OncoKB extends React.Component<IOncoKbProps, {}> {
     private tooltipContent(): JSX.Element {
         return (
             <OncoKbTooltip
+                usingPublicOncoKbInstance={this.props.usingPublicOncoKbInstance}
                 hugoSymbol={this.props.hugoGeneSymbol}
                 geneNotExist={this.props.geneNotExist}
                 isCancerGene={this.props.isCancerGene}

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbSummaryTable.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbSummaryTable.tsx
@@ -14,6 +14,7 @@ import {
 import { levelIconClassNames } from '../../util/OncoKbUtils';
 
 export type OncoKbSummaryTableProps = {
+    usingPublicOncoKbInstance: boolean;
     data: OncoKbSummary[];
     initialSortColumn?: string;
     initialSortDirection?: 'asc' | 'desc';
@@ -52,7 +53,7 @@ export default class OncoKbSummaryTable extends React.Component<
 
     @computed
     get columns(): Column[] {
-        return [
+        let columns: Column[] = [
             {
                 id: 'proteinChange',
                 accessor: 'proteinChange',
@@ -89,7 +90,9 @@ export default class OncoKbSummaryTable extends React.Component<
                 sortMethod: defaultStringArraySortMethod,
                 minWidth: 150,
             },
-            {
+        ];
+        if (!this.props.usingPublicOncoKbInstance) {
+            columns.push({
                 id: 'level',
                 accessor: 'level',
                 Header: 'Level',
@@ -125,8 +128,9 @@ export default class OncoKbSummaryTable extends React.Component<
                     </React.Fragment>
                 ),
                 minWidth: this.hasLevelData ? 180 : 50,
-            },
-        ];
+            });
+        }
+        return columns;
     }
 
     public render() {

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbTooltip.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbTooltip.tsx
@@ -14,6 +14,7 @@ export interface IOncoKbTooltipProps {
     hugoSymbol: string;
     isCancerGene: boolean;
     geneNotExist: boolean;
+    usingPublicOncoKbInstance: boolean;
 }
 
 /**
@@ -60,6 +61,9 @@ export default class OncoKbTooltip extends React.Component<
         if (this.props.geneNotExist) {
             tooltipContent = (
                 <OncoKbCard
+                    usingPublicOncoKbInstance={
+                        this.props.usingPublicOncoKbInstance
+                    }
                     gene={this.props.hugoSymbol}
                     geneNotExist={this.props.geneNotExist}
                     isCancerGene={this.props.isCancerGene}
@@ -77,6 +81,9 @@ export default class OncoKbTooltip extends React.Component<
             const pmidData: ICache<any> = this.pmidData;
             tooltipContent = (
                 <OncoKbCard
+                    usingPublicOncoKbInstance={
+                        this.props.usingPublicOncoKbInstance
+                    }
                     geneNotExist={this.props.geneNotExist}
                     isCancerGene={this.props.isCancerGene}
                     title={`${this.props.indicator.query.hugoSymbol} ${this.props.indicator.query.alteration} in ${this.props.indicator.query.tumorType}`}

--- a/packages/react-mutation-mapper/src/component/oncokb/main.module.scss
+++ b/packages/react-mutation-mapper/src/component/oncokb/main.module.scss
@@ -16,7 +16,6 @@
 .disclaimer {
     color: grey;
     font-style: italic;
-    padding: 5px 10px;
 }
 
 .orange-icon {

--- a/packages/react-mutation-mapper/src/component/track/OncoKbTrack.tsx
+++ b/packages/react-mutation-mapper/src/component/track/OncoKbTrack.tsx
@@ -36,6 +36,9 @@ export default class OncoKbTrack extends React.Component<OncoKbTrackProps, {}> {
                     color: '#007FFF',
                     tooltip: (
                         <OncoKbTrackTooltip
+                            usingPublicOncoKbInstance={
+                                this.props.store.usingPublicOncoKbInstance
+                            }
                             mutations={
                                 this.props.store.mutationsByPosition[
                                     Number(position)

--- a/packages/react-mutation-mapper/src/component/track/OncoKbTrackTooltip.tsx
+++ b/packages/react-mutation-mapper/src/component/track/OncoKbTrackTooltip.tsx
@@ -8,12 +8,16 @@ import { IndicatorQueryResp } from 'oncokb-ts-api-client';
 import OncoKbSummaryTable from '../oncokb/OncoKbSummaryTable';
 
 type OncoKbTrackTooltipProps = {
+    usingPublicOncoKbInstance: boolean;
     mutations: Mutation[];
     indicatorData?: IndicatorQueryResp[];
     hugoGeneSymbol?: string;
 };
 
-export function oncoKbTooltip(indicatorData: IndicatorQueryResp[]) {
+export function oncoKbTooltip(
+    usingPublicOncoKbInstance: boolean,
+    indicatorData: IndicatorQueryResp[]
+) {
     const sampleCount = indicatorData.length;
 
     // generate info
@@ -73,7 +77,10 @@ export function oncoKbTooltip(indicatorData: IndicatorQueryResp[]) {
         <span>
             <b>{sampleCount}</b> sample{pluralSuffix} with {oncogenicInfo}{' '}
             mutations.
-            <OncoKbSummaryTable data={tableData} />
+            <OncoKbSummaryTable
+                usingPublicOncoKbInstance={usingPublicOncoKbInstance}
+                data={tableData}
+            />
         </span>
     );
 }
@@ -104,7 +111,10 @@ export default class OncoKbTrackTooltip extends React.Component<
 > {
     public render() {
         return this.props.indicatorData
-            ? oncoKbTooltip(this.props.indicatorData)
+            ? oncoKbTooltip(
+                  this.props.usingPublicOncoKbInstance,
+                  this.props.indicatorData
+              )
             : null;
     }
 }

--- a/packages/react-mutation-mapper/src/model/MutationMapperDataFetcher.ts
+++ b/packages/react-mutation-mapper/src/model/MutationMapperDataFetcher.ts
@@ -11,7 +11,7 @@ import {
     PostTranslationalModification,
     VariantAnnotation,
 } from 'genome-nexus-ts-api-client';
-import { CancerGene, OncoKbAPI } from 'oncokb-ts-api-client';
+import { CancerGene, OncoKbAPI, OncoKBInfo } from 'oncokb-ts-api-client';
 import request from 'superagent';
 
 import { AggregatedHotspots } from './CancerHotspot';
@@ -63,6 +63,7 @@ export interface MutationMapperDataFetcher {
         client?: GenomeNexusAPIInternal
     ): Promise<AggregatedHotspots[]>;
     fetchOncoKbCancerGenes(client?: OncoKbAPI): Promise<CancerGene[]>;
+    fetchOncoKbInfo(client?: OncoKbAPI): Promise<OncoKBInfo>;
     fetchOncoKbData(
         mutations: Mutation[],
         annotatedGenes: { [entrezGeneId: number]: boolean } | Error,

--- a/packages/react-mutation-mapper/src/model/MutationMapperStore.ts
+++ b/packages/react-mutation-mapper/src/model/MutationMapperStore.ts
@@ -8,7 +8,11 @@ import {
     PostTranslationalModification,
     VariantAnnotation,
 } from 'genome-nexus-ts-api-client';
-import { CancerGene, IndicatorQueryResp } from 'oncokb-ts-api-client';
+import {
+    CancerGene,
+    IndicatorQueryResp,
+    OncoKBInfo,
+} from 'oncokb-ts-api-client';
 import { IHotspotIndex } from './CancerHotspot';
 import { ICivicGene, ICivicVariant } from './Civic';
 import DataStore from './DataStore';
@@ -55,6 +59,8 @@ export interface MutationMapperStore {
     oncoKbCancerGenes: RemoteData<CancerGene[] | Error | undefined>;
     oncoKbData: RemoteData<IOncoKbData | Error | undefined>;
     oncoKbDataByPosition: { [pos: number]: IndicatorQueryResp[] };
+    oncoKbInfo: RemoteData<OncoKBInfo | undefined>;
+    usingPublicOncoKbInstance: boolean;
     civicGenes?: RemoteData<ICivicGene | undefined>;
     civicVariants?: RemoteData<ICivicVariant | undefined>;
     myCancerGenomeData?: IMyCancerGenomeData;

--- a/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
+++ b/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
@@ -45,6 +45,7 @@ import {
     initOncoKbClient,
     ONCOKB_DEFAULT_DATA,
 } from '../util/DataFetcherUtils';
+import { OncoKBInfo } from 'oncokb-ts-api-client';
 
 export interface MutationMapperDataFetcherConfig {
     myGeneUrlTemplate?: string;
@@ -265,6 +266,12 @@ export class DefaultMutationMapperDataFetcher
         client: OncoKbAPI = this.oncoKbClient
     ): Promise<CancerGene[]> {
         return client.utilsCancerGeneListGetUsingGET_1({});
+    }
+
+    public fetchOncoKbInfo(
+        client: OncoKbAPI = this.oncoKbClient
+    ): Promise<OncoKBInfo> {
+        return client.infoGetUsingGET_1({});
     }
 
     public async fetchOncoKbData(

--- a/packages/react-mutation-mapper/src/store/DefaultMutationMapperStore.ts
+++ b/packages/react-mutation-mapper/src/store/DefaultMutationMapperStore.ts
@@ -7,7 +7,11 @@ import {
     uniqueGenomicLocations,
 } from 'cbioportal-utils';
 import { Gene, Mutation } from 'cbioportal-utils';
-import { CancerGene, IndicatorQueryResp } from 'oncokb-ts-api-client';
+import {
+    CancerGene,
+    IndicatorQueryResp,
+    OncoKBInfo,
+} from 'oncokb-ts-api-client';
 import {
     EnsemblTranscript,
     GenomicLocation,
@@ -37,7 +41,11 @@ import {
     indexHotspotsData,
 } from '../util/CancerHotspotsUtils';
 import { fetchCivicGenes, fetchCivicVariants } from '../util/CivicUtils';
-import { ONCOKB_DEFAULT_DATA } from '../util/DataFetcherUtils';
+import {
+    ONCOKB_DEFAULT_DATA,
+    ONCOKB_DEFAULT_INFO,
+    USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
+} from '../util/DataFetcherUtils';
 import {
     applyDataFilters,
     groupDataByProteinImpactType,
@@ -779,6 +787,21 @@ class DefaultMutationMapperStore implements MutationMapperStore {
         },
         []
     );
+
+    readonly oncoKbInfo: MobxPromise<OncoKBInfo> = remoteData(
+        {
+            invoke: () => this.dataFetcher.fetchOncoKbInfo(),
+            onError: () => ONCOKB_DEFAULT_INFO,
+        },
+        ONCOKB_DEFAULT_INFO
+    );
+
+    @computed
+    get usingPublicOncoKbInstance() {
+        return this.oncoKbInfo.result
+            ? this.oncoKbInfo.result.publicInstance
+            : USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB;
+    }
 
     readonly oncoKbAnnotatedGenes: MobxPromise<{
         [entrezGeneId: number]: boolean;

--- a/packages/react-mutation-mapper/src/util/DataFetcherUtils.ts
+++ b/packages/react-mutation-mapper/src/util/DataFetcherUtils.ts
@@ -11,7 +11,7 @@ import {
     GenomeNexusAPI,
     GenomeNexusAPIInternal,
 } from 'genome-nexus-ts-api-client';
-import { OncoKbAPI } from 'oncokb-ts-api-client';
+import { OncoKbAPI, OncoKBInfo } from 'oncokb-ts-api-client';
 import _ from 'lodash';
 
 export const DEFAULT_MUTATION_ALIGNER_URL_TEMPLATE =
@@ -26,6 +26,22 @@ export const DEFAULT_GENOME_NEXUS_URL = 'https://www.genomenexus.org/';
 export const DEFAULT_ONCO_KB_URL = 'https://legacy.oncokb.org/';
 export const ONCOKB_DEFAULT_DATA: IOncoKbData = {
     indicatorMap: {},
+};
+
+// Set the default to false since most of the instances are not public instance.
+// The only one we have right now is public.api.oncokb.org
+export const USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB = false;
+
+export const ONCOKB_DEFAULT_INFO: OncoKBInfo = {
+    apiVersion: 'v1.0.0',
+    dataVersion: {
+        version: 'v2.0',
+        date: '12/19/2019',
+    },
+    levels: [],
+    ncitVersion: '19.03d',
+    oncoTreeVersion: 'oncotree_2019_12_01',
+    publicInstance: USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
 };
 
 const DEFAULT_GENOME_NEXUS_CLIENT = initGenomeNexusClient();

--- a/packages/react-mutation-mapper/src/util/OncoKbUtils.ts
+++ b/packages/react-mutation-mapper/src/util/OncoKbUtils.ts
@@ -112,6 +112,7 @@ export function oncogenicYPosition(
 }
 
 export function annotationIconClassNames(
+    usingPublicOncoKbInstance: boolean,
     indicatorQueryResp: IndicatorQueryResp | undefined
 ): string {
     const classNames = ['oncokb', 'annotation-icon', 'unknown', 'no-level'];
@@ -124,7 +125,7 @@ export function annotationIconClassNames(
             ONCOGENIC_CLASS_NAMES[indicatorQueryResp.oncogenic] ||
             (indicatorQueryResp.vus ? 'vus' : 'unknown');
 
-        if (sl || rl) {
+        if (!usingPublicOncoKbInstance && (sl || rl)) {
             let levelName = 'level';
 
             if (sl) {

--- a/src/appShell/App/Container.tsx
+++ b/src/appShell/App/Container.tsx
@@ -62,31 +62,6 @@ export default class Container extends React.Component<IContainerProps, {}> {
             );
         }
 
-        if (ServerConfigHelpers.oncoKbIsEnabledWithoutToken()) {
-            return (
-                <div className="contentWrapper">
-                    <ErrorScreen
-                        title={'OncoKB is enabled but token is not defined'}
-                        body={
-                            <p>
-                                As of version 3.2.6, all cBioPortal
-                                installations require an access token to use the
-                                latest OncoKB data. You should either disable
-                                OncoKB by setting the <code>show.oncokb</code>{' '}
-                                property to <code>false</code> or register an
-                                OncoKB account and set the{' '}
-                                <code>oncokb.token</code> property. Please
-                                review these instructions for how to do so.{' '}
-                                <a href="https://docs.cbioportal.org/2.4-integration-with-other-webservices/oncokb-data-access">
-                                    https://docs.cbioportal.org/2.4-integration-with-other-webservices/oncokb-data-access
-                                </a>
-                            </p>
-                        }
-                    />
-                </div>
-            );
-        }
-
         return (
             <div>
                 <Helmet>

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -1134,6 +1134,11 @@ export default class PatientViewPage extends React.Component<
                                                             .patientViewPageStore
                                                             .oncoKbCancerGenes
                                                     }
+                                                    usingPublicOncoKbInstance={
+                                                        this
+                                                            .patientViewPageStore
+                                                            .usingPublicOncoKbInstance
+                                                    }
                                                     civicGenes={
                                                         this
                                                             .patientViewPageStore
@@ -1274,6 +1279,11 @@ export default class PatientViewPage extends React.Component<
                                                         this
                                                             .patientViewPageStore
                                                             .oncoKbCancerGenes
+                                                    }
+                                                    usingPublicOncoKbInstance={
+                                                        this
+                                                            .patientViewPageStore
+                                                            .usingPublicOncoKbInstance
                                                     }
                                                     enableOncoKb={
                                                         AppConfig.serverConfig

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -50,6 +50,7 @@ import {
     IHotspotIndex,
     IMyCancerGenomeData,
     indexHotspotsData,
+    ONCOKB_DEFAULT_INFO,
 } from 'react-mutation-mapper';
 import { ClinicalInformationData } from 'shared/model/ClinicalInformation';
 import VariantCountCache from 'shared/cache/VariantCountCache';
@@ -75,6 +76,7 @@ import {
     fetchMutSigData,
     fetchOncoKbCancerGenes,
     fetchOncoKbData,
+    fetchOncoKbInfo,
     fetchReferenceGenomeGenes,
     fetchSamplesForPatient,
     fetchStudiesForSamplesWithoutCancerTypeClinicalData,
@@ -127,6 +129,7 @@ import { getGeneFilterDefault } from './PatientViewPageStoreUtil';
 import { checkNonProfiledGenesExist } from '../PatientViewPageUtils';
 import autobind from 'autobind-decorator';
 import { createVariantAnnotationsByMutationFetcher } from 'shared/components/mutationMapper/MutationMapperUtils';
+import { USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB } from 'react-mutation-mapper';
 
 type PageMode = 'patient' | 'sample';
 
@@ -1060,6 +1063,25 @@ export class PatientViewPageStore {
         },
         []
     );
+
+    readonly oncoKbInfo = remoteData(
+        {
+            invoke: () => {
+                if (AppConfig.serverConfig.show_oncokb) {
+                    return fetchOncoKbInfo();
+                } else {
+                    return Promise.resolve(ONCOKB_DEFAULT_INFO);
+                }
+            },
+        },
+        ONCOKB_DEFAULT_INFO
+    );
+
+    @computed get usingPublicOncoKbInstance() {
+        return this.oncoKbInfo.result
+            ? this.oncoKbInfo.result.publicInstance
+            : USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB;
+    }
 
     readonly oncoKbAnnotatedGenes = remoteData(
         {

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.spec.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.spec.tsx
@@ -3,6 +3,7 @@ import { ReactWrapper, mount } from 'enzyme';
 import { assert } from 'chai';
 import { default as CopyNumberTableWrapper } from './CopyNumberTableWrapper';
 import { GeneFilterOption } from '../mutation/GeneFilterMenu';
+import { USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB } from 'react-mutation-mapper';
 
 function hasColumn(
     tableWrapper: ReactWrapper<any, any>,
@@ -26,6 +27,7 @@ function getTable(
             genePanelIdToEntrezGeneIds={{}}
             sampleIds={samples}
             gisticData={{}}
+            usingPublicOncoKbInstance={USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB}
             status="available"
             referenceGenes={[]}
             currentGeneFilter={GeneFilterOption.ANY_SAMPLE}

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -43,6 +43,7 @@ type ICopyNumberTableWrapperProps = {
     cnaCivicGenes?: RemoteData<ICivicGene | undefined>;
     cnaCivicVariants?: RemoteData<ICivicVariant | undefined>;
     oncoKbCancerGenes?: RemoteData<CancerGene[] | Error | undefined>;
+    usingPublicOncoKbInstance: boolean;
     enableOncoKb?: boolean;
     enableCivic?: boolean;
     pubMedCache?: PubMedCache;
@@ -204,6 +205,8 @@ export default class CopyNumberTableWrapper extends React.Component<
                         .uniqueSampleKeyToTumorType,
                     oncoKbData: this.props.cnaOncoKbData,
                     oncoKbCancerGenes: this.props.oncoKbCancerGenes,
+                    usingPublicOncoKbInstance: this.props
+                        .usingPublicOncoKbInstance,
                     enableOncoKb: this.props.enableOncoKb as boolean,
                     pubMedCache: this.props.pubMedCache,
                     civicGenes: this.props.cnaCivicGenes,
@@ -218,6 +221,7 @@ export default class CopyNumberTableWrapper extends React.Component<
                 return AnnotationColumnFormatter.sortValue(
                     d,
                     this.props.oncoKbCancerGenes,
+                    this.props.usingPublicOncoKbInstance,
                     this.props.cnaOncoKbData,
                     this.props.uniqueSampleKeyToTumorType,
                     this.props.cnaCivicGenes,

--- a/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.tsx
@@ -11,6 +11,7 @@ import {
     ICivicGeneData,
     ICivicVariant,
     ICivicVariantData,
+    USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
     oncoKbAnnotationSortValue,
     RemoteData,
 } from 'react-mutation-mapper';
@@ -32,6 +33,7 @@ export default class AnnotationColumnFormatter {
         copyNumberData: DiscreteCopyNumberData[] | undefined,
         oncoKbCancerGenes?: RemoteData<CancerGene[] | Error | undefined>,
         oncoKbData?: RemoteData<IOncoKbData | Error | undefined>,
+        usingPublicOncoKbInstance?: boolean,
         uniqueSampleKeyToTumorType?: { [sampleId: string]: string },
         civicGenes?: RemoteData<ICivicGene | undefined>,
         civicVariants?: RemoteData<ICivicVariant | undefined>,
@@ -90,6 +92,10 @@ export default class AnnotationColumnFormatter {
                 oncoKbIndicator,
                 oncoKbGeneExist,
                 isOncoKbCancerGene,
+                usingPublicOncoKbInstance:
+                    usingPublicOncoKbInstance === undefined
+                        ? USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB
+                        : usingPublicOncoKbInstance,
                 civicEntry:
                     civicGenes &&
                     civicGenes.result &&
@@ -231,6 +237,7 @@ export default class AnnotationColumnFormatter {
     public static sortValue(
         data: DiscreteCopyNumberData[],
         oncoKbCancerGenes?: RemoteData<CancerGene[] | Error | undefined>,
+        usingPublicOncoKbInstance?: boolean,
         oncoKbData?: RemoteData<IOncoKbData | Error | undefined>,
         uniqueSampleKeyToTumorType?: { [sampleId: string]: string },
         civicGenes?: RemoteData<ICivicGene | undefined>,
@@ -240,6 +247,7 @@ export default class AnnotationColumnFormatter {
             data,
             oncoKbCancerGenes,
             oncoKbData,
+            usingPublicOncoKbInstance,
             uniqueSampleKeyToTumorType,
             civicGenes,
             civicVariants
@@ -260,6 +268,7 @@ export default class AnnotationColumnFormatter {
             data,
             columnProps.oncoKbCancerGenes,
             columnProps.oncoKbData,
+            columnProps.usingPublicOncoKbInstance,
             columnProps.uniqueSampleKeyToTumorType,
             columnProps.civicGenes,
             columnProps.civicVariants,

--- a/src/pages/patientView/mutation/PatientViewMutationTable.spec.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.spec.tsx
@@ -4,6 +4,7 @@ import { assert } from 'chai';
 import { default as PatientViewMutationTable } from './PatientViewMutationTable';
 import { MutationTableColumnType } from 'shared/components/mutationTable/MutationTable';
 import { GeneFilterOption } from './GeneFilterMenu';
+import { USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB } from 'react-mutation-mapper';
 
 function hasColumn(
     tableWrapper: ReactWrapper<any, any>,
@@ -28,6 +29,7 @@ function getTable(
             sampleToGenePanelId={{}}
             genePanelIdToEntrezGeneIds={{}}
             mrnaExprRankMolecularProfileId={mrnaId}
+            usingPublicOncoKbInstance={USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB}
             discreteCNAMolecularProfileId={cnaId}
             currentGeneFilter={GeneFilterOption.ANY_SAMPLE}
             columns={[

--- a/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
@@ -317,6 +317,9 @@ export default class PatientViewMutationsTab extends React.Component<
                     cosmicData={this.props.store.cosmicData.result}
                     oncoKbData={this.props.store.oncoKbData}
                     oncoKbCancerGenes={this.props.store.oncoKbCancerGenes}
+                    usingPublicOncoKbInstance={
+                        this.props.store.usingPublicOncoKbInstance
+                    }
                     civicGenes={this.props.store.civicGenes}
                     civicVariants={this.props.store.civicVariants}
                     userEmailAddress={ServerConfigHelpers.getUserEmailAddress()}

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -128,6 +128,9 @@ export default class ResultsViewMutationMapper extends MutationMapper<
                 }
                 cosmicData={this.props.store.cosmicData.result}
                 oncoKbData={this.props.store.oncoKbData}
+                usingPublicOncoKbInstance={
+                    this.props.store.usingPublicOncoKbInstance
+                }
                 civicGenes={this.props.store.civicGenes}
                 civicVariants={this.props.store.civicVariants}
                 userEmailAddress={this.props.userEmailAddress}

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
@@ -27,6 +27,9 @@ export default class StandaloneMutationMapper extends MutationMapper<
                     this.props.store.uniqueSampleKeyToTumorType
                 }
                 oncoKbCancerGenes={this.props.store.oncoKbCancerGenes}
+                usingPublicOncoKbInstance={
+                    this.props.store.usingPublicOncoKbInstance
+                }
                 indexedVariantAnnotations={
                     this.props.store.indexedVariantAnnotations
                 }

--- a/src/shared/components/mutationMapper/MutationMapperStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperStore.ts
@@ -37,7 +37,7 @@ import {
     GenomeNexusAPI,
     GenomeNexusAPIInternal,
 } from 'genome-nexus-ts-api-client';
-import { CancerGene } from 'oncokb-ts-api-client';
+import { CancerGene, OncoKBInfo } from 'oncokb-ts-api-client';
 import { IPdbChain, PdbAlignmentIndex } from 'shared/model/Pdb';
 import {
     calcPdbIdNumericalValue,
@@ -58,6 +58,10 @@ import { IMutationMapperConfig } from './MutationMapperConfig';
 import autobind from 'autobind-decorator';
 import { normalizeMutation, normalizeMutations } from './MutationMapperUtils';
 import { getOncoKbApiUrl } from 'shared/api/urls';
+import {
+    ONCOKB_DEFAULT_INFO,
+    USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
+} from 'react-mutation-mapper';
 
 export interface IMutationMapperStoreConfig {
     filterMutationsBySelectedTranscript?: boolean;
@@ -116,6 +120,20 @@ export default class MutationMapperStore extends DefaultMutationMapperStore {
             this.genomenexusInternalClient || defaultInternalGenomeNexusClient,
             oncoKBClient
         );
+    }
+
+    readonly oncoKbInfo: MobxPromise<OncoKBInfo> = remoteData(
+        {
+            invoke: () => this.dataFetcher.fetchOncoKbInfo(),
+            onError: () => ONCOKB_DEFAULT_INFO,
+        },
+        ONCOKB_DEFAULT_INFO
+    );
+
+    @computed get usingPublicOncoKbInstance() {
+        return this.oncoKbInfo.result
+            ? this.oncoKbInfo.result.publicInstance
+            : USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB;
     }
 
     readonly mutationData = remoteData(

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -55,7 +55,7 @@ import {
     IOncoKbData,
 } from 'cbioportal-frontend-commons';
 import { VariantAnnotation } from 'genome-nexus-ts-api-client';
-import { CancerGene } from 'oncokb-ts-api-client';
+import { CancerGene, OncoKBInfo } from 'oncokb-ts-api-client';
 import {
     getAnnotationData,
     IAnnotation,
@@ -100,6 +100,7 @@ export interface IMutationTableProps {
     >;
     cosmicData?: ICosmicData;
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
+    usingPublicOncoKbInstance: boolean;
     civicGenes?: RemoteData<ICivicGene | undefined>;
     civicVariants?: RemoteData<ICivicVariant | undefined>;
     mrnaExprRankMolecularProfileId?: string;
@@ -751,6 +752,8 @@ export default class MutationTable<
                     myCancerGenomeData: this.props.myCancerGenomeData,
                     oncoKbData: this.props.oncoKbData,
                     oncoKbCancerGenes: this.props.oncoKbCancerGenes,
+                    usingPublicOncoKbInstance: this.props
+                        .usingPublicOncoKbInstance,
                     pubMedCache: this.props.pubMedCache,
                     civicGenes: this.props.civicGenes,
                     civicVariants: this.props.civicVariants,
@@ -776,6 +779,7 @@ export default class MutationTable<
                             this.props.hotspotData,
                             this.props.myCancerGenomeData,
                             this.props.oncoKbData,
+                            this.props.usingPublicOncoKbInstance,
                             this.props.civicGenes,
                             this.props.civicVariants,
                             this.resolveTumorType
@@ -816,6 +820,7 @@ export default class MutationTable<
                     this.props.hotspotData,
                     this.props.myCancerGenomeData,
                     this.props.oncoKbData,
+                    this.props.usingPublicOncoKbInstance,
                     this.props.civicGenes,
                     this.props.civicVariants,
                     this.resolveTumorType
@@ -828,6 +833,7 @@ export default class MutationTable<
                     this.props.hotspotData,
                     this.props.myCancerGenomeData,
                     this.props.oncoKbData,
+                    this.props.usingPublicOncoKbInstance,
                     this.props.civicGenes,
                     this.props.civicVariants,
                     this.resolveTumorType

--- a/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
@@ -32,6 +32,7 @@ export default class AnnotationColumnFormatter {
         hotspotData?: RemoteData<IHotspotIndex | undefined>,
         myCancerGenomeData?: IMyCancerGenomeData,
         oncoKbData?: RemoteData<IOncoKbData | Error | undefined>,
+        usingPublicOncoKbInstance?: boolean,
         civicGenes?: RemoteData<ICivicGene | undefined>,
         civicVariants?: RemoteData<ICivicVariant | undefined>,
         resolveTumorType?: (mutation: Mutation) => string
@@ -42,6 +43,7 @@ export default class AnnotationColumnFormatter {
             hotspotData,
             myCancerGenomeData,
             oncoKbData,
+            usingPublicOncoKbInstance,
             civicGenes,
             civicVariants,
             resolveTumorType
@@ -56,6 +58,7 @@ export default class AnnotationColumnFormatter {
         hotspotData?: RemoteData<IHotspotIndex | undefined>,
         myCancerGenomeData?: IMyCancerGenomeData,
         oncoKbData?: RemoteData<IOncoKbData | Error | undefined>,
+        usingPublicOncoKbInstance?: boolean,
         civicGenes?: RemoteData<ICivicGene | undefined>,
         civicVariants?: RemoteData<ICivicVariant | undefined>,
         resolveTumorType?: (mutation: Mutation) => string
@@ -66,6 +69,7 @@ export default class AnnotationColumnFormatter {
             hotspotData,
             myCancerGenomeData,
             oncoKbData,
+            usingPublicOncoKbInstance,
             civicGenes,
             civicVariants,
             resolveTumorType

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -74,6 +74,7 @@ import {
     IndicatorQueryResp,
     CancerGene,
     OncoKbAPI,
+    OncoKBInfo,
 } from 'oncokb-ts-api-client';
 import { EvidenceType, IOncoKbData } from 'cbioportal-frontend-commons';
 import { REFERENCE_GENOME } from './referenceGenomeUtils';
@@ -693,6 +694,12 @@ export async function fetchOncoKbCancerGenes(
     client: OncoKbAPI = oncokbClient
 ): Promise<CancerGene[]> {
     return await client.utilsCancerGeneListGetUsingGET_1({});
+}
+
+export async function fetchOncoKbInfo(
+    client: OncoKbAPI = oncokbClient
+): Promise<OncoKBInfo> {
+    return await client.infoGetUsingGET_1({});
 }
 
 export async function fetchOncoKbData(


### PR DESCRIPTION
This is a part of fix for https://github.com/oncokb/oncokb/issues/1975

- we no longer require a token to display biological data from oncokb(it connects to public.api.oncokb.org)
- we allow users to configure the cbioportal instance to use www.oncokb.org to include clinical data
- Levels column will be disabled for mutation mapper annotation track

Here is the tooltip when portal connects to the public instance:
![Screen Shot 2020-04-29 at 7 51 54 PM](https://user-images.githubusercontent.com/5400599/80657949-e90b3a80-8a52-11ea-9aba-d49cd7a7b07a.png)
