### PR TITLE
update Generic Assay data tooltip on Oncoprint heatmap

### DIFF
--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -163,6 +163,7 @@ export interface IHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     onRemove?: () => void;
     onClickRemoveInTrackMenu?: () => void;
     molecularProfileName?: string;
+    genericAssayType?: string;
     pivotThreshold?: number;
     sortOrder?: string;
     maxProfileValue?: number;

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -1131,6 +1131,7 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
                     .genericAssayMolecularDataCache.result!;
 
                 const entityId = query.stableId;
+                const genericAssayType = profile.genericAssayType;
                 const pivotThreshold = profile.pivotThreshold;
                 const sortOrder = profile.sortOrder;
                 const entityLinkMap = oncoprint.props.store
@@ -1164,6 +1165,7 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
                         })),
                         sortOrder
                     ),
+                    genericAssayType: genericAssayType,
                     pivotThreshold: pivotThreshold,
                     sortOrder: sortOrder,
                     trackLinkUrl: entityLinkMap[entityId],

--- a/src/shared/components/oncoprint/TooltipUtils.spec.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.spec.ts
@@ -15,6 +15,8 @@ import {
 import $ from 'jquery';
 import { MolecularProfile, Mutation } from 'cbioportal-ts-api-client';
 import { getPatientViewUrl, getSampleViewUrl } from '../../api/urls';
+import AppConfig from 'appConfig';
+import ServerConfigDefaults from 'config/serverConfigDefaults';
 
 describe('Oncoprint TooltipUtils', () => {
     describe('getCaseViewElt', () => {
@@ -2581,6 +2583,10 @@ describe('Oncoprint TooltipUtils', () => {
             false
         );
 
+        before(() => {
+            AppConfig.serverConfig.generic_assay_display_text = ServerConfigDefaults.generic_assay_display_text!;
+        });
+
         it('should show data rounded to 2 decimal digits', () => {
             // one data
             let tooltipResult = tooltip([
@@ -2685,49 +2691,59 @@ describe('Oncoprint TooltipUtils', () => {
             );
         });
 
-        const fTreamentTooltip = makeHeatmapTrackTooltip(
-            { molecularAlterationType: 'GENERIC_ASSAY' } as any,
+        const genericAssayTooltip = makeHeatmapTrackTooltip(
+            {
+                molecularAlterationType: 'GENERIC_ASSAY',
+                genericAssayType: 'TREATMENT_RESPONSE',
+            } as any,
             false
         );
 
         it('Should handle categories for generic assay genetic alterations', () => {
-            const tooltipResult = fTreamentTooltip([
+            const tooltipResult = genericAssayTooltip([
                 { profile_data: 8, sample: 'sampleID', category: '>8.00' },
             ]);
             assert.isTrue(
-                tooltipResult.html().indexOf('<b>&gt;8.00</b>') > -1,
+                tooltipResult
+                    .html()
+                    .indexOf('<br>Treatment Response: <b>&gt;8.00</b><br>') >
+                    -1,
                 'generic assay - category is displayed when available'
             );
         });
 
         it('Should handle categories for multiple generic assay genetic alterations', () => {
-            const tooltipResult = fTreamentTooltip([
+            const tooltipResult = genericAssayTooltip([
                 { profile_data: 8, sample: 'sampleID', category: '>8.00' },
                 { profile_data: 7, sample: 'sampleID', category: '>7.00' },
             ]);
             assert.isTrue(
                 tooltipResult
                     .html()
-                    .indexOf('<b>&gt;8.00, &gt;7.00 (2 data points)</b>') > -1,
+                    .indexOf(
+                        '<br>Treatment Response: <b>&gt;8.00, &gt;7.00 (2 data points)</b><br>'
+                    ) > -1,
                 'generic assay - multiple categories are displayed when under mouse'
             );
         });
 
         it('Should handle single values and single category for multiple generic assay genetic alterations', () => {
-            const tooltipResult = fTreamentTooltip([
+            const tooltipResult = genericAssayTooltip([
                 { profile_data: 8, sample: 'sampleID', category: '' },
                 { profile_data: 7, sample: 'sampleID', category: '>7.00' },
             ]);
             assert.isTrue(
                 tooltipResult
                     .html()
-                    .indexOf('<b>8.00</b> and <b>&gt;7.00</b>') > -1,
+                    .indexOf(
+                        '<br>Treatment Response: <b>8.00</b> and <b>&gt;7.00</b><br>'
+                    ) > -1,
                 'generic assay - multiple categories are displayed when under mouse'
             );
         });
 
         it('Should handle multiple values and multiple categories for multiple generic assay genetic alterations', () => {
-            const tooltipResult = fTreamentTooltip([
+            const tooltipResult = genericAssayTooltip([
                 { profile_data: 6, sample: 'sampleID', category: '' },
                 { profile_data: 8, sample: 'sampleID', category: '' },
                 { profile_data: 7, sample: 'sampleID', category: '>7.00' },
@@ -2738,7 +2754,7 @@ describe('Oncoprint TooltipUtils', () => {
                 tooltipResult
                     .html()
                     .indexOf(
-                        '<b>7.00 (average of 2 values)</b> and <b>&gt;7.00, &gt;9.00 (3 data points)</b>'
+                        '<br>Treatment Response: <b>7.00 (average of 2 values)</b> and <b>&gt;7.00, &gt;9.00 (3 data points)</b><br>'
                     ) > -1,
                 'generic assay - multiple values and categories (unique) are displayed when under mouse'
             );

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -12,6 +12,7 @@ import {
     ClinicalTrackSpec,
     GeneticTrackDatum,
     IBaseHeatmapTrackSpec,
+    IHeatmapTrackSpec,
 } from './Oncoprint';
 import {
     AnnotatedExtendedAlteration,
@@ -36,6 +37,7 @@ export const TOOLTIP_DIV_CLASS = 'oncoprint__tooltip';
 
 const tooltipTextElementNaN = 'N/A';
 import './styles.scss';
+import { deriveDisplayTextFromGenericAssayType } from 'pages/resultsView/plots/PlotsTabUtils';
 
 function sampleViewAnchorTag(study_id: string, sample_id: string) {
     return `<a class="nobreak" href="${getSampleViewUrl(
@@ -219,7 +221,10 @@ export function makeHeatmapTrackTooltip(
                     data_header = 'METHYLATION: ';
                     break;
                 case AlterationTypeConstants.GENERIC_ASSAY:
-                    data_header = 'GENERIC ASSAY: ';
+                    // track for GENERIC_ASSAY type always has the genericAssayType
+                    data_header = `${deriveDisplayTextFromGenericAssayType(
+                        (trackSpec as IHeatmapTrackSpec).genericAssayType!
+                    )}: `;
                     break;
                 default:
                     data_header = 'Value: ';


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7690

Describe changes proposed in this pull request:
- Show generic assay type instead of "Generic Assay"
![image](https://user-images.githubusercontent.com/15748980/88339795-ab901380-cd08-11ea-88f9-8617fc20911b.png)
