### PR TITLE
Hide mutation assessor on functional impact column

### DIFF
--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -46,6 +46,9 @@ interface FunctionalImpactData {
     polyPhenScore: number | undefined;
     polyPhenPrediction: string | undefined;
 }
+// mutation assessor server is not stable
+// set "SHOW_MUTATION_ASSESSOR = true" to enable mutation assessor
+const SHOW_MUTATION_ASSESSOR = false;
 
 class FunctionalImpactColumnTooltip extends React.Component<
     FunctionalImpactColumnTooltipProps,
@@ -65,27 +68,29 @@ class FunctionalImpactColumnTooltip extends React.Component<
                     <thead>
                         <tr>
                             <th>Legend</th>
-                            <th>
-                                <span
-                                    style={{
-                                        display: 'inline-block',
-                                        width: 22,
-                                    }}
-                                    title="Mutation Asessor"
-                                    onMouseOver={() =>
-                                        this.setState({
-                                            active: 'mutationAssessor',
-                                        })
-                                    }
-                                >
-                                    <img
-                                        height={14}
-                                        width={14}
-                                        src={require('./mutationAssessor.png')}
-                                        alt="Mutation Assessor"
-                                    />
-                                </span>
-                            </th>
+                            {SHOW_MUTATION_ASSESSOR && (
+                                <th>
+                                    <span
+                                        style={{
+                                            display: 'inline-block',
+                                            width: 22,
+                                        }}
+                                        title="Mutation Asessor"
+                                        onMouseOver={() =>
+                                            this.setState({
+                                                active: 'mutationAssessor',
+                                            })
+                                        }
+                                    >
+                                        <img
+                                            height={14}
+                                            width={14}
+                                            src={require('./mutationAssessor.png')}
+                                            alt="Mutation Assessor"
+                                        />
+                                    </span>
+                                </th>
+                            )}
                             <th>
                                 <span
                                     style={{
@@ -143,9 +148,15 @@ class FunctionalImpactColumnTooltip extends React.Component<
                                     ></i>
                                 </span>
                             </td>
-                            <td className={mutationAssessorStyles['ma-high']}>
-                                high
-                            </td>
+                            {SHOW_MUTATION_ASSESSOR && (
+                                <td
+                                    className={
+                                        mutationAssessorStyles['ma-high']
+                                    }
+                                >
+                                    high
+                                </td>
+                            )}
                             <td className={siftStyles['sift-deleterious']}>
                                 deleterious
                             </td>
@@ -159,28 +170,34 @@ class FunctionalImpactColumnTooltip extends React.Component<
                                 probably_damaging
                             </td>
                         </tr>
-                        <tr>
-                            <td>
-                                <span
-                                    className={classNames(
-                                        annotationStyles[
-                                            'annotation-item-text'
-                                        ],
-                                        mutationAssessorStyles[`ma-medium`]
-                                    )}
+                        {SHOW_MUTATION_ASSESSOR && (
+                            <tr>
+                                <td>
+                                    <span
+                                        className={classNames(
+                                            annotationStyles[
+                                                'annotation-item-text'
+                                            ],
+                                            mutationAssessorStyles[`ma-medium`]
+                                        )}
+                                    >
+                                        <i
+                                            className="fa fa-circle"
+                                            aria-hidden="true"
+                                        ></i>
+                                    </span>
+                                </td>
+                                <td
+                                    className={
+                                        mutationAssessorStyles['ma-medium']
+                                    }
                                 >
-                                    <i
-                                        className="fa fa-circle"
-                                        aria-hidden="true"
-                                    ></i>
-                                </span>
-                            </td>
-                            <td className={mutationAssessorStyles['ma-medium']}>
-                                medium
-                            </td>
-                            <td>-</td>
-                            <td>-</td>
-                        </tr>
+                                    medium
+                                </td>
+                                <td>-</td>
+                                <td>-</td>
+                            </tr>
+                        )}
                         <tr>
                             <td>
                                 <span
@@ -197,9 +214,13 @@ class FunctionalImpactColumnTooltip extends React.Component<
                                     ></i>
                                 </span>
                             </td>
-                            <td className={mutationAssessorStyles['ma-low']}>
-                                low
-                            </td>
+                            {SHOW_MUTATION_ASSESSOR && (
+                                <td
+                                    className={mutationAssessorStyles['ma-low']}
+                                >
+                                    low
+                                </td>
+                            )}
                             <td
                                 className={
                                     siftStyles[
@@ -235,11 +256,15 @@ class FunctionalImpactColumnTooltip extends React.Component<
                                     ></i>
                                 </span>
                             </td>
-                            <td
-                                className={mutationAssessorStyles['ma-neutral']}
-                            >
-                                neutral
-                            </td>
+                            {SHOW_MUTATION_ASSESSOR && (
+                                <td
+                                    className={
+                                        mutationAssessorStyles['ma-neutral']
+                                    }
+                                >
+                                    neutral
+                                </td>
+                            )}
                             <td
                                 className={
                                     siftStyles['sift-tolerated_low_confidence']
@@ -267,7 +292,7 @@ class FunctionalImpactColumnTooltip extends React.Component<
                                     ></i>
                                 </span>
                             </td>
-                            <td>-</td>
+                            {SHOW_MUTATION_ASSESSOR && <td>-</td>}
                             <td className={siftStyles['sift-tolerated']}>
                                 tolerated
                             </td>
@@ -355,25 +380,29 @@ export default class FunctionalImpactColumnFormatter {
                 {name}
                 <br />
                 <div style={{ height: 14 }}>
-                    <DefaultTooltip
-                        overlay={
-                            <FunctionalImpactColumnTooltip active="mutationAssessor" />
-                        }
-                        placement="topLeft"
-                        trigger={['hover', 'focus']}
-                        arrowContent={arrowContent}
-                        destroyTooltipOnHide={true}
-                        onPopupAlign={placeArrow}
-                    >
-                        <span style={{ display: 'inline-block', width: 22 }}>
-                            <img
-                                height={14}
-                                width={14}
-                                src={require('./mutationAssessor.png')}
-                                alt="Sift"
-                            />
-                        </span>
-                    </DefaultTooltip>
+                    {SHOW_MUTATION_ASSESSOR && (
+                        <DefaultTooltip
+                            overlay={
+                                <FunctionalImpactColumnTooltip active="mutationAssessor" />
+                            }
+                            placement="topLeft"
+                            trigger={['hover', 'focus']}
+                            arrowContent={arrowContent}
+                            destroyTooltipOnHide={true}
+                            onPopupAlign={placeArrow}
+                        >
+                            <span
+                                style={{ display: 'inline-block', width: 22 }}
+                            >
+                                <img
+                                    height={14}
+                                    width={14}
+                                    src={require('./mutationAssessor.png')}
+                                    alt="Sift"
+                                />
+                            </span>
+                        </DefaultTooltip>
+                    )}
                     <DefaultTooltip
                         overlay={
                             <FunctionalImpactColumnTooltip active="sift" />
@@ -524,10 +553,11 @@ export default class FunctionalImpactColumnFormatter {
         );
         return (
             <div>
-                {FunctionalImpactColumnFormatter.makeFunctionalImpactViz(
-                    mutationAssessorCacheData,
-                    FunctionalImpactColumnsName.MUTATION_ASSESSOR
-                )}
+                {SHOW_MUTATION_ASSESSOR &&
+                    FunctionalImpactColumnFormatter.makeFunctionalImpactViz(
+                        mutationAssessorCacheData,
+                        FunctionalImpactColumnsName.MUTATION_ASSESSOR
+                    )}
                 {FunctionalImpactColumnFormatter.makeFunctionalImpactViz(
                     siftPolyphenCacheData,
                     FunctionalImpactColumnsName.SIFT


### PR DESCRIPTION
Partial of https://github.com/cBioPortal/cbioportal/issues/7691


Describe changes proposed in this pull request:
- Because mutation assessor server is not stable, adding a parameter `SHOW_MUTATION_ASSESSOR` to hide or show mutation assessor
- by default the `SHOW_MUTATION_ASSESSOR` is set to false since the mutation assessor is down for a while


In the future if we decide to show mutation assessor again, just set `SHOW_MUTATION_ASSESSOR = true`, or remove `SHOW_MUTATION_ASSESSOR` parts completely if mutation assessor is stable.

