### PR TITLE
Fix relative path on institute image logo

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -6,7 +6,10 @@ import { If, Then, Else } from 'react-if';
 import { openSocialAuthWindow } from '../../shared/lib/openSocialAuthWindow';
 import { AppStore } from '../../AppStore';
 import { observer } from 'mobx-react';
-import { buildCBioPortalPageUrl } from '../../shared/api/urls';
+import {
+    buildCBioPortalPageUrl,
+    getInstituteLogoUrl,
+} from '../../shared/api/urls';
 import SocialAuthButton from '../../shared/components/SocialAuthButton';
 import { Dropdown } from 'react-bootstrap';
 import { DataAccessTokensDropdown } from '../../shared/components/dataAccessTokens/DataAccessTokensDropdown';
@@ -166,15 +169,10 @@ export default class PortalHeader extends React.Component<
                             </Else>
                         </If>
                     </If>
-                    <If
-                        condition={
-                            !_.isEmpty(AppConfig.serverConfig.skin_right_logo)
-                        }
-                    >
+                    <If condition={!_.isEmpty(getInstituteLogoUrl())}>
                         <img
                             id="institute-logo"
-                            src={`images/${AppConfig.serverConfig
-                                .skin_right_logo!}`}
+                            src={getInstituteLogoUrl()}
                             alt="Institute Logo"
                         />
                     </If>

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -206,6 +206,20 @@ export function getOncoKbApiUrl() {
     return buildCBioPortalAPIUrl(`proxy/oncokb`);
 }
 
+export function getInstituteLogoUrl() {
+    if (AppConfig.serverConfig.skin_right_logo) {
+        if (/^http/.test(AppConfig.serverConfig.skin_right_logo)) {
+            return AppConfig.serverConfig.skin_right_logo;
+        } else {
+            return buildCBioPortalPageUrl(
+                `images/${AppConfig.serverConfig.skin_right_logo}`
+            );
+        }
+    } else {
+        return undefined;
+    }
+}
+
 export function getGenomeNexusApiUrl() {
     let url = AppConfig.serverConfig.genomenexus_url;
     return getProxyUrlIfNecessary(url);


### PR DESCRIPTION
The path to logo (or any image) cannot every be relative because we have nested paths to subpages (results/oncoprint).    This PR allows installers to specify a path that starts with /images/ or an absolute path.   The former will allow things to work as they have in the past but will fix the image on interior pages.  The only time it will fail is when a portal is hosted in a sub folder.  In that case, the only option is to use the absolute path.