### PR TITLE
Fix jitpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "syncmock": "node src/test/fetchMockData.js --diff"
   },
   "engines": {
-    "node": "8.12.0",
+    "node": "12.16.3",
     "yarn": "1.21.1"
   },
   "author": "",

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.9.1</version>
 
                 <executions>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
                         </goals>
 
                         <configuration>
-                            <nodeVersion>v8.12.0</nodeVersion>
+                            <nodeVersion>v12.16.3</nodeVersion>
                             <yarnVersion>v1.21.1</yarnVersion>
                         </configuration>
 


### PR DESCRIPTION
Node doesn't get installed anymore for some reason on jitpack. Maybe the binary moved. Upgrade `frontend-maven-plugin` to allow building on jitpack again