### PR TITLE
Retire use of api-legacy endpoints

### DIFF
--- a/src/shared/api/MatchMinerAPI.ts
+++ b/src/shared/api/MatchMinerAPI.ts
@@ -6,12 +6,12 @@ import { buildCBioPortalAPIUrl } from './urls';
  * Retrieves the trial matches for the query given, if they are in the MatchMiner API.
  */
 // It cannot be set globally since it will cause test error: undefined of 'replace'.
-// const cbioportalUrl = buildCBioPortalAPIUrl('api-legacy/proxy/matchminer/api');
+// const cbioportalUrl = buildCBioPortalAPIUrl('api/proxy/matchminer/api');
 export async function fetchTrialMatchesUsingPOST(
     query: object
 ): Promise<Array<ITrialMatch>> {
     const cbioportalUrl = buildCBioPortalAPIUrl(
-        'api-legacy/proxy/matchminer/api'
+        'api/proxy/matchminer/api'
     );
     return request
         .post(cbioportalUrl + '/post_trial_match')
@@ -59,7 +59,7 @@ export async function fetchTrialsByTypeAndId(
     id: string
 ): Promise<ITrial> {
     const cbioportalUrl = buildCBioPortalAPIUrl(
-        'api-legacy/proxy/matchminer/api'
+        'api/proxy/matchminer/api'
     );
     return request.get(cbioportalUrl + '/' + type + '/' + id).then(res => {
         const response = JSON.parse(res.text);
@@ -80,7 +80,7 @@ export async function fetchTrialsUsingPost(
     query: object
 ): Promise<Array<ITrial>> {
     const cbioportalUrl = buildCBioPortalAPIUrl(
-        'api-legacy/proxy/matchminer/api'
+        'api/proxy/matchminer/api'
     );
     return request
         .post(cbioportalUrl + '/post_trial')
@@ -102,7 +102,7 @@ export async function fetchTrialsUsingPost(
 
 export async function fetchTrialsById(query: object): Promise<Array<ITrial>> {
     const cbioportalUrl = buildCBioPortalAPIUrl(
-        'api-legacy/proxy/matchminer/api'
+        'api/proxy/matchminer/api'
     );
     return request
         .post(cbioportalUrl + '/trials')

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -242,9 +242,9 @@ export function getSessionUrl() {
         // TODO: remove this after switch to AWS. This is a hack to use proxy
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
-        return buildCBioPortalPageUrl('api-legacy/proxy/session');
+        return buildCBioPortalPageUrl('api/proxy/session');
     } else {
-        return buildCBioPortalAPIUrl('api-legacy/proxy/session');
+        return buildCBioPortalAPIUrl('api/proxy/session');
     }
 }
 
@@ -256,9 +256,9 @@ export function fetchComparisonGroupsServiceUrl() {
         // TODO: remove this after switch to AWS. This is a hack to use proxy
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
-        return buildCBioPortalPageUrl('api-legacy/proxy/session/groups/fetch');
+        return buildCBioPortalPageUrl('api/proxy/session/groups/fetch');
     } else {
-        return buildCBioPortalAPIUrl('api-legacy/proxy/session/groups/fetch');
+        return buildCBioPortalAPIUrl('api/proxy/session/groups/fetch');
     }
 }
 
@@ -270,9 +270,9 @@ export function getComparisonGroupServiceUrl() {
         // TODO: remove this after switch to AWS. This is a hack to use proxy
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
-        return buildCBioPortalPageUrl('api-legacy/proxy/session/group');
+        return buildCBioPortalPageUrl('api/proxy/session/group');
     } else {
-        return buildCBioPortalAPIUrl('api-legacy/proxy/session/group');
+        return buildCBioPortalAPIUrl('api/proxy/session/group');
     }
 }
 
@@ -285,11 +285,11 @@ export function getComparisonSessionServiceUrl() {
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
         return buildCBioPortalPageUrl(
-            'api-legacy/proxy/session/comparison_session'
+            'api/proxy/session/comparison_session'
         );
     } else {
         return buildCBioPortalAPIUrl(
-            'api-legacy/proxy/session/comparison_session'
+            'api/proxy/session/comparison_session'
         );
     }
 }
@@ -332,11 +332,7 @@ export function getStudyDownloadListUrl() {
 }
 
 export function getBitlyServiceUrl() {
-    return buildCBioPortalAPIUrl('api-legacy/proxy/bitly');
-}
-
-export function getLegacyCopyNumberUrl() {
-    return buildCBioPortalAPIUrl('api-legacy/copynumbersegments');
+    return buildCBioPortalAPIUrl('api/proxy/bitly');
 }
 
 export function getMDAndersonHeatmapPatientUrl(patientId: string) {


### PR DESCRIPTION
Retires the use of the api-legacy endpoint.  Should be deployed in coordination with backend PR [#7653](https://github.com/cBioPortal/cbioportal/pull/7653).