### PR TITLE
survival data frontend implementation

### DIFF
--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -23,9 +23,9 @@ import ComparisonStore, {
     OverlapStrategy,
 } from '../../shared/lib/comparison/ComparisonStore';
 import {
-    survivalClinicalDataVocabulary,
     survivalPlotTooltipxLabelWithEvent,
     generateSurvivalPlotTitleFromDisplayName,
+    getStatusCasesHeaderText,
 } from 'pages/resultsView/survival/SurvivalUtil';
 import { observable, action } from 'mobx';
 import survivalPlotStyle from './styles.module.scss';
@@ -215,6 +215,7 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
             this.analysisGroupsComputations,
             this.props.store.overlapComputations,
             this.props.store.uidToGroup,
+            this.props.store.patientSurvivalUniqueStatusText,
         ],
         render: () => {
             let content: any = [];
@@ -330,19 +331,20 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                                     xAxisLabel={`Months ${survivalTitleText[key]}`}
                                     yAxisLabel={survivalTitleText[key]}
                                     totalCasesHeader="Number of Cases, Total"
-                                    statusCasesHeader={`Number of Cases, ${_.startCase(
-                                        _.toLower(
-                                            survivalClinicalDataVocabulary[
-                                                key
-                                            ][0]
-                                        )
+                                    statusCasesHeader={`Number of Cases, ${getStatusCasesHeaderText(
+                                        key,
+                                        this.props.store
+                                            .patientSurvivalUniqueStatusText
+                                            .result![key]
                                     )}`}
                                     medianMonthsHeader={`Median Months ${survivalTitleText[key]}`}
                                     yLabelTooltip={`${_.startCase(
                                         _.toLower(survivalTitleText[key])
                                     )} estimate`}
                                     xLabelWithEventTooltip={
-                                        survivalPlotTooltipxLabelWithEvent[key]
+                                        survivalPlotTooltipxLabelWithEvent[
+                                            key
+                                        ] || 'Time of Death'
                                     }
                                     xLabelWithoutEventTooltip="Time of last observation"
                                     fileName={survivalTitleText[key].replace(

--- a/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
+++ b/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
@@ -106,15 +106,15 @@ $sample-color-xenograft: pink;
         content: ' years old';
     }
     /* attributes with special colors */
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='DECEASED'],
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='DEAD'],
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='1:DECEASED'],
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='1:DEAD'],
     .clinical-attribute[attr-id='DFS_STATUS'] {
         color: #f00;
     }
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='LIVING'],
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='ALIVE'],
-    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='DiseaseFree'],
-    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='Yes'] {
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='0:LIVING'],
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='0:ALIVE'],
+    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='0:DiseaseFree'],
+    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='0:Yes'] {
         color: rgb(0, 128, 0);
     }
     .clinical-attribute[attr-id='DERIVED_NORMALIZED_CASE_TYPE'][attr-value='Primary'] {

--- a/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
+++ b/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
@@ -106,15 +106,15 @@ $sample-color-xenograft: pink;
         content: ' years old';
     }
     /* attributes with special colors */
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='1:DECEASED'],
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='1:DEAD'],
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='DECEASED'],
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='DEAD'],
     .clinical-attribute[attr-id='DFS_STATUS'] {
         color: #f00;
     }
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='0:LIVING'],
-    .clinical-attribute[attr-id='OS_STATUS'][attr-value='0:ALIVE'],
-    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='0:DiseaseFree'],
-    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='0:Yes'] {
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='LIVING'],
+    .clinical-attribute[attr-id='OS_STATUS'][attr-value='ALIVE'],
+    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='DiseaseFree'],
+    .clinical-attribute[attr-id='DFS_STATUS'][attr-value='Yes'] {
         color: rgb(0, 128, 0);
     }
     .clinical-attribute[attr-id='DERIVED_NORMALIZED_CASE_TYPE'][attr-value='Primary'] {

--- a/src/pages/resultsView/SurvivalStoreHelper.spec.ts
+++ b/src/pages/resultsView/SurvivalStoreHelper.spec.ts
@@ -1,8 +1,11 @@
 import { assert } from 'chai';
-import { getPatientSurvivals } from './SurvivalStoreHelper';
-import { Patient } from 'cbioportal-ts-api-client';
+import {
+    getPatientSurvivals,
+    getClinicalDataOfPatientSurvivalStatus,
+} from './SurvivalStoreHelper';
+import { Patient, ClinicalData } from 'cbioportal-ts-api-client';
 
-const exampleClinicalData = {
+const exampleClinicalData: { [patientKey: string]: any[] } = {
     '1': [
         {
             clinicalAttributeId: 'OS_MONTHS',
@@ -112,6 +115,40 @@ describe('SurvivalStoreHelper', () => {
                         months: 0,
                         status: true,
                     },
+                ]
+            );
+        });
+    });
+
+    describe('#getClinicalDataOfPatientSurvivalStatus()', () => {
+        it('returns empty list for empty clinical data', () => {
+            assert.deepEqual(
+                getClinicalDataOfPatientSurvivalStatus(
+                    {},
+                    [],
+                    'OS_STATUS',
+                    'OS_MONTHS'
+                ),
+                []
+            );
+        });
+
+        it('returns correct result for example data', () => {
+            assert.deepEqual(
+                getClinicalDataOfPatientSurvivalStatus(
+                    exampleClinicalData,
+                    exampleTargetKeys,
+                    'OS_STATUS',
+                    'OS_MONTHS'
+                ),
+                [
+                    {
+                        clinicalAttributeId: 'OS_STATUS',
+                        value: 'DECEASED',
+                        patientId: 'patient_1',
+                        studyId: 'study_1',
+                        uniquePatientKey: '1',
+                    } as ClinicalData,
                 ]
             );
         });

--- a/src/pages/resultsView/survival/SurvivalUtil.tsx
+++ b/src/pages/resultsView/survival/SurvivalUtil.tsx
@@ -42,6 +42,48 @@ export type ParsedSurvivalData = {
     label: string;
 };
 
+// TODO should remove this if we want to be generic
+export const survivalClinicalDataVocabulary: { [prefix: string]: string[] } = {
+    OS: ['DECEASED', '1:DECEASED'],
+    PFS: [
+        'Progressed',
+        'Recurred/Progressed',
+        'PROGRESSION',
+        'Yes',
+        '1',
+        '1:Progressed',
+        '1:Recurred/Progressed',
+        '1:PROGRESSION',
+        '1:Yes',
+        '1:1',
+    ],
+    DFS: [
+        'Recurred/Progressed',
+        'Recurred',
+        'Progressed',
+        'Yes',
+        '1',
+        '1:Recurred/Progressed',
+        '1:Recurred',
+        '1:Progressed',
+        '1:Yes',
+        '1:1',
+    ],
+    DSS: [
+        'DECEASED',
+        'Yes',
+        'DEAD OF MELANOMA',
+        'DEAD WITH TUMOR',
+        '1',
+        '1:DECEASED',
+        '1:Yes',
+        '1:DEAD OF MELANOMA',
+        '1:DEAD WITH TUMOR',
+        '1:1',
+    ],
+};
+
+// TODO should remove this if we want to be generic
 export const survivalCasesHeaderText: { [prefix: string]: string } = {
     OS: 'DECEASED',
     PFS: 'Progressed',
@@ -119,9 +161,16 @@ export function parseSurvivalData(s: string) {
 }
 
 export function getSurvivalStatusBoolean(s: string, prefix: string) {
-    const parsedSurvivalData = parseSurvivalData(s);
-    if (parsedSurvivalData.status) {
-        return parsedSurvivalData.status === '1';
+    // if prefix is in predefined survival type
+    if (prefix in survivalClinicalDataVocabulary) {
+        return survivalClinicalDataVocabulary[prefix].includes(s);
+    }
+    // if prefix is custom survival type
+    else {
+        const parsedSurvivalData = parseSurvivalData(s);
+        if (parsedSurvivalData.status) {
+            return parsedSurvivalData.status === '1';
+        }
     }
     // return false as default for values that cannot get mapped
     return false;

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -166,7 +166,7 @@ import {
     generateStudyViewSurvivalPlotTitle,
     getSurvivalAttributes,
     plotsPriority,
-    survivalClinicalDataVocabulary,
+    getSurvivalStatusBoolean,
 } from 'pages/resultsView/survival/SurvivalUtil';
 import { ISurvivalDescription } from 'pages/resultsView/survival/SurvivalDescriptionTable';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
@@ -217,7 +217,7 @@ export type SurvivalType = {
     id: string;
     title: string;
     associatedAttrs: string[];
-    filter: string[];
+    filter: (s: string) => boolean;
     survivalData: PatientSurvival[];
 };
 
@@ -4704,7 +4704,7 @@ export class StudyViewPageStore {
                     id: `${prefix}_SURVIVAL`,
                     title: plotTitle,
                     associatedAttrs: [`${prefix}_STATUS`, `${prefix}_MONTHS`],
-                    filter: survivalClinicalDataVocabulary[prefix],
+                    filter: s => getSurvivalStatusBoolean(s, prefix),
                     survivalData: [],
                 };
             }
@@ -5148,7 +5148,7 @@ export class StudyViewPageStore {
                     this.selectedPatientKeys.result!,
                     obj.associatedAttrs[0],
                     obj.associatedAttrs[1],
-                    s => obj.filter.includes(s)
+                    obj.filter
                 );
                 return obj;
             });
@@ -6098,15 +6098,9 @@ export class StudyViewPageStore {
                 },
                 [] as string[]
             );
-            // TODO: after we migrate data into new format, we can support all survival data type
-            // this is a tempory fix for current data format, for now we only support survival types defined in survivalClinicalDataVocabulary
-            const filteredAttributePrefixes = _.filter(
-                attributePrefixes,
-                prefix => survivalClinicalDataVocabulary[prefix]
-            );
             // change prefix order based on priority
             return Promise.resolve(
-                _.sortBy(filteredAttributePrefixes, prefix => {
+                _.sortBy(attributePrefixes, prefix => {
                     return plotsPriority[prefix] || 999;
                 })
             );

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -167,6 +167,7 @@ import {
     getSurvivalAttributes,
     plotsPriority,
     getSurvivalStatusBoolean,
+    survivalClinicalDataVocabulary,
 } from 'pages/resultsView/survival/SurvivalUtil';
 import { ISurvivalDescription } from 'pages/resultsView/survival/SurvivalDescriptionTable';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
@@ -6098,9 +6099,15 @@ export class StudyViewPageStore {
                 },
                 [] as string[]
             );
+            // TODO: after we migrate data into new format, we can support all survival data type
+            // this is a tempory fix for current data format, for now we only support survival types defined in survivalClinicalDataVocabulary
+            const filteredAttributePrefixes = _.filter(
+                attributePrefixes,
+                prefix => survivalClinicalDataVocabulary[prefix]
+            );
             // change prefix order based on priority
             return Promise.resolve(
-                _.sortBy(attributePrefixes, prefix => {
+                _.sortBy(filteredAttributePrefixes, prefix => {
                     return plotsPriority[prefix] || 999;
                 })
             );

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -72,6 +72,7 @@ import {
     getSurvivalAttributes,
     DEFAULT_SURVIVAL_PRIORITY,
     getSurvivalStatusBoolean,
+    survivalClinicalDataVocabulary,
 } from 'pages/resultsView/survival/SurvivalUtil';
 
 export enum OverlapStrategy {
@@ -1295,9 +1296,15 @@ export default class ComparisonStore {
                 },
                 [] as string[]
             );
+            // TODO: after we migrate data into new format, we can support all survival data type
+            // this is a tempory fix for current data format, for now we only support survival types defined in survivalClinicalDataVocabulary
+            const filteredAttributePrefixes = _.filter(
+                attributePrefixes,
+                prefix => survivalClinicalDataVocabulary[prefix]
+            );
             // change prefix order based on priority
             return Promise.resolve(
-                _.sortBy(attributePrefixes, prefix => {
+                _.sortBy(filteredAttributePrefixes, prefix => {
                     return plotsPriority[prefix] || DEFAULT_SURVIVAL_PRIORITY;
                 })
             );


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7433

Describe changes proposed in this pull request:
- a support old data format and new (we should merge this before backend, then remove old format support) 

**screenshots:**
**oncoprint:** 
<img width="1023" alt="oncoprint" src="https://user-images.githubusercontent.com/15748980/80668928-1ff04900-8a71-11ea-984b-000446a67702.png">
**patient view:**
<img width="760" alt="patient_view" src="https://user-images.githubusercontent.com/15748980/81591332-41fb9c80-938a-11ea-84cf-f5d762d6282d.png">
**study view:**
<img width="402" alt="study_view" src="https://user-images.githubusercontent.com/15748980/80669003-4e6e2400-8a71-11ea-8550-43bcf33cd0bf.png">
**clinical data:**
<img width="1416" alt="clinical_data" src="https://user-images.githubusercontent.com/15748980/80669019-5928b900-8a71-11ea-829a-82d098689bbd.png">
**survival plot:**
![image](https://user-images.githubusercontent.com/15748980/80669206-d18f7a00-8a71-11ea-9f34-bad9e30c11a7.png)

