### PR TITLE
Datasets page: update column header text

### DIFF
--- a/src/pages/staticPages/datasetView/DatasetList.tsx
+++ b/src/pages/staticPages/datasetView/DatasetList.tsx
@@ -158,7 +158,7 @@ export default class DataSetsPageTable extends React.Component<
                                 },
                             },
                             { name: 'All', type: 'all' },
-                            { name: 'Sequenced', type: 'sequenced' },
+                            { name: 'Mutations', type: 'sequenced' }, // product team requested this be titled mutations
                             { name: 'CNA', type: 'cna' },
                             {
                                 name: 'RNA-Seq',


### PR DESCRIPTION
At product team request, data field named sequenced count should have column header "Mutations" 