### PR TITLE
add webinar section

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -47,7 +47,7 @@ export default class PortalHeader extends React.Component<
 
             {
                 id: 'tutorials',
-                text: 'Tutorials',
+                text: 'Tutorials/Webinars',
                 address: '/tutorials',
                 internal: true,
                 hide: () =>

--- a/src/pages/staticPages/tutorials/Tutorials.tsx
+++ b/src/pages/staticPages/tutorials/Tutorials.tsx
@@ -12,10 +12,13 @@ export default class Tutorials extends React.Component<{}, {}> {
         return (
             <PageLayout className={'whiteBackground staticPage'}>
                 <Helmet>
-                    <title>{'cBioPortal for Cancer Genomics::Tutorials'}</title>
+                    <title>
+                        {
+                            'cBioPortal for Cancer Genomics::Tutorials and Webinars'
+                        }
+                    </title>
                 </Helmet>
-                <h1>Tutorials</h1>
-
+                <h1>Tutorials and Webinars</h1>
                 <h2>Step-by-step Guide to cBioPortal: a Protocol Paper</h2>
                 <p>
                     Gao, Aksoy, Dogrusoz, Dresdner, Gross, Sumer, Sun, Jacobsen,
@@ -28,7 +31,6 @@ export default class Tutorials extends React.Component<{}, {}> {
                     <i>Sci. Signal.</i> 6, pl1 (2013). [
                     <a href={getNCBIlink('/pubmed/23550210')}>Reprint</a>].
                 </p>
-
                 <hr />
                 <h2 className={'tutorialsFolderText'}>
                     View tutorial slides below or download from{' '}
@@ -49,7 +51,6 @@ export default class Tutorials extends React.Component<{}, {}> {
                     .
                 </h2>
                 <hr />
-
                 <h2 id={'single-study-exploration'}>
                     Tutorial #1: Single Study Exploration
                 </h2>
@@ -69,7 +70,6 @@ export default class Tutorials extends React.Component<{}, {}> {
                     </a>
                 </h4>
                 <hr />
-
                 <h2 id={'single-study-query'}>
                     Tutorial #2: Single Study Query
                 </h2>
@@ -89,7 +89,6 @@ export default class Tutorials extends React.Component<{}, {}> {
                     </a>
                 </h4>
                 <hr />
-
                 <h2 id={'patient-view'}>Tutorial #3: Patient View</h2>
                 <iframe
                     src="https://docs.google.com/presentation/d/1Jr_2yEfgjKBn4DBiXRk4kmhIbtsRp6gd0iD3k1fIUUk/embed?start=false&loop=false&delayms=60000"
@@ -107,7 +106,6 @@ export default class Tutorials extends React.Component<{}, {}> {
                     </a>
                 </h4>
                 <hr />
-
                 <h2 id={'virtual-studies'}>Tutorial #4: Virtual Studies</h2>
                 <iframe
                     src="https://docs.google.com/presentation/d/1rQE5rbFNdmup-rAtySHFxlLp3i4qa8SBA7MiQpMdn1I/embed?start=false&loop=false&delayms=60000"
@@ -125,7 +123,6 @@ export default class Tutorials extends React.Component<{}, {}> {
                     </a>
                 </h4>
                 <hr />
-
                 <h2 id={'oql'}>Tutorial #5: Onco Query Language (OQL)</h2>
                 <iframe
                     src="https://docs.google.com/presentation/d/1U39xgVujtBodwW20qIfcGu4E5n2zzaKkl2KmzzHqj4A/embed?startfalse&loop=false&delayms=60000"
@@ -143,7 +140,6 @@ export default class Tutorials extends React.Component<{}, {}> {
                     </a>
                 </h4>
                 <hr />
-
                 <h2 id={'group-comparison'}>Tutorial #6: Group Comparison</h2>
                 <iframe
                     src="https://docs.google.com/presentation/d/1P2boDph8IfpvjxoxDj_496CLHGtshzJnbbZhszPsmf4/embed?startfalse&loop=false&delayms=60000"
@@ -160,7 +156,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                         Download tutorial
                     </a>
                 </h4>
-
+                <hr />
                 <h2 id={'pathways'}>Tutorial #7: Pathways</h2>
                 <iframe
                     src="https://docs.google.com/presentation/d/1O5WGucz0lrfdY25b5QS6zaID_26i434EYXBluqZfT2g/embed?startfalse&loop=false&delayms=60000"
@@ -175,6 +171,34 @@ export default class Tutorials extends React.Component<{}, {}> {
                             .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 7 Pathways.pdf`}
                     >
                         Download tutorial
+                    </a>
+                </h4>
+                <hr />
+                <h1 id={'webinars'}>Webinars</h1>
+                Join are webinar series{' '}
+                <strong>every Thursday 11am-12pm EDT</strong>, register{' '}
+                <a
+                    target="_blank"
+                    href="https://dfci.zoom.us/webinar/register/7315875611981/WN_An_3l0XYQHCoinWvclUrlw"
+                >
+                    here
+                </a>
+                .
+                <h2 id={'webinar-1'}>Webinar #1: Introduction to cBioPortal</h2>
+                <iframe
+                    src="https://www.youtube.com/embed/fPIAxH--cSo"
+                    frameBorder="0"
+                    width="720"
+                    height="434"
+                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen={true}
+                ></iframe>
+                <h4>
+                    <a
+                        href={`${AppConfig.serverConfig
+                            .skin_documentation_baseurl!}tutorials/cBioPortal Webinar 1 Introduction to cBioPortal.pdf`}
+                    >
+                        Download slides
                     </a>
                 </h4>
             </PageLayout>


### PR DESCRIPTION
add to bottom of the tutorials page, can directly link to sections with /tutorials#webinars and /tutorials#webinar-1



<img width="714" alt="Screen Shot 2020-04-30 at 5 54 14 PM" src="https://user-images.githubusercontent.com/1334004/80763732-30560180-8b0d-11ea-9ddc-2ec6b6194c82.png">
<img width="829" alt="Screen Shot 2020-04-30 at 6 05 52 PM" src="https://user-images.githubusercontent.com/1334004/80763756-406de100-8b0d-11ea-8741-e1e09e1dd7d4.png">
