### PR TITLE
add mutation assessor back to functional impact column

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -57,6 +57,7 @@ export interface IServerConfig {
     show_oncokb: boolean;
     show_civic: boolean;
     show_genomenexus: boolean;
+    show_genomenexus_annotation_sources: string;
     show_pathway_mapper: boolean;
     show_mutation_mapper_tool_grch38: boolean;
     show_transcript_dropdown: boolean;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -45,6 +45,8 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     skin_description:
         'The cBioPortal for Cancer Genomics provides visualization, analysis and download of large-scale cancer genomics data sets',
     show_genomenexus: true,
+    // TODO should support more sources such as clinvar,gnomad,sift
+    show_genomenexus_annotation_sources: 'mutation_assessor',
     skin_authorization_message:
         'Access to this portal is only available to authorized users.',
     skin_documentation_about: 'About-Us.md',

--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -24,6 +24,7 @@ import GenomeNexusCache, {
     GenomeNexusCacheDataType,
 } from 'shared/cache/GenomeNexusCache';
 import * as _ from 'lodash';
+import { SHOW_MUTATION_ASSESSOR } from 'shared/lib/genomeNexusAnnotationSourcesUtils';
 
 type FunctionalImpactColumnTooltipProps = {
     active: 'mutationAssessor' | 'sift' | 'polyPhen2';
@@ -46,9 +47,6 @@ interface FunctionalImpactData {
     polyPhenScore: number | undefined;
     polyPhenPrediction: string | undefined;
 }
-// mutation assessor server is not stable
-// set "SHOW_MUTATION_ASSESSOR = true" to enable mutation assessor
-const SHOW_MUTATION_ASSESSOR = false;
 
 class FunctionalImpactColumnTooltip extends React.Component<
     FunctionalImpactColumnTooltipProps,

--- a/src/shared/lib/genomeNexusAnnotationSourcesUtils.ts
+++ b/src/shared/lib/genomeNexusAnnotationSourcesUtils.ts
@@ -1,0 +1,5 @@
+import AppConfig from 'appConfig';
+
+export const SHOW_MUTATION_ASSESSOR = RegExp('mutation_assessor', 'gi').test(
+    AppConfig.serverConfig.show_genomenexus_annotation_sources
+);


### PR DESCRIPTION
Partial Fix https://github.com/cBioPortal/cbioportal/issues/7756

`show.genome_nexus.annotation_sources` will set which sources to show on the frontend, list all sources name with comma-separated.

For now we only support `mutation_assessor`.

By default;
```
show.genome_nexus.annotation_sources=mutation_assessor
```
TODO: support more sources like clinvar and gnomad
