### PR TITLE
Disabled cohort button on study view while loading.

### DIFF
--- a/src/pages/studyView/studyPageHeader/ActionButtons.tsx
+++ b/src/pages/studyView/studyPageHeader/ActionButtons.tsx
@@ -148,6 +148,7 @@ export default class ActionButtons extends React.Component<
                 >
                     <button
                         className="btn btn-default btn-sm"
+                        disabled={!this.props.loadingComplete}
                         onClick={this.openCases}
                         data-event={serializeEvent({
                             category: 'studyPage',


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7625

Describe changes proposed in this pull request:
- Added change to cohort button such that when study view is not yet fully loaded, it is visibly grayed out. 

## Any screenshots or GIFs?
Before: Seen in issue
After: [screenshot_button](https://user-images.githubusercontent.com/33106214/86280627-25215f80-bbaa-11ea-9d79-888037f608ff.png)
