### PR TITLE
Make sure reference genome json is parsed regardless of contentype

### DIFF
--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -202,9 +202,10 @@ export async function fetchAllReferenceGenomeGenes(
 ) {
     if (AppConfig.serverConfig.app_name === 'public-portal') {
         // this is temporary
-        return $.get(
-            getFrontendAssetUrl('reactapp/reference_genome_hg19.json')
-        );
+        return $.ajax({
+            url: getFrontendAssetUrl('reactapp/reference_genome_hg19.json'),
+            dataType: 'json',
+        });
     }
     if (genomeName) {
         return await client.getAllReferenceGenomeGenesUsingGET({


### PR DESCRIPTION
On public portal we load json from a deployed file (to save hit on api).  Load is dependent on content type of response which is server dependent.