### PR TITLE
Add structural variant table in patient page

### DIFF
--- a/packages/cbioportal-frontend-commons/src/lib/oncokb/OncoKbUtils.ts
+++ b/packages/cbioportal-frontend-commons/src/lib/oncokb/OncoKbUtils.ts
@@ -76,6 +76,19 @@ export function generateQueryVariant(
     return query;
 }
 
+export function generateQueryStructuralVariantId(
+    site1EntrezGeneId: number,
+    site2EntrezGeneId: number,
+    tumorType: string | null
+): string {
+    let id = `${site1EntrezGeneId}_${site2EntrezGeneId}`;
+    if (tumorType) {
+        id = `${id}_${tumorType}`;
+    }
+
+    return id.trim().replace(/\s/g, '_');
+}
+
 export function generateQueryVariantId(
     entrezGeneId: number,
     tumorType: string | null,
@@ -221,6 +234,45 @@ export function generateAnnotateStructuralVariantQuery(
         structuralVariantType: 'FUSION',
         functionalFusion: false,
         tumorType: tumorType,
+        evidenceTypes: evidenceTypes,
+    } as AnnotateStructuralVariantQuery;
+}
+
+export enum StructuralVariantType {
+    DELETION = 'DELETION',
+    TRANSLOCATION = 'TRANSLOCATION',
+    DUPLICATION = 'DUPLICATION',
+    INSERTION = 'INSERTION',
+    INVERSION = 'INVERSION',
+    FUSION = 'FUSION',
+    UNKNOWN = 'UNKNOWN',
+}
+
+export function generateAnnotateStructuralVariantQueryFromGenes(
+    site1EntrezGeneId: number,
+    site2EntrezGeneId: number,
+    tumorType: string | null,
+    structuralVariantType: keyof typeof StructuralVariantType,
+    evidenceTypes?: EvidenceType[]
+): AnnotateStructuralVariantQuery {
+    return {
+        id: generateQueryStructuralVariantId(
+            site1EntrezGeneId,
+            site2EntrezGeneId,
+            tumorType
+        ),
+        geneA: {
+            entrezGeneId: site1EntrezGeneId,
+        },
+        geneB: {
+            entrezGeneId: site2EntrezGeneId,
+        },
+        structuralVariantType,
+        functionalFusion: !(
+            site1EntrezGeneId === site2EntrezGeneId ||
+            site2EntrezGeneId === null
+        ),
+        tumorType,
         evidenceTypes: evidenceTypes,
     } as AnnotateStructuralVariantQuery;
 }

--- a/src/pages/patientView/structuralVariant/PatientViewStructuralVariantTable.tsx
+++ b/src/pages/patientView/structuralVariant/PatientViewStructuralVariantTable.tsx
@@ -1,0 +1,426 @@
+import * as React from 'react';
+import { computed } from 'mobx';
+import { observer } from 'mobx-react';
+import { PatientViewPageStore } from '../clinicalInformation/PatientViewPageStore';
+import LazyMobXTable, {
+    Column,
+} from 'shared/components/lazyMobXTable/LazyMobXTable';
+import { StructuralVariant } from 'cbioportal-ts-api-client';
+import TumorColumnFormatter from '../mutation/column/TumorColumnFormatter';
+import HeaderIconMenu from '../mutation/HeaderIconMenu';
+import GeneFilterMenu from '../mutation/GeneFilterMenu';
+import PanelColumnFormatter from 'shared/components/mutationTable/column/PanelColumnFormatter';
+import * as _ from 'lodash';
+import { MakeMobxView } from 'shared/components/MobxView';
+import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
+import ErrorMessage from 'shared/components/ErrorMessage';
+import AnnotationColumnFormatter from './column/AnnotationColumnFormatter';
+import AppConfig from 'appConfig';
+import { ServerConfigHelpers } from 'config/config';
+import ChromosomeColumnFormatter from 'shared/components/mutationTable/column/ChromosomeColumnFormatter';
+import { remoteData } from 'cbioportal-frontend-commons';
+
+export interface IPatientViewStructuralVariantTableProps {
+    store: PatientViewPageStore;
+    onSelectGenePanel?: (name: string) => void;
+}
+
+type CNATableColumn = Column<StructuralVariant[]> & { order: number };
+
+class StructuralVariantTableComponent extends LazyMobXTable<
+    StructuralVariant[]
+> {}
+
+@observer
+export default class PatientViewStructuralVariantTable extends React.Component<
+    IPatientViewStructuralVariantTableProps,
+    {}
+> {
+    constructor(props: IPatientViewStructuralVariantTableProps) {
+        super(props);
+    }
+
+    readonly columns = remoteData({
+        await: () => [
+            this.props.store.sampleManager,
+            this.props.store.sampleToStructuralVariantGenePanelId,
+            this.props.store.genePanelIdToEntrezGeneIds,
+            this.props.store.structuralVariantTableShowGeneFilterMenu,
+            this.props.store.oncoKbAnnotatedGenes,
+            this.props.store.studyIdToStudy,
+            this.props.store.oncoKbCancerGenes,
+        ],
+        invoke: async () => {
+            const columns: CNATableColumn[] = [];
+            const numSamples = this.props.store.sampleIds.length;
+
+            if (numSamples >= 2) {
+                columns.push({
+                    name: 'Samples',
+                    render: (d: StructuralVariant[]) =>
+                        TumorColumnFormatter.renderFunction(
+                            d.map(datum => ({
+                                sampleId: datum.sampleId,
+                                entrezGeneId: datum.site1EntrezGeneId,
+                            })),
+                            this.props.store.sampleManager.result!,
+                            this.props.store
+                                .sampleToStructuralVariantGenePanelId.result!,
+                            this.props.store.genePanelIdToEntrezGeneIds.result!,
+                            this.props.onSelectGenePanel
+                        ),
+                    sortBy: (d: StructuralVariant[]) =>
+                        TumorColumnFormatter.getSortValue(
+                            d,
+                            this.props.store.sampleManager.result!
+                        ),
+                    download: (d: StructuralVariant[]) =>
+                        TumorColumnFormatter.getSample(d),
+                    order: 20,
+                    resizable: true,
+                });
+            }
+
+            columns.push({
+                name: 'Gene 1',
+                render: (d: StructuralVariant[]) => (
+                    <span data-test="sv-table-gene1-column">
+                        {d[0].site1HugoSymbol}
+                    </span>
+                ),
+                filter: (
+                    d: StructuralVariant[],
+                    filterString: string,
+                    filterStringUpper: string
+                ) => {
+                    return d[0].site1HugoSymbol.indexOf(filterStringUpper) > -1;
+                },
+                download: (d: StructuralVariant[]) => d[0].site1HugoSymbol,
+                sortBy: (d: StructuralVariant[]) => d[0].site1HugoSymbol,
+                headerRender: (name: string) => {
+                    return (
+                        <HeaderIconMenu
+                            name={name}
+                            showIcon={
+                                this.props.store
+                                    .structuralVariantTableShowGeneFilterMenu
+                                    .result
+                            }
+                        >
+                            <GeneFilterMenu
+                                onOptionChanged={
+                                    this.props.store
+                                        .onFilterGenesStructuralVariantTable
+                                }
+                                currentSelection={
+                                    this.props.store
+                                        .structuralVariantTableGeneFilterOption
+                                }
+                            />
+                        </HeaderIconMenu>
+                    );
+                },
+                visible: true,
+                order: 30,
+            });
+
+            columns.push({
+                name: 'Gene 2',
+                render: (d: StructuralVariant[]) => (
+                    <span data-test="sv-table-gene2-column">
+                        {d[0].site2HugoSymbol}
+                    </span>
+                ),
+                filter: (
+                    d: StructuralVariant[],
+                    filterString: string,
+                    filterStringUpper: string
+                ) => {
+                    return (
+                        (d[0].site2HugoSymbol || '').indexOf(
+                            filterStringUpper
+                        ) > -1
+                    );
+                },
+                download: (d: StructuralVariant[]) => d[0].site2HugoSymbol,
+                sortBy: (d: StructuralVariant[]) => d[0].site2HugoSymbol,
+                headerRender: (name: string) => {
+                    return (
+                        <HeaderIconMenu
+                            name={name}
+                            showIcon={
+                                this.props.store
+                                    .structuralVariantTableShowGeneFilterMenu
+                                    .result
+                            }
+                        >
+                            <GeneFilterMenu
+                                onOptionChanged={
+                                    this.props.store
+                                        .onFilterGenesStructuralVariantTable
+                                }
+                                currentSelection={
+                                    this.props.store
+                                        .structuralVariantTableGeneFilterOption
+                                }
+                            />
+                        </HeaderIconMenu>
+                    );
+                },
+                visible: true,
+                order: 35,
+            });
+
+            const genePanelProps = (d: StructuralVariant[]) => ({
+                data: d.map(datum => ({
+                    sampleId: datum.sampleId,
+                    entrezGeneId: datum.site1EntrezGeneId,
+                })),
+                sampleToGenePanelId: this.props.store
+                    .sampleToStructuralVariantGenePanelId.result!,
+                sampleManager: this.props.store.sampleManager.result!,
+                genePanelIdToGene: this.props.store.genePanelIdToEntrezGeneIds
+                    .result!,
+                onSelectGenePanel: this.props.onSelectGenePanel,
+            });
+
+            columns.push({
+                name: 'Gene panel',
+                render: (d: StructuralVariant[]) =>
+                    PanelColumnFormatter.renderFunction(genePanelProps(d)),
+                download: (d: StructuralVariant[]) =>
+                    PanelColumnFormatter.download(genePanelProps(d)),
+                sortBy: (d: StructuralVariant[]) =>
+                    PanelColumnFormatter.getGenePanelIds(genePanelProps(d)),
+                visible: false,
+                order: 40,
+            });
+
+            columns.push({
+                name: 'Annotation',
+                render: (d: StructuralVariant[]) =>
+                    AnnotationColumnFormatter.renderFunction(d, {
+                        uniqueSampleKeyToTumorType: this.props.store
+                            .uniqueSampleKeyToTumorType,
+                        oncoKbData: this.props.store
+                            .structuralVariantOncoKbData,
+                        oncoKbCancerGenes: this.props.store.oncoKbCancerGenes,
+                        usingPublicOncoKbInstance: this.props.store
+                            .usingPublicOncoKbInstance,
+                        enableOncoKb: AppConfig.serverConfig
+                            .show_oncokb as boolean,
+                        pubMedCache: this.props.store.pubMedCache,
+                        enableCivic: false,
+                        enableMyCancerGenome: false,
+                        enableHotspot: false,
+                        userEmailAddress: ServerConfigHelpers.getUserEmailAddress(),
+                        studyIdToStudy: this.props.store.studyIdToStudy.result,
+                    }),
+                sortBy: (d: StructuralVariant[]) => {
+                    return AnnotationColumnFormatter.sortValue(
+                        d,
+                        this.props.store.oncoKbCancerGenes,
+                        this.props.store.usingPublicOncoKbInstance,
+                        this.props.store.structuralVariantOncoKbData,
+                        this.props.store.uniqueSampleKeyToTumorType
+                    );
+                },
+                order: 45,
+            });
+
+            columns.push({
+                name: 'Variant Class',
+                render: (d: StructuralVariant[]) => (
+                    <span>{d[0].variantClass}</span>
+                ),
+                filter: (
+                    d: StructuralVariant[],
+                    filterString: string,
+                    filterStringUpper: string
+                ) => {
+                    return (
+                        d[0].variantClass
+                            .toUpperCase()
+                            .indexOf(filterStringUpper) > -1
+                    );
+                },
+                download: (d: StructuralVariant[]) => d[0].variantClass,
+                sortBy: (d: StructuralVariant[]) => d[0].variantClass,
+                visible: true,
+                order: 50,
+            });
+
+            columns.push({
+                name: 'Site1 Chromosome',
+                render: (d: StructuralVariant[]) => (
+                    <span>
+                        {ChromosomeColumnFormatter.getData(
+                            d.map(datum => ({ chr: datum.site1Chromosome }))
+                        )}
+                    </span>
+                ),
+                download: (d: StructuralVariant[]) =>
+                    ChromosomeColumnFormatter.getData(
+                        d.map(datum => ({ chr: datum.site1Chromosome }))
+                    ) || '',
+                sortBy: (d: StructuralVariant[]) =>
+                    ChromosomeColumnFormatter.getSortValue(
+                        d.map(datum => ({ chr: datum.site1Chromosome }))
+                    ),
+                filter: (
+                    d: StructuralVariant[],
+                    filterString: string,
+                    filterStringUpper: string
+                ) =>
+                    (
+                        ChromosomeColumnFormatter.getData(
+                            d.map(datum => ({ chr: datum.site1Chromosome }))
+                        ) + ''
+                    )
+                        .toUpperCase()
+                        .includes(filterStringUpper),
+                visible: false,
+                order: 51,
+            });
+
+            columns.push({
+                name: 'Site2 Chromosome',
+                render: (d: StructuralVariant[]) => (
+                    <span>
+                        {ChromosomeColumnFormatter.getData(
+                            d.map(datum => ({ chr: datum.site2Chromosome }))
+                        )}
+                    </span>
+                ),
+                download: (d: StructuralVariant[]) =>
+                    ChromosomeColumnFormatter.getData(
+                        d.map(datum => ({ chr: datum.site2Chromosome }))
+                    ) || '',
+                sortBy: (d: StructuralVariant[]) =>
+                    ChromosomeColumnFormatter.getSortValue(
+                        d.map(datum => ({ chr: datum.site2Chromosome }))
+                    ),
+                filter: (
+                    d: StructuralVariant[],
+                    filterString: string,
+                    filterStringUpper: string
+                ) =>
+                    (
+                        ChromosomeColumnFormatter.getData(
+                            d.map(datum => ({ chr: datum.site2Chromosome }))
+                        ) + ''
+                    )
+                        .toUpperCase()
+                        .includes(filterStringUpper),
+                visible: false,
+                order: 52,
+            });
+
+            columns.push({
+                name: 'Site1 Position',
+                render: (d: StructuralVariant[]) => (
+                    <span>{d[0].site1Position}</span>
+                ),
+                download: (d: StructuralVariant[]) => `${d[0].site1Position}`,
+                sortBy: (d: StructuralVariant[]) => `${d[0].site1Position}`,
+                visible: false,
+                order: 55,
+            });
+
+            columns.push({
+                name: 'Site2 Position',
+                render: (d: StructuralVariant[]) => (
+                    <span>{d[0].site2Position}</span>
+                ),
+                download: (d: StructuralVariant[]) => `${d[0].site2Position}`,
+                sortBy: (d: StructuralVariant[]) => `${d[0].site2Position}`,
+                visible: false,
+                order: 65,
+            });
+
+            columns.push({
+                name: 'Event Info',
+                render: (d: StructuralVariant[]) => (
+                    <span>{d[0].eventInfo}</span>
+                ),
+                download: (d: StructuralVariant[]) => d[0].eventInfo,
+                sortBy: (d: StructuralVariant[]) => d[0].eventInfo,
+                visible: false,
+                order: 66,
+            });
+
+            columns.push({
+                name: 'Connection Type',
+                render: (d: StructuralVariant[]) => (
+                    <span>{d[0].connectionType}</span>
+                ),
+                download: (d: StructuralVariant[]) => d[0].connectionType,
+                sortBy: (d: StructuralVariant[]) => d[0].connectionType,
+                visible: true,
+                order: 70,
+            });
+
+            columns.push({
+                name: 'Breakpoint Type',
+                render: (d: StructuralVariant[]) => (
+                    <span>{d[0].breakpointType}</span>
+                ),
+                download: (d: StructuralVariant[]) => d[0].breakpointType,
+                sortBy: (d: StructuralVariant[]) => d[0].breakpointType,
+                visible: false,
+                order: 75,
+            });
+
+            columns.push({
+                name: 'Additional Annotation',
+                render: (d: StructuralVariant[]) => (
+                    <span>{d[0].annotation}</span>
+                ),
+                download: (d: StructuralVariant[]) => d[0].annotation,
+                sortBy: (d: StructuralVariant[]) => d[0].annotation,
+                visible: false,
+                order: 80,
+            });
+
+            return _.sortBy(columns, (c: CNATableColumn) => c.order);
+        },
+        default: [],
+    });
+
+    readonly tableUI = MakeMobxView({
+        await: () => [
+            this.props.store.structuralVariantProfile,
+            this.props.store.groupedStructuralVariantData,
+            this.columns,
+        ],
+        render: () => {
+            if (
+                this.props.store.structuralVariantProfile.result === undefined
+            ) {
+                return (
+                    <div className="alert alert-info" role="alert">
+                        Structural Variants are not available.
+                    </div>
+                );
+            }
+            return (
+                <StructuralVariantTableComponent
+                    columns={this.columns.result}
+                    data={this.props.store.groupedStructuralVariantData.result!}
+                    initialSortColumn="Annotation"
+                    initialSortDirection="desc"
+                    initialItemsPerPage={10}
+                    itemsLabel="Structural Variants"
+                    itemsLabelPlural="Structural Variants"
+                    showCountHeader={true}
+                />
+            );
+        },
+        renderPending: () => <LoadingIndicator isLoading={true} />,
+        renderError: () => <ErrorMessage />,
+    });
+
+    public render() {
+        return this.tableUI.component;
+    }
+}

--- a/src/pages/patientView/structuralVariant/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/structuralVariant/column/AnnotationColumnFormatter.tsx
@@ -1,0 +1,207 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {
+    civicSortValue,
+    DEFAULT_ANNOTATION_DATA,
+    GenericAnnotation,
+    IAnnotation,
+    USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
+    oncoKbAnnotationSortValue,
+    RemoteData,
+} from 'react-mutation-mapper';
+import { CancerStudy, StructuralVariant } from 'cbioportal-ts-api-client';
+import { IAnnotationColumnProps } from 'shared/components/mutationTable/column/AnnotationColumnFormatter';
+import {
+    IOncoKbData,
+    generateQueryStructuralVariantId,
+} from 'cbioportal-frontend-commons';
+import { CancerGene, IndicatorQueryResp } from 'oncokb-ts-api-client';
+
+export default class AnnotationColumnFormatter {
+    public static getData(
+        structuralVariantData: StructuralVariant[] | undefined,
+        oncoKbCancerGenes?: RemoteData<CancerGene[] | Error | undefined>,
+        oncoKbData?: RemoteData<IOncoKbData | Error | undefined>,
+        usingPublicOncoKbInstance?: boolean,
+        uniqueSampleKeyToTumorType?: { [sampleId: string]: string },
+        studyIdToStudy?: { [studyId: string]: CancerStudy }
+    ) {
+        let value: IAnnotation;
+
+        if (structuralVariantData) {
+            let oncoKbIndicator: IndicatorQueryResp | undefined = undefined;
+            let oncoKbStatus: IAnnotation['oncoKbStatus'] = 'complete';
+
+            let oncoKbGeneExist = false;
+            let isOncoKbCancerGene = false;
+            let isSite1GeneOncoKbAnnotated = false;
+            let isSite1oncoKbCancerGene = false;
+            let isSite2GeneOncoKbAnnotated = false;
+            let isSite2oncoKbCancerGene = false;
+            if (
+                oncoKbCancerGenes &&
+                !(oncoKbCancerGenes instanceof Error) &&
+                !(oncoKbCancerGenes.result instanceof Error)
+            ) {
+                const oncoKbCancerGeneSetByEntrezGeneId = _.keyBy(
+                    oncoKbCancerGenes.result,
+                    gene => gene.entrezGeneId
+                );
+                isSite1oncoKbCancerGene =
+                    oncoKbCancerGeneSetByEntrezGeneId[
+                        structuralVariantData[0].site1EntrezGeneId
+                    ] !== undefined;
+                isSite2oncoKbCancerGene =
+                    oncoKbCancerGeneSetByEntrezGeneId[
+                        structuralVariantData[0].site2EntrezGeneId
+                    ] !== undefined;
+                isSite1GeneOncoKbAnnotated =
+                    isSite1oncoKbCancerGene &&
+                    oncoKbCancerGeneSetByEntrezGeneId[
+                        structuralVariantData[0].site1EntrezGeneId
+                    ].oncokbAnnotated;
+                isSite2GeneOncoKbAnnotated =
+                    isSite2oncoKbCancerGene &&
+                    oncoKbCancerGeneSetByEntrezGeneId[
+                        structuralVariantData[0].site2EntrezGeneId
+                    ].oncokbAnnotated;
+                oncoKbGeneExist =
+                    isSite1GeneOncoKbAnnotated || isSite2GeneOncoKbAnnotated;
+                isOncoKbCancerGene =
+                    isSite1oncoKbCancerGene || isSite2oncoKbCancerGene;
+            }
+
+            // oncoKbData may exist but it might be an instance of Error, in that case we flag the status as error
+            if (oncoKbData && oncoKbData.result instanceof Error) {
+                oncoKbStatus = 'error';
+            } else if (oncoKbGeneExist) {
+                // actually, oncoKbData.result shouldn't be an instance of Error in this case (we already check it above),
+                // but we need to check it again in order to avoid TS errors/warnings
+                if (
+                    oncoKbData &&
+                    oncoKbData.result &&
+                    !(oncoKbData.result instanceof Error) &&
+                    oncoKbData.isComplete
+                ) {
+                    oncoKbIndicator = this.getIndicatorData(
+                        structuralVariantData,
+                        oncoKbData.result,
+                        uniqueSampleKeyToTumorType,
+                        studyIdToStudy
+                    );
+                }
+                oncoKbStatus = oncoKbData ? oncoKbData.status : 'pending';
+            }
+
+            const site1HugoSymbol = structuralVariantData[0].site1HugoSymbol;
+            const site2HugoSymbol = structuralVariantData[0].site2HugoSymbol;
+            let hugoGeneSymbol = site1HugoSymbol;
+            if (oncoKbGeneExist) {
+                hugoGeneSymbol = isSite1GeneOncoKbAnnotated
+                    ? site1HugoSymbol
+                    : site2HugoSymbol;
+            } else if (isOncoKbCancerGene) {
+                hugoGeneSymbol = isSite1oncoKbCancerGene
+                    ? site1HugoSymbol
+                    : site2HugoSymbol;
+            }
+
+            value = {
+                hugoGeneSymbol,
+                oncoKbStatus,
+                oncoKbIndicator,
+                oncoKbGeneExist,
+                isOncoKbCancerGene,
+                usingPublicOncoKbInstance:
+                    usingPublicOncoKbInstance === undefined
+                        ? USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB
+                        : usingPublicOncoKbInstance,
+                civicEntry: undefined,
+                civicStatus: 'complete',
+                hasCivicVariants: false,
+                myCancerGenomeLinks: [],
+                hotspotStatus: 'complete',
+                isHotspot: false,
+                is3dHotspot: false,
+            };
+        } else {
+            value = DEFAULT_ANNOTATION_DATA;
+        }
+
+        return value;
+    }
+
+    public static getIndicatorData(
+        structuralVariantData: StructuralVariant[],
+        oncoKbData: IOncoKbData,
+        uniqueSampleKeyToTumorType?: { [sampleId: string]: string },
+        studyIdToStudy?: { [studyId: string]: CancerStudy }
+    ): IndicatorQueryResp | undefined {
+        if (
+            uniqueSampleKeyToTumorType === null ||
+            oncoKbData.indicatorMap === null
+        ) {
+            return undefined;
+        }
+
+        const id = generateQueryStructuralVariantId(
+            structuralVariantData[0].site1EntrezGeneId,
+            structuralVariantData[0].site2EntrezGeneId,
+            uniqueSampleKeyToTumorType![
+                structuralVariantData[0].uniqueSampleKey
+            ]
+        );
+
+        if (oncoKbData.indicatorMap[id]) {
+            let indicator = oncoKbData.indicatorMap[id];
+            if (indicator.query.tumorType === null && studyIdToStudy) {
+                const studyMetaData =
+                    studyIdToStudy[structuralVariantData[0].studyId];
+                if (studyMetaData.cancerTypeId !== 'mixed') {
+                    indicator.query.tumorType = studyMetaData.cancerType.name;
+                }
+            }
+            return indicator;
+        } else {
+            return undefined;
+        }
+    }
+
+    public static sortValue(
+        data: StructuralVariant[],
+        oncoKbCancerGenes?: RemoteData<CancerGene[] | Error | undefined>,
+        usingPublicOncoKbInstance?: boolean,
+        oncoKbData?: RemoteData<IOncoKbData | Error | undefined>,
+        uniqueSampleKeyToTumorType?: { [sampleId: string]: string }
+    ): number[] {
+        const annotationData: IAnnotation = this.getData(
+            data,
+            oncoKbCancerGenes,
+            oncoKbData,
+            usingPublicOncoKbInstance,
+            uniqueSampleKeyToTumorType
+        );
+
+        return _.flatten([
+            oncoKbAnnotationSortValue(annotationData.oncoKbIndicator),
+            civicSortValue(annotationData.civicEntry),
+            annotationData.isOncoKbCancerGene ? 1 : 0,
+        ]);
+    }
+
+    public static renderFunction(
+        data: StructuralVariant[],
+        columnProps: IAnnotationColumnProps
+    ) {
+        const annotation: IAnnotation = this.getData(
+            data,
+            columnProps.oncoKbCancerGenes,
+            columnProps.oncoKbData,
+            columnProps.usingPublicOncoKbInstance,
+            columnProps.uniqueSampleKeyToTumorType,
+            columnProps.studyIdToStudy
+        );
+
+        return <GenericAnnotation {...columnProps} annotation={annotation} />;
+    }
+}

--- a/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ChromosomeColumnFormatter.tsx
@@ -4,12 +4,12 @@ import { Mutation } from 'cbioportal-ts-api-client';
  * @author Selcuk Onur Sumer
  */
 export default class ChromosomeColumnFormatter {
-    public static getSortValue(data: Mutation[]): number | null {
-        const chromosome = ChromosomeColumnFormatter.getData(data);
+    public static getSortValue(data: Pick<Mutation, 'chr'>[]): number | null {
+        const chromosome = this.getData(data);
         if (!chromosome) {
             return null;
         } else {
-            return ChromosomeColumnFormatter.extractSortValue(chromosome);
+            return this.extractSortValue(chromosome);
         }
     }
 
@@ -31,7 +31,7 @@ export default class ChromosomeColumnFormatter {
         return value;
     }
 
-    public static getData(data: Mutation[]): string | null {
+    public static getData(data: Pick<Mutation, 'chr'>[]): string | null {
         if (data.length > 0) {
             return data[0].chr;
         } else {


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7545

<img width="1435" alt="Screen Shot 2020-06-09 at 5 56 27 PM" src="https://user-images.githubusercontent.com/12956870/84205200-9d4ca780-aa7a-11ea-8cf2-f4b3fef34dff.png">

To test

https://cbioportal-fix-7545-z0u0djy00p.herokuapp.com and set `localStorage.netlify = "deploy-preview-3270--cbioportalfrontend"`

Example, sample having structural variant data
https://cbioportal-fix-7545-z0u0djy00p.herokuapp.com/patient?studyId=msk_impact_2017&caseId=P-0000373