### PR TITLE
Nonstart mutations should be categorized as Truncating

### DIFF
--- a/packages/cbioportal-frontend-commons/src/lib/getCanonicalMutationType.ts
+++ b/packages/cbioportal-frontend-commons/src/lib/getCanonicalMutationType.ts
@@ -99,6 +99,7 @@ export function getProteinImpactTypeFromCanonical(
         case CanonicalMutationType.FRAMESHIFT:
         case CanonicalMutationType.NONSENSE:
         case CanonicalMutationType.SPLICE_SITE:
+        case CanonicalMutationType.NONSTART:
         case CanonicalMutationType.NONSTOP:
         case CanonicalMutationType.TRUNCATING:
             return ProteinImpactType.TRUNCATING;
@@ -106,7 +107,6 @@ export function getProteinImpactTypeFromCanonical(
         case CanonicalMutationType.IN_FRAME_DEL:
         case CanonicalMutationType.INFRAME:
             return ProteinImpactType.INFRAME;
-        case CanonicalMutationType.NONSTART:
         case CanonicalMutationType.FUSION:
             return ProteinImpactType.FUSION;
         case CanonicalMutationType.SILENT:


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7761
Describe changes proposed in this pull request:
- Nonstart mutations should be categorized as Truncating

![image](https://user-images.githubusercontent.com/16869603/89435203-9062d200-d712-11ea-87c7-46b6249e88af.png)
