### PR TITLE
(survival) Reset range after switch to another plot

### DIFF
--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -321,6 +321,7 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                             <p>{attributeDescriptions[key]}</p>
                             <div style={{ width: '920px' }}>
                                 <SurvivalChart
+                                    key={key}
                                     className="borderedChart"
                                     patientSurvivals={value}
                                     analysisGroups={analysisGroups}

--- a/src/pages/resultsView/survival/SurvivalChart.tsx
+++ b/src/pages/resultsView/survival/SurvivalChart.tsx
@@ -1,36 +1,30 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import { PatientSurvival } from '../../../shared/model/PatientSurvival';
-import { action, computed, observable, runInAction } from 'mobx';
+import { action, computed, observable } from 'mobx';
 import Slider from 'react-rangeslider';
-import { Popover, Table } from 'react-bootstrap';
+import { Popover } from 'react-bootstrap';
 import styles from './styles.module.scss';
 import './styles.scss';
 import { sleep } from '../../../shared/lib/TimeUtils';
 import * as _ from 'lodash';
 import {
     VictoryChart,
-    VictoryContainer,
     VictoryLine,
-    VictoryTooltip,
     VictoryAxis,
     VictoryLegend,
     VictoryLabel,
     VictoryScatter,
-    VictoryTheme,
     VictoryZoomContainer,
 } from 'victory';
 import {
     getEstimates,
-    getMedian,
     getLineData,
     getScatterData,
     getScatterDataWithOpacity,
     getStats,
     calculateLogRank,
     getDownloadContent,
-    convertScatterDataToDownloadData,
-    downSampling,
     GroupedScatterData,
     filterScatterData,
     SurvivalPlotFilters,


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7890

Reset range after switch to another plot.
Testing:
[Reproduce the issue](https://www.cbioportal.org/results/comparison?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=brca_tcga&case_set_id=brca_tcga_cnaseq&data_priority=0&gene_list=TP53&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=brca_tcga_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=brca_tcga_mutations&profileFilter=0&tab_index=tab_visualize&comparison_subtab=survival)
[After fix](https://deploy-preview-3405--cbioportalfrontend.netlify.app/results/comparison?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=brca_tcga&case_set_id=brca_tcga_cnaseq&data_priority=0&gene_list=TP53&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=brca_tcga_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=brca_tcga_mutations&profileFilter=0&tab_index=tab_visualize&comparison_subtab=survival)
