### PR TITLE
Pick default profile for any alteration types included in OQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ end-to-end-test/local/screenshots/diff
 end-to-end-test/local/screenshots/screen
 end-to-end-test/local/screenshots/error
 end-to-end-test/local/screenshots/junit
+end-to-end-test/undefined
+end-to-end-test/results-0-0..xml
+end-to-end-test/customReport.json
+end-to-end-test/customReportJSONP.js
 wdio/browserstack.txt
 env/custom.sh
 image-compare/errors.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,4 @@ packages/**/dist/**
 yarn.lock
 .prettierignore
 .DS_Store
+.gitignore

--- a/end-to-end-test/remote/specs/core/home.spec.js
+++ b/end-to-end-test/remote/specs/core/home.spec.js
@@ -9,6 +9,7 @@ var {
     clickQueryByGeneButton,
     waitForNumberOfStudyCheckboxes,
     clickModifyStudySelectionButton,
+    waitForOncoprint,
 } = require('../../../shared/specUtils');
 
 const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
@@ -597,6 +598,174 @@ describe('genetic profile selection in front page query form', () => {
                 'div[data-test="molecularProfileSelector"] input[type="checkbox"][data-test="MRNA_EXPRESSION"]'
             ),
             'mrna profile not selected'
+        );
+    });
+});
+
+describe('auto-selecting needed profiles for oql in query form', () => {
+    before(() => {
+        goToUrlAndSetLocalStorage(CBIOPORTAL_URL);
+    });
+    it('gives a submit error if protein oql is inputted and no protein profile is available for the study', () => {
+        browser.waitForExist('.studyItem_acc_tcga_pan_can_atlas_2018', 20000);
+        browser.click('.studyItem_acc_tcga_pan_can_atlas_2018');
+        clickQueryByGeneButton();
+
+        // enter oql
+        browser.waitForExist('textarea[data-test="geneSet"]', 2000);
+        setInputText('textarea[data-test="geneSet"]', 'BRCA1: PROT>1');
+
+        // error appears
+        browser.waitUntil(() => {
+            return (
+                browser.isExisting('[data-test="oqlErrorMessage"]') &&
+                browser.getText('[data-test="oqlErrorMessage"]') ===
+                    'Protein level data query specified in OQL, but no protein level profile is available in the selected study.'
+            );
+        }, 20000);
+
+        // submit is disabled
+        assert(!browser.isEnabled('button[data-test="queryButton"]'));
+    });
+    it('auto-selects an mrna profile when mrna oql is entered', () => {
+        // make sure profiles selector is loaded
+        browser.waitForExist(
+            'div[data-test="molecularProfileSelector"] input[type="checkbox"]',
+            3000
+        );
+        // mutations, CNA should be selected
+        assert(
+            browser.isSelected(
+                'div[data-test="molecularProfileSelector"] input[type="checkbox"][data-test="MUTATION_EXTENDED"]'
+            ),
+            'mutation profile should be selected'
+        );
+        assert(
+            browser.isSelected(
+                'div[data-test="molecularProfileSelector"] input[type="checkbox"][data-test="COPY_NUMBER_ALTERATION"]'
+            ),
+            'cna profile should be selected'
+        );
+        assert(
+            !browser.isSelected(
+                'div[data-test="molecularProfileSelector"] input[type="checkbox"][data-test="MRNA_EXPRESSION"]'
+            ),
+            'mrna profile not selected'
+        );
+
+        // enter oql
+        browser.waitForExist('textarea[data-test="geneSet"]', 2000);
+        setInputText('textarea[data-test="geneSet"]', 'BRCA1: EXP>1');
+
+        browser.waitForEnabled('button[data-test="queryButton"]', 5000);
+        browser.click('button[data-test="queryButton"]');
+
+        // wait for query to load
+        waitForOncoprint(20000);
+
+        const query = browser.execute(function() {
+            return urlWrapper.query;
+        }).value;
+        // mutation, cna, mrna profiles are there
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_MUTATION_EXTENDED,
+            'acc_tcga_pan_can_atlas_2018_mutations'
+        );
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION,
+            'acc_tcga_pan_can_atlas_2018_gistic'
+        );
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_MRNA_EXPRESSION,
+            'acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna_median_Zscores'
+        );
+    });
+});
+
+describe('results page quick oql edit', () => {
+    before(() => {
+        goToUrlAndSetLocalStorage(
+            `${CBIOPORTAL_URL}/results/oncoprint?genetic_profile_ids_PROFILE_MUTATION_EXTENDED=acc_tcga_pan_can_atlas_2018_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=acc_tcga_pan_can_atlas_2018_gistic&cancer_study_list=acc_tcga_pan_can_atlas_2018&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=0&case_set_id=acc_tcga_pan_can_atlas_2018_cnaseq&gene_list=BRCA1&geneset_list=%20&tab_index=tab_visualize&Action=Submit`
+        );
+    });
+
+    it('gives a submit error if protein oql is inputted and no protein profile is available for the study', () => {
+        browser.waitForExist('[data-test="oqlQuickEditButton"]', 20000);
+        browser.click('[data-test="oqlQuickEditButton"]');
+
+        browser.waitForExist('.quick_oql_edit [data-test="geneSet"]', 5000);
+        setInputText('.quick_oql_edit [data-test="geneSet"]', 'PTEN: PROT>0');
+
+        // error appears
+        browser.waitUntil(() => {
+            return (
+                browser.isExisting(
+                    '.quick_oql_edit [data-test="oqlErrorMessage"]'
+                ) &&
+                browser.getText(
+                    '.quick_oql_edit [data-test="oqlErrorMessage"]'
+                ) ===
+                    'Protein level data query specified in OQL, but no protein level profile is available in the selected study.'
+            );
+        }, 20000);
+
+        // submit is disabled
+        assert(
+            !browser.isEnabled('button[data-test="oqlQuickEditSubmitButton"]')
+        );
+    });
+    it('auto-selects an mrna profile when mrna oql is entered', () => {
+        let query = browser.execute(function() {
+            return urlWrapper.query;
+        }).value;
+        // mutation and cna profile are there
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_MUTATION_EXTENDED,
+            'acc_tcga_pan_can_atlas_2018_mutations'
+        );
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION,
+            'acc_tcga_pan_can_atlas_2018_gistic'
+        );
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_MRNA_EXPRESSION,
+            undefined
+        );
+
+        // enter oql
+        browser.waitForExist(
+            '.quick_oql_edit textarea[data-test="geneSet"]',
+            2000
+        );
+        setInputText(
+            '.quick_oql_edit textarea[data-test="geneSet"]',
+            'PTEN: EXP>1'
+        );
+
+        browser.waitForEnabled(
+            'button[data-test="oqlQuickEditSubmitButton"]',
+            5000
+        );
+        browser.click('button[data-test="oqlQuickEditSubmitButton"]');
+
+        // wait for query to load
+        waitForOncoprint(20000);
+
+        // mutation, cna, mrna profiles are there
+        query = browser.execute(function() {
+            return urlWrapper.query;
+        }).value;
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_MUTATION_EXTENDED,
+            'acc_tcga_pan_can_atlas_2018_mutations'
+        );
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION,
+            'acc_tcga_pan_can_atlas_2018_gistic'
+        );
+        assert.equal(
+            query.genetic_profile_ids_PROFILE_MRNA_EXPRESSION,
+            'acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna_median_Zscores'
         );
     });
 });

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -56,6 +56,7 @@ import { GroupComparisonTab } from '../groupComparison/GroupComparisonTabs';
 import NotUsingGenePanelWarning from './NotUsingGenePanelWarning';
 import Survival from '../groupComparison/Survival';
 import ResultsViewComparisonStore from './comparison/ResultsViewComparisonStore';
+import { QueryStore } from '../../shared/components/query/QueryStore';
 
 export function initStore(
     appStore: AppStore,
@@ -542,13 +543,18 @@ export default class ResultsViewPage extends React.Component<
         return isRoutedTo || (!isExcludedInList && !isExcluded);
     }
 
-    @computed get quickOQLSubmitButtion() {
+    @autobind
+    private getQuickOQLSubmitButton(store: QueryStore) {
         return (
             <>
                 <button
                     className={'btn btn-primary btn-sm'}
                     style={{ marginLeft: 10 }}
-                    onClick={this.handleQuickOQLSubmission}
+                    onClick={() => {
+                        //this.handleQuickOQLSubmission();
+                        store.submit();
+                    }}
+                    disabled={!store.submitEnabled}
                 >
                     Submit Query
                 </button>
@@ -567,9 +573,6 @@ export default class ResultsViewPage extends React.Component<
     @action
     handleQuickOQLSubmission() {
         this.showOQLEditor = false;
-        this.urlWrapper.updateURL({
-            gene_list: this.oqlSubmission,
-        });
     }
 
     @autobind
@@ -669,9 +672,11 @@ export default class ResultsViewPage extends React.Component<
                                     {this.showOQLEditor && (
                                         <div className={'quick_oql_edit'}>
                                             <OQLTextArea
-                                                inputGeneQuery={
-                                                    this.resultsViewPageStore
-                                                        .oqlText
+                                                getQueryStore={() =>
+                                                    createQueryStore(
+                                                        this.urlWrapper.query,
+                                                        this.urlWrapper
+                                                    )
                                                 }
                                                 validateInputGeneQuery={true}
                                                 callback={(...args) => {
@@ -679,8 +684,8 @@ export default class ResultsViewPage extends React.Component<
                                                         args[2];
                                                 }}
                                                 location={GeneBoxType.DEFAULT}
-                                                submitButton={
-                                                    this.quickOQLSubmitButtion
+                                                getSubmitButton={
+                                                    this.getQuickOQLSubmitButton
                                                 }
                                             />
                                         </div>

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -574,7 +574,8 @@ export default class ResultsViewPage extends React.Component<
         if (s) {
             this.quickOQLQueryStore = createQueryStore(
                 this.urlWrapper.query,
-                this.urlWrapper
+                this.urlWrapper,
+                false
             );
         } else {
             this.quickOQLQueryStore = null;

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -549,6 +549,7 @@ export default class ResultsViewPage extends React.Component<
                 <>
                     <button
                         className={'btn btn-primary btn-sm'}
+                        data-test="oqlQuickEditSubmitButton"
                         style={{ marginLeft: 10 }}
                         onClick={this.handleQuickOQLSubmission}
                         disabled={!this.quickOQLQueryStore!.submitEnabled}

--- a/src/pages/resultsView/enrichments/GeneBarPlot.tsx
+++ b/src/pages/resultsView/enrichments/GeneBarPlot.tsx
@@ -22,7 +22,10 @@ import styles from './frequencyPlotStyles.module.scss';
 import { AlterationEnrichmentRow } from 'shared/model/AlterationEnrichmentRow';
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
 import { FormControl } from 'react-bootstrap';
-import { GeneReplacement } from 'shared/components/query/QueryStore';
+import {
+    GeneReplacement,
+    QueryStore,
+} from 'shared/components/query/QueryStore';
 import { EnrichmentsTableDataStore } from './EnrichmentsTableDataStore';
 
 export interface IGeneBarPlotProps {

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -122,7 +122,10 @@ export default class QuerySummary extends React.Component<
                     {getGeneSummary(this.props.store.hugoGeneSymbols)}
                     &nbsp;
                     <DefaultTooltip overlay={'Edit genes or OQL'}>
-                        <a onClick={this.props.onToggleOQLEditUIVisibility}>
+                        <a
+                            data-test="oqlQuickEditButton"
+                            onClick={this.props.onToggleOQLEditUIVisibility}
+                        >
                             <i className={'fa fa-pencil'}></i>
                         </a>
                     </DefaultTooltip>

--- a/src/pages/resultsView/styles.scss
+++ b/src/pages/resultsView/styles.scss
@@ -132,6 +132,7 @@
 .quick_oql_edit {
     display: flex;
     margin-top: 10px;
+    margin-bottom: 10px;
     align-items: flex-start;
 
     .oqlValidationContainer {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -47,6 +47,7 @@ import {
 import {
     fetchCopyNumberSegmentsForSamples,
     getAlterationTypesInOql,
+    getDefaultProfilesForOql,
 } from 'shared/lib/StoreUtils';
 import { PatientSurvival } from 'shared/model/PatientSurvival';
 import { getPatientSurvivals } from 'pages/resultsView/SurvivalStoreHelper';
@@ -1308,49 +1309,39 @@ export class StudyViewPageStore {
         return getAlterationTypesInOql(this.geneQueries);
     }
 
-    @computed get defaultMutationProfile() {
+    @computed get defaultProfilesForOql() {
         if (this.molecularProfiles.isComplete) {
-            return this.molecularProfiles.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.MUTATION_EXTENDED
-            );
+            return getDefaultProfilesForOql(this.molecularProfiles.result);
         }
         return undefined;
+    }
+    @computed get defaultMutationProfile() {
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[
+                AlterationTypeConstants.MUTATION_EXTENDED
+            ]
+        );
     }
     @computed get defaultCnaProfile() {
-        if (this.molecularProfiles.isComplete) {
-            return this.molecularProfiles.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.COPY_NUMBER_ALTERATION
-            );
-        }
-        return undefined;
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[
+                AlterationTypeConstants.COPY_NUMBER_ALTERATION
+            ]
+        );
     }
     @computed get defaultMrnaProfile() {
-        if (this.molecularProfiles.isComplete) {
-            return this.molecularProfiles.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.MRNA_EXPRESSION
-            );
-        }
-        return undefined;
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[AlterationTypeConstants.MRNA_EXPRESSION]
+        );
     }
     @computed get defaultProtProfile() {
-        if (this.molecularProfiles.isComplete) {
-            return this.molecularProfiles.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.PROTEIN_LEVEL
-            );
-        }
-        return undefined;
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[AlterationTypeConstants.PROTEIN_LEVEL]
+        );
     }
 
     @autobind

--- a/src/pages/studyView/studyPageHeader/rightPanel/RightPanel.tsx
+++ b/src/pages/studyView/studyPageHeader/rightPanel/RightPanel.tsx
@@ -12,6 +12,10 @@ import OQLTextArea, {
 import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import classnames from 'classnames';
 import { serializeEvent } from '../../../../shared/lib/tracking';
+import { getOqlMessages } from '../../../../shared/lib/StoreUtils';
+import { CUSTOM_CASE_LIST_ID } from '../../../../shared/components/query/QueryStore';
+import AppConfig from 'appConfig';
+import { remoteData } from 'cbioportal-frontend-commons';
 
 export interface IRightPanelProps {
     store: StudyViewPageStore;
@@ -53,6 +57,76 @@ export default class RightPanel extends React.Component<IRightPanelProps, {}> {
         );
     }
 
+    @computed get isQueryLimitReached(): boolean {
+        if (this.props.store.selectedSamples.isComplete) {
+            return (
+                this.props.store.geneQueries.length *
+                    this.props.store.selectedSamples.result.length >
+                AppConfig.serverConfig.query_product_limit
+            );
+        } else {
+            return false;
+        }
+    }
+
+    @computed get geneLimit(): number {
+        if (this.props.store.selectedSamples.isComplete) {
+            return Math.floor(
+                AppConfig.serverConfig.query_product_limit /
+                    this.props.store.selectedSamples.result.length
+            );
+        } else {
+            // won't be used here
+            return 0;
+        }
+    }
+
+    @computed get oqlMessages() {
+        return getOqlMessages(this.props.store.geneQueries);
+    }
+
+    @computed get oqlSubmitError() {
+        if (this.props.store.isSingleNonVirtualStudyQueried) {
+            if (
+                this.props.store.alterationTypesInOQL.haveMutInQuery &&
+                !this.props.store.defaultMutationProfile
+            )
+                return 'Mutation data query specified in OQL, but no mutation profile is available for the selected study.';
+            if (
+                this.props.store.alterationTypesInOQL.haveCnaInQuery &&
+                !this.props.store.defaultCnaProfile
+            )
+                return 'CNA data query specified in OQL, but no CNA profile is available in the selected study.';
+            if (
+                this.props.store.alterationTypesInOQL.haveMrnaInQuery &&
+                !this.props.store.defaultMrnaProfile
+            )
+                return 'mRNA expression data query specified in OQL, but no mRNA profile is available in the selected study.';
+            if (
+                this.props.store.alterationTypesInOQL.haveProtInQuery &&
+                !this.props.store.defaultProtProfile
+            )
+                return 'Protein level data query specified in OQL, but no protein level profile is available in the selected study.';
+        }
+        if (
+            this.props.store.alterationTypesInOQL.haveMrnaInQuery &&
+            this.props.store.displayedStudies.isComplete &&
+            this.props.store.displayedStudies.result.length > 1
+        ) {
+            return 'Expression filtering in the gene list (the EXP command) is not supported when doing cross cancer queries.';
+        } else if (
+            this.props.store.alterationTypesInOQL.haveProtInQuery &&
+            this.props.store.displayedStudies.isComplete &&
+            this.props.store.displayedStudies.result.length > 1
+        ) {
+            return 'Protein level filtering in the gene list (the PROT command) is not supported when doing cross cancer queries.';
+        }
+
+        if (this.isQueryLimitReached) {
+            return `Please limit your queries to ${this.geneLimit} genes or fewer.`;
+        }
+    }
+
     render() {
         return (
             <div className="studyViewSummaryHeader">
@@ -60,9 +134,11 @@ export default class RightPanel extends React.Component<IRightPanelProps, {}> {
                     <div className={'small'}>
                         <OQLTextArea
                             inputGeneQuery={this.props.store.geneQueryStr}
-                            validateInputGeneQuery={false}
+                            validateInputGeneQuery={true}
                             callback={this.updateSelectedGenes}
                             location={GeneBoxType.STUDY_VIEW_PAGE}
+                            error={this.oqlSubmitError}
+                            messages={this.oqlMessages}
                         />
                     </div>
                     <button

--- a/src/pages/studyView/studyPageHeader/rightPanel/RightPanel.tsx
+++ b/src/pages/studyView/studyPageHeader/rightPanel/RightPanel.tsx
@@ -53,7 +53,9 @@ export default class RightPanel extends React.Component<IRightPanelProps, {}> {
     @computed
     get isQueryButtonDisabled() {
         return (
-            this.props.store.geneQueryStr === '' || this.geneValidationHasIssue
+            this.props.store.geneQueryStr === '' ||
+            this.geneValidationHasIssue ||
+            !!this.oqlSubmitError
         );
     }
 
@@ -153,6 +155,7 @@ export default class RightPanel extends React.Component<IRightPanelProps, {}> {
                             label: this.props.store.queriedPhysicalStudyIds
                                 .result,
                         })}
+                        data-test="geneSetSubmit"
                         onClick={() => this.props.store.onSubmitQuery()}
                     >
                         Query

--- a/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
+++ b/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
@@ -33,8 +33,10 @@ import { createQueryStore } from '../../lib/createQueryStore';
 import { FlexCol } from '../flexbox/FlexBox';
 
 export interface IGeneSelectionBoxProps {
-    getQueryStore?: () => QueryStore;
-    getSubmitButton?: (store?: QueryStore) => JSX.Element;
+    submitButton?: JSX.Element;
+    error?: string;
+    messages?: string[];
+
     focus?: Focus;
     inputGeneQuery?: string;
     validateInputGeneQuery?: boolean;
@@ -127,8 +129,6 @@ export default class OQLTextArea extends React.Component<
             this.skipGenesValidation = true;
         }
         this.textAreaRef = React.createRef<HTMLTextAreaElement>();
-        this.queryStore =
-            this.props.getQueryStore && this.props.getQueryStore();
     }
 
     componentDidMount(): void {
@@ -285,12 +285,11 @@ export default class OQLTextArea extends React.Component<
         this.updateGeneQuery(updatedQuery);
     }
 
-    @computed get submitButton() {
-        if (this.props.getSubmitButton) {
-            return this.props.getSubmitButton(this.queryStore);
-        }
-
-        return null;
+    @computed get showErrorsAndMessages() {
+        return (
+            this.props.location !== GeneBoxType.STUDY_VIEW_PAGE ||
+            this.isFocused
+        );
     }
 
     render() {
@@ -312,7 +311,7 @@ export default class OQLTextArea extends React.Component<
                         style={{ height: this.props.textAreaHeight }}
                     />
 
-                    {this.submitButton}
+                    {this.props.submitButton}
                 </div>
                 <div className={'oqlValidationContainer'}>
                     <GeneSymbolValidator
@@ -330,32 +329,30 @@ export default class OQLTextArea extends React.Component<
                         {this.props.children}
                     </GeneSymbolValidator>
                 </div>
-                {this.queryStore && (
-                    <div>
-                        {!!this.queryStore.submitError && (
-                            <span
-                                className={queryStoreStyles.errorMessage}
-                                data-test="oqlErrorMessage"
-                            >
-                                {this.queryStore.submitError}
-                            </span>
-                        )}
+                <div>
+                    {this.showErrorsAndMessages && this.props.error && (
+                        <span
+                            className={queryStoreStyles.errorMessage}
+                            data-test="oqlErrorMessage"
+                        >
+                            {this.props.error}
+                        </span>
+                    )}
 
-                        {this.queryStore.oqlMessages.map(msg => {
-                            return (
-                                <span className={queryStoreStyles.oqlMessage}>
-                                    <i
-                                        className="fa fa-info-circle"
-                                        style={{
-                                            marginRight: 5,
-                                        }}
-                                    />
-                                    {msg}
-                                </span>
-                            );
-                        })}
-                    </div>
-                )}
+                    {this.showErrorsAndMessages &&
+                        this.props.messages &&
+                        this.props.messages.map(msg => (
+                            <span className={queryStoreStyles.oqlMessage}>
+                                <i
+                                    className="fa fa-info-circle"
+                                    style={{
+                                        marginRight: 5,
+                                    }}
+                                />
+                                {msg}
+                            </span>
+                        ))}
+                </div>
             </div>
         );
     }

--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -139,7 +139,8 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
                             'Enter HUGO Gene Symbols, Gene Aliases, or OQL'
                         }
                         callback={this.handleOQLUpdate}
-                        getQueryStore={() => this.store}
+                        error={this.store.submitError}
+                        messages={this.store.oqlMessages}
                     >
                         {this.customError}
                     </OQLTextArea>

--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -139,6 +139,7 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
                             'Enter HUGO Gene Symbols, Gene Aliases, or OQL'
                         }
                         callback={this.handleOQLUpdate}
+                        getQueryStore={() => this.store}
                     >
                         {this.customError}
                     </OQLTextArea>

--- a/src/shared/components/query/QueryContainer.tsx
+++ b/src/shared/components/query/QueryContainer.tsx
@@ -326,36 +326,6 @@ export default class QueryContainer extends React.Component<
                                                 ? 'Submit Query'
                                                 : 'Download'}
                                         </button>
-                                        <FlexCol>
-                                            {!!this.store.submitError && (
-                                                <span
-                                                    className={
-                                                        styles.errorMessage
-                                                    }
-                                                    data-test="oqlErrorMessage"
-                                                >
-                                                    {this.store.submitError}
-                                                </span>
-                                            )}
-
-                                            {this.store.oqlMessages.map(msg => {
-                                                return (
-                                                    <span
-                                                        className={
-                                                            styles.oqlMessage
-                                                        }
-                                                    >
-                                                        <i
-                                                            className="fa fa-info-circle"
-                                                            style={{
-                                                                marginRight: 5,
-                                                            }}
-                                                        />
-                                                        {msg}
-                                                    </span>
-                                                );
-                                            })}
-                                        </FlexCol>
                                     </FlexRow>
                                 </>
                             </If>

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -50,7 +50,11 @@ import {
 import getOverlappingStudies from '../../lib/getOverlappingStudies';
 import MolecularProfilesInStudyCache from '../../cache/MolecularProfilesInStudyCache';
 import { CacheData } from '../../lib/LazyMobXCache';
-import { getHierarchyData } from 'shared/lib/StoreUtils';
+import {
+    getAlterationTypesInOql,
+    getHierarchyData,
+    getOqlMessages,
+} from 'shared/lib/StoreUtils';
 import sessionServiceClient from 'shared/api//sessionServiceInstance';
 import { VirtualStudy } from 'shared/model/VirtualStudy';
 import {
@@ -1806,20 +1810,7 @@ export class QueryStore {
     }
 
     @computed get oqlMessages(): string[] {
-        let unrecognizedMutations = _.flatten(
-            this.oql.query.map(result => {
-                return (result.alterations || []).filter(
-                    alt =>
-                        alt.alteration_type === 'mut' &&
-                        (alt.info as any).unrecognized
-                ) as MUTCommand<any>[];
-            })
-        );
-        return unrecognizedMutations.map(mutCommand => {
-            return `Unrecognized input "${
-                (mutCommand as any).constr_val
-            }" is interpreted as a mutation code.`;
-        });
+        return getOqlMessages(this.oql.query);
     }
 
     /**
@@ -1884,29 +1875,7 @@ export class QueryStore {
     }
 
     @computed get alterationTypesInOQL() {
-        let haveMutInQuery = false;
-        let haveCnaInQuery = false;
-        let haveMrnaInQuery = false;
-        let haveProtInQuery = false;
-
-        for (const queryLine of this.oql.query) {
-            for (const alteration of queryLine.alterations || []) {
-                haveMutInQuery =
-                    haveMutInQuery || alteration.alteration_type === 'mut';
-                haveCnaInQuery =
-                    haveCnaInQuery || alteration.alteration_type === 'cna';
-                haveMrnaInQuery =
-                    haveMrnaInQuery || alteration.alteration_type === 'exp';
-                haveProtInQuery =
-                    haveProtInQuery || alteration.alteration_type === 'prot';
-            }
-        }
-        return {
-            haveMutInQuery,
-            haveCnaInQuery,
-            haveMrnaInQuery,
-            haveProtInQuery,
-        };
+        return getAlterationTypesInOql(this.oql.query);
     }
 
     @computed get submitError() {

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -52,6 +52,7 @@ import MolecularProfilesInStudyCache from '../../cache/MolecularProfilesInStudyC
 import { CacheData } from '../../lib/LazyMobXCache';
 import {
     getAlterationTypesInOql,
+    getDefaultProfilesForOql,
     getHierarchyData,
     getOqlMessages,
 } from 'shared/lib/StoreUtils';
@@ -1539,49 +1540,41 @@ export class QueryStore {
         return result;
     }
 
-    @computed get defaultMutationProfile() {
+    @computed get defaultProfilesForOql() {
         if (this.molecularProfilesInSelectedStudies.isComplete) {
-            return this.molecularProfilesInSelectedStudies.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.MUTATION_EXTENDED
+            return getDefaultProfilesForOql(
+                this.molecularProfilesInSelectedStudies.result
             );
         }
         return undefined;
+    }
+    @computed get defaultMutationProfile() {
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[
+                AlterationTypeConstants.MUTATION_EXTENDED
+            ]
+        );
     }
     @computed get defaultCnaProfile() {
-        if (this.molecularProfilesInSelectedStudies.isComplete) {
-            return this.molecularProfilesInSelectedStudies.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.COPY_NUMBER_ALTERATION
-            );
-        }
-        return undefined;
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[
+                AlterationTypeConstants.COPY_NUMBER_ALTERATION
+            ]
+        );
     }
     @computed get defaultMrnaProfile() {
-        if (this.molecularProfilesInSelectedStudies.isComplete) {
-            return this.molecularProfilesInSelectedStudies.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.MRNA_EXPRESSION
-            );
-        }
-        return undefined;
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[AlterationTypeConstants.MRNA_EXPRESSION]
+        );
     }
     @computed get defaultProtProfile() {
-        if (this.molecularProfilesInSelectedStudies.isComplete) {
-            return this.molecularProfilesInSelectedStudies.result.find(
-                x =>
-                    x.showProfileInAnalysisTab &&
-                    x.molecularAlterationType ===
-                        AlterationTypeConstants.PROTEIN_LEVEL
-            );
-        }
-        return undefined;
+        return (
+            this.defaultProfilesForOql &&
+            this.defaultProfilesForOql[AlterationTypeConstants.PROTEIN_LEVEL]
+        );
     }
 
     // SAMPLE LIST

--- a/src/shared/components/query/QueryStoreUtils.ts
+++ b/src/shared/components/query/QueryStoreUtils.ts
@@ -16,16 +16,59 @@ export function currentQueryParams(store: QueryStore) {
         .map(caseRow => caseRow.studyId + ':' + caseRow.sampleId)
         .join('+');
 
+    // select default profiles for OQL alteration types
+    let genetic_profile_ids_PROFILE_MUTATION_EXTENDED = store.getSelectedProfileIdFromMolecularAlterationType(
+        'MUTATION_EXTENDED'
+    );
+    if (
+        store.alterationTypesInOQL.haveMutInQuery &&
+        !genetic_profile_ids_PROFILE_MUTATION_EXTENDED &&
+        store.defaultMutationProfile
+    ) {
+        genetic_profile_ids_PROFILE_MUTATION_EXTENDED =
+            store.defaultMutationProfile.molecularProfileId;
+    }
+
+    let genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION = store.getSelectedProfileIdFromMolecularAlterationType(
+        'COPY_NUMBER_ALTERATION'
+    );
+    if (
+        store.alterationTypesInOQL.haveCnaInQuery &&
+        !genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION &&
+        store.defaultCnaProfile
+    ) {
+        genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION =
+            store.defaultCnaProfile.molecularProfileId;
+    }
+
+    let genetic_profile_ids_PROFILE_MRNA_EXPRESSION = store.getSelectedProfileIdFromMolecularAlterationType(
+        'MRNA_EXPRESSION'
+    );
+    if (
+        store.alterationTypesInOQL.haveMrnaInQuery &&
+        !genetic_profile_ids_PROFILE_MRNA_EXPRESSION &&
+        store.defaultMrnaProfile
+    ) {
+        genetic_profile_ids_PROFILE_MRNA_EXPRESSION =
+            store.defaultMrnaProfile.molecularProfileId;
+    }
+
+    let genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION = store.getSelectedProfileIdFromMolecularAlterationType(
+        'PROTEIN_LEVEL'
+    );
+    if (
+        store.alterationTypesInOQL.haveProtInQuery &&
+        !genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION &&
+        store.defaultProtProfile
+    ) {
+        genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION =
+            store.defaultProtProfile.molecularProfileId;
+    }
+
     const ret: CancerStudyQueryUrlParams = {
-        genetic_profile_ids_PROFILE_MUTATION_EXTENDED: store.getSelectedProfileIdFromMolecularAlterationType(
-            'MUTATION_EXTENDED'
-        ),
-        genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION: store.getSelectedProfileIdFromMolecularAlterationType(
-            'COPY_NUMBER_ALTERATION'
-        ),
-        genetic_profile_ids_PROFILE_MRNA_EXPRESSION: store.getSelectedProfileIdFromMolecularAlterationType(
-            'MRNA_EXPRESSION'
-        ),
+        genetic_profile_ids_PROFILE_MUTATION_EXTENDED,
+        genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION,
+        genetic_profile_ids_PROFILE_MRNA_EXPRESSION,
         genetic_profile_ids_PROFILE_METHYLATION:
             store.getSelectedProfileIdFromMolecularAlterationType(
                 'METHYLATION'
@@ -33,9 +76,7 @@ export function currentQueryParams(store: QueryStore) {
             store.getSelectedProfileIdFromMolecularAlterationType(
                 'METHYLATION_BINARY'
             ),
-        genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: store.getSelectedProfileIdFromMolecularAlterationType(
-            'PROTEIN_LEVEL'
-        ),
+        genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION,
         genetic_profile_ids_PROFILE_GENESET_SCORE: store.getSelectedProfileIdFromMolecularAlterationType(
             'GENESET_SCORE'
         ),

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -217,6 +217,7 @@ export default class StudyList extends QueryStoreComponent<
                             [styles.DeletedStudy]: this.store.isDeletedVirtualStudy(
                                 study.studyId
                             ),
+                            [`studyItem_${study.studyId}`]: true,
                         });
                         return (
                             <CancerTreeCheckbox view={this.view} node={study}>

--- a/src/shared/components/query/styles/styles.module.scss
+++ b/src/shared/components/query/styles/styles.module.scss
@@ -38,16 +38,16 @@
         margin-bottom: 0;
         font-weight: normal;
     }
+}
 
-    .errorMessage {
-        color: $redError;
-        font-weight: bold;
-    }
+.errorMessage {
+    color: $redError;
+    font-weight: bold;
+}
 
-    .oqlMessage {
-        color: $brand-info;
-        font-weight: bold;
-    }
+.oqlMessage {
+    color: $brand-info;
+    font-weight: bold;
 }
 
 .CancerStudySelector {

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -85,7 +85,7 @@ import {
     plotsPriority,
 } from '../../pages/resultsView/survival/SurvivalUtil';
 import request from 'superagent';
-import { MUTCommand, SingleGeneQuery } from './oql/oql-parser';
+import { Alteration, MUTCommand, SingleGeneQuery } from './oql/oql-parser';
 import { CUSTOM_CASE_LIST_ID } from '../components/query/QueryStore';
 
 export const ONCOKB_DEFAULT: IOncoKbData = {
@@ -1394,4 +1394,22 @@ export function getOqlMessages(parsedLines: SingleGeneQuery[]) {
             (mutCommand as any).constr_val
         }" is interpreted as a mutation code.`;
     });
+}
+
+export function getDefaultProfilesForOql(profiles: MolecularProfile[]) {
+    return _.mapValues(
+        _.keyBy([
+            AlterationTypeConstants.MUTATION_EXTENDED,
+            AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+            AlterationTypeConstants.MRNA_EXPRESSION,
+            AlterationTypeConstants.PROTEIN_LEVEL,
+        ]),
+        alterationType =>
+            profiles.find(profile => {
+                return (
+                    profile.showProfileInAnalysisTab &&
+                    profile.molecularAlterationType === alterationType
+                );
+            })
+    );
 }

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -85,6 +85,8 @@ import {
     plotsPriority,
 } from '../../pages/resultsView/survival/SurvivalUtil';
 import request from 'superagent';
+import { MUTCommand, SingleGeneQuery } from './oql/oql-parser';
+import { CUSTOM_CASE_LIST_ID } from '../components/query/QueryStore';
 
 export const ONCOKB_DEFAULT: IOncoKbData = {
     indicatorMap: {},
@@ -1349,4 +1351,47 @@ export async function fetchSurvivalDataExists(
             return parseInt(response.header['total-count'], 10);
         });
     return count > 0;
+}
+
+export function getAlterationTypesInOql(parsedQueryLines: SingleGeneQuery[]) {
+    let haveMutInQuery = false;
+    let haveCnaInQuery = false;
+    let haveMrnaInQuery = false;
+    let haveProtInQuery = false;
+
+    for (const queryLine of parsedQueryLines) {
+        for (const alteration of queryLine.alterations || []) {
+            haveMutInQuery =
+                haveMutInQuery || alteration.alteration_type === 'mut';
+            haveCnaInQuery =
+                haveCnaInQuery || alteration.alteration_type === 'cna';
+            haveMrnaInQuery =
+                haveMrnaInQuery || alteration.alteration_type === 'exp';
+            haveProtInQuery =
+                haveProtInQuery || alteration.alteration_type === 'prot';
+        }
+    }
+    return {
+        haveMutInQuery,
+        haveCnaInQuery,
+        haveMrnaInQuery,
+        haveProtInQuery,
+    };
+}
+
+export function getOqlMessages(parsedLines: SingleGeneQuery[]) {
+    const unrecognizedMutations = _.flatten(
+        parsedLines.map(result => {
+            return (result.alterations || []).filter(
+                alt =>
+                    alt.alteration_type === 'mut' &&
+                    (alt.info as any).unrecognized
+            ) as MUTCommand<any>[];
+        })
+    );
+    return unrecognizedMutations.map(mutCommand => {
+        return `Unrecognized input "${
+            (mutCommand as any).constr_val
+        }" is interpreted as a mutation code.`;
+    });
 }


### PR DESCRIPTION
If OQL is submitted which involves an alteration type that does not have a selected profile, a default profile for that type will automatically be selected.

e.g. if OQL is `BRCA1: EXP>0` but no mrna profile is selected, submission will now be allowed and an mrna profile will automatically be selected.

On the other hand, if there is no mrna profile at all, then there will be an error indicating that.

This PR standardizes the OQL submission flow, including this new feature, for the home page query form, the modify query form, the quick gene edit (pencil) on the results view, and the quick gene query box in the study view.
