### PR TITLE
Survival plots fix: show only OS/DFS/PFS/DSS

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -6082,25 +6082,31 @@ export class StudyViewPageStore {
                 this.clinicalAttributes.result!
             );
             // get paired attributes
-            const attributesPrefix = _.reduce(
+            const attributePrefixes = _.reduce(
                 attributes,
-                (attributesPrefix, attribute) => {
+                (attributePrefixes, attribute) => {
                     let prefix = attribute.substring(
                         0,
                         attribute.indexOf('_STATUS')
                     );
-                    if (!attributesPrefix.includes(prefix)) {
+                    if (!attributePrefixes.includes(prefix)) {
                         if (attributes.includes(`${prefix}_MONTHS`)) {
-                            attributesPrefix.push(prefix);
+                            attributePrefixes.push(prefix);
                         }
                     }
-                    return attributesPrefix;
+                    return attributePrefixes;
                 },
                 [] as string[]
             );
+            // TODO: after we migrate data into new format, we can support all survival data type
+            // this is a tempory fix for current data format, for now we only support survival types defined in survivalClinicalDataVocabulary
+            const filteredAttributePrefixes = _.filter(
+                attributePrefixes,
+                prefix => survivalClinicalDataVocabulary[prefix]
+            );
             // change prefix order based on priority
             return Promise.resolve(
-                _.sortBy(attributesPrefix, prefix => {
+                _.sortBy(filteredAttributePrefixes, prefix => {
                     return plotsPriority[prefix] || 999;
                 })
             );

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -1276,25 +1276,31 @@ export default class ComparisonStore {
                 this.activeStudiesClinicalAttributes.result!
             );
             // get paired attributes
-            const attributesPrefix = _.reduce(
+            const attributePrefixes = _.reduce(
                 attributes,
-                (attributesPrefix, attribute) => {
+                (attributePrefixes, attribute) => {
                     let prefix = attribute.substring(
                         0,
                         attribute.indexOf('_STATUS')
                     );
-                    if (!attributesPrefix.includes(prefix)) {
+                    if (!attributePrefixes.includes(prefix)) {
                         if (attributes.includes(`${prefix}_MONTHS`)) {
-                            attributesPrefix.push(prefix);
+                            attributePrefixes.push(prefix);
                         }
                     }
-                    return attributesPrefix;
+                    return attributePrefixes;
                 },
                 [] as string[]
             );
+            // TODO: after we migrate data into new format, we can support all survival data type
+            // this is a tempory fix for current data format, for now we only support survival types defined in survivalClinicalDataVocabulary
+            const filteredAttributePrefixes = _.filter(
+                attributePrefixes,
+                prefix => survivalClinicalDataVocabulary[prefix]
+            );
             // change prefix order based on priority
             return Promise.resolve(
-                _.sortBy(attributesPrefix, prefix => {
+                _.sortBy(filteredAttributePrefixes, prefix => {
                     return plotsPriority[prefix] || DEFAULT_SURVIVAL_PRIORITY;
                 })
             );


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7473

For current data format, we can only show survival plots for those pre-defined survival types:
`OS`, `DFS`, `PFS`, `DSS`.
This pr will filter out other survival types which are not included in these four types.

Test links:
https://deploy-preview-3199--cbioportalfrontend.netlify.app/study/summary?id=gbm_columbia_2019
https://deploy-preview-3199--cbioportalfrontend.netlify.app/comparison/survival?sessionId=5eb2c5afe4b0ff7ef5fe3bbf