### PR TITLE
Color by structural variants in plots tab

### DIFF
--- a/end-to-end-test/remote/specs/core/plots.screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/plots.screenshot.spec.js
@@ -449,6 +449,12 @@ describe('plots tab screenshot tests', function() {
         browser.click('.coloringLogScale');
         waitForAndCheckPlotsTab();
     });
+    it('plots tab with structural variant coloring', () => {
+        goToUrlAndSetLocalStorage(
+            `${CBIOPORTAL_URL}/results/plots?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=prad_mich&case_set_id=prad_mich_cna_seq&data_priority=0&gene_list=ERG&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=prad_mich_cna&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=prad_mich_mutations&genetic_profile_ids_PROFILE_STRUCTURAL_VARIANT=prad_mich_fusion&plots_coloring_selection=%7B"colorByCopyNumber"%3A"true"%2C"colorBySv"%3A"true"%7D&plots_horz_selection=%7B"dataType"%3A"clinical_attribute"%7D&plots_vert_selection=%7B"selectedGeneOption"%3A2078%2C"dataType"%3A"COPY_NUMBER_ALTERATION"%7D&profileFilter=0&tab_index=tab_visualize`
+        );
+        waitForAndCheckPlotsTab();
+    });
 });
 
 describe('plots tab multiple studies screenshot tests', function() {

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -36,6 +36,7 @@ export type PlotsColoringParam = {
     logScale?: string;
     colorByMutationType?: string;
     colorByCopyNumber?: string;
+    colorBySv?: string;
 };
 
 const PlotsColoringParamProps: Required<PlotsColoringParam> = {
@@ -43,6 +44,7 @@ const PlotsColoringParamProps: Required<PlotsColoringParam> = {
     logScale: '',
     colorByMutationType: '',
     colorByCopyNumber: '',
+    colorBySv: '',
 };
 
 export enum ResultsViewURLQueryEnum {

--- a/src/pages/resultsView/expression/ExpressionWrapper.tsx
+++ b/src/pages/resultsView/expression/ExpressionWrapper.tsx
@@ -52,7 +52,11 @@ import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicato
 import BoxScatterPlot, {
     IBoxScatterPlotData,
 } from '../../../shared/components/plots/BoxScatterPlot';
-import { ColoringType, PlotType } from '../plots/PlotsTab';
+import {
+    ColoringType,
+    PlotType,
+    SelectedColoringTypes,
+} from '../plots/PlotsTab';
 import AlterationFilterWarning from '../../../shared/components/banners/AlterationFilterWarning';
 import CaseFilterWarning from '../../../shared/components/banners/CaseFilterWarning';
 
@@ -603,23 +607,23 @@ export default class ExpressionWrapper extends React.Component<
 
     @computed get scatterPlotAppearance() {
         return makeScatterPlotPointAppearance(
-            this.viewType,
-            this.mutationDataExists,
-            this.cnaDataExists,
+            this.coloringTypes,
+            this.mutationDataExists.result!,
+            this.cnaDataExists.result!,
+            false,
             this.props.store.driverAnnotationSettings.driversAnnotated
         );
     }
 
-    @computed get viewType() {
-        if (this.showMutations && this.showCna) {
-            return ColoringType.MutationTypeAndCopyNumber;
-        } else if (this.showMutations) {
-            return ColoringType.MutationType;
-        } else if (this.showCna) {
-            return ColoringType.CopyNumber;
-        } else {
-            return ColoringType.None;
+    @computed get coloringTypes() {
+        const ret: SelectedColoringTypes = {};
+        if (this.showMutations) {
+            ret[ColoringType.MutationType] = true;
         }
+        if (this.showCna) {
+            ret[ColoringType.CopyNumber] = true;
+        }
+        return ret;
     }
 
     private boxCalculationFilter(d: IBoxScatterPlotPoint) {
@@ -642,7 +646,7 @@ export default class ExpressionWrapper extends React.Component<
     }
 
     @computed get zIndexSortBy() {
-        return scatterPlotZIndexSortBy<IPlotSampleData>(this.viewType);
+        return scatterPlotZIndexSortBy<IPlotSampleData>(this.coloringTypes);
     }
 
     @computed get axisLogScaleFunction(): IAxisLogScaleParams | undefined {
@@ -661,7 +665,11 @@ export default class ExpressionWrapper extends React.Component<
 
     @autobind
     private getChart() {
-        if (this.boxPlotData.isComplete) {
+        if (
+            this.boxPlotData.isComplete &&
+            this.mutationDataExists.isComplete &&
+            this.cnaDataExists.isComplete
+        ) {
             return (
                 <ChartContainer
                     getSVGElement={this.getSvg}
@@ -689,10 +697,8 @@ export default class ExpressionWrapper extends React.Component<
                         useLogSpaceTicks={true}
                         legendData={scatterPlotLegendData(
                             _.flatten(this.boxPlotData.result.map(d => d.data)),
-                            this.viewType,
+                            this.coloringTypes,
                             PlotType.BoxPlot,
-                            this.mutationDataExists,
-                            this.cnaDataExists,
                             this.props.store.driverAnnotationSettings
                                 .driversAnnotated,
                             []

--- a/src/shared/lib/joinJsx.tsx
+++ b/src/shared/lib/joinJsx.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export default function joinJsx(list: JSX.Element[], delimiter: JSX.Element) {
+    const elements: JSX.Element[] = [];
+    list.forEach((element, index) => {
+        elements.push(element);
+        if (index < list.length - 1) {
+            elements.push(delimiter);
+        }
+    });
+    return <>{elements}</>;
+}


### PR DESCRIPTION
fixes https://github.com/cBioPortal/cbioportal/issues/7828

To test, open [Link](https://beta.cbioportal.org/results/plots?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=prad_su2c_2019&case_set_id=prad_su2c_2019_cnaseq&data_priority=0&gene_list=ERG%2520AR&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=prad_su2c_2019_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=prad_su2c_2019_mutations&genetic_profile_ids_PROFILE_STRUCTURAL_VARIANT=prad_su2c_2019_fusion&plots_coloring_selection=%7B%22colorByCopyNumber%22%3A%22false%22%2C%22colorBySv%22%3A%22true%22%7D&plots_horz_selection=%7B%22dataType%22%3A%22clinical_attribute%22%7D&plots_vert_selection=%7B%22selectedGeneOption%22%3A2078%7D&profileFilter=0&tab_index=tab_visualize), run `localStorage.netlify = "deploy-preview-3388--cbioportalfrontend"`, and reload.

![image](https://user-images.githubusercontent.com/636232/92027987-4c72e500-ed31-11ea-8476-c1eafa0aeee5.png)


