### PR TITLE
Fix reload of ResultsView components after opening annotation config menu when custom driver annotations are present

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -4809,7 +4809,11 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                                 <Observer>{this.controls}</Observer>
                             ) : (
                                 <LoadingIndicator
-                                    isLoading={true}
+                                    isLoading={
+                                        this.props.store
+                                            .customDriverAnnotationReport
+                                            .isPending
+                                    }
                                     center={true}
                                     size={'big'}
                                 />

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -1553,7 +1553,8 @@ export default class ResultsViewOncoprint extends React.Component<
                 this.props.store.molecularProfileIdToMolecularProfile,
                 this.alterationTypesInQuery,
                 this.alteredKeys,
-                this.heatmapTrackHeaders
+                this.heatmapTrackHeaders,
+                this.props.store.customDriverAnnotationReport
             ) === 'pending'
         );
     }


### PR DESCRIPTION
# Problem
When custom driver annotations are present and activated in portal.properties, opening the configuration menu in ResultsView triggers re-rendering of tab components (see video 1). Also, custom driver annotation data is not incorporated when loading the oncoprint for the first time (see incorrect legend labels in video 1).

# Analysis
The re-rendering is triggered by a store update via the variable `customDriverAnnotationReport` in the store that is first observed when the config menu is opened.

# Partial solution
I have added `customDriverAnnotationReport` as observed variable to ResultsViewOncoprint and PlotsTab. This solves the problem for these componens.

# Assistance required
Since this solution has to be applied to all ResultsView components individually, I think a more elegant solution that does this evaluation at a more central place would be preferred. I do not know what such a solution would look like. Help and advise here would be welcomed.

## Video 1 (before)
![Peek 2020-08-19 08-32](https://user-images.githubusercontent.com/745885/90601279-3f65da00-e1f8-11ea-8e49-85185e41d676.gif)

## Video 2 (after)
![Peek 2020-08-19 08-36](https://user-images.githubusercontent.com/745885/90601274-3d038000-e1f8-11ea-8c8b-b2596b352983.gif)