### PR TITLE
oncoprint - make comparison group clinical tracks based on queried studies (even virtual)

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -790,14 +790,14 @@ export class ResultsViewPageStore {
     }
 
     readonly comparisonGroups = remoteData<Group[]>({
-        await: () => [this.studyIds],
+        await: () => [this.queriedStudies],
         invoke: async () => {
             let ret: Group[] = [];
             if (this.appStore.isLoggedIn) {
                 try {
                     ret = ret.concat(
                         await comparisonClient.getGroupsForStudies(
-                            this.studyIds.result!
+                            this.queriedStudies.result!.map(x => x.studyId)
                         )
                     );
                 } catch (e) {


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7113.

When querying a virtual study, show the group in that virtual study:

![Screen Shot 2020-05-20 at 9 54 29 AM](https://user-images.githubusercontent.com/1334004/82454605-f29b2780-9a7f-11ea-8a8e-0f1ae788ed90.png)
similar to study view:

![Screen Shot 2020-05-15 at 10 59 59 AM](https://user-images.githubusercontent.com/1334004/82064827-47fbc100-969b-11ea-8a9d-a2041f2552ae.png)

Before this PR the oncoprint showed for the same virtual study:

![Screen Shot 2020-05-15 at 10 53 19 AM](https://user-images.githubusercontent.com/1334004/82064084-50073100-969a-11ea-8c85-e35eacf651cb.png)

Of note: groups are associated to a study set, not to each study individually

There were a few options about what groups to show given a virtual study V which comes from physical studies A,B,C:

1. V groups, A groups, B groups, C groups
2. V groups, ABC groups
3. V groups, A, B, C, AB, AC, BC, ABC
4. V groups

Since the study view only shows 4, we chose to do the same thing for Oncoprint