### PR TITLE
Study page: updates to comparison group manager

### DIFF
--- a/src/pages/groupComparison/GroupComparisonUtils.tsx
+++ b/src/pages/groupComparison/GroupComparisonUtils.tsx
@@ -56,6 +56,7 @@ export type StudyViewComparisonGroup = Omit<GroupData, 'studies' | 'color'> & {
     uid: string; // unique in the session
     studies: { id: string; samples: string[]; patients: string[] }[]; // include patients, filter out nonexistent samples
     nonExistentSamples: SampleIdentifier[]; // samples specified in the group which no longer exist in our DB
+    isSharedGroup?: boolean;
 };
 
 export type ClinicalDataEnrichmentWithQ = ClinicalDataEnrichment & {

--- a/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManagerUtils.ts
+++ b/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManagerUtils.ts
@@ -66,17 +66,3 @@ export function getGroupParameters(
         color,
     };
 }
-
-export function addSamplesParameters(
-    group: GroupData,
-    sampleIdentifiers: SampleIdentifier[]
-) {
-    group = Object.assign({}, group);
-    const prevSampleIdentifiers = getSampleIdentifiers([group]);
-    const newSampleIdentifiers = _.uniqWith(
-        prevSampleIdentifiers.concat(sampleIdentifiers),
-        (a, b) => a.studyId === b.studyId && a.sampleId === b.sampleId
-    );
-    group.studies = getStudiesAttr(newSampleIdentifiers);
-    return group;
-}

--- a/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import {
     caseCounts,
-    DUPLICATE_GROUP_NAME_MSG,
     getNumPatients,
     getNumSamples,
     MissingSamplesMessage,
@@ -10,24 +9,24 @@ import {
 } from '../GroupComparisonUtils';
 import { StudyViewPageStore } from '../../studyView/StudyViewPageStore';
 import autobind from 'autobind-decorator';
-import { computed, observable } from 'mobx';
+import { computed } from 'mobx';
 import ErrorIcon from '../../../shared/components/ErrorIcon';
 import styles from '../styles.module.scss';
-import { SyntheticEvent } from 'react';
+
 import {
     DefaultTooltip,
     EllipsisTextTooltip,
 } from 'cbioportal-frontend-commons';
+import classnames from 'classnames';
 
 export interface IGroupCheckboxProps {
     group: StudyViewComparisonGroup;
     store: StudyViewPageStore;
     markedForDeletion: boolean;
+    studyIds: string[];
     restore: (group: StudyViewComparisonGroup) => void;
-    rename: (newName: string, currentGroup: StudyViewComparisonGroup) => void;
     delete: (group: StudyViewComparisonGroup) => void;
-    addSelectedSamples: (group: StudyViewComparisonGroup) => void;
-    allGroupNames: string[];
+    shareGroup: (group: StudyViewComparisonGroup) => void;
 }
 
 @observer
@@ -35,13 +34,6 @@ export default class GroupCheckbox extends React.Component<
     IGroupCheckboxProps,
     {}
 > {
-    @observable _editingName = false;
-    @observable nameInput = '';
-
-    @computed get editingName() {
-        return this._editingName && !this.props.markedForDeletion;
-    }
-
     @autobind
     private onCheckboxClick() {
         this.props.store.toggleComparisonGroupSelected(this.props.group.uid);
@@ -53,40 +45,13 @@ export default class GroupCheckbox extends React.Component<
     }
 
     @autobind
-    private onEditClick() {
-        this._editingName = true;
-        this.nameInput = this.props.group.name;
-    }
-
-    @autobind
     private onDeleteClick() {
         this.props.delete(this.props.group);
     }
 
     @autobind
-    private onAddSelectedSamplesClick() {
-        this.props.addSelectedSamples(this.props.group);
-    }
-
-    @autobind
-    private onEditSubmit() {
-        if (
-            this.nameInput.length > 0 &&
-            this.nameInput !== this.props.group.name
-        ) {
-            this.props.rename(this.nameInput, this.props.group);
-        }
-        this._editingName = false;
-    }
-
-    @autobind
-    private onEditCancel() {
-        this._editingName = false;
-    }
-
-    @autobind
-    private handleNameInputChange(evt: SyntheticEvent<HTMLInputElement>) {
-        this.nameInput = (evt.target as HTMLInputElement).value;
+    private shareGroup() {
+        this.props.shareGroup(this.props.group);
     }
 
     @computed get label() {
@@ -101,51 +66,6 @@ export default class GroupCheckbox extends React.Component<
                 )
             </span>
         );
-    }
-
-    @computed get editingNameUI() {
-        return (
-            <DefaultTooltip
-                visible={
-                    !!(this.editSubmitError && this.editSubmitError.message)
-                }
-                overlay={
-                    <div>
-                        <i
-                            className="fa fa-md fa-exclamation-triangle"
-                            style={{
-                                color: '#BB1700',
-                                marginRight: 5,
-                            }}
-                        />
-                        <span>
-                            {this.editSubmitError &&
-                                this.editSubmitError.message}
-                        </span>
-                    </div>
-                }
-            >
-                <input
-                    type="text"
-                    value={this.nameInput}
-                    onChange={this.handleNameInputChange}
-                    style={{ width: 174 }}
-                />
-            </DefaultTooltip>
-        );
-    }
-
-    @computed get editSubmitError() {
-        if (this.nameInput.length === 0) {
-            return { message: 'Please enter a name.' };
-        } else if (this.nameInput === this.props.group.name) {
-            // Non-null object signifies that submit should be disabled, but no message specified means no tooltip.
-            return {};
-        } else if (this.props.allGroupNames.indexOf(this.nameInput) > -1) {
-            return { message: DUPLICATE_GROUP_NAME_MSG };
-        } else {
-            return null;
-        }
     }
 
     render() {
@@ -169,77 +89,17 @@ export default class GroupCheckbox extends React.Component<
                         )}
                         onClick={this.onCheckboxClick}
                     />
-                    {this.editingName ? this.editingNameUI : this.label}
+                    {this.label}
                 </div>
             );
-        }
-
-        let editingRelatedIcons;
-        if (this.editingName) {
-            editingRelatedIcons = [
-                <button
-                    className="btn btn-xs btn-primary"
-                    onClick={this.onEditSubmit}
-                    disabled={!!this.editSubmitError}
-                    style={{ marginRight: 3 }}
-                >
-                    Save
-                </button>,
-                <button
-                    className="btn btn-xs btn-default"
-                    onClick={this.onEditCancel}
-                >
-                    Cancel
-                </button>,
-            ];
-        } else if (!this.props.markedForDeletion) {
-            editingRelatedIcons = [
-                <DefaultTooltip overlay={'Edit Name'}>
-                    <span onClick={this.onEditClick}>
-                        <i
-                            className="fa fa-md fa-pencil"
-                            style={{
-                                cursor: 'pointer',
-                            }}
-                        />
-                    </span>
-                </DefaultTooltip>,
-                <DefaultTooltip overlay={'Delete Group'}>
-                    <span onClick={this.onDeleteClick}>
-                        <i
-                            className="fa fa-md fa-trash"
-                            style={{
-                                cursor: 'pointer',
-                            }}
-                        />
-                    </span>
-                </DefaultTooltip>,
-                <DefaultTooltip
-                    overlay={
-                        <span>
-                            {`Add currently selected samples (${getNumSamples(
-                                group
-                            )}) to `}
-                            <strong>{group.name}</strong>
-                        </span>
-                    }
-                >
-                    <span onClick={this.onAddSelectedSamplesClick}>
-                        <i
-                            className="fa fa-md fa-plus"
-                            style={{
-                                cursor: 'pointer',
-                            }}
-                        />
-                    </span>
-                </DefaultTooltip>,
-            ];
         }
 
         return (
             <div
                 key={group.uid}
-                className={styles.groupRow}
+                className={classnames(styles.groupRow, {
+                    [styles.sharedGroup]: this.props.group.isSharedGroup,
+                })}
                 style={{
                     display: 'flex',
                     flexDirection: 'row',
@@ -247,11 +107,34 @@ export default class GroupCheckbox extends React.Component<
                     alignItems: 'center',
                     paddingBottom: 4,
                     paddingTop: 4,
+                    minHeight: '35px',
                 }}
             >
                 {checkboxAndLabel}
                 <div className={styles.groupLineItemActionButtons}>
-                    {editingRelatedIcons}
+                    {!this.props.markedForDeletion && (
+                        <>
+                            <DefaultTooltip overlay={'Delete Group'}>
+                                <span onClick={this.onDeleteClick}>
+                                    <i
+                                        className="fa fa-md fa-trash"
+                                        style={{
+                                            cursor: 'pointer',
+                                        }}
+                                    />
+                                </span>
+                            </DefaultTooltip>
+                            <span onClick={this.shareGroup}>
+                                <i
+                                    className="fa fa-share-alt"
+                                    style={{
+                                        cursor: 'pointer',
+                                    }}
+                                />
+                            </span>
+                        </>
+                    )}
+
                     {this.props.group.nonExistentSamples.length > 0 && (
                         <ErrorIcon
                             tooltip={

--- a/src/pages/groupComparison/styles.module.scss
+++ b/src/pages/groupComparison/styles.module.scss
@@ -77,7 +77,7 @@
 }
 
 .groupLineItemActionButtons {
-    min-width: 45px;
+    display: flex;
     > span {
         margin-left: 5px;
         i {
@@ -87,6 +87,10 @@
             }
         }
     }
+}
+
+.sharedGroup {
+    background-color: #ffffaa !important;
 }
 
 .headerControls {

--- a/src/pages/groupComparison/styles.module.scss.d.ts
+++ b/src/pages/groupComparison/styles.module.scss.d.ts
@@ -10,6 +10,7 @@ declare const styles: {
   readonly "headerControls": string;
   readonly "markedForDeletion": string;
   readonly "noGroupsMessage": string;
+  readonly "sharedGroup": string;
   readonly "survivalPlotHeader": string;
   readonly "survivalPlotHeaderContainer": string;
   readonly "survivalTypeOptions": string;

--- a/src/pages/resultsView/bookmark/BookmarkModal.tsx
+++ b/src/pages/resultsView/bookmark/BookmarkModal.tsx
@@ -11,7 +11,12 @@ var Clipboard = require('clipboard');
 
 @observer
 export class BookmarkModal extends React.Component<
-    { onHide: () => void; urlPromise: Promise<any>; title: string },
+    {
+        onHide: () => void;
+        urlPromise: Promise<any>;
+        title: string;
+        description?: string;
+    },
     {}
 > {
     @observable
@@ -91,9 +96,7 @@ export class BookmarkModal extends React.Component<
                     >
                         <form>
                             <div className="form-group">
-                                <label htmlFor="exampleInputAmount">
-                                    Share link
-                                </label>
+                                <p>{this.props.description}</p>
                                 <div className="input-group">
                                     <input
                                         type="text"

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -61,6 +61,8 @@ import StudyViewURLWrapper from './StudyViewURLWrapper';
 import ResourcesTab, { RESOURCES_TAB_NAME } from './resources/ResourcesTab';
 import { ResourceData } from 'cbioportal-ts-api-client';
 import $ from 'jquery';
+import { StudyViewComparisonGroup } from 'pages/groupComparison/GroupComparisonUtils';
+import { getStudySummaryUrl } from 'shared/api/urls';
 
 export interface IStudyViewPageProps {
     routing: any;
@@ -112,7 +114,6 @@ export default class StudyViewPage extends React.Component<
     @observable private toolbarLeft: number = 0;
 
     @observable showCustomSelectTooltip = false;
-    @observable showGroupsTooltip = false;
     @observable private showReturnToDefaultChartListModal: boolean = false;
 
     constructor(props: IStudyViewPageProps) {
@@ -156,14 +157,26 @@ export default class StudyViewPage extends React.Component<
             'filterValues',
         ]);
 
-        const filterJson = hash || getBrowserWindow().studyPageFilter;
+        let hashString: string = hash || getBrowserWindow().studyPageFilter;
         delete (window as any).studyPageFilter;
 
-        if (filterJson) {
-            const filters = filterJson.match(/filterJson=([^&]*)/);
-            if (filters && filters.length > 1) {
-                newStudyViewFilter.filters = filters[1];
-            }
+        if (hashString) {
+            hashString = hashString.substring(1);
+            hashString.split('&').forEach(datum => {
+                if (datum.startsWith('filterJson')) {
+                    const filters = datum.match(/filterJson=([^&]*)/);
+                    if (filters && filters.length > 1) {
+                        newStudyViewFilter.filters = filters[1];
+                    }
+                } else if (datum.startsWith('sharedGroups')) {
+                    const sharedGroups = datum.match(/sharedGroups=([^&]*)/);
+                    if (sharedGroups && sharedGroups.length > 1) {
+                        newStudyViewFilter.sharedGroups = sharedGroups[1];
+                        // Open group comparison manager if there are shared groups in the url
+                        this.store.showComparisonGroupUI = true;
+                    }
+                }
+            });
         }
         if (!_.isEqual(newStudyViewFilter, this.store.studyViewQueryFilter)) {
             this.store.updateStoreFromURL(newStudyViewFilter);
@@ -218,6 +231,33 @@ export default class StudyViewPage extends React.Component<
     @action
     toggleBookmarkModal() {
         this.showBookmarkModal = !this.showBookmarkModal;
+    }
+
+    @observable shareLinkModal = false;
+
+    @autobind
+    @action
+    toggleShareLinkModal() {
+        this.shareLinkModal = !this.shareLinkModal;
+        this.sharedGroups = [];
+    }
+
+    private getShareBookmarkUrl: Promise<any> = Promise.resolve(null);
+    private sharedGroups: StudyViewComparisonGroup[] = [];
+
+    @autobind
+    @action
+    openShareUrlModal(groups: StudyViewComparisonGroup[]) {
+        this.shareLinkModal = true;
+        this.sharedGroups = groups;
+        const groupIds = groups.map(group => group.uid);
+        this.getShareBookmarkUrl = Promise.resolve({
+            bitlyUrl: undefined,
+            fullUrl: `${window.location.protocol}//${window.location.host}${
+                window.location.pathname
+            }${window.location.search}#sharedGroups=${groupIds.join(',')}`,
+            sessionUrl: undefined,
+        });
     }
 
     @autobind
@@ -334,7 +374,7 @@ export default class StudyViewPage extends React.Component<
                 {/*    </InfoBeacon>*/}
                 {/*</If>*/}
                 <DefaultTooltip
-                    visible={this.showGroupsTooltip}
+                    visible={this.store.showComparisonGroupUI}
                     trigger={['click']}
                     placement="bottomLeft"
                     destroyTooltipOnHide={true}
@@ -345,7 +385,9 @@ export default class StudyViewPage extends React.Component<
                         arrowEl.style.right = '10px';
                     }}
                     onVisibleChange={visible => {
-                        this.showGroupsTooltip = !!visible;
+                        if (!this.shareLinkModal) {
+                            this.store.showComparisonGroupUI = !!visible;
+                        }
                     }}
                     getTooltipContainer={() =>
                         document.getElementById(
@@ -354,42 +396,20 @@ export default class StudyViewPage extends React.Component<
                     }
                     overlay={
                         <div style={{ width: 350 }}>
-                            {this.props.appStore.isLoggedIn ? (
-                                <ComparisonGroupManager store={this.store} />
-                            ) : (
-                                <span>
-                                    Please log in to use the custom groups
-                                    feature to save and compare sub-cohorts.
-                                    <If
-                                        condition={
-                                            AppConfig.serverConfig
-                                                .authenticationMethod &&
-                                            AppConfig.serverConfig.authenticationMethod.includes(
-                                                'social_auth'
-                                            )
-                                        }
-                                    >
-                                        <div
-                                            className={'text-center'}
-                                            style={{ padding: 20 }}
-                                        >
-                                            <SocialAuthButton
-                                                appStore={this.props.appStore}
-                                            />
-                                        </div>
-                                    </If>
-                                </span>
-                            )}
+                            <ComparisonGroupManager
+                                store={this.store}
+                                shareGroups={this.openShareUrlModal}
+                            />
                         </div>
                     }
                 >
                     <button
                         className={classNames('btn btn-primary btn-xs', {
-                            active: this.showGroupsTooltip,
+                            active: this.store.showComparisonGroupUI,
                         })}
                         id={'groupManagementButton'}
                         data-test="groups-button"
-                        aria-pressed={this.showGroupsTooltip}
+                        aria-pressed={this.store.showComparisonGroupUI}
                         style={{ marginLeft: '10px' }}
                         data-event={serializeEvent({
                             action: 'openGroupManagement',
@@ -453,6 +473,20 @@ export default class StudyViewPage extends React.Component<
                         onHide={this.toggleBookmarkModal}
                         title={'Bookmark this filter'}
                         urlPromise={this.getBookmarkUrl()}
+                    />
+                )}
+                {this.shareLinkModal && (
+                    <BookmarkModal
+                        onHide={this.toggleShareLinkModal}
+                        title={
+                            this.sharedGroups.length > 1
+                                ? `Share ${this.sharedGroups.length} Groups`
+                                : 'Share Group'
+                        }
+                        urlPromise={this.getShareBookmarkUrl}
+                        description={
+                            'Please send the following link to users with whom you want to share the selected group(s).'
+                        }
                     />
                 )}
 

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
@@ -214,7 +214,7 @@ export default class GeneLevelSelection extends React.Component<
             <div>
                 <ErrorMessage
                     message={
-                        'There was an error loading saved groups. Please try again.'
+                        'There was an error loading data. Please try again.'
                     }
                 />
             </div>

--- a/src/shared/api/ComparisonGroupClient.ts
+++ b/src/shared/api/ComparisonGroupClient.ts
@@ -4,9 +4,7 @@ import {
     getComparisonGroupServiceUrl,
     getComparisonSessionServiceUrl,
 } from './urls';
-import { VirtualStudy, VirtualStudyData } from '../model/VirtualStudy';
-import { ClinicalAttribute } from 'cbioportal-ts-api-client';
-import PromisePlus from '../lib/PromisePlus';
+import { VirtualStudyData } from '../model/VirtualStudy';
 import { Omit } from '../lib/TypeScriptUtils';
 
 export type SessionGroupData = GroupData & {
@@ -27,21 +25,6 @@ export type Group = {
 export type GroupData = Omit<VirtualStudyData, 'studyViewFilter'>;
 
 export default class ComparisonGroupClient {
-    // edge case: user deletes a group, then opens the panel again,
-    //          and the getGroups request responds before the deleteGroup
-    //          request completes, thus showing a group that should be
-    //          (and soon will be) deleted. We fix this by waiting
-    //          until deletions are done before allowing getGroups requests.
-    private _pendingDeletions: PromisePlus<any>[] = [];
-
-    private getPendingDeletions() {
-        // filter out non-pending deletions
-        this._pendingDeletions = this._pendingDeletions.filter(
-            x => x.status !== 'pending'
-        );
-        return this._pendingDeletions.map(p => p.promise);
-    }
-
     // Groups
     public addGroup(group: GroupData): Promise<{ id: string }> {
         return request
@@ -68,8 +51,6 @@ export default class ComparisonGroupClient {
     }
 
     public async getGroupsForStudies(studyIds: string[]): Promise<Group[]> {
-        await Promise.all(this.getPendingDeletions()); // wait for pending deletions to finish
-
         return request
             .post(fetchComparisonGroupsServiceUrl())
             .send(studyIds)
@@ -79,12 +60,15 @@ export default class ComparisonGroupClient {
     }
 
     public deleteGroup(id: string) {
-        const req = request
+        return request
             .get(`${getComparisonGroupServiceUrl()}/delete/${id}`)
             .then(() => {});
+    }
 
-        this._pendingDeletions.push(new PromisePlus(req));
-        return req;
+    public addGroupToUser(id: string) {
+        return request
+            .get(`${getComparisonGroupServiceUrl()}/add/${id}`)
+            .then(() => {});
     }
 
     // Group Comparison Sessions


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7280

Other Updates
- [x] Allow group creation whether the user is logged in or not
    - [x] For logged in users -> groups would be saved to his account
    - [x] For non-logged in users-> created groups would have page scope
        - A warning should show: "The groups above will not be saved without log-in"
- [x] Always show shared groups in groups panel
    - [x] For logged in users-> shared groups are saved to his account and are highlighted
- [x] Groups panel should be visible by default on page load if there are any shared groups in the URL
    - [x] Highlight the shared groups