### PR TITLE
Timeline: scrollbar overlaps bottom row when timeline is zoomed

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/Timeline.tsx
+++ b/packages/cbioportal-clinical-timeline/src/Timeline.tsx
@@ -249,10 +249,12 @@ const Timeline: React.FunctionComponent<ITimelineProps> = observer(function({
     width,
 }: ITimelineProps) {
     const tracks = store.data;
-    const height =
+    const SCROLLBAR_PADDING = 15;
+    let height =
         TICK_AXIS_HEIGHT +
         _.sumBy(tracks, t => t.height) +
-        _.sumBy(customTracks || [], t => t.height(store));
+        _.sumBy(customTracks || [], t => t.height(store)) +
+        SCROLLBAR_PADDING;
 
     const refs = {
         cursor: useRef(null),
@@ -368,6 +370,10 @@ const Timeline: React.FunctionComponent<ITimelineProps> = observer(function({
                     </div>
                 </div>
                 <div
+                    className={'tl-viewport-pseudo-border'}
+                    style={{ height: height - SCROLLBAR_PADDING }}
+                />
+                <div
                     ref={refs.timelineViewPort}
                     className={'tl-timelineviewport'}
                     style={{ flexShrink: 1, height }}
@@ -418,6 +424,10 @@ const Timeline: React.FunctionComponent<ITimelineProps> = observer(function({
                         </div>
                     )}
                 </div>
+                <div
+                    className={'tl-viewport-pseudo-border'}
+                    style={{ height: height - SCROLLBAR_PADDING }}
+                />
                 <DownloadControls
                     filename="timeline"
                     getSvg={() =>

--- a/packages/cbioportal-clinical-timeline/src/timeline.scss
+++ b/packages/cbioportal-clinical-timeline/src/timeline.scss
@@ -24,14 +24,17 @@ $borderColor: #ccc;
 }
 
 .tl-timelineviewport {
-    border-left: 1px solid $borderColor;
-    border-right: 1px solid $borderColor;
     border-top: none;
     overflow-x: auto;
     overflow-y: hidden;
     display: inline-block;
     width: $width;
     flex-grow: 1;
+}
+
+.tl-viewport-pseudo-border {
+    width: 1px;
+    background: $borderColor;
 }
 
 .tl-timeline {


### PR DESCRIPTION
Fixes https://github.com/cbioportal/cbioportal/issues/7812

Before:
![image](https://user-images.githubusercontent.com/186521/92139748-3707c480-edde-11ea-86cc-255efde10d6d.png)


After:
![image](https://user-images.githubusercontent.com/186521/92139709-20616d80-edde-11ea-9097-43e983f65033.png)
