### PR TITLE
Only call genome nexus annotation when transcript switch is enabled

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -4237,6 +4237,7 @@ export class ResultsViewPageStore {
         {
             await: () => [this.mutations],
             invoke: async () =>
+                AppConfig.serverConfig.show_transcript_dropdown &&
                 this.mutations.result
                     ? await fetchVariantAnnotationsIndexedByGenomicLocation(
                           this.mutations.result,


### PR DESCRIPTION
Only call genome nexus annotation when transcript switch is enabled. Pfam, ptm, transcripts, and hotspots are called as usual