### PR TITLE
Fix selection of custom driver annotations source in Results View config menu

### DIFF
--- a/end-to-end-test/local/runtime-config/portal.properties
+++ b/end-to-end-test/local/runtime-config/portal.properties
@@ -4,3 +4,8 @@ db.portal_db_name=endtoend_local_cbiodb
 db.connection_string=jdbc:mysql://cbiodb-endtoend:3306/
 db.host=cbiodb-endtoend
 show.oncokb=false
+
+oncoprint.custom_driver_annotation.binary.menu_label=Custom driver annotation
+oncoprint.custom_driver_annotation.tiers.menu_label=Custom driver tiers
+oncoprint.custom_driver_annotation.binary.default=true
+oncoprint.custom_driver_annotation.tiers.default=true

--- a/end-to-end-test/local/specs/custom-driver-annotations.spec.js
+++ b/end-to-end-test/local/specs/custom-driver-annotations.spec.js
@@ -8,8 +8,8 @@ var getReactSelectOptions = require('../../shared/specUtils')
 var selectReactSelectOption = require('../../shared/specUtils')
     .selectReactSelectOption;
 var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
-
-// var { clickQueryByGeneButton } = require('../../shared/specUtils');
+var setResultsPageSettingsMenuOpen = require('../../../shared/specUtils')
+    .setResultsPageSettingsMenuOpen;
 
 const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
 const oncoprintTabUrl =
@@ -17,24 +17,21 @@ const oncoprintTabUrl =
     '/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=study_es_0&case_set_id=study_es_0_all&data_priority=0&gene_list=OR11H1%250ATMEM247%250AABLIM1%250AADAMTS20%250ACADM2%250ADTNB%250AKAT2A%250AMSH3%250AMYB%250ANPIPB15%250AOTOR%250AP2RY10%250APIEZO1&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&profileFilter=0&tab_index=tab_visualize';
 
 describe('custom driver annotations feature', function() {
-
     if (useExternalFrontend) {
-
         describe('oncoprint tab', () => {
             beforeEach(() => {
                 goToUrlAndSetLocalStorage(oncoprintTabUrl);
                 waitForOncoprint();
+                setResultsPageSettingsMenuOpen(true);
             });
 
             it('shows custom driver annotation elements in config menu', () => {
-                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
-                configMenuButton.click();
-                $('label=Custom driver annotation').waitForExist();
-
                 var topCheckBox = $('input[data-test=annotateCustomBinary]');
                 assert(topCheckBox.isSelected());
 
-                var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$('input');
+                var tiersCheckboxes = $(
+                    'span[data-test=annotateCustomTiers]'
+                ).$$('input');
                 assert(tiersCheckboxes[0].isSelected());
                 assert(tiersCheckboxes[1].isSelected());
                 assert(tiersCheckboxes[2].isSelected());
@@ -42,78 +39,84 @@ describe('custom driver annotations feature', function() {
             });
 
             it('allows deselection of Tiers checkboxes', () => {
-                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
-                configMenuButton.click();
-                $('label=Custom driver annotation').waitForExist();
-
                 var class1Checkbox = $('label*=Class 1').$('input');
                 class1Checkbox.click();
                 waitForOncoprint();
-                assert(! class1Checkbox.isSelected());
+                assert(!class1Checkbox.isSelected());
 
                 var class2Checkbox = $('label*=Class 2').$('input');
                 class2Checkbox.click();
                 waitForOncoprint();
-                assert(! class2Checkbox.isSelected());
+                assert(!class2Checkbox.isSelected());
 
                 var class3Checkbox = $('label*=Class 3').$('input');
                 class3Checkbox.click();
                 waitForOncoprint();
-                assert(! class3Checkbox.isSelected());
+                assert(!class3Checkbox.isSelected());
 
                 var class4Checkbox = $('label*=Class 4').$('input');
                 class4Checkbox.click();
                 waitForOncoprint();
-                assert(! class4Checkbox.isSelected());
+                assert(!class4Checkbox.isSelected());
             });
 
             it('updates selected samples when VUS alterations are excluded', () => {
-                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
-                configMenuButton.click();
-                $('label=Custom driver annotation').waitForExist();
-
                 // deselected all checkboxes except Custom driver annotation
                 $('input[data-test=annotateHotspots]').click();
-                $('label*=Class 1').$('input').click();
-                $('label*=Class 2').$('input').click();
-                $('label*=Class 3').$('input').click();
-                $('label*=Class 4').$('input').click();
+                $('label*=Class 1')
+                    .$('input')
+                    .click();
+                $('label*=Class 2')
+                    .$('input')
+                    .click();
+                $('label*=Class 3')
+                    .$('input')
+                    .click();
+                $('label*=Class 4')
+                    .$('input')
+                    .click();
 
                 $('input[data-test=HideVUS]').click();
                 waitForOncoprint();
                 assert($('div.alert-info*=8 mutations').isExisting());
 
-                $('label*=Class 1').$('input').click();
+                $('label*=Class 1')
+                    .$('input')
+                    .click();
                 waitForOncoprint();
                 assert($('div.alert-info*=6 mutations').isExisting());
 
-                $('label*=Class 2').$('input').click();
+                $('label*=Class 2')
+                    .$('input')
+                    .click();
                 waitForOncoprint();
                 assert($('div.alert-info*=4 mutations').isExisting());
 
-                $('label*=Class 3').$('input').click();
+                $('label*=Class 3')
+                    .$('input')
+                    .click();
                 waitForOncoprint();
                 assert($('div.alert-info*=2 mutations').isExisting());
 
-                $('label*=Class 4').$('input').click();
+                $('label*=Class 4')
+                    .$('input')
+                    .click();
                 waitForOncoprint();
                 assert($('div.alert-info*=1 mutation').isExisting());
             });
 
             it('(de-)selects custom driver checkboxes with main annotation select option', () => {
-                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
-                configMenuButton.click();
-                $('label=Custom driver annotation').waitForExist();
-
                 var topCheckBox = $('input[data-test=annotateCustomBinary]');
-                var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$('input');
+                var tiersCheckboxes = $(
+                    'span[data-test=annotateCustomTiers]'
+                ).$$('input');
 
                 $('input[data-test=ColorByDriver]').click();
-                assert(! topCheckBox.isSelected());
-                assert(! tiersCheckboxes[0].isSelected());
-                assert(! tiersCheckboxes[1].isSelected());
-                assert(! tiersCheckboxes[2].isSelected());
-                assert(! tiersCheckboxes[3].isSelected());
+                assert(!topCheckBox.isSelected());
+                assert(!tiersCheckboxes[0].isSelected());
+                assert(!tiersCheckboxes[1].isSelected());
+                assert(!tiersCheckboxes[2].isSelected());
+                assert(!tiersCheckboxes[3].isSelected());
 
                 $('input[data-test=ColorByDriver]').click();
                 assert(topCheckBox.isSelected());
@@ -121,9 +124,7 @@ describe('custom driver annotations feature', function() {
                 assert(tiersCheckboxes[1].isSelected());
                 assert(tiersCheckboxes[2].isSelected());
                 assert(tiersCheckboxes[3].isSelected());
-
             });
-
         });
     }
 });

--- a/end-to-end-test/local/specs/custom-driver-annotations.spec.js
+++ b/end-to-end-test/local/specs/custom-driver-annotations.spec.js
@@ -18,9 +18,7 @@ const oncoprintTabUrl =
 
 describe('custom driver annotations feature', function() {
     if (useExternalFrontend) {
-        
         describe('oncoprint tab', () => {
-            
             beforeEach(() => {
                 goToUrlAndSetLocalStorage(oncoprintTabUrl);
                 waitForOncoprint(100000);
@@ -75,7 +73,6 @@ describe('custom driver annotations feature', function() {
                     .click();
                 waitForOncoprint();
                 assert(!$('div.alert-info').isExisting());
-
             });
 
             it('(de-)selects custom driver checkboxes with main annotation select option', () => {

--- a/end-to-end-test/local/specs/custom-driver-annotations.spec.js
+++ b/end-to-end-test/local/specs/custom-driver-annotations.spec.js
@@ -1,0 +1,129 @@
+var assert = require('assert');
+var goToUrlAndSetLocalStorage = require('../../shared/specUtils')
+    .goToUrlAndSetLocalStorage;
+var waitForOncoprint = require('../../shared/specUtils').waitForOncoprint;
+var reactSelectOption = require('../../shared/specUtils').reactSelectOption;
+var getReactSelectOptions = require('../../shared/specUtils')
+    .getReactSelectOptions;
+var selectReactSelectOption = require('../../shared/specUtils')
+    .selectReactSelectOption;
+var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
+
+// var { clickQueryByGeneButton } = require('../../shared/specUtils');
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+const oncoprintTabUrl =
+    CBIOPORTAL_URL +
+    '/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=study_es_0&case_set_id=study_es_0_all&data_priority=0&gene_list=OR11H1%250ATMEM247%250AABLIM1%250AADAMTS20%250ACADM2%250ADTNB%250AKAT2A%250AMSH3%250AMYB%250ANPIPB15%250AOTOR%250AP2RY10%250APIEZO1&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&profileFilter=0&tab_index=tab_visualize';
+
+describe('custom driver annotations feature', function() {
+
+    if (useExternalFrontend) {
+
+        describe('oncoprint tab', () => {
+            beforeEach(() => {
+                goToUrlAndSetLocalStorage(oncoprintTabUrl);
+                waitForOncoprint();
+            });
+
+            it('shows custom driver annotation elements in config menu', () => {
+                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
+                configMenuButton.click();
+                $('label=Custom driver annotation').waitForExist();
+
+                var topCheckBox = $('input[data-test=annotateCustomBinary]');
+                assert(topCheckBox.isSelected());
+
+                var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$('input');
+                assert(tiersCheckboxes[0].isSelected());
+                assert(tiersCheckboxes[1].isSelected());
+                assert(tiersCheckboxes[2].isSelected());
+                assert(tiersCheckboxes[3].isSelected());
+            });
+
+            it('allows deselection of Tiers checkboxes', () => {
+                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
+                configMenuButton.click();
+                $('label=Custom driver annotation').waitForExist();
+
+                var class1Checkbox = $('label*=Class 1').$('input');
+                class1Checkbox.click();
+                waitForOncoprint();
+                assert(! class1Checkbox.isSelected());
+
+                var class2Checkbox = $('label*=Class 2').$('input');
+                class2Checkbox.click();
+                waitForOncoprint();
+                assert(! class2Checkbox.isSelected());
+
+                var class3Checkbox = $('label*=Class 3').$('input');
+                class3Checkbox.click();
+                waitForOncoprint();
+                assert(! class3Checkbox.isSelected());
+
+                var class4Checkbox = $('label*=Class 4').$('input');
+                class4Checkbox.click();
+                waitForOncoprint();
+                assert(! class4Checkbox.isSelected());
+            });
+
+            it('updates selected samples when VUS alterations are excluded', () => {
+                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
+                configMenuButton.click();
+                $('label=Custom driver annotation').waitForExist();
+
+                // deselected all checkboxes except Custom driver annotation
+                $('input[data-test=annotateHotspots]').click();
+                $('label*=Class 1').$('input').click();
+                $('label*=Class 2').$('input').click();
+                $('label*=Class 3').$('input').click();
+                $('label*=Class 4').$('input').click();
+
+                $('input[data-test=HideVUS]').click();
+                waitForOncoprint();
+                assert($('div.alert-info*=8 mutations').isExisting());
+
+                $('label*=Class 1').$('input').click();
+                waitForOncoprint();
+                assert($('div.alert-info*=6 mutations').isExisting());
+
+                $('label*=Class 2').$('input').click();
+                waitForOncoprint();
+                assert($('div.alert-info*=4 mutations').isExisting());
+
+                $('label*=Class 3').$('input').click();
+                waitForOncoprint();
+                assert($('div.alert-info*=2 mutations').isExisting());
+
+                $('label*=Class 4').$('input').click();
+                waitForOncoprint();
+                assert($('div.alert-info*=1 mutation').isExisting());
+            });
+
+            it('(de-)selects custom driver checkboxes with main annotation select option', () => {
+                var configMenuButton = browser.$('button[data-test=GlobalSettingsButton]');
+                configMenuButton.click();
+                $('label=Custom driver annotation').waitForExist();
+
+                var topCheckBox = $('input[data-test=annotateCustomBinary]');
+                var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$('input');
+
+                $('input[data-test=ColorByDriver]').click();
+                assert(! topCheckBox.isSelected());
+                assert(! tiersCheckboxes[0].isSelected());
+                assert(! tiersCheckboxes[1].isSelected());
+                assert(! tiersCheckboxes[2].isSelected());
+                assert(! tiersCheckboxes[3].isSelected());
+
+                $('input[data-test=ColorByDriver]').click();
+                assert(topCheckBox.isSelected());
+                assert(tiersCheckboxes[0].isSelected());
+                assert(tiersCheckboxes[1].isSelected());
+                assert(tiersCheckboxes[2].isSelected());
+                assert(tiersCheckboxes[3].isSelected());
+
+            });
+
+        });
+    }
+});

--- a/end-to-end-test/local/specs/custom-driver-annotations.spec.js
+++ b/end-to-end-test/local/specs/custom-driver-annotations.spec.js
@@ -8,20 +8,22 @@ var getReactSelectOptions = require('../../shared/specUtils')
 var selectReactSelectOption = require('../../shared/specUtils')
     .selectReactSelectOption;
 var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
-var setResultsPageSettingsMenuOpen = require('../../../shared/specUtils')
+var setResultsPageSettingsMenuOpen = require('../../shared/specUtils')
     .setResultsPageSettingsMenuOpen;
 
 const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
 const oncoprintTabUrl =
     CBIOPORTAL_URL +
-    '/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=study_es_0&case_set_id=study_es_0_all&data_priority=0&gene_list=OR11H1%250ATMEM247%250AABLIM1%250AADAMTS20%250ACADM2%250ADTNB%250AKAT2A%250AMSH3%250AMYB%250ANPIPB15%250AOTOR%250AP2RY10%250APIEZO1&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&profileFilter=0&tab_index=tab_visualize';
+    '/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=study_es_0&case_set_id=study_es_0_all&data_priority=0&gene_list=ABLIM1%250ATMEM247&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&profileFilter=0&tab_index=tab_visualize';
 
 describe('custom driver annotations feature', function() {
     if (useExternalFrontend) {
+        
         describe('oncoprint tab', () => {
+            
             beforeEach(() => {
                 goToUrlAndSetLocalStorage(oncoprintTabUrl);
-                waitForOncoprint();
+                waitForOncoprint(100000);
                 setResultsPageSettingsMenuOpen(true);
             });
 
@@ -34,8 +36,6 @@ describe('custom driver annotations feature', function() {
                 ).$$('input');
                 assert(tiersCheckboxes[0].isSelected());
                 assert(tiersCheckboxes[1].isSelected());
-                assert(tiersCheckboxes[2].isSelected());
-                assert(tiersCheckboxes[3].isSelected());
             });
 
             it('allows deselection of Tiers checkboxes', () => {
@@ -48,16 +48,6 @@ describe('custom driver annotations feature', function() {
                 class2Checkbox.click();
                 waitForOncoprint();
                 assert(!class2Checkbox.isSelected());
-
-                var class3Checkbox = $('label*=Class 3').$('input');
-                class3Checkbox.click();
-                waitForOncoprint();
-                assert(!class3Checkbox.isSelected());
-
-                var class4Checkbox = $('label*=Class 4').$('input');
-                class4Checkbox.click();
-                waitForOncoprint();
-                assert(!class4Checkbox.isSelected());
             });
 
             it('updates selected samples when VUS alterations are excluded', () => {
@@ -69,40 +59,23 @@ describe('custom driver annotations feature', function() {
                 $('label*=Class 2')
                     .$('input')
                     .click();
-                $('label*=Class 3')
-                    .$('input')
-                    .click();
-                $('label*=Class 4')
-                    .$('input')
-                    .click();
 
                 $('input[data-test=HideVUS]').click();
                 waitForOncoprint();
-                assert($('div.alert-info*=8 mutations').isExisting());
+                assert($('div.alert-info*=1 mutation').isExisting());
 
                 $('label*=Class 1')
                     .$('input')
                     .click();
                 waitForOncoprint();
-                assert($('div.alert-info*=6 mutations').isExisting());
+                assert($('div.alert-info*=1 mutation').isExisting());
 
                 $('label*=Class 2')
                     .$('input')
                     .click();
                 waitForOncoprint();
-                assert($('div.alert-info*=4 mutations').isExisting());
+                assert(!$('div.alert-info').isExisting());
 
-                $('label*=Class 3')
-                    .$('input')
-                    .click();
-                waitForOncoprint();
-                assert($('div.alert-info*=2 mutations').isExisting());
-
-                $('label*=Class 4')
-                    .$('input')
-                    .click();
-                waitForOncoprint();
-                assert($('div.alert-info*=1 mutation').isExisting());
             });
 
             it('(de-)selects custom driver checkboxes with main annotation select option', () => {
@@ -115,15 +88,11 @@ describe('custom driver annotations feature', function() {
                 assert(!topCheckBox.isSelected());
                 assert(!tiersCheckboxes[0].isSelected());
                 assert(!tiersCheckboxes[1].isSelected());
-                assert(!tiersCheckboxes[2].isSelected());
-                assert(!tiersCheckboxes[3].isSelected());
 
                 $('input[data-test=ColorByDriver]').click();
                 assert(topCheckBox.isSelected());
                 assert(tiersCheckboxes[0].isSelected());
                 assert(tiersCheckboxes[1].isSelected());
-                assert(tiersCheckboxes[2].isSelected());
-                assert(tiersCheckboxes[3].isSelected());
             });
         });
     }

--- a/end-to-end-test/local/specs/gsva.spec.js
+++ b/end-to-end-test/local/specs/gsva.spec.js
@@ -177,13 +177,9 @@ describe('gsva feature', function() {
             });
 
             it('adds gene set name to entry component', () => {
-                console.log('A');
                 $('button[data-test=GENESET_VOLCANO_BUTTON]').waitForExist();
-                console.log('B');
                 browser.$('button[data-test=GENESET_VOLCANO_BUTTON]').click();
-                console.log('C');
                 $('div.modal-dialog').waitForExist();
-                console.log('D');
                 // find the GO_ATP_DEPENDENT_CHROMATIN_REMODELING entry and check its checkbox
                 $('span=GO_ATP_DEPENDENT_CHROMATIN_REMODELING').waitForExist();
                 var checkBox = $('span=GO_ATP_DEPENDENT_CHROMATIN_REMODELING')
@@ -191,27 +187,19 @@ describe('gsva feature', function() {
                     .$('..')
                     .$$('td')[3]
                     .$('label input');
-                console.log('E');
                 checkBox.waitForVisible();
-                console.log('F');
                 browser.waitUntil(() => {
                     checkBox.click();
                     return checkBox.isSelected();
                 });
 
-                console.log('G');
                 $('button=Add selection to the query').waitForExist();
-                console.log('H');
                 browser.$('button=Add selection to the query').click();
 
-                console.log('I');
                 $('span*=All gene sets are valid').waitForExist();
 
-                console.log('J');
                 var textArea = browser.$('[data-test=GENESETS_TEXT_AREA]');
-                console.log('K');
                 textArea.waitForExist();
-                console.log('L');
                 assert.equal(
                     textArea.getText(),
                     'GO_ATP_DEPENDENT_CHROMATIN_REMODELING'

--- a/end-to-end-test/shared/read_portalproperties.py
+++ b/end-to-end-test/shared/read_portalproperties.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 import sys
-import yaml
-import re
 
 filename = sys.argv[1]
 with open(filename, 'r') as f:
   for l in f:
-    e = l.rstrip().split("=")
-    e[0] = e[0].replace(".","_").upper()
-    print('export '+e[0].rstrip()+"="+e[1].rstrip())
+    l = l.strip()
+    if l:
+      e = l.split("=")
+      e[0] = e[0].replace(".","_").upper()
+      print('export '+e[0].rstrip()+"="+e[1].rstrip())

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:watch": "yarn run test -- --watch",
     "test:debug": "yarn run test -- --debug --browsers=Chrome_with_debugging --single-run=false",
     "prettierFixCurrentChanges": "STAGED_AND_CHANGED_FILES=$(git diff HEAD --name-only --cached --diff-filter=d) && ([ -z \"$STAGED_AND_CHANGED_FILES\" ] && echo \"Nothing to prettify\" || (yarn run prettier --write $(echo $STAGED_AND_CHANGED_FILES) && git add -f $(echo $STAGED_AND_CHANGED_FILES)))",
-    "prettierCheckCircleCI": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && CHANGED_FILES=$(git diff origin/$(echo $BRANCH_ENV) --name-only --diff-filter=d) && [ ! -z \"$CHANGED_FILES\" ] && yarn run prettier -c $(echo $CHANGED_FILES)",
+    "prettierCheckCircleCI": "./scripts/env_vars.sh && eval \"$(./scripts/env_vars.sh)\" && git remote add cbio-repo https://github.com/cBioPortal/cbioportal-frontend.git && git fetch cbio-repo $(echo $BRANCH_ENV) && CHANGED_FILES=$(git diff cbio-repo/$(echo $BRANCH_ENV) --name-only --diff-filter=d) && [ ! -z \"$CHANGED_FILES\" ] && yarn run prettier -c $(echo $CHANGED_FILES) && git remote remove cbio-repo",
     "prettierFixLocal": "CHANGED_FILES=$(git diff $(echo $BRANCH_ENV) --name-only --diff-filter=d) && ([ ! -z \"$CHANGED_FILES\" ] && yarn run prettier --write $(echo $CHANGED_FILES) || echo \"Nothing to prettify\")",
     "prettierAll": "yarn run prettier --write $(git ls-files | grep '\\(.js\\|.ts\\|.scss\\|.css\\)')",
     "checkIncorrectImportStatements": "./scripts/check_incorrect_import_statements.sh",

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -465,10 +465,10 @@ export class ResultsViewPageStore {
             cosmicCountThreshold: 0,
             driverTiers: observable.map<boolean>(),
 
-            _customBinary: undefined,
             _hotspots: false,
             _oncoKb: false,
             _excludeVUS: false,
+            _customBinary: undefined,
 
             set hotspots(val: boolean) {
                 this._hotspots = val;
@@ -518,13 +518,15 @@ export class ResultsViewPageStore {
                 return anySelected;
             },
 
+            set customBinary(val: boolean) {
+                this._customBinary = val;
+            },
             get customBinary() {
                 return this._customBinary === undefined
                     ? AppConfig.serverConfig
                           .oncoprint_custom_driver_annotation_binary_default
                     : this._customBinary;
             },
-
             get customTiersDefault() {
                 return AppConfig.serverConfig
                     .oncoprint_custom_driver_annotation_tiers_default;

--- a/src/pages/resultsView/settings/DriverAnnotationControls.tsx
+++ b/src/pages/resultsView/settings/DriverAnnotationControls.tsx
@@ -108,7 +108,6 @@ export default class DriverAnnotationControls extends React.Component<
     private onCustomDriverTierCheckboxClick(
         event: React.MouseEvent<HTMLInputElement>
     ) {
-        let a = 1;
         this.props.handlers.onSelectCustomDriverAnnotationTier &&
             this.props.handlers.onSelectCustomDriverAnnotationTier(
                 (event.target as HTMLInputElement).value,

--- a/src/pages/resultsView/settings/DriverAnnotationControls.tsx
+++ b/src/pages/resultsView/settings/DriverAnnotationControls.tsx
@@ -359,7 +359,7 @@ export default class DriverAnnotationControls extends React.Component<
                     )}
                     {!!this.props.state
                         .customDriverAnnotationTiersMenuLabel && (
-                        <span>
+                        <span data-test="annotateCustomTiers" >
                             <span className="caret" />
                             &nbsp;&nbsp;
                             <span>

--- a/src/pages/resultsView/settings/DriverAnnotationControls.tsx
+++ b/src/pages/resultsView/settings/DriverAnnotationControls.tsx
@@ -44,9 +44,6 @@ export interface IDriverAnnotationControlsHandlers {
     onChangeAnnotateCOSMICInputValue?: (value: string) => void;
     onSelectCustomDriverAnnotationBinary?: (s: boolean) => void;
     onSelectCustomDriverAnnotationTier?: (value: string, s: boolean) => void;
-    onCustomDriverTierCheckboxClick?: (
-        event: React.MouseEvent<HTMLInputElement>
-    ) => void;
 }
 
 export interface IDriverAnnotationControlsProps {
@@ -105,6 +102,23 @@ export default class DriverAnnotationControls extends React.Component<
                     );
                 break;
         }
+    }
+
+    @autobind
+    private onCustomDriverTierCheckboxClick(
+        event: React.MouseEvent<HTMLInputElement>
+    ) {
+        let a = 1;
+        this.props.handlers.onSelectCustomDriverAnnotationTier &&
+            this.props.handlers.onSelectCustomDriverAnnotationTier(
+                (event.target as HTMLInputElement).value,
+                !(
+                    this.props.state.selectedCustomDriverAnnotationTiers &&
+                    this.props.state.selectedCustomDriverAnnotationTiers.get(
+                        (event.target as HTMLInputElement).value
+                    )
+                )
+            );
     }
 
     render() {
@@ -385,7 +399,7 @@ export default class DriverAnnotationControls extends React.Component<
                                                     )
                                                 }
                                                 onClick={
-                                                    this.props.handlers
+                                                    this
                                                         .onCustomDriverTierCheckboxClick
                                                 }
                                             />{' '}

--- a/src/pages/resultsView/settings/DriverAnnotationControls.tsx
+++ b/src/pages/resultsView/settings/DriverAnnotationControls.tsx
@@ -359,7 +359,7 @@ export default class DriverAnnotationControls extends React.Component<
                     )}
                     {!!this.props.state
                         .customDriverAnnotationTiersMenuLabel && (
-                        <span data-test="annotateCustomTiers" >
+                        <span data-test="annotateCustomTiers">
                             <span className="caret" />
                             &nbsp;&nbsp;
                             <span>


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7616

# Problem
The selection of custom driver annotations in the configuration menu of Results View (see figure below) was broken  (checkboxes could not be de-selected). 

# Fix
This PR  fixes this feature and add serveral e2e-tests to make sure it will stay intact in the future.

Example of the custom driver selection in Results View configuration menu.
![image](https://user-images.githubusercontent.com/745885/85268505-e50a0080-b476-11ea-8b7f-d1337216dfb8.png)
