### PR TITLE
Add extra header to aid debugging in sentry (cbioportal only)

### DIFF
--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -30,6 +30,7 @@ import { AppStore } from './AppStore';
 import { handleLongUrls } from 'shared/lib/handleLongUrls';
 import 'shared/polyfill/canvasToBlob';
 import mobx from 'mobx';
+import { setCurrentURLHeader } from 'shared/lib/extraHeader';
 
 superagentCache(superagent);
 
@@ -70,6 +71,12 @@ if (getBrowserWindow().navigator.webdriver) {
     });
 
     setNetworkListener();
+}
+
+// for cbioportal instances, add an extra custom HTTP header to
+// aid debugging in Sentry
+if (/cbioportal\.org/.test(getBrowserWindow().location.href)) {
+    setCurrentURLHeader();
 }
 
 // expose version on window

--- a/src/shared/lib/extraHeader.ts
+++ b/src/shared/lib/extraHeader.ts
@@ -1,0 +1,18 @@
+export function setCurrentURLHeader() {
+    const old_send = XMLHttpRequest.prototype.send;
+
+    var xhrProto = XMLHttpRequest.prototype,
+        origOpen = xhrProto.open;
+
+    xhrProto.open = function(method: string, url: string) {
+        this._url = url;
+        return origOpen.apply(this, arguments);
+    };
+
+    XMLHttpRequest.prototype.send = function() {
+        if (this._url && /www\.cbioportal\.org\/api/.test(this._url)) {
+            this.setRequestHeader('X-CURRENT-URL', window.location.href);
+        }
+        old_send.apply(this, arguments);
+    };
+}


### PR DESCRIPTION
In Sentry error log, http referrer is set to the url when page was loaded. Subsequent SPA navigation is not respected.  This PR sets custom header which will reflect url at moment network request was sent.