### PR TITLE
Named tracks in oncoprinter. This allows duplicate gene tracks and combined gene tracks

### DIFF
--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.spec.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.spec.ts
@@ -28,6 +28,26 @@ describe('OncoprinterGeneticUtils', () => {
     });
 
     describe('parseGeneticInput', () => {
+        it('skips header line', () => {
+            assert.deepEqual(
+                parseGeneticInput(
+                    'sample gene alteration type\nsample_id TP53 FUSION FUSION\n'
+                ),
+                {
+                    parseSuccess: true,
+                    result: [
+                        {
+                            sampleId: 'sample_id',
+                            hugoGeneSymbol: 'TP53',
+                            alteration: 'fusion',
+                            proteinChange: 'FUSION',
+                            trackName: undefined,
+                        },
+                    ],
+                    error: undefined,
+                }
+            );
+        });
         it('parses fusion command correctly', () => {
             assert.deepEqual(
                 parseGeneticInput('sample_id TP53 FUSION FUSION'),
@@ -39,6 +59,7 @@ describe('OncoprinterGeneticUtils', () => {
                             hugoGeneSymbol: 'TP53',
                             alteration: 'fusion',
                             proteinChange: 'FUSION',
+                            trackName: undefined,
                         },
                     ],
                     error: undefined,
@@ -65,6 +86,7 @@ describe('OncoprinterGeneticUtils', () => {
                             alteration: 'missense',
                             proteinChange: 'Q1538A',
                             isGermline: true,
+                            trackName: undefined,
                         },
                     ],
                     error: undefined,
@@ -83,6 +105,7 @@ describe('OncoprinterGeneticUtils', () => {
                             alteration: 'trunc',
                             proteinChange: 'Q1538A',
                             isCustomDriver: true,
+                            trackName: undefined,
                         },
                     ],
                     error: undefined,
@@ -104,6 +127,7 @@ describe('OncoprinterGeneticUtils', () => {
                             proteinChange: 'Q1538A',
                             isGermline: true,
                             isCustomDriver: true,
+                            trackName: undefined,
                         },
                     ],
                     error: undefined,
@@ -117,6 +141,28 @@ describe('OncoprinterGeneticUtils', () => {
                 );
                 assert(false);
             } catch (e) {}
+        });
+        it('parses a line with a given track name correctly', () => {
+            assert.deepEqual(
+                parseGeneticInput(
+                    'sampleid	BRCA1	Q1538A	MISSENSE_GERMLINE_DRIVER	testTrackName'
+                ),
+                {
+                    parseSuccess: true,
+                    result: [
+                        {
+                            sampleId: 'sampleid',
+                            hugoGeneSymbol: 'BRCA1',
+                            alteration: 'missense',
+                            proteinChange: 'Q1538A',
+                            isGermline: true,
+                            isCustomDriver: true,
+                            trackName: 'testTrackName',
+                        },
+                    ],
+                    error: undefined,
+                }
+            );
         });
     });
 });

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterHelp.tsx
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterHelp.tsx
@@ -18,7 +18,8 @@ export const GenomicFormatHelp = (
         <br />
         <strong>(2)</strong> <code>Sample</code>&#9;<code>Gene</code>&#9;
         <code>Alteration</code>&#9;
-        <code>Type</code>
+        <code>Type</code>&#9;
+        <code>Track Name (optional)</code>
         <br />
         {/*<strong>(3) (MAF format, mutation only)</strong> <code>Sample</code>, <code>Cancer Type</code>, <code>Protein Change</code>, <code>Mutation Type</code>,	<code>Chromosome</code>,
         <code>Start position</code>, <code>End position</code>, <code>Reference allele</code>,	<code>Variant allele</code><br/>
@@ -134,6 +135,13 @@ export const GenomicFormatHelp = (
                         <code>PROT</code>: a protein expression event
                     </li>
                 </ul>
+            </li>
+            <li>
+                <code>Track Name</code>: Optional way to create a track with a
+                different label than the gene. A common use case is to have more
+                than one track with the same gene, e.g. where one track shows
+                different data for each sample. Another use case could be to
+                have one track that has data from more than one gene.
             </li>
         </ol>
     </div>

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterImportUtils.spec.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterImportUtils.spec.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import {
+    generateUniqueLabel,
     getOncoprinterClinicalInput,
     getOncoprinterGeneticInput,
     getOncoprinterHeatmapInput,
@@ -14,108 +15,147 @@ import { ONCOPRINTER_VAL_NA } from './OncoprinterClinicalAndHeatmapUtils';
 import { IHeatmapTrackSpec } from '../../../../shared/components/oncoprint/Oncoprint';
 
 describe('OncoprinterImportUtils', () => {
+    describe('generateUniqueLabel', () => {
+        it('returns the same unique label if its unused, and keeps count correctly', () => {
+            const counts: any = {};
+            const label = generateUniqueLabel('label', counts);
+            assert.equal(label, 'label');
+            assert.deepEqual(counts, { label: 1 });
+        });
+        it('disambiguates an already-used label, and keeps track of counts correctly', () => {
+            const counts: any = { label: 1 };
+            const label = generateUniqueLabel('label', counts);
+            assert.equal(label, 'label_2');
+            assert.deepEqual(counts, { label: 2, label_2: 1 });
+        });
+        it('disambiguates correctly when the same label is already used, and keeps track of counts correctly', () => {
+            const counts: any = { label: 2, label_2: 1 };
+            let label = generateUniqueLabel('label', counts);
+            assert.equal(label, 'label_3');
+            assert.deepEqual(counts, { label: 3, label_2: 1, label_3: 1 });
+
+            label = generateUniqueLabel('label_2', counts);
+            assert.equal(label, 'label_2_2');
+            assert.deepEqual(counts, {
+                label: 3,
+                label_2: 2,
+                label_3: 1,
+                label_2_2: 1,
+            });
+        });
+    });
     describe('getOncoprinterGeneticInput', () => {
         const data: any[] = [
             {
-                sample: 'sample1',
-                patient: 'patient1',
+                label: 'label1',
                 data: [
                     {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.MUTATION_EXTENDED,
-                        proteinChange: 'proteinChange1',
-                        mutationType: 'missense',
-                        hugoGeneSymbol: 'gene1',
-                        mutationStatus: 'germline',
-                        driverFilter: PUTATIVE_DRIVER,
+                        sample: 'sample1',
+                        patient: 'patient1',
+                        data: [
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.MUTATION_EXTENDED,
+                                proteinChange: 'proteinChange1',
+                                mutationType: 'missense',
+                                hugoGeneSymbol: 'gene1',
+                                mutationStatus: 'germline',
+                                driverFilter: PUTATIVE_DRIVER,
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+                                hugoGeneSymbol: 'gene1',
+                                value: -2,
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.MRNA_EXPRESSION,
+                                hugoGeneSymbol: 'gene1',
+                                alterationSubType: 'high',
+                            },
+                        ],
                     },
                     {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.COPY_NUMBER_ALTERATION,
-                        hugoGeneSymbol: 'gene1',
-                        value: -2,
-                    },
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.MRNA_EXPRESSION,
-                        hugoGeneSymbol: 'gene1',
-                        alterationSubType: 'high',
+                        sample: 'sample2',
+                        patient: 'patient2',
+                        data: [
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.MUTATION_EXTENDED,
+                                proteinChange: 'proteinChange2',
+                                mutationType: 'frameshift',
+                                mutationStatus: 'germline',
+                                hugoGeneSymbol: 'gene1',
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+                                hugoGeneSymbol: 'gene1',
+                                value: 2,
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.PROTEIN_LEVEL,
+                                hugoGeneSymbol: 'gene1',
+                                alterationSubType: 'high',
+                            },
+                        ],
                     },
                 ],
             },
             {
-                sample: 'sample1',
-                patient: 'patient1',
+                label: 'label2',
                 data: [
                     {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.MUTATION_EXTENDED,
-                        proteinChange: 'promoter',
-                        mutationType: 'promoter',
-                        hugoGeneSymbol: 'gene2',
+                        sample: 'sample1',
+                        patient: 'patient1',
+                        data: [
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.MUTATION_EXTENDED,
+                                proteinChange: 'promoter',
+                                mutationType: 'promoter',
+                                hugoGeneSymbol: 'gene2',
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+                                hugoGeneSymbol: 'gene2',
+                                value: 1,
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.MRNA_EXPRESSION,
+                                hugoGeneSymbol: 'gene2',
+                                alterationSubType: 'low',
+                            },
+                        ],
                     },
                     {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.COPY_NUMBER_ALTERATION,
-                        hugoGeneSymbol: 'gene2',
-                        value: 1,
-                    },
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.MRNA_EXPRESSION,
-                        hugoGeneSymbol: 'gene2',
-                        alterationSubType: 'low',
-                    },
-                ],
-            },
-            {
-                sample: 'sample2',
-                patient: 'patient2',
-                data: [
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.MUTATION_EXTENDED,
-                        proteinChange: 'proteinChange2',
-                        mutationType: 'frameshift',
-                        mutationStatus: 'germline',
-                        hugoGeneSymbol: 'gene1',
-                    },
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.COPY_NUMBER_ALTERATION,
-                        hugoGeneSymbol: 'gene1',
-                        value: 2,
-                    },
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.PROTEIN_LEVEL,
-                        hugoGeneSymbol: 'gene1',
-                        alterationSubType: 'high',
-                    },
-                ],
-            },
-            {
-                sample: 'sample2',
-                patient: 'patient2',
-                data: [
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.MUTATION_EXTENDED,
-                        proteinChange: 'proteinChange3',
-                        mutationType: 'fusion',
-                        hugoGeneSymbol: 'gene2',
-                    },
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.COPY_NUMBER_ALTERATION,
-                        hugoGeneSymbol: 'gene2',
-                        value: 0,
-                    },
-                    {
-                        molecularProfileAlterationType:
-                            AlterationTypeConstants.PROTEIN_LEVEL,
-                        hugoGeneSymbol: 'gene2',
-                        alterationSubType: 'low',
+                        sample: 'sample2',
+                        patient: 'patient2',
+                        data: [
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.MUTATION_EXTENDED,
+                                proteinChange: 'proteinChange3',
+                                mutationType: 'fusion',
+                                hugoGeneSymbol: 'gene2',
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+                                hugoGeneSymbol: 'gene2',
+                                value: 0,
+                            },
+                            {
+                                molecularProfileAlterationType:
+                                    AlterationTypeConstants.PROTEIN_LEVEL,
+                                hugoGeneSymbol: 'gene2',
+                                alterationSubType: 'low',
+                            },
+                        ],
                     },
                 ],
             },
@@ -127,18 +167,18 @@ describe('OncoprinterImportUtils', () => {
                     ['sample1', 'sample2'],
                     'sample'
                 ),
-                'sample1  gene1  proteinChange1  MISSENSE_GERMLINE_DRIVER\n' +
-                    'sample1  gene1  HOMDEL  CNA\n' +
-                    'sample1  gene1  HIGH  EXP\n' +
-                    'sample1  gene2  promoter  PROMOTER\n' +
-                    'sample1  gene2  GAIN  CNA\n' +
-                    'sample1  gene2  LOW  EXP\n' +
-                    'sample2  gene1  proteinChange2  TRUNC_GERMLINE\n' +
-                    'sample2  gene1  AMP  CNA\n' +
-                    'sample2  gene1  HIGH  PROT\n' +
-                    'sample2  gene2  proteinChange3  FUSION\n' +
+                'sample1  gene1  proteinChange1  MISSENSE_GERMLINE_DRIVER  label1\n' +
+                    'sample1  gene1  HOMDEL  CNA  label1\n' +
+                    'sample1  gene1  HIGH  EXP  label1\n' +
+                    'sample2  gene1  proteinChange2  TRUNC_GERMLINE  label1\n' +
+                    'sample2  gene1  AMP  CNA  label1\n' +
+                    'sample2  gene1  HIGH  PROT  label1\n' +
+                    'sample1  gene2  promoter  PROMOTER  label2\n' +
+                    'sample1  gene2  GAIN  CNA  label2\n' +
+                    'sample1  gene2  LOW  EXP  label2\n' +
+                    'sample2  gene2  proteinChange3  FUSION  label2\n' +
                     'sample2\n' +
-                    'sample2  gene2  LOW  PROT\n' +
+                    'sample2  gene2  LOW  PROT  label2\n' +
                     'sample1\nsample2'
             );
         });
@@ -149,18 +189,18 @@ describe('OncoprinterImportUtils', () => {
                     ['patient1', 'patient2'],
                     'patient'
                 ),
-                'patient1  gene1  proteinChange1  MISSENSE_GERMLINE_DRIVER\n' +
-                    'patient1  gene1  HOMDEL  CNA\n' +
-                    'patient1  gene1  HIGH  EXP\n' +
-                    'patient1  gene2  promoter  PROMOTER\n' +
-                    'patient1  gene2  GAIN  CNA\n' +
-                    'patient1  gene2  LOW  EXP\n' +
-                    'patient2  gene1  proteinChange2  TRUNC_GERMLINE\n' +
-                    'patient2  gene1  AMP  CNA\n' +
-                    'patient2  gene1  HIGH  PROT\n' +
-                    'patient2  gene2  proteinChange3  FUSION\n' +
+                'patient1  gene1  proteinChange1  MISSENSE_GERMLINE_DRIVER  label1\n' +
+                    'patient1  gene1  HOMDEL  CNA  label1\n' +
+                    'patient1  gene1  HIGH  EXP  label1\n' +
+                    'patient2  gene1  proteinChange2  TRUNC_GERMLINE  label1\n' +
+                    'patient2  gene1  AMP  CNA  label1\n' +
+                    'patient2  gene1  HIGH  PROT  label1\n' +
+                    'patient1  gene2  promoter  PROMOTER  label2\n' +
+                    'patient1  gene2  GAIN  CNA  label2\n' +
+                    'patient1  gene2  LOW  EXP  label2\n' +
+                    'patient2  gene2  proteinChange3  FUSION  label2\n' +
                     'patient2\n' +
-                    'patient2  gene2  LOW  PROT\n' +
+                    'patient2  gene2  LOW  PROT  label2\n' +
                     'patient1\npatient2'
             );
         });

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -927,12 +927,8 @@ export default class ResultsViewOncoprint extends React.Component<
 
                                 let geneticInput = '';
                                 if (geneticTracks.length > 0) {
-                                    const oncoprintGeneticData = _.flatMap(
-                                        geneticTracks,
-                                        (track: GeneticTrackSpec) => track.data
-                                    );
                                     geneticInput = getOncoprinterGeneticInput(
-                                        oncoprintGeneticData,
+                                        geneticTracks,
                                         caseIds,
                                         this.oncoprintAnalysisCaseType
                                     );


### PR DESCRIPTION
The main use case will be using the "Open in Oncoprinter" feature from the results view.

[Combined gene track](https://www.cbioportal.org/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_id=coadread_tcga_pub&cancer_study_list=coadread_tcga_pub&case_set_id=coadread_tcga_pub_nonhypermut&data_priority=0&gene_list=%255BKRAS%2520NRAS%2520BRAF%255D&gene_set_choice=user-defined-list&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=coadread_tcga_pub_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=coadread_tcga_pub_mutations&profileFilter=0&tab_index=tab_visualize)
![image](https://user-images.githubusercontent.com/636232/88109965-638eb680-cb79-11ea-8064-3a4fe355caa5.png)

[Duplicate gene tracks](https://www.cbioportal.org/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_id=coadread_tcga_pub&cancer_study_list=coadread_tcga_pub&case_set_id=coadread_tcga_pub_nonhypermut&data_priority=0&gene_list=PTEN%253AMUT%2520%250APTEN%253AAMP%2520HOMDEL&gene_set_choice=user-defined-list&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=coadread_tcga_pub_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=coadread_tcga_pub_mutations&profileFilter=0&tab_index=tab_visualize)
![image](https://user-images.githubusercontent.com/636232/88110054-8751fc80-cb79-11ea-8d8f-ab6ceb9c0987.png)
