### PR TITLE
For localdb e2e tests use ping from busybox

### DIFF
--- a/end-to-end-test/local/docker/setup_docker_containers.sh
+++ b/end-to-end-test/local/docker/setup_docker_containers.sh
@@ -101,7 +101,7 @@ run_cbioportal_container() {
 
     sleeptime=0
     maxtime=180
-    while ! docker run --rm --net=$DOCKER_NETWORK_NAME $BACKEND_IMAGE_NAME ping -c 1 "$E2E_CBIOPORTAL_HOST_NAME" &> /dev/null; do
+    while ! docker run --rm --net=$DOCKER_NETWORK_NAME busybox ping -c 1 "$E2E_CBIOPORTAL_HOST_NAME" &> /dev/null; do
         echo Waiting for cbioportal to initialize...
         sleeptime=$sleeptime+10
         if (($sleeptime > $maxtime)); then


### PR DESCRIPTION
The code was using ping from the backend container to check whether the
container is alive. The java 11 slim image does not have ping. Busybox is a
very small image that has tons of common unix utilities, so maybe a
decent choice of image to check for liveness. That said I'm not sure if
there is a more common approach in e.g. docker itself to check for
liveness of a container in a network.

See backend PR that introduces java 11: https://github.com/cBioPortal/cbioportal/pull/7464