### PR TITLE
fix missing mutations in ATRX

### DIFF
--- a/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
@@ -128,6 +128,9 @@ export function getMutationByTranscriptId(
             (tc: TranscriptConsequenceSummary) =>
                 tc.transcriptId === ensemblTranscriptId
         );
+    if (isCanonicalTranscript) {
+        return mutation;
+    }
     if (
         variantAnnotation &&
         transcriptConsequenceSummaries &&

--- a/packages/cbioportal-utils/src/mutation/MutationUtils.spec.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationUtils.spec.ts
@@ -165,18 +165,12 @@ describe('MutationUtils', () => {
                 'genomic location string should be:  1,100,100,C,G'
             );
         });
-        it('normalizes chromosome and extracts genomic location', () => {
-            let genomicLocation: GenomicLocation = {
-                chromosome: '23',
-                start: 100,
-                end: 100,
-                referenceAllele: 'C',
-                variantAllele: 'G',
-            };
+        it('normalizes chromosome', () => {
+            let chromosome: string = '23';
             assert.equal(
-                genomicLocationString(genomicLocation),
-                'X,100,100,C,G',
-                'genomic location string should be:  X,100,100,C,G'
+                normalizeChromosome(chromosome),
+                'X',
+                'normalized chromosome should be: X'
             );
         });
     });

--- a/packages/cbioportal-utils/src/mutation/MutationUtils.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationUtils.ts
@@ -67,11 +67,7 @@ export function extractGenomicLocation(
 }
 
 export function genomicLocationString(genomicLocation: GenomicLocation) {
-    return `${normalizeChromosome(genomicLocation.chromosome)},${
-        genomicLocation.start
-    },${genomicLocation.end},${genomicLocation.referenceAllele},${
-        genomicLocation.variantAllele
-    }`;
+    return `${genomicLocation.chromosome},${genomicLocation.start},${genomicLocation.end},${genomicLocation.referenceAllele},${genomicLocation.variantAllele}`;
 }
 
 export function uniqueGenomicLocations(


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7754

Mutations are missing because all of them have chromosome 23, there are some mismatching for 23 and X. We have [this issue](https://github.com/cBioPortal/cbioportal/issues/7504) before, but now we are mapping with `originalVariantQuery`, so we can support 23 and 24 now without normalizing it.
- For canonical transcript, return mutation data directly to avoid difference with originalVariantQuery
- Remove normalization because by using originalVariantQuery we no longer need it


