### PR TITLE
Fix Plots tab error when querying multiple studies with empty sample ids

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1432,9 +1432,10 @@ export class ResultsViewPageStore {
                 const dataQueryFilter = studyToDataQueryFilter[profile.studyId];
 
                 // there could be no samples if a study doesn't have a sample list matching a specified category (e.g. cna only)
+                // skip when sampleIds is an empty list
                 if (
                     !dataQueryFilter ||
-                    (!dataQueryFilter.sampleIds &&
+                    (_.isEmpty(dataQueryFilter.sampleIds) &&
                         !dataQueryFilter.sampleListId)
                 ) {
                     continue;
@@ -4792,16 +4793,24 @@ export class ResultsViewPageStore {
                         const molecularProfileId = this
                             .studyToMutationMolecularProfile.result![studyId]
                             .molecularProfileId;
-                        const dqf = this.studyToDataQueryFilter.result![
-                            studyId
-                        ];
-                        if (dqf && molecularProfileId) {
+                        const dataQueryFilter = this.studyToDataQueryFilter
+                            .result![studyId];
+
+                        if (
+                            !dataQueryFilter ||
+                            (_.isEmpty(dataQueryFilter.sampleIds) &&
+                                !dataQueryFilter.sampleListId)
+                        ) {
+                            return Promise.resolve([]);
+                        }
+
+                        if (molecularProfileId) {
                             return client.fetchMutationsInMolecularProfileUsingPOST(
                                 {
                                     molecularProfileId,
                                     mutationFilter: {
                                         entrezGeneIds: [q.entrezGeneId],
-                                        ...dqf,
+                                        ...dataQueryFilter,
                                     } as MutationFilter,
                                     projection: 'DETAILED',
                                 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7713

[Test link](https://deploy-preview-3328--cbioportalfrontend.netlify.app/results/plots?Action=Submit&data_priority=0&plots_coloring_selection=%7B%7D&plots_horz_selection=%7B%7D&plots_vert_selection=%7B%7D&session_id=5e9f6e08e4b0ff7ef5fe0ba4&tab_index=tab_visualize)
The sample ids sometimes will be an empty list, 400 errors happens in that case. Do not send request with empty sample ids.