### PR TITLE
map variant annotation with mutation by originalVariantQuery

### DIFF
--- a/end-to-end-test/remote/specs/core/mutationMapperTool.spec.js
+++ b/end-to-end-test/remote/specs/core/mutationMapperTool.spec.js
@@ -288,10 +288,10 @@ describe('Mutation Mapper Tool', function() {
 
             browser.waitForVisible('[class=borderedChart]', 20000);
 
-            // check total number of mutations (this gets Showing 1-12 of 12
+            // check total number of mutations (this gets Showing 1-14 of 14
             // Mutations)
             const mutationCount = browser.getText(
-                './/*[text()[contains(.,"12 Mutations")]]'
+                './/*[text()[contains(.,"14 Mutations")]]'
             );
             assert.ok(mutationCount.length > 0);
         });

--- a/packages/cbioportal-utils/src/mutation/MutationAnnotator.spec.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationAnnotator.spec.ts
@@ -12,6 +12,7 @@ describe('MutationAnnotator', () => {
     const variantAnnotations = [
         {
             variant: 'X:g.66937331T>A',
+            originalVariantQuery: 'X,66937331,66937331,T,A',
             colocatedVariants: [
                 {
                     dbSnpId: 'COSM73703',
@@ -172,6 +173,7 @@ describe('MutationAnnotator', () => {
         },
         {
             variant: '17:g.41242962_41242963insGA',
+            originalVariantQuery: '17,41242962,41242963,-,GA',
             colocatedVariants: [
                 {
                     gnomad_nfe_maf: '9.314E-6',
@@ -997,6 +999,7 @@ describe('MutationAnnotator', () => {
         },
         {
             variant: '13:g.32912813G>T',
+            originalVariantQuery: '13,32912813,32912813,G,T',
             colocatedVariants: [
                 {
                     dbSnpId: 'COSM946800',
@@ -1129,6 +1132,7 @@ describe('MutationAnnotator', () => {
         },
         {
             variant: '12:g.133214671G>C',
+            originalVariantQuery: '12,133214671,133214671,G,C',
             colocatedVariants: [
                 {
                     dbSnpId: 'COSM78324',
@@ -1417,6 +1421,7 @@ describe('MutationAnnotator', () => {
         },
         {
             variant: '17:g.7577539G>A',
+            originalVariantQuery: '17,7577539,7577539,G,A',
             colocatedVariants: [
                 {
                     dbSnpId: 'CM010465',
@@ -1981,6 +1986,7 @@ describe('MutationAnnotator', () => {
         },
         {
             variant: '10:g.89692905G>A',
+            originalVariantQuery: '10,89692905,89692905,G,A',
             colocatedVariants: [
                 {
                     dbSnpId: 'CM981670',
@@ -2241,7 +2247,6 @@ describe('MutationAnnotator', () => {
                 mutationsWithGenomicLocation,
                 indexedVariantAnnotations
             );
-
             assert.notDeepEqual(
                 data,
                 mutationsWithGenomicLocation,

--- a/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
@@ -128,7 +128,6 @@ export function getMutationByTranscriptId(
             (tc: TranscriptConsequenceSummary) =>
                 tc.transcriptId === ensemblTranscriptId
         );
-
     if (
         variantAnnotation &&
         transcriptConsequenceSummaries &&
@@ -148,7 +147,6 @@ export function getMutationByTranscriptId(
         }
         return annotatedMutation as Mutation;
     } else {
-        // if mutation is not annotatable or can't map back (due to genomic location normalization or other reasons), return undefined
         return undefined;
     }
 }
@@ -325,10 +323,8 @@ export function indexAnnotationsByGenomicLocation(
     variantAnnotations: VariantAnnotation[]
 ): { [genomicLocation: string]: VariantAnnotation } {
     return _.keyBy(variantAnnotations, annotation =>
-        annotation.annotation_summary
-            ? genomicLocationString(
-                  annotation.annotation_summary.genomicLocation
-              )
+        annotation.originalVariantQuery
+            ? annotation.originalVariantQuery
             : genomicLocationStringFromVariantAnnotation(annotation)
     );
 }

--- a/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
+++ b/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
@@ -144,7 +144,6 @@ export class DefaultMutationMapperDataFetcher
             isoformOverrideSource,
             client
         );
-
         return getMyVariantInfoAnnotationsFromIndexedVariantAnnotations(
             indexedVariantAnnotations
         );
@@ -241,7 +240,6 @@ export class DefaultMutationMapperDataFetcher
         const genomicLocations: GenomicLocation[] = uniqueGenomicLocations(
             mutations
         );
-
         return client.fetchHotspotAnnotationByGenomicLocationPOST({
             genomicLocations: genomicLocations,
         });

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -686,7 +686,6 @@ export class PatientViewPageStore {
                 AppConfig.serverConfig.isoformOverrideSource,
                 this.genomeNexusClient
             );
-
             return getMyVariantInfoAnnotationsFromIndexedVariantAnnotations(
                 indexedVariantAnnotations
             );


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7707

Describe changes proposed in this pull request:
- map variant annotation with mutation by `originalVariantQuery`

Example:
https://deploy-preview-3327--cbioportalfrontend.netlify.app/results/mutations?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=msk_impact_2017&case_set_id=msk_impact_2017_cnaseq&data_priority=0&gene_list=ABL1&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=msk_impact_2017_cna&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=msk_impact_2017_mutations&mutations_transcript_id=ENST00000318560&profileFilter=0&tab_index=tab_visualize

Filter by `P-0006124-T01-IM5`. 

The genomic location of this mutation is 
```
9,133759441,133759501,GCGCCTTCTCCCCAAAGACAAAAAGACCAACTTGTTCAGCGCCTTGATCAAGAAGAAGAAG,GCGCCTTCTCCCCAAAGACAAAAAGACCAACTTGTTCAGCGCCTTGATCAAGAAGAAGAAGA
```
But in variant annotation is
```
9,133759501,133759502,-,A
```
Mapping with`originalVariantQuery` can make this variant show up in the mutation table


