### PR TITLE
Remove deprecated DAT-related property

### DIFF
--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
@@ -943,13 +943,6 @@
             "type": "object"
           },
           {
-            "name": "myAllowRevocationOfOtherTokens",
-            "in": "query",
-            "description": "myAllowRevocationOfOtherTokens",
-            "required": false,
-            "type": "boolean"
-          },
-          {
             "name": "principal",
             "in": "query",
             "required": false,

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -2405,7 +2405,6 @@ export default class CBioPortalAPIInternal {
         'authorities0Authority' ? : string,
         'credentials' ? : {},
         'details' ? : {},
-        'myAllowRevocationOfOtherTokens' ? : boolean,
         'principal' ? : {},
         $queryParameters ? : any
     }): string {
@@ -2425,10 +2424,6 @@ export default class CBioPortalAPIInternal {
 
         if (parameters['details'] !== undefined) {
             queryParameters['details'] = parameters['details'];
-        }
-
-        if (parameters['myAllowRevocationOfOtherTokens'] !== undefined) {
-            queryParameters['myAllowRevocationOfOtherTokens'] = parameters['myAllowRevocationOfOtherTokens'];
         }
 
         if (parameters['principal'] !== undefined) {
@@ -2453,7 +2448,6 @@ export default class CBioPortalAPIInternal {
      * @param {string} authorities0Authority - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
      * @param {object} credentials - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
      * @param {object} details - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
-     * @param {boolean} myAllowRevocationOfOtherTokens - myAllowRevocationOfOtherTokens
      * @param {object} principal - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
      */
     createDataAccessTokenUsingPOSTWithHttpInfo(parameters: {
@@ -2461,7 +2455,6 @@ export default class CBioPortalAPIInternal {
         'authorities0Authority' ? : string,
         'credentials' ? : {},
         'details' ? : {},
-        'myAllowRevocationOfOtherTokens' ? : boolean,
         'principal' ? : {},
         $queryParameters ? : any,
             $domain ? : string
@@ -2494,10 +2487,6 @@ export default class CBioPortalAPIInternal {
                 queryParameters['details'] = parameters['details'];
             }
 
-            if (parameters['myAllowRevocationOfOtherTokens'] !== undefined) {
-                queryParameters['myAllowRevocationOfOtherTokens'] = parameters['myAllowRevocationOfOtherTokens'];
-            }
-
             if (parameters['principal'] !== undefined) {
                 queryParameters['principal'] = parameters['principal'];
             }
@@ -2522,7 +2511,6 @@ export default class CBioPortalAPIInternal {
      * @param {string} authorities0Authority - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
      * @param {object} credentials - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
      * @param {object} details - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
-     * @param {boolean} myAllowRevocationOfOtherTokens - myAllowRevocationOfOtherTokens
      * @param {object} principal - A web service for supplying JSON formatted data to cBioPortal clients. Please note that this API is currently in beta and subject to change.
      */
     createDataAccessTokenUsingPOST(parameters: {
@@ -2530,7 +2518,6 @@ export default class CBioPortalAPIInternal {
         'authorities0Authority' ? : string,
         'credentials' ? : {},
         'details' ? : {},
-        'myAllowRevocationOfOtherTokens' ? : boolean,
         'principal' ? : {},
         $queryParameters ? : any,
             $domain ? : string

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -121,7 +121,6 @@ export interface IServerConfig {
     session_url_length_threshold: string;
     mskWholeSlideViewerToken: string;
     query_product_limit: number;
-    dat_uuid_revoke_other_tokens: boolean;
     dat_method: string;
     skin_show_gsva: boolean;
     oncoKbTokenDefined: boolean;


### PR DESCRIPTION
The (optional) argument for revoking existing tokens before issuing a
new one to a user is being removed from the backend. This PR brings the
frontend up-to-date.

Also added the updated generated cbio api docs.

Relevant PR to backend: https://github.com/cBioPortal/cbioportal/pull/7859


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
