### PR TITLE
Use client posted data method to pass data for number of patients larger than a limit (2000) from study view to patient view

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -21,6 +21,7 @@ import { toggleColumnVisibility } from 'cbioportal-frontend-commons';
 import {
     parseCohortIds,
     PatientViewPageStore,
+    buildCohortIdsFromNavCaseIds,
 } from './clinicalInformation/PatientViewPageStore';
 import ClinicalInformationPatientTable from './clinicalInformation/ClinicalInformationPatientTable';
 import ClinicalInformationSamples from './clinicalInformation/ClinicalInformationSamplesTable';
@@ -198,6 +199,17 @@ export default class PatientViewPage extends React.Component<
         this.onCnaTableColumnVisibilityToggled = this.onCnaTableColumnVisibilityToggled.bind(
             this
         );
+    }
+
+    componentDidMount() {
+        // Load posted data, if it exists
+        const postData = getBrowserWindow().clientPostedData;
+        if (postData && postData.navCaseIds) {
+            this.patientViewPageStore.patientIdsInCohort = buildCohortIdsFromNavCaseIds(
+                postData.navCaseIds
+            );
+            getBrowserWindow().clientPostedData = null;
+        }
     }
 
     public handleSampleClick(

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -157,6 +157,14 @@ export function parseCohortIds(concatenatedIds: string) {
     });
 }
 
+export function buildCohortIdsFromNavCaseIds(
+    navCaseIds: { patientId: string; studyId: string }[]
+) {
+    return _.map(navCaseIds, navCaseId => {
+        return navCaseId.studyId + ':' + navCaseId.patientId;
+    });
+}
+
 export function handlePathologyReportCheckResponse(
     patientId: string,
     resp: any

--- a/src/pages/studyView/studyPageHeader/ActionButtons.tsx
+++ b/src/pages/studyView/studyPageHeader/ActionButtons.tsx
@@ -20,6 +20,8 @@ export interface ActionButtonsProps {
     appStore: AppStore;
 }
 
+export const MAXIMUM_NAV_CASE_IDS_IN_URL = 2000;
+
 @observer
 export default class ActionButtons extends React.Component<
     ActionButtonsProps,
@@ -62,13 +64,27 @@ export default class ActionButtons extends React.Component<
                 }
             );
 
-            window.open(
-                getPatientViewUrl(
-                    firstPatient.studyId,
-                    firstPatient.patientId,
-                    navCaseIds
-                )
-            );
+            // if number of cases large equal to MAXIMUM_NAV_CASE_IDS_IN_URL, use clientPostedData to pass navCaseIds
+            if (navCaseIds.length >= MAXIMUM_NAV_CASE_IDS_IN_URL) {
+                const patientViewWindow = window.open(
+                    getPatientViewUrl(
+                        firstPatient.studyId,
+                        firstPatient.patientId
+                    )
+                ) as any;
+                patientViewWindow.clientPostedData = {
+                    navCaseIds: navCaseIds,
+                };
+            } else {
+                // add navCaseIds into url if number of cases less than MAXIMUM_NAV_CASE_IDS_IN_URL
+                window.open(
+                    getPatientViewUrl(
+                        firstPatient.studyId,
+                        firstPatient.patientId,
+                        navCaseIds
+                    )
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/cbioportal/cbioportal/issues/7506

We proposed to solve this issue by using `client posted data`:
1. Set a limit for numbers of patients can exist in url (the limit is 2000 patients).
2. For number of patients larger than 2000, using `client posted data` to pass the data, do not put patient ids in url anymore.
3. For number of patients smaller than 2000, still put the ids in url.

Describe changes proposed in this pull request:
- a number of patients larger than 2000 (url doesn't include case ids anymore)
![image](https://user-images.githubusercontent.com/15748980/83171654-6e324f80-a0e4-11ea-91c2-7f135b919e5c.png)
