### PR TITLE
Add Treatments Charts To Study View (Frontend)

### DIFF
--- a/src/pages/studyView/StudyViewConfig.ts
+++ b/src/pages/studyView/StudyViewConfig.ts
@@ -71,6 +71,8 @@ export enum ChartTypeEnum {
     CNA_GENES_TABLE = 'CNA_GENES_TABLE',
     GENOMIC_PROFILES_TABLE = 'GENOMIC_PROFILES_TABLE',
     CASE_LIST_TABLE = 'CASE_LIST_TABLE',
+    SAMPLE_TREATMENTS_TABLE = 'SAMPLE_TREATMENTS_TABLE',
+    PATIENT_TREATMENTS_TABLE = 'PATIENT_TREATMENTS_TABLE',
     NONE = 'NONE',
 }
 
@@ -85,6 +87,8 @@ export enum ChartTypeNameEnum {
     CNA_GENES_TABLE = 'table',
     GENOMIC_PROFILES_TABLE = 'table',
     CASE_LIST_TABLE = 'table',
+    SAMPLE_TREATMENTS_TABLE = 'table',
+    PATIENT_TREATMENTS_TABLE = 'table',
     NONE = 'none',
 }
 
@@ -189,6 +193,16 @@ const studyViewFrontEnd = {
                 minW: 2,
             },
             [ChartTypeEnum.CASE_LIST_TABLE]: {
+                w: 2,
+                h: 2,
+                minW: 2,
+            },
+            [ChartTypeEnum.SAMPLE_TREATMENTS_TABLE]: {
+                w: 2,
+                h: 2,
+                minW: 2,
+            },
+            [ChartTypeEnum.PATIENT_TREATMENTS_TABLE]: {
                 w: 2,
                 h: 2,
                 minW: 2,

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -333,6 +333,8 @@ export default class StudyViewPage extends React.Component<
                 this.store.cnaProfiles,
                 this.store.selectedSamples,
                 this.store.molecularProfileSampleCounts,
+                this.store.sampleTreatments,
+                this.store.patientTreatments,
             ];
         },
         invoke: async () => {
@@ -545,6 +547,10 @@ export default class StudyViewPage extends React.Component<
                                         }
                                         linkText={
                                             StudyViewPageTabDescriptions.CLINICAL_DATA
+                                        }
+                                        hide={
+                                            this.store.selectedSamples.result
+                                                .length === 0
                                         }
                                     >
                                         <ClinicalDataTab store={this.store} />

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -28,6 +28,13 @@ import {
     GenomicDataBinFilter,
     GenomicDataFilter,
     GenomicDataBin,
+    AndedPatientTreatmentFilters,
+    AndedSampleTreatmentFilters,
+    OredPatientTreatmentFilters,
+    OredSampleTreatmentFilters,
+    SampleTreatmentFilter,
+    SampleTreatmentRow,
+    PatientTreatmentRow,
 } from 'cbioportal-ts-api-client';
 import {
     CancerStudy,
@@ -106,7 +113,7 @@ import {
     getGenomicChartUniqueKey,
     pickNewColorForClinicData,
 } from './StudyViewUtils';
-import MobxPromise from 'mobxpromise';
+import MobxPromise, { MobxPromiseUnionType } from 'mobxpromise';
 import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
 import autobind from 'autobind-decorator';
 import { updateGeneQuery } from 'pages/studyView/StudyViewUtils';
@@ -173,6 +180,11 @@ import {
     notSurvivalAttribute,
 } from 'pages/resultsView/survival/SurvivalUtil';
 import { ISurvivalDescription } from 'pages/resultsView/survival/SurvivalDescriptionTable';
+import {
+    toSampleTreatmentFilter,
+    toPatientTreatmentFilter,
+    treatmentUniqueKey,
+} from './table/treatments/treatmentsTableUtil';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
@@ -709,22 +721,28 @@ export class StudyViewPageStore {
                             const entityIdKey = clinicalAttribute.patientAttribute
                                 ? 'patientId'
                                 : 'sampleId';
-                            data = await defaultClient.fetchClinicalDataUsingPOST(
-                                {
-                                    clinicalDataType: clinicalAttribute.patientAttribute
-                                        ? ClinicalDataTypeEnum.PATIENT
-                                        : ClinicalDataTypeEnum.SAMPLE,
-                                    clinicalDataMultiStudyFilter: {
-                                        attributeIds: [
-                                            clinicalAttribute.clinicalAttributeId,
-                                        ],
-                                        identifiers: selectedSamples.map(s => ({
-                                            studyId: s.studyId,
-                                            entityId: s[entityIdKey],
-                                        })),
-                                    },
-                                }
-                            );
+                            if (selectedSamples.length === 0) {
+                                data = [];
+                            } else {
+                                data = await defaultClient.fetchClinicalDataUsingPOST(
+                                    {
+                                        clinicalDataType: clinicalAttribute.patientAttribute
+                                            ? ClinicalDataTypeEnum.PATIENT
+                                            : ClinicalDataTypeEnum.SAMPLE,
+                                        clinicalDataMultiStudyFilter: {
+                                            attributeIds: [
+                                                clinicalAttribute.clinicalAttributeId,
+                                            ],
+                                            identifiers: selectedSamples.map(
+                                                s => ({
+                                                    studyId: s.studyId,
+                                                    entityId: s[entityIdKey],
+                                                })
+                                            ),
+                                        },
+                                    }
+                                );
+                            }
                         }
                     }
 
@@ -1134,6 +1152,8 @@ export class StudyViewPageStore {
             this.setGenomicProfilesFilter(filters.genomicProfiles);
         }
 
+        this.setTreatmentFilters(filters);
+
         if (filters.caseLists !== undefined) {
             this.setCaseListsFilter(filters.caseLists);
         }
@@ -1193,7 +1213,9 @@ export class StudyViewPageStore {
                     decodeURIComponent(query.filters)
                 ) as Partial<StudyViewFilter>;
                 this.updateStoreByFilters(filters);
-            } catch (e) {}
+            } catch (e) {
+                //  TODO: add some logging here?
+            }
         } else if (query.filterAttributeId && query.filterValues) {
             const clinicalAttributes = _.uniqBy(
                 await defaultClient.fetchClinicalAttributesUsingPOST({
@@ -1263,6 +1285,9 @@ export class StudyViewPageStore {
         if (!_.isEmpty(studyViewFilter.sampleIdentifiers)) {
             delete studyViewFilter.studyIds;
         }
+
+        studyViewFilter.patientTreatmentFilters = { filters: [] };
+        studyViewFilter.sampleTreatmentFilters = { filters: [] };
 
         return studyViewFilter;
     }
@@ -1506,6 +1531,8 @@ export class StudyViewPageStore {
         this._customBinsFromScatterPlotSelectionSet.clear();
         this.setGenomicProfilesFilter([]);
         this.setCaseListsFilter([]);
+        this.clearPatientTreatmentFilters();
+        this.clearSampleTreatmentFilters();
     }
 
     @computed
@@ -1956,6 +1983,12 @@ export class StudyViewPageStore {
                     break;
                 case ChartTypeEnum.SURVIVAL:
                     break;
+                case ChartTypeEnum.SAMPLE_TREATMENTS_TABLE:
+                    this.setSampleTreatmentFilters({ filters: [] });
+                    break;
+                case ChartTypeEnum.PATIENT_TREATMENTS_TABLE:
+                    this.setPatientTreatmentFilters({ filters: [] });
+                    break;
                 default:
                     this._clinicalDataFilterSet.delete(chartUniqueKey);
                     this._chartSampleIdentifiersFilterSet.delete(
@@ -2170,6 +2203,24 @@ export class StudyViewPageStore {
 
         if (this.caseListsFilter.length > 0) {
             filters.caseLists = toJS(this.caseListsFilter);
+        }
+
+        if (
+            this.sampleTreatmentFilters &&
+            this.sampleTreatmentFilters.filters.length > 0
+        ) {
+            filters.sampleTreatmentFilters = this.sampleTreatmentFilters;
+        } else {
+            filters.sampleTreatmentFilters = { filters: [] };
+        }
+
+        if (
+            this.patientTreatmentFilters &&
+            this.patientTreatmentFilters.filters.length > 0
+        ) {
+            filters.patientTreatmentFilters = this.patientTreatmentFilters;
+        } else {
+            filters.patientTreatmentFilters = { filters: [] };
         }
 
         let sampleIdentifiersFilterSets = this._chartSampleIdentifiersFilterSet.values();
@@ -3592,6 +3643,44 @@ export class StudyViewPageStore {
             _chartMetaSet
         );
 
+        if (
+            this.displayTreatments.result &&
+            ['triage-portal', 'genie-portal'].includes(
+                AppConfig.serverConfig.app_name!
+            )
+        ) {
+            _chartMetaSet['SAMPLE_TREATMENTS'] = {
+                uniqueKey: 'SAMPLE_TREATMENTS',
+                dataType: ChartMetaDataTypeEnum.CLINICAL,
+                patientAttribute: true,
+                displayName: 'Sample Treatments',
+                priority: getDefaultPriorityByUniqueKey(
+                    ChartTypeEnum.SAMPLE_TREATMENTS_TABLE
+                ),
+                renderWhenDataChange: true,
+                description: '',
+            };
+        }
+
+        if (
+            this.displayTreatments.result &&
+            ['triage-portal', 'genie-portal'].includes(
+                AppConfig.serverConfig.app_name!
+            )
+        ) {
+            _chartMetaSet['PATIENT_TREATMENTS'] = {
+                uniqueKey: 'PATIENT_TREATMENTS',
+                dataType: ChartMetaDataTypeEnum.CLINICAL,
+                patientAttribute: true,
+                displayName: 'Patient Treatments',
+                priority: getDefaultPriorityByUniqueKey(
+                    ChartTypeEnum.PATIENT_TREATMENTS_TABLE
+                ),
+                renderWhenDataChange: true,
+                description: '',
+            };
+        }
+
         if (!_.isEmpty(this.mutationProfiles.result)) {
             const uniqueKey = getUniqueKeyFromMolecularProfileIds(
                 this.mutationProfiles.result.map(
@@ -3770,7 +3859,9 @@ export class StudyViewPageStore {
             this.mutationProfiles.isPending ||
             this.cnaProfiles.isPending ||
             this.structuralVariantProfiles.isPending ||
-            this.survivalClinicalAttributesPrefix.isPending;
+            this.survivalClinicalAttributesPrefix.isPending ||
+            this.sampleTreatments.isPending ||
+            this.patientTreatments.isPending;
 
         if (
             this.clinicalAttributes.isComplete &&
@@ -4057,6 +4148,20 @@ export class StudyViewPageStore {
             }
         }
 
+        if (!_.isEmpty(this.patientTreatments.result)) {
+            this.chartsType.set(
+                SpecialChartsUniqueKeyEnum.PATIENT_TREATMENTS,
+                ChartTypeEnum.PATIENT_TREATMENTS_TABLE
+            );
+        }
+
+        if (!_.isEmpty(this.sampleTreatments.result)) {
+            this.chartsType.set(
+                SpecialChartsUniqueKeyEnum.SAMPLE_TREATMENTS,
+                ChartTypeEnum.SAMPLE_TREATMENTS_TABLE
+            );
+        }
+
         if (!_.isEmpty(this.mutationProfiles.result)) {
             const uniqueKey = getUniqueKeyFromMolecularProfileIds(
                 this.mutationProfiles.result.map(
@@ -4197,6 +4302,18 @@ export class StudyViewPageStore {
         this.chartsDimension.set(
             SpecialChartsUniqueKeyEnum.MUTATION_COUNT_CNA_FRACTION,
             STUDY_VIEW_CONFIG.layout.dimensions[ChartTypeEnum.SCATTER]
+        );
+        this.chartsDimension.set(
+            SpecialChartsUniqueKeyEnum.SAMPLE_TREATMENTS,
+            STUDY_VIEW_CONFIG.layout.dimensions[
+                ChartTypeEnum.SAMPLE_TREATMENTS_TABLE
+            ]
+        );
+        this.chartsDimension.set(
+            SpecialChartsUniqueKeyEnum.PATIENT_TREATMENTS,
+            STUDY_VIEW_CONFIG.layout.dimensions[
+                ChartTypeEnum.SAMPLE_TREATMENTS_TABLE
+            ]
         );
         if (
             mutationCountFlag &&
@@ -5507,6 +5624,9 @@ export class StudyViewPageStore {
     readonly sampleMutationCountAndFractionGenomeAlteredData = remoteData({
         await: () => [this.clinicalAttributes, this.selectedSamples],
         invoke: () => {
+            if (this.selectedSamples.result.length === 0) {
+                return Promise.resolve([]);
+            }
             const filter: ClinicalDataMultiStudyFilter = {
                 attributeIds: [
                     SpecialChartsUniqueKeyEnum.MUTATION_COUNT,
@@ -5590,6 +5710,9 @@ export class StudyViewPageStore {
         await: () => [this.clinicalAttributes, this.selectedSamples],
         onError: error => {},
         invoke: async () => {
+            if (this.selectedSamples.result.length === 0) {
+                return Promise.resolve([]);
+            }
             let sampleClinicalDataMap: {
                 [attributeId: string]: { [attributeId: string]: string };
             } = await getClinicalDataBySamples(this.selectedSamples.result);
@@ -5764,6 +5887,10 @@ export class StudyViewPageStore {
         await: () => [this.selectedSamples],
         onError: error => {},
         invoke: () => {
+            if (this.selectedSamples.result.length === 0) {
+                return Promise.resolve([]);
+            }
+
             let sampleIdentifiers = this.selectedSamples.result.map(sample => {
                 return {
                     sampleId: sample.sampleId,
@@ -5787,6 +5914,8 @@ export class StudyViewPageStore {
             this.clinicalAttributesCounts,
             this.mutationCountVsFractionGenomeAlteredDataSet,
             this.molecularProfileOptions,
+            this.sampleTreatments,
+            this.patientTreatments,
         ],
         invoke: async () => {
             if (!_.isEmpty(this.chartMetaSet)) {
@@ -5842,6 +5971,13 @@ export class StudyViewPageStore {
                                 ] || []
                             ).length
                     );
+                }
+
+                if (!_.isEmpty(this.sampleTreatments.result)) {
+                    ret['SAMPLE_TREATMENTS'] = 1;
+                }
+                if (!_.isEmpty(this.patientTreatments.result)) {
+                    ret['PATIENT_TREATMENTS'] = 1;
                 }
 
                 if (!_.isEmpty(this.structuralVariantProfiles.result)) {
@@ -6463,5 +6599,196 @@ export class StudyViewPageStore {
         if (this.queriedPhysicalStudies.result) {
             return isMixedReferenceGenome(this.queriedPhysicalStudies.result);
         }
+    }
+
+    @observable
+    private _patientTreatmentsFilter: AndedPatientTreatmentFilters = {
+        filters: [],
+    };
+
+    @observable
+    private _sampleTreatmentsFilters: AndedSampleTreatmentFilters = {
+        filters: [],
+    };
+
+    @computed
+    public get patientTreatmentFilters(): AndedPatientTreatmentFilters {
+        return this._patientTreatmentsFilter;
+    }
+
+    @computed
+    public get sampleTreatmentFilters(): AndedSampleTreatmentFilters {
+        return this._sampleTreatmentsFilters;
+    }
+
+    @computed
+    get sampleTreatmentFiltersAsStrings(): string[][] {
+        return this.sampleTreatmentFilters.filters.map(outer => {
+            return outer.filters.map(treatmentUniqueKey);
+        });
+    }
+
+    @computed
+    get patientTreatmentFiltersAsStrings(): string[][] {
+        return this.patientTreatmentFilters.filters.map(outer => {
+            return outer.filters.map(treatmentUniqueKey);
+        });
+    }
+
+    @action
+    public clearPatientTreatmentFilters() {
+        this._patientTreatmentsFilter = { filters: [] };
+    }
+
+    @action
+    public setPatientTreatmentFilters(filters: AndedPatientTreatmentFilters) {
+        this._patientTreatmentsFilter = filters;
+    }
+
+    @action
+    public addPatientTreatmentFilters(filters: OredPatientTreatmentFilters[]) {
+        this._patientTreatmentsFilter.filters = this._patientTreatmentsFilter.filters.concat(
+            filters
+        );
+    }
+
+    @action
+    public clearSampleTreatmentFilters() {
+        this._sampleTreatmentsFilters = { filters: [] };
+    }
+
+    @action
+    public setSampleTreatmentFilters(filters: AndedSampleTreatmentFilters) {
+        this._sampleTreatmentsFilters = filters;
+    }
+
+    @action
+    public addSampleTreatmentFilters(filters: OredSampleTreatmentFilters[]) {
+        this._sampleTreatmentsFilters.filters = this._sampleTreatmentsFilters.filters.concat(
+            filters
+        );
+    }
+
+    @action
+    public setTreatmentFilters(filters: Partial<StudyViewFilter>) {
+        if (
+            filters.patientTreatmentFilters &&
+            _.isArray(filters.patientTreatmentFilters.filters)
+        ) {
+            this.setPatientTreatmentFilters(filters.patientTreatmentFilters);
+        }
+        if (
+            filters.sampleTreatmentFilters &&
+            _.isArray(filters.sampleTreatmentFilters.filters)
+        ) {
+            this.setSampleTreatmentFilters(filters.sampleTreatmentFilters);
+        }
+    }
+
+    // a row represents a list of patients that either have or have not recieved
+    // a specific treatment
+    public readonly sampleTreatments = remoteData({
+        await: () => [
+            this.studyViewFilterWithFilteredSampleIdentifiers,
+            this.selectedSamples,
+        ],
+        invoke: () => {
+            return defaultClient.getAllSampleTreatmentsUsingPOST({
+                studyViewFilter: this
+                    .studyViewFilterWithFilteredSampleIdentifiers.result!,
+            });
+        },
+    });
+
+    @computed
+    public get displayTreatments() {
+        const filters = this.initialFilters;
+
+        return remoteData({
+            await: () => [this.studyViewFilterWithFilteredSampleIdentifiers],
+            invoke: () => {
+                return defaultClient.getContainsTreatmentDataUsingPOST({
+                    studyViewFilter: filters,
+                });
+            },
+        });
+    }
+
+    // a row represents a list of samples that ether have or have not recieved
+    // a specific treatment
+    public readonly patientTreatments = remoteData({
+        await: () => [
+            this.studyViewFilterWithFilteredSampleIdentifiers,
+            this.selectedSamples,
+        ],
+        invoke: () => {
+            return defaultClient.getAllPatientTreatmentsUsingPOST({
+                studyViewFilter: this
+                    .studyViewFilterWithFilteredSampleIdentifiers.result!,
+            });
+        },
+    });
+
+    @autobind
+    @action
+    public onSampleTreatmentSelection(meta: ChartMeta, values: string[][]) {
+        const filters = values.map(outerFilter => {
+            return {
+                filters: outerFilter.map(innerFilter => {
+                    return toSampleTreatmentFilter(innerFilter);
+                }),
+            };
+        });
+
+        this.addSampleTreatmentFilters(filters);
+    }
+
+    @autobind
+    @action
+    public onPatientTreatmentSelection(meta: ChartMeta, values: string[][]) {
+        const filters = values.map(outerFilter => {
+            return {
+                filters: outerFilter.map(innerFilter => {
+                    return toPatientTreatmentFilter(innerFilter);
+                }),
+            };
+        });
+
+        this.addPatientTreatmentFilters(filters);
+    }
+
+    @autobind
+    @action
+    public removeSampleTreatmentsFilter(andedIndex: number, oredIndex: number) {
+        const updatedFilters = this.sampleTreatmentFilters.filters
+            .map((oFil, oInd) => {
+                return {
+                    filters: oFil.filters.filter((unused, iInd) => {
+                        return !(andedIndex === oInd && oredIndex === iInd);
+                    }),
+                };
+            })
+            .filter(outerFilter => outerFilter.filters.length > 0);
+
+        this.setSampleTreatmentFilters({ filters: updatedFilters });
+    }
+
+    @autobind
+    @action
+    public removePatientTreatmentsFilter(
+        andedIndex: number,
+        oredIndex: number
+    ) {
+        const updatedFilters = this.patientTreatmentFilters.filters
+            .map((oFil, oInd) => {
+                return {
+                    filters: oFil.filters.filter((unused, iInd) => {
+                        return !(andedIndex === oInd && oredIndex === iInd);
+                    }),
+                };
+            })
+            .filter(outerFilter => outerFilter.filters.length > 0);
+
+        this.setPatientTreatmentFilters({ filters: updatedFilters });
     }
 }

--- a/src/pages/studyView/StudyViewUtils.spec.ts
+++ b/src/pages/studyView/StudyViewUtils.spec.ts
@@ -208,6 +208,8 @@ describe('StudyViewUtils', () => {
                         ],
                     },
                 ],
+                sampleTreatmentFilters: { filters: [] },
+                patientTreatmentFilters: { filters: [] },
                 genomicDataFilters: [],
                 geneFilters: [
                     {
@@ -247,8 +249,6 @@ describe('StudyViewUtils', () => {
                 genomicProfiles: [],
                 caseLists: [],
                 genericAssayDataFilters: [],
-                patientTreatmentFilters: {} as any,
-                sampleTreatmentFilters: {} as any,
             } as StudyViewFilterWithSampleIdentifierFilters;
 
             assert.isTrue(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -110,6 +110,8 @@ export type ChartType =
     | 'GENOMIC_PROFILES_TABLE'
     | 'CASE_LIST_TABLE'
     | 'CNA_GENES_TABLE'
+    | 'SAMPLE_TREATMENTS_TABLE'
+    | 'PATIENT_TREATMENTS_TABLE'
     | 'NONE';
 
 export enum SpecialChartsUniqueKeyEnum {
@@ -121,6 +123,8 @@ export enum SpecialChartsUniqueKeyEnum {
     FRACTION_GENOME_ALTERED = 'FRACTION_GENOME_ALTERED',
     GENOMIC_PROFILES_SAMPLE_COUNT = 'GENOMIC_PROFILES_SAMPLE_COUNT',
     CASE_LISTS_SAMPLE_COUNT = 'CASE_LISTS_SAMPLE_COUNT',
+    PATIENT_TREATMENTS = 'PATIENT_TREATMENTS',
+    SAMPLE_TREATMENTS = 'SAMPLE_TREATMENTS',
 }
 
 export type AnalysisGroup = {
@@ -822,7 +826,11 @@ export function isFiltered(
             _.isEmpty(filter.geneFilters) &&
             _.isEmpty(filter.genomicProfiles) &&
             _.isEmpty(filter.genomicDataFilters) &&
-            _.isEmpty(filter.caseLists))
+            _.isEmpty(filter.caseLists) &&
+            (!filter.patientTreatmentFilters ||
+                _.isEmpty(filter.patientTreatmentFilters.filters)) &&
+            (!filter.sampleTreatmentFilters ||
+                _.isEmpty(filter.sampleTreatmentFilters.filters)))
     );
 
     if (filter.sampleIdentifiersSet) {
@@ -1053,11 +1061,11 @@ export function isLogScaleByValues(values: number[]) {
 }
 
 export function shouldShowChart(
-    filer: Partial<StudyViewFilterWithSampleIdentifierFilters>,
+    filter: Partial<StudyViewFilterWithSampleIdentifierFilters>,
     uniqueDataSize: number,
     sizeOfAllSamples: number
 ) {
-    return isFiltered(filer) || uniqueDataSize >= 2 || sizeOfAllSamples === 1;
+    return isFiltered(filter) || uniqueDataSize >= 2 || sizeOfAllSamples === 1;
 }
 
 export function isEveryBinDistinct(data?: ClinicalDataBin[]) {

--- a/src/pages/studyView/UserSelections.tsx
+++ b/src/pages/studyView/UserSelections.tsx
@@ -3,7 +3,13 @@ import * as _ from 'lodash';
 import { observer } from 'mobx-react';
 import { computed } from 'mobx';
 import styles from './styles.module.scss';
-import { DataFilterValue } from 'cbioportal-ts-api-client';
+import {
+    DataFilterValue,
+    AndedPatientTreatmentFilters,
+    AndedSampleTreatmentFilters,
+    PatientTreatmentFilter,
+    SampleTreatmentFilter,
+} from 'cbioportal-ts-api-client';
 import {
     SpecialChartsUniqueKeyEnum,
     DataType,
@@ -34,6 +40,12 @@ import {
     StudyViewComparisonGroup,
 } from '../groupComparison/GroupComparisonUtils';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import { accessibilityOverscanIndicesGetter } from 'react-virtualized';
+import {
+    OredPatientTreatmentFilters,
+    OredSampleTreatmentFilters,
+} from 'cbioportal-ts-api-client/dist/generated/CBioPortalAPIInternal';
+import { toPatientTreatmentFilter } from './table/treatments/treatmentsTableUtil';
 
 export interface IUserSelectionsProps {
     filter: StudyViewFilterWithSampleIdentifierFilters;
@@ -60,6 +72,14 @@ export interface IUserSelectionsProps {
     caseListNameSet: { [key: string]: string };
     removeGenomicProfileFilter: (value: string) => void;
     removeCaseListsFilter: (value: string) => void;
+    removeSampleTreatmentsFilter: (
+        andedIndex: number,
+        oredIndex: number
+    ) => void;
+    removePatientTreatmentsFilter: (
+        andedIndex: number,
+        oredIndex: number
+    ) => void;
 }
 
 @observer
@@ -439,7 +459,94 @@ export default class UserSelections extends React.Component<
                 </div>
             );
         }
+
+        if (
+            this.props.filter.sampleTreatmentFilters &&
+            this.props.filter.sampleTreatmentFilters.filters.length > 0
+        ) {
+            const f = this.renderTreatmentFilter(
+                this.props.filter.sampleTreatmentFilters
+            );
+            components.push(f);
+        }
+
+        if (
+            this.props.filter.patientTreatmentFilters &&
+            this.props.filter.patientTreatmentFilters.filters.length > 0
+        ) {
+            const f = this.renderTreatmentFilter(
+                this.props.filter.patientTreatmentFilters
+            );
+            components.push(f);
+        }
         return components;
+    }
+
+    private renderTreatmentFilter(
+        f: AndedPatientTreatmentFilters | AndedSampleTreatmentFilters
+    ): JSX.Element {
+        type OuterFilter =
+            | OredPatientTreatmentFilters
+            | OredSampleTreatmentFilters;
+        type InnerFilter = PatientTreatmentFilter | SampleTreatmentFilter;
+
+        // the gross "as any" casting shouldn't be necessary for a type of
+        // OredSampleTreatmentFilters[] | OredPatientTreatmentFilters[],
+        // but the compiler complains if I remove it
+        const filters = (f.filters as any).map(
+            (oFilter: OuterFilter, oIndex: number) => {
+                const pills = (oFilter.filters as any).map(
+                    (iFilter: InnerFilter, iIndex: number) => {
+                        const filterInfo = this.getFilterStringAndRemoveFunc(
+                            iFilter
+                        );
+
+                        return (
+                            <PillTag
+                                content={
+                                    iFilter.treatment + ' ' + filterInfo.str
+                                }
+                                backgroundColor={
+                                    STUDY_VIEW_CONFIG.colors.theme
+                                        .clinicalFilterContent
+                                }
+                                onDelete={() => {
+                                    filterInfo.func(oIndex, iIndex);
+                                }}
+                            />
+                        );
+                    }
+                );
+
+                return (
+                    <GroupLogic
+                        components={pills}
+                        operation={'or'}
+                        group={true}
+                    />
+                );
+            }
+        );
+
+        return (
+            <GroupLogic components={filters} operation={'and'} group={false} />
+        );
+    }
+
+    private getFilterStringAndRemoveFunc(
+        filter: PatientTreatmentFilter | SampleTreatmentFilter
+    ): { str: string; func: (o: number, i: number) => void } {
+        if (filter.hasOwnProperty('time')) {
+            return {
+                str: (filter as SampleTreatmentFilter).time,
+                func: this.props.removeSampleTreatmentsFilter,
+            };
+        } else {
+            return {
+                str: '',
+                func: this.props.removePatientTreatmentsFilter,
+            };
+        }
     }
 
     private groupedGeneQueries(

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -56,6 +56,15 @@ import {
 } from 'pages/studyView/table/MultiSelectionTable';
 import { FreqColumnTypeEnum } from '../TableUtils';
 import { Dimensions } from 'react-virtualized';
+import {
+    SampleTreatmentsTable,
+    SampleTreatmentsTableColumnKey,
+} from '../table/treatments/SampleTreatmentsTable';
+import { TreatmentTableType } from '../table/treatments/treatmentsTableUtil';
+import {
+    PatientTreatmentsTableColumnKey,
+    PatientTreatmentsTable,
+} from '../table/treatments/PatientTreatmentsTable';
 
 export interface AbstractChart {
     toSVGDOMNode: () => Element;
@@ -144,7 +153,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
             resetFilters: action(() => {
                 this.props.onResetSelection(this.props.chartMeta, []);
             }),
-            onValueSelection: action((values: string[]) => {
+            onValueSelection: action((values: any) => {
                 this.props.onValueSelection(this.props.chartMeta, values);
             }),
             onDataBinSelection: action((dataBins: ClinicalDataBin[]) => {
@@ -354,7 +363,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
     }
 
     @computed
-    get chart() {
+    get chart(): (() => JSX.Element) | null {
         switch (this.chartType) {
             case ChartTypeEnum.PIE_CHART: {
                 return () => (
@@ -691,6 +700,64 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                 } else {
                     return null;
                 }
+            }
+            case ChartTypeEnum.SAMPLE_TREATMENTS_TABLE: {
+                return () => (
+                    <SampleTreatmentsTable
+                        tableType={TreatmentTableType.SAMPLE}
+                        promise={this.props.promise}
+                        width={getWidthByDimension(
+                            this.props.dimension,
+                            this.borderWidth
+                        )}
+                        height={getHeightByDimension(
+                            this.props.dimension,
+                            this.chartHeaderHeight
+                        )}
+                        filters={this.props.filters}
+                        onUserSelection={this.handlers.onValueSelection}
+                        columns={[
+                            {
+                                columnKey:
+                                    SampleTreatmentsTableColumnKey.TREATMENT,
+                            },
+                            { columnKey: SampleTreatmentsTableColumnKey.TIME },
+                            { columnKey: SampleTreatmentsTableColumnKey.COUNT },
+                        ]}
+                        defaultSortBy={SampleTreatmentsTableColumnKey.COUNT}
+                        selectedTreatments={[]}
+                    />
+                );
+            }
+            case ChartTypeEnum.PATIENT_TREATMENTS_TABLE: {
+                return () => (
+                    <PatientTreatmentsTable
+                        tableType={TreatmentTableType.PATIENT}
+                        promise={this.props.promise}
+                        width={getWidthByDimension(
+                            this.props.dimension,
+                            this.borderWidth
+                        )}
+                        height={getHeightByDimension(
+                            this.props.dimension,
+                            this.chartHeaderHeight
+                        )}
+                        filters={this.props.filters}
+                        onUserSelection={this.handlers.onValueSelection}
+                        columns={[
+                            {
+                                columnKey:
+                                    PatientTreatmentsTableColumnKey.TREATMENT,
+                            },
+                            {
+                                columnKey:
+                                    PatientTreatmentsTableColumnKey.COUNT,
+                            },
+                        ]}
+                        defaultSortBy={PatientTreatmentsTableColumnKey.COUNT}
+                        selectedTreatments={[]}
+                    />
+                );
             }
             case ChartTypeEnum.SCATTER: {
                 return () => (

--- a/src/pages/studyView/studyPageHeader/StudyPageHeader.tsx
+++ b/src/pages/studyView/studyPageHeader/StudyPageHeader.tsx
@@ -102,6 +102,12 @@ export default class StudyPageHeader extends React.Component<
                         removeCaseListsFilter={
                             this.props.store.removeCaseListsFilter
                         }
+                        removeSampleTreatmentsFilter={
+                            this.props.store.removeSampleTreatmentsFilter
+                        }
+                        removePatientTreatmentsFilter={
+                            this.props.store.removePatientTreatmentsFilter
+                        }
                     />
                 )}
             </div>

--- a/src/pages/studyView/table/treatments/AbstractTreatmentsTable.tsx
+++ b/src/pages/studyView/table/treatments/AbstractTreatmentsTable.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { action, computed, observable } from 'mobx';
+import autobind from 'autobind-decorator';
+import {
+    PatientTreatmentRow,
+    SampleTreatmentRow,
+} from 'cbioportal-ts-api-client';
+import { SelectionOperatorEnum } from 'pages/studyView/TableUtils';
+import styles from 'pages/studyView/table/tables.module.scss';
+import { treatmentUniqueKey, TreatmentTableType } from './treatmentsTableUtil';
+import { stringListToSet } from 'cbioportal-frontend-commons';
+import { SortDirection } from 'shared/components/lazyMobXTable/LazyMobXTable';
+
+type TreatmentsTableProps = {
+    filters: string[][];
+    tableType: TreatmentTableType;
+    onUserSelection: (value: string[][]) => void;
+};
+
+export abstract class TreatmentsTable<
+    P extends TreatmentsTableProps
+> extends React.Component<P, {}> {
+    @observable protected _selectionType: SelectionOperatorEnum;
+    @observable protected selectedRowsKeys: string[] = [];
+    @observable protected sortDirection: SortDirection;
+    @observable protected modalSettings: {
+        modalOpen: boolean;
+        modalPanelName: string;
+    } = {
+        modalOpen: false,
+        modalPanelName: '',
+    };
+
+    abstract get preSelectedRowsKeys(): string[];
+
+    @computed
+    get flattenedFilters(): string[] {
+        return _.flatMap(this.props.filters);
+    }
+
+    @computed
+    get allSelectedRowsKeysSet() {
+        return stringListToSet([
+            ...this.selectedRowsKeys,
+            ...this.preSelectedRowsKeys,
+        ]);
+    }
+
+    @computed
+    get filterKeyToIndexSet() {
+        const keyIndexSet: { [id: string]: number } = {};
+        return _.reduce(
+            this.props.filters,
+            (acc, next, index) => {
+                next.forEach(key => {
+                    acc[key] = index;
+                });
+                return acc;
+            },
+            keyIndexSet
+        );
+    }
+
+    @computed
+    get selectionType(): SelectionOperatorEnum {
+        if (this._selectionType) {
+            return this._selectionType;
+        }
+        switch (
+            (localStorage.getItem(this.props.tableType) || '').toUpperCase()
+        ) {
+            case SelectionOperatorEnum.INTERSECTION:
+                return SelectionOperatorEnum.INTERSECTION;
+            case SelectionOperatorEnum.UNION:
+                return SelectionOperatorEnum.UNION;
+            default:
+                return SelectionOperatorEnum.UNION;
+        }
+    }
+
+    @autobind
+    isDisabled(uniqueKey: string) {
+        return _.some(this.preSelectedRowsKeys, key => key === uniqueKey);
+    }
+
+    @autobind
+    isChecked(uniqueKey: string) {
+        return !!this.allSelectedRowsKeysSet[uniqueKey];
+    }
+
+    @autobind
+    @action
+    toggleModal(panelName: string) {
+        this.modalSettings.modalOpen = !this.modalSettings.modalOpen;
+        if (!this.modalSettings.modalOpen) {
+            return;
+        }
+        this.modalSettings.modalPanelName = panelName;
+    }
+
+    @autobind
+    @action
+    closeModal() {
+        this.modalSettings.modalOpen = !this.modalSettings.modalOpen;
+    }
+
+    @autobind
+    @action
+    togglePreSelectRow(uniqueKey: string) {
+        const record = _.find(this.selectedRowsKeys, key => key === uniqueKey);
+        if (_.isUndefined(record)) {
+            this.selectedRowsKeys.push(uniqueKey);
+        } else {
+            this.selectedRowsKeys = _.xorBy(this.selectedRowsKeys, [record]);
+        }
+    }
+
+    @autobind
+    @action
+    afterSelectingRows() {
+        if (this.selectionType === SelectionOperatorEnum.UNION) {
+            this.props.onUserSelection([this.selectedRowsKeys]);
+        } else {
+            this.props.onUserSelection(
+                this.selectedRowsKeys.map(selectedRowsKey => [selectedRowsKey])
+            );
+        }
+        this.selectedRowsKeys = [];
+    }
+
+    @autobind
+    @action
+    toggleSelectionOperator() {
+        const selectionType = this._selectionType || this.selectionType;
+        if (selectionType === SelectionOperatorEnum.INTERSECTION) {
+            this._selectionType = SelectionOperatorEnum.UNION;
+        } else {
+            this._selectionType = SelectionOperatorEnum.INTERSECTION;
+        }
+        localStorage.setItem(this.props.tableType, this.selectionType);
+    }
+
+    @autobind
+    isSelectedRow(data: PatientTreatmentRow | SampleTreatmentRow) {
+        return this.isChecked(treatmentUniqueKey(data));
+    }
+
+    @autobind
+    selectedRowClassName(data: PatientTreatmentRow | SampleTreatmentRow) {
+        const index = this.filterKeyToIndexSet[treatmentUniqueKey(data)];
+        if (index === undefined) {
+            return this.props.filters.length % 2 === 0
+                ? styles.highlightedEvenRow
+                : styles.highlightedOddRow;
+        }
+        return index % 2 === 0
+            ? styles.highlightedEvenRow
+            : styles.highlightedOddRow;
+    }
+}

--- a/src/pages/studyView/table/treatments/PatientTreatmentsTable.tsx
+++ b/src/pages/studyView/table/treatments/PatientTreatmentsTable.tsx
@@ -1,0 +1,263 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import * as _ from 'lodash';
+import FixedHeaderTable from '../FixedHeaderTable';
+import { action, computed, observable } from 'mobx';
+import autobind from 'autobind-decorator';
+import {
+    Column,
+    SortDirection,
+} from '../../../../shared/components/lazyMobXTable/LazyMobXTable';
+import { PatientTreatmentRow } from 'cbioportal-ts-api-client';
+import { correctColumnWidth } from 'pages/studyView/StudyViewUtils';
+import LabeledCheckbox from 'shared/components/labeledCheckbox/LabeledCheckbox';
+import styles from 'pages/studyView/table/tables.module.scss';
+import MobxPromise from 'mobxpromise';
+import {
+    stringListToIndexSet,
+    stringListToSet,
+} from 'cbioportal-frontend-commons';
+import ifNotDefined from 'shared/lib/ifNotDefined';
+import {
+    treatmentUniqueKey,
+    TreatmentTableType,
+    TreatmentGenericColumnHeader,
+    TreatmentColumnCell,
+    filterTreatmentCell,
+} from './treatmentsTableUtil';
+import { TreatmentsTable } from './AbstractTreatmentsTable';
+
+export enum PatientTreatmentsTableColumnKey {
+    TREATMENT = 'Treatment',
+    COUNT = '#',
+}
+
+export type PatientTreatmentsTableColumn = {
+    columnKey: PatientTreatmentsTableColumnKey;
+    columnWidthRatio?: number;
+};
+
+export type PatientTreatmentsTableProps = {
+    tableType: TreatmentTableType;
+    promise: MobxPromise<PatientTreatmentRow[]>;
+    width: number;
+    height: number;
+    filters: string[][];
+    onUserSelection: (value: string[][]) => void;
+    selectedTreatments: string[];
+    defaultSortBy: PatientTreatmentsTableColumnKey;
+    columns: PatientTreatmentsTableColumn[];
+};
+
+const DEFAULT_COLUMN_WIDTH_RATIO: {
+    [key in PatientTreatmentsTableColumnKey]: number;
+} = {
+    [PatientTreatmentsTableColumnKey.TREATMENT]: 0.8,
+    [PatientTreatmentsTableColumnKey.COUNT]: 0.2,
+};
+
+class MultiSelectionTableComponent extends FixedHeaderTable<
+    PatientTreatmentRow
+> {}
+
+@observer
+export class PatientTreatmentsTable extends TreatmentsTable<
+    PatientTreatmentsTableProps
+> {
+    @observable protected sortBy: PatientTreatmentsTableColumnKey;
+
+    public static defaultProps = {
+        cancerGeneFilterEnabled: false,
+    };
+
+    constructor(props: PatientTreatmentsTableProps, context: any) {
+        super(props, context);
+        this.sortBy = this.props.defaultSortBy;
+    }
+
+    createNubmerColumnCell(
+        row: PatientTreatmentRow,
+        cellMargin: number
+    ): JSX.Element {
+        return (
+            <LabeledCheckbox
+                checked={this.isChecked(treatmentUniqueKey(row))}
+                disabled={this.isDisabled(treatmentUniqueKey(row))}
+                onChange={_ => this.togglePreSelectRow(treatmentUniqueKey(row))}
+                labelProps={{
+                    style: {
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        marginLeft: 0,
+                        marginRight: cellMargin,
+                    },
+                }}
+                inputProps={{
+                    className: styles.autoMarginCheckbox,
+                }}
+            >
+                <span>{row.count.toLocaleString()}</span>
+            </LabeledCheckbox>
+        );
+    }
+
+    getDefaultColumnDefinition = (
+        columnKey: PatientTreatmentsTableColumnKey,
+        columnWidth: number,
+        cellMargin: number
+    ) => {
+        const defaults: {
+            [key in PatientTreatmentsTableColumnKey]: Column<
+                PatientTreatmentRow
+            >;
+        } = {
+            [PatientTreatmentsTableColumnKey.TREATMENT]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: (data: PatientTreatmentRow) => (
+                    <TreatmentColumnCell row={data} />
+                ),
+                sortBy: (data: PatientTreatmentRow) => data.treatment,
+                defaultSortDirection: 'asc' as 'asc',
+                filter: filterTreatmentCell,
+                width: columnWidth,
+            },
+            [PatientTreatmentsTableColumnKey.COUNT]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: (data: PatientTreatmentRow) =>
+                    this.createNubmerColumnCell(data, 28),
+                sortBy: (data: PatientTreatmentRow) => data.count,
+                defaultSortDirection: 'desc' as 'desc',
+                filter: filterTreatmentCell,
+                width: columnWidth,
+            },
+        };
+        return defaults[columnKey];
+    };
+
+    @computed
+    get columnsWidth() {
+        return _.reduce(
+            this.props.columns,
+            (acc, column) => {
+                acc[column.columnKey] = correctColumnWidth(
+                    (column.columnWidthRatio
+                        ? column.columnWidthRatio
+                        : DEFAULT_COLUMN_WIDTH_RATIO[column.columnKey]) *
+                        this.props.width
+                );
+                return acc;
+            },
+            {} as { [key in PatientTreatmentsTableColumnKey]: number }
+        );
+    }
+
+    @computed
+    get cellMargin() {
+        return _.reduce(
+            this.props.columns,
+            (acc, column) => {
+                acc[column.columnKey] = 0;
+                return acc;
+            },
+            {} as { [key in PatientTreatmentsTableColumnKey]: number }
+        );
+    }
+
+    @computed get tableData(): PatientTreatmentRow[] {
+        return this.props.promise.result || [];
+    }
+
+    @computed
+    get selectableTableData() {
+        if (this.flattenedFilters.length === 0) {
+            return this.tableData;
+        }
+        return _.filter(
+            this.tableData,
+            data => !this.flattenedFilters.includes(treatmentUniqueKey(data))
+        );
+    }
+
+    @computed
+    get preSelectedRows() {
+        if (this.flattenedFilters.length === 0) {
+            return [];
+        }
+        const order = stringListToIndexSet(this.flattenedFilters);
+        return _.chain(this.tableData)
+            .filter(data =>
+                this.flattenedFilters.includes(treatmentUniqueKey(data))
+            )
+            .sortBy<PatientTreatmentRow>(data =>
+                ifNotDefined(
+                    order[treatmentUniqueKey(data)],
+                    Number.POSITIVE_INFINITY
+                )
+            )
+            .value();
+    }
+
+    @computed
+    get preSelectedRowsKeys() {
+        return this.preSelectedRows.map(row => treatmentUniqueKey(row));
+    }
+
+    @computed
+    get tableColumns() {
+        return this.props.columns.map(column =>
+            this.getDefaultColumnDefinition(
+                column.columnKey,
+                this.columnsWidth[column.columnKey],
+                this.cellMargin[column.columnKey]
+            )
+        );
+    }
+
+    @autobind
+    @action
+    afterSorting(
+        sortBy: PatientTreatmentsTableColumnKey,
+        sortDirection: SortDirection
+    ) {
+        this.sortBy = sortBy;
+        this.sortDirection = sortDirection;
+    }
+
+    public render() {
+        const tableId = `${this.props.tableType}-table`;
+        return (
+            <div data-test={tableId} key={tableId}>
+                {this.props.promise.isComplete && (
+                    <MultiSelectionTableComponent
+                        width={this.props.width}
+                        height={this.props.height}
+                        data={this.selectableTableData}
+                        columns={this.tableColumns}
+                        isSelectedRow={this.isSelectedRow}
+                        afterSelectingRows={this.afterSelectingRows}
+                        defaultSelectionOperator={this.selectionType}
+                        toggleSelectionOperator={this.toggleSelectionOperator}
+                        sortBy={this.sortBy}
+                        sortDirection={this.sortDirection}
+                        afterSorting={this.afterSorting}
+                        fixedTopRowsData={this.preSelectedRows}
+                        highlightedRowClassName={this.selectedRowClassName}
+                        numberOfSelectedRows={this.selectedRowsKeys.length}
+                    />
+                )}
+            </div>
+        );
+    }
+}

--- a/src/pages/studyView/table/treatments/SampleTreatmentsTable.tsx
+++ b/src/pages/studyView/table/treatments/SampleTreatmentsTable.tsx
@@ -1,0 +1,277 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import * as _ from 'lodash';
+import FixedHeaderTable from '../FixedHeaderTable';
+import { action, computed, observable } from 'mobx';
+import autobind from 'autobind-decorator';
+import {
+    Column,
+    SortDirection,
+} from '../../../../shared/components/lazyMobXTable/LazyMobXTable';
+import { SampleTreatmentRow } from 'cbioportal-ts-api-client';
+import { correctColumnWidth } from 'pages/studyView/StudyViewUtils';
+import LabeledCheckbox from 'shared/components/labeledCheckbox/LabeledCheckbox';
+import styles from 'pages/studyView/table/tables.module.scss';
+import MobxPromise from 'mobxpromise';
+import { stringListToIndexSet } from 'cbioportal-frontend-commons';
+import ifNotDefined from 'shared/lib/ifNotDefined';
+import {
+    treatmentUniqueKey,
+    TreatmentTableType,
+    TreatmentGenericColumnHeader,
+    TreatmentColumnCell,
+    filterTreatmentCell,
+} from './treatmentsTableUtil';
+import { TreatmentsTable } from './AbstractTreatmentsTable';
+
+export enum SampleTreatmentsTableColumnKey {
+    TREATMENT = 'Treatment',
+    TIME = 'Pre / Post',
+    COUNT = '#',
+}
+
+export type SampleTreatmentsTableColumn = {
+    columnKey: SampleTreatmentsTableColumnKey;
+    columnWidthRatio?: number;
+};
+
+export type SampleTreatmentsTableProps = {
+    tableType: TreatmentTableType;
+    promise: MobxPromise<SampleTreatmentRow[]>;
+    width: number;
+    height: number;
+    filters: string[][];
+    onUserSelection: (value: string[][]) => void;
+    selectedTreatments: string[];
+    defaultSortBy: SampleTreatmentsTableColumnKey;
+    columns: SampleTreatmentsTableColumn[];
+};
+
+const DEFAULT_COLUMN_WIDTH_RATIO: {
+    [key in SampleTreatmentsTableColumnKey]: number;
+} = {
+    [SampleTreatmentsTableColumnKey.TREATMENT]: 0.6,
+    [SampleTreatmentsTableColumnKey.TIME]: 0.3,
+    [SampleTreatmentsTableColumnKey.COUNT]: 0.2,
+};
+
+class MultiSelectionTableComponent extends FixedHeaderTable<
+    SampleTreatmentRow
+> {}
+
+@observer
+export class SampleTreatmentsTable extends TreatmentsTable<
+    SampleTreatmentsTableProps
+> {
+    @observable protected sortBy: SampleTreatmentsTableColumnKey;
+
+    public static defaultProps = {
+        cancerGeneFilterEnabled: false,
+    };
+
+    constructor(props: SampleTreatmentsTableProps, context: any) {
+        super(props, context);
+        this.sortBy = this.props.defaultSortBy;
+    }
+
+    createTemporalRelationColumnCell(row: SampleTreatmentRow): JSX.Element {
+        return <div>{row.time}</div>;
+    }
+
+    createNubmerColumnCell(
+        row: SampleTreatmentRow,
+        cellMargin: number
+    ): JSX.Element {
+        return (
+            <LabeledCheckbox
+                checked={this.isChecked(treatmentUniqueKey(row))}
+                disabled={this.isDisabled(treatmentUniqueKey(row))}
+                onChange={_ => this.togglePreSelectRow(treatmentUniqueKey(row))}
+                labelProps={{
+                    style: {
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        marginLeft: 0,
+                        marginRight: cellMargin,
+                    },
+                }}
+                inputProps={{
+                    className: styles.autoMarginCheckbox,
+                }}
+            >
+                <span>{row.count.toLocaleString()}</span>
+            </LabeledCheckbox>
+        );
+    }
+
+    getDefaultColumnDefinition = (
+        columnKey: SampleTreatmentsTableColumnKey,
+        columnWidth: number,
+        cellMargin: number
+    ) => {
+        const defaults: {
+            [key in SampleTreatmentsTableColumnKey]: Column<SampleTreatmentRow>;
+        } = {
+            [SampleTreatmentsTableColumnKey.TREATMENT]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: (data: SampleTreatmentRow) => (
+                    <TreatmentColumnCell row={data} />
+                ),
+                sortBy: (data: SampleTreatmentRow) => data.treatment,
+                defaultSortDirection: 'asc' as 'asc',
+                filter: filterTreatmentCell,
+                width: columnWidth,
+            },
+            [SampleTreatmentsTableColumnKey.TIME]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: this.createTemporalRelationColumnCell,
+                sortBy: (data: SampleTreatmentRow) => data.time,
+                defaultSortDirection: 'asc' as 'asc',
+                filter: filterTreatmentCell,
+                width: columnWidth,
+            },
+            [SampleTreatmentsTableColumnKey.COUNT]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: (data: SampleTreatmentRow) =>
+                    this.createNubmerColumnCell(data, 28),
+                sortBy: (data: SampleTreatmentRow) => data.count,
+                defaultSortDirection: 'desc' as 'desc',
+                filter: filterTreatmentCell,
+                width: columnWidth,
+            },
+        };
+        return defaults[columnKey];
+    };
+
+    @computed
+    get columnsWidth() {
+        return _.reduce(
+            this.props.columns,
+            (acc, column) => {
+                acc[column.columnKey] = correctColumnWidth(
+                    (column.columnWidthRatio
+                        ? column.columnWidthRatio
+                        : DEFAULT_COLUMN_WIDTH_RATIO[column.columnKey]) *
+                        this.props.width
+                );
+                return acc;
+            },
+            {} as { [key in SampleTreatmentsTableColumnKey]: number }
+        );
+    }
+
+    @computed
+    get cellMargin() {
+        return _.reduce(
+            this.props.columns,
+            (acc, column) => {
+                acc[column.columnKey] = 0;
+                return acc;
+            },
+            {} as { [key in SampleTreatmentsTableColumnKey]: number }
+        );
+    }
+
+    @computed get tableData(): SampleTreatmentRow[] {
+        return this.props.promise.result || [];
+    }
+
+    @computed get selectableTableData() {
+        if (this.flattenedFilters.length === 0) {
+            return this.tableData;
+        }
+        return _.filter(
+            this.tableData,
+            data => !this.flattenedFilters.includes(treatmentUniqueKey(data))
+        );
+    }
+
+    @computed
+    get preSelectedRows() {
+        if (this.flattenedFilters.length === 0) {
+            return [];
+        }
+        const order = stringListToIndexSet(this.flattenedFilters);
+        return _.chain(this.tableData)
+            .filter(data =>
+                this.flattenedFilters.includes(treatmentUniqueKey(data))
+            )
+            .sortBy<SampleTreatmentRow>(data =>
+                ifNotDefined(
+                    order[treatmentUniqueKey(data)],
+                    Number.POSITIVE_INFINITY
+                )
+            )
+            .value();
+    }
+
+    @computed
+    get preSelectedRowsKeys() {
+        return this.preSelectedRows.map(row => treatmentUniqueKey(row));
+    }
+
+    @computed
+    get tableColumns() {
+        return this.props.columns.map(column =>
+            this.getDefaultColumnDefinition(
+                column.columnKey,
+                this.columnsWidth[column.columnKey],
+                this.cellMargin[column.columnKey]
+            )
+        );
+    }
+
+    @autobind
+    @action
+    afterSorting(
+        sortBy: SampleTreatmentsTableColumnKey,
+        sortDirection: SortDirection
+    ) {
+        this.sortBy = sortBy;
+        this.sortDirection = sortDirection;
+    }
+
+    public render() {
+        const tableId = `${this.props.tableType}-table`;
+        return (
+            <div data-test={tableId} key={tableId}>
+                {this.props.promise.isComplete && (
+                    <MultiSelectionTableComponent
+                        width={this.props.width}
+                        height={this.props.height}
+                        data={this.selectableTableData}
+                        columns={this.tableColumns}
+                        isSelectedRow={this.isSelectedRow}
+                        afterSelectingRows={this.afterSelectingRows}
+                        defaultSelectionOperator={this.selectionType}
+                        toggleSelectionOperator={this.toggleSelectionOperator}
+                        sortBy={this.sortBy}
+                        sortDirection={this.sortDirection}
+                        afterSorting={this.afterSorting}
+                        fixedTopRowsData={this.preSelectedRows}
+                        highlightedRowClassName={this.selectedRowClassName}
+                        numberOfSelectedRows={this.selectedRowsKeys.length}
+                    />
+                )}
+            </div>
+        );
+    }
+}

--- a/src/pages/studyView/table/treatments/treatmentsTableUtil.tsx
+++ b/src/pages/studyView/table/treatments/treatmentsTableUtil.tsx
@@ -1,0 +1,81 @@
+import {
+    SampleTreatmentRow,
+    SampleTreatmentFilter,
+    PatientTreatmentFilter,
+    PatientTreatmentRow,
+} from 'cbioportal-ts-api-client';
+import styles from 'pages/studyView/table/tables.module.scss';
+import React from 'react';
+
+export type Treatment =
+    | SampleTreatmentRow
+    | SampleTreatmentFilter
+    | PatientTreatmentRow
+    | PatientTreatmentFilter;
+
+export function treatmentUniqueKey(cell: Treatment) {
+    if (
+        (cell as SampleTreatmentFilter | SampleTreatmentRow).time !== undefined
+    ) {
+        const castCell = cell as SampleTreatmentFilter | SampleTreatmentRow;
+        return castCell.treatment + '::' + castCell.time;
+    } else {
+        return cell.treatment;
+    }
+}
+
+export function toSampleTreatmentFilter(
+    uniqueKey: string
+): SampleTreatmentFilter {
+    const split = uniqueKey.split('::');
+    return {
+        treatment: split[0],
+        time: split[1] as 'Pre' | 'Post' | 'Unknown',
+    };
+}
+
+export function toPatientTreatmentFilter(
+    uniqueKey: string
+): PatientTreatmentFilter {
+    const split = uniqueKey.split('::');
+    return {
+        treatment: split[0],
+    };
+}
+
+export enum TreatmentTableType {
+    SAMPLE = 'SAMPLE_TREATMENTS',
+    PATIENT = 'PATIENT_TREATMENTS',
+}
+
+export const TreatmentGenericColumnHeader = class GenericColumnHeader extends React.Component<
+    { margin: number; headerName: string },
+    {}
+> {
+    render() {
+        return (
+            <div
+                style={{ marginLeft: this.props.margin }}
+                className={styles.displayFlex}
+            >
+                {this.props.headerName}
+            </div>
+        );
+    }
+};
+
+export const TreatmentColumnCell = class TreatmentColumnCell extends React.Component<
+    { row: PatientTreatmentRow | SampleTreatmentRow },
+    {}
+> {
+    render() {
+        return <div>{this.props.row.treatment}</div>;
+    }
+};
+
+export function filterTreatmentCell(
+    cell: PatientTreatmentRow | SampleTreatmentRow,
+    filter: string
+): boolean {
+    return cell.treatment.toUpperCase().includes(filter.toUpperCase());
+}

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -29,6 +29,8 @@ import autobind from 'autobind-decorator';
 import LabeledCheckbox from '../../../shared/components/labeledCheckbox/LabeledCheckbox';
 import { ChartMeta, ChartType, RectangleBounds } from '../StudyViewUtils';
 import { DataType } from 'cbioportal-frontend-commons';
+import { toSampleTreatmentFilter } from '../table/treatments/treatmentsTableUtil';
+import { OredSampleTreatmentFilters } from 'cbioportal-ts-api-client/dist/generated/CBioPortalAPIInternal';
 
 export interface IStudySummaryTabProps {
     store: StudyViewPageStore;
@@ -340,6 +342,24 @@ export class StudySummaryTab extends React.Component<
                 props.downloadTypes = ['Data', 'SVG', 'PDF'];
                 break;
             }
+            case ChartTypeEnum.SAMPLE_TREATMENTS_TABLE: {
+                props.filters = this.store.sampleTreatmentFiltersAsStrings;
+                props.promise = this.store.sampleTreatments;
+                props.onValueSelection = this.store.onSampleTreatmentSelection;
+                props.onResetSelection = () => {
+                    this.store.clearSampleTreatmentFilters();
+                };
+                break;
+            }
+            case ChartTypeEnum.PATIENT_TREATMENTS_TABLE: {
+                props.filters = this.store.patientTreatmentFiltersAsStrings;
+                props.promise = this.store.patientTreatments;
+                props.onValueSelection = this.store.onPatientTreatmentSelection;
+                props.onResetSelection = () => {
+                    this.store.clearPatientTreatmentFilters();
+                };
+                break;
+            }
             default:
                 break;
         }
@@ -418,7 +438,6 @@ export class StudySummaryTab extends React.Component<
                         sequential={false}
                     />
                 </LoadingIndicator>
-
                 {this.store.invalidSampleIds.result.length > 0 &&
                     this.showErrorMessage && (
                         <div>
@@ -493,44 +512,68 @@ export class StudySummaryTab extends React.Component<
                     </div>
                 )}
 
-                {!this.store.loadingInitialDataForSummaryTab && (
-                    <div data-test="summary-tab-content">
-                        <div className={styles.studyViewFlexContainer}>
-                            {this.store.defaultVisibleAttributes.isComplete && (
-                                <ReactGridLayout
-                                    className="layout"
-                                    style={{ width: this.store.containerWidth }}
-                                    width={this.store.containerWidth}
-                                    cols={
-                                        this.store.studyViewPageLayoutProps.cols
-                                    }
-                                    rowHeight={
-                                        this.store.studyViewPageLayoutProps.grid
-                                            .h
-                                    }
-                                    layout={
-                                        this.store.studyViewPageLayoutProps
-                                            .layout
-                                    }
-                                    margin={[
-                                        STUDY_VIEW_CONFIG.layout.gridMargin.x,
-                                        STUDY_VIEW_CONFIG.layout.gridMargin.y,
-                                    ]}
-                                    useCSSTransforms={false}
-                                    draggableHandle={`.${chartHeaderStyles.draggable}`}
-                                    onLayoutChange={
-                                        this.handlers.onLayoutChange
-                                    }
-                                    onResizeStop={this.onResize}
-                                >
-                                    {this.store.visibleAttributes.map(
-                                        this.renderAttributeChart
-                                    )}
-                                </ReactGridLayout>
-                            )}
+                {this.props.store.selectedSamples.result.length > 0 &&
+                    !this.store.loadingInitialDataForSummaryTab && (
+                        <div data-test="summary-tab-content">
+                            <div className={styles.studyViewFlexContainer}>
+                                {this.store.defaultVisibleAttributes
+                                    .isComplete && (
+                                    <ReactGridLayout
+                                        className="layout"
+                                        style={{
+                                            width: this.store.containerWidth,
+                                        }}
+                                        width={this.store.containerWidth}
+                                        cols={
+                                            this.store.studyViewPageLayoutProps
+                                                .cols
+                                        }
+                                        rowHeight={
+                                            this.store.studyViewPageLayoutProps
+                                                .grid.h
+                                        }
+                                        layout={
+                                            this.store.studyViewPageLayoutProps
+                                                .layout
+                                        }
+                                        margin={[
+                                            STUDY_VIEW_CONFIG.layout.gridMargin
+                                                .x,
+                                            STUDY_VIEW_CONFIG.layout.gridMargin
+                                                .y,
+                                        ]}
+                                        useCSSTransforms={false}
+                                        draggableHandle={`.${chartHeaderStyles.draggable}`}
+                                        onLayoutChange={
+                                            this.handlers.onLayoutChange
+                                        }
+                                        onResizeStop={this.onResize}
+                                    >
+                                        {this.store.visibleAttributes.map(
+                                            this.renderAttributeChart
+                                        )}
+                                    </ReactGridLayout>
+                                )}
+                            </div>
                         </div>
-                    </div>
-                )}
+                    )}
+                {this.props.store.selectedSamples.isComplete &&
+                    this.props.store.selectedSamples.result.length === 0 && (
+                        <div className={styles.studyViewNoSamples}>
+                            <div className={styles.studyViewNoSamplesInner}>
+                                <p>
+                                    The filters you have selected have filtered
+                                    out all the samples in this study; because
+                                    of this, no data visualizations are shown.
+                                </p>
+                                <p>
+                                    You can remove filters in the header of this
+                                    page to widen your search criteria and add
+                                    samples back to your results.
+                                </p>
+                            </div>
+                        </div>
+                    )}
             </div>
         );
     }

--- a/src/pages/studyView/tabs/studySummaryTabStyles.module.scss
+++ b/src/pages/studyView/tabs/studySummaryTabStyles.module.scss
@@ -5,6 +5,21 @@
     width: 100%;
 }
 
+.studyViewNoSamples {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.studyViewNoSamplesInner {
+    width: 500px;
+    margin: 10px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    background: #f5f5f5;
+}
+
 .quickFilters {
     display: flex;
     padding: 5px 10px;

--- a/src/pages/studyView/tabs/studySummaryTabStyles.module.scss.d.ts
+++ b/src/pages/studyView/tabs/studySummaryTabStyles.module.scss.d.ts
@@ -1,6 +1,8 @@
 declare const styles: {
   readonly "quickFilters": string;
   readonly "studyViewFlexContainer": string;
+  readonly "studyViewNoSamples": string;
+  readonly "studyViewNoSamplesInner": string;
 };
 export = styles;
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7578
Fix cBioPortal/cbioportal#7577

This is a preliminary commit for adding treatment timeline data
to the study view page. The data will be presented in two charts:
- Sample Treatments Chart
  - Each sample is taken before or after a patient recieves a treatments
  - For each treatment, there are two rows in the chart
    - A row for all the samples for patients that recieved that treatment
    that occured before the patient recieved that treatment
    - A row for all the samples for patients that recieved that treatment
    that occured during or after the patient recieved that treatment
