### PR TITLE
Skip all oncokb tests

### DIFF
--- a/end-to-end-test/remote/specs/core/oncokb.spec.js
+++ b/end-to-end-test/remote/specs/core/oncokb.spec.js
@@ -83,7 +83,7 @@ onoKbCardWithInfoSuite = (prefix, gene, showLevelsOfEvidence = false) => {
     });
 };
 
-describe('OncoKB Integration', () => {
+describe.skip('OncoKB Integration', () => {
     describe('Check oncokb card', () => {
         describe('Check patient view', () => {
             beforeEach(() => {


### PR DESCRIPTION
OncoKB tests are based on the tooltip screenshots but often they are unstable due to
- Tooltip shifting
- Data change resulted in the table layout change

Disable for now until finding a better solution

Signed-off-by: Hongxin Zhang <hongxin@cbio.mskcc.org>

