### PR TITLE
Remove survival clinical attribute from study view

### DIFF
--- a/src/pages/resultsView/survival/SurvivalUtil.tsx
+++ b/src/pages/resultsView/survival/SurvivalUtil.tsx
@@ -489,3 +489,15 @@ export function getSurvivalAttributes(clinicalAttributes: ClinicalAttribute[]) {
         .uniq()
         .value();
 }
+
+export function notSurvivalAttribute(
+    survivalClinicalAttributesPrefixes: string[],
+    attributeId: string
+) {
+    return _.every(survivalClinicalAttributesPrefixes, prefix => {
+        return (
+            `${prefix}_STATUS` !== attributeId &&
+            `${prefix}_MONTHS` !== attributeId
+        );
+    });
+}

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -170,6 +170,7 @@ import {
     getSurvivalAttributes,
     plotsPriority,
     getSurvivalStatusBoolean,
+    notSurvivalAttribute,
 } from 'pages/resultsView/survival/SurvivalUtil';
 import { ISurvivalDescription } from 'pages/resultsView/survival/SurvivalDescriptionTable';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
@@ -3543,10 +3544,20 @@ export class StudyViewPageStore {
         let _chartMetaSet = this._customCharts.toJS();
         _chartMetaSet = _.merge(_chartMetaSet, this._geneSpecificCharts.toJS());
 
+        // only filter out survival attributes when there are more than 4 types of survival attributes
+        const filteredClinicalAttributes =
+            _.entries(this.survivalClinicalAttributesPrefix.result).length > 4
+                ? _.filter(this.clinicalAttributes.result, attribute =>
+                      notSurvivalAttribute(
+                          this.survivalClinicalAttributesPrefix.result,
+                          attribute.clinicalAttributeId
+                      )
+                  )
+                : this.clinicalAttributes.result;
         // Add meta information for each of the clinical attribute
         // Convert to a Set for easy access and to update attribute meta information(would be useful while adding new features)
         _.reduce(
-            this.clinicalAttributes.result,
+            filteredClinicalAttributes,
             (acc: { [id: string]: ChartMeta }, attribute) => {
                 const uniqueKey = getUniqueKey(attribute);
                 acc[uniqueKey] = {


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Remove status and month attribute charts when there are more than 4 types of attribute
Before:
![image](https://user-images.githubusercontent.com/15748980/90925451-3ecb7000-e3bf-11ea-8102-9e4ddf1379c0.png)

After:
![image](https://user-images.githubusercontent.com/15748980/90925393-28bdaf80-e3bf-11ea-8d87-2f6c26b96315.png)
