### PR TITLE
Add iframe on homepage sidebar that leads to offsite installation map

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -90,6 +90,14 @@ export default class PortalHeader extends React.Component<
                 hide: () =>
                     AppConfig.serverConfig.skin_show_about_tab === false,
             },
+
+            {
+                id: 'installation-map',
+                text: 'cBioPortal Installations',
+                address: '/installations',
+                internal: false,
+                hide: () => !AppConfig.serverConfig.installation_map_url,
+            },
         ];
     }
 

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -129,4 +129,5 @@ export interface IServerConfig {
     generic_assay_display_text: string; // this has a default
     saml_logout_local: boolean;
     patient_view_use_legacy_timeline: boolean;
+    installation_map_url: string;
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -168,6 +168,8 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
 
     saml_logout_local: false,
     patient_view_use_legacy_timeline: false,
+
+    installation_map_url: 'https://installationmap.netlify.app/',
 };
 
 export default ServerConfigDefaults;

--- a/src/pages/staticPages/installations/InstallationMap.tsx
+++ b/src/pages/staticPages/installations/InstallationMap.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
+import './styles.scss';
+import Helmet from 'react-helmet';
+import AppConfig from 'appConfig';
+
+export default class InstallationMap extends React.Component<{}, {}> {
+    public render() {
+        const installations_url = AppConfig.serverConfig.installation_map_url;
+        return (
+            <PageLayout
+                className={'whiteBackground staticPage installationMap'}
+                hideFooter={true}
+            >
+                <Helmet>
+                    <title>
+                        {'cBioPortal for Cancer Genomics::Installation Map'}
+                    </title>
+                </Helmet>
+                <iframe
+                    frameBorder="0"
+                    scrolling="yes"
+                    src={installations_url}
+                />
+            </PageLayout>
+        );
+    }
+}

--- a/src/pages/staticPages/installations/styles.scss
+++ b/src/pages/staticPages/installations/styles.scss
@@ -1,0 +1,10 @@
+.mainContainer {
+    .installationMap {
+        padding-bottom: 0 !important;
+        iframe,
+        #mainColumn > div {
+            width: 100%;
+            height: 90vh;
+        }
+    }
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -39,6 +39,7 @@ import RMATLAB from 'bundle-loader?lazy!babel-loader!./pages/staticPages/rmatlab
 import Tutorials from 'bundle-loader?lazy!babel-loader!./pages/staticPages/tutorials/Tutorials';
 import Visualize from 'bundle-loader?lazy!babel-loader!./pages/staticPages/visualize/Visualize';
 import AboutUs from 'bundle-loader?lazy!babel-loader!./pages/staticPages/aboutus/AboutUs';
+import InstallationMap from 'bundle-loader?lazy!babel-loader!./pages/staticPages/installations/InstallationMap';
 import Software from 'bundle-loader?lazy!babel-loader!./pages/staticPages/software/Software';
 import News from 'bundle-loader?lazy!babel-loader!./pages/staticPages/news/News';
 import FAQ from 'bundle-loader?lazy!babel-loader!./pages/staticPages/faq/FAQ';
@@ -317,6 +318,10 @@ export const makeRoutes = routing => {
                 path="/tutorials"
                 onEnter={handleEnter}
                 getComponent={lazyLoadComponent(Tutorials)}
+            />
+            <Route
+                path="/installations"
+                getComponent={lazyLoadComponent(InstallationMap)}
             />
             <Route
                 path="/visualize"

--- a/src/shared/components/rightbar/RightBar.tsx
+++ b/src/shared/components/rightbar/RightBar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import BarGraph from '../barGraph/BarGraph';
 import { observer } from 'mobx-react';
 import { TypeOfCancer as CancerType } from 'cbioportal-ts-api-client';
 import Testimonials from '../testimonials/Testimonials';
@@ -8,7 +7,7 @@ import AppConfig from 'appConfig';
 import { QueryStore } from 'shared/components/query/QueryStore';
 import { Link } from 'react-router';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
-import { redirectToStudyView } from '../../api/urls';
+import { buildCBioPortalPageUrl, redirectToStudyView } from '../../api/urls';
 import { ResultsViewTab } from '../../../pages/resultsView/ResultsViewPageHelpers';
 
 interface IRightBarProps {
@@ -161,8 +160,21 @@ export default class RightBar extends React.Component<
         const installations_url = AppConfig.serverConfig.installation_map_url;
         return !installations_url ? null : (
             <div className="rightBarSection">
-                <h3>cBioPortal Installations</h3>
-                <a href="/installations" style={{ display: 'block' }}>
+                <h3 style={{ paddingBottom: 8 }}>
+                    Local Installations{' '}
+                    <a
+                        className={'btn btn-link btn-xs pull-right'}
+                        target={'_blank'}
+                        href={buildCBioPortalPageUrl('/visualize')}
+                    >
+                        Host your own
+                    </a>
+                </h3>
+                <a
+                    href={buildCBioPortalPageUrl('/installations')}
+                    target={'_blank'}
+                    style={{ display: 'block' }}
+                >
                     <iframe
                         frameBorder="0"
                         height={200}
@@ -172,11 +184,18 @@ export default class RightBar extends React.Component<
                         style={{ pointerEvents: 'none' }}
                     />
                 </a>
-                <a href="https://docs.google.com/forms/d/e/1FAIpQLSflQdN956q7Xh5caO8z8jIaF6uMLBkKrSxFvPi8OhNBWB247w/viewform">
+
+                <p>
                     Are you running a local instance of cBioPortal, public or
-                    private? Complete the survey here to add your installation
-                    to the map.
-                </a>
+                    private?{' '}
+                    <a
+                        target={'_blank'}
+                        href="https://docs.google.com/forms/d/e/1FAIpQLSflQdN956q7Xh5caO8z8jIaF6uMLBkKrSxFvPi8OhNBWB247w/viewform"
+                    >
+                        Complete the survey here
+                    </a>{' '}
+                    to add your installation to the map.
+                </p>
             </div>
         );
     }
@@ -276,46 +295,45 @@ export default class RightBar extends React.Component<
         ) : null;
     }
 
-    public getDataSetsSection() {
-        return AppConfig.serverConfig.skin_right_nav_show_data_sets ? (
-            <div className="rightBarSection">
-                <h3>Cancer Studies</h3>
-                {this.studyStore.cancerStudies.isComplete &&
-                    this.studyStore.cancerTypes.isComplete && (
-                        <div>
-                            <p>
-                                The portal contains{' '}
-                                {this.studyStore.cancerStudies.result.length}{' '}
-                                cancer studies{' '}
-                                <Link to={'/datasets'}>(details)</Link>
-                            </p>
-
-                            <BarGraph
-                                data={this.CancerTypeDescendantStudies(
-                                    this.CancerTypeList()
-                                )}
-                                openStudy={studyId => {
-                                    redirectToStudyView(studyId);
-                                }}
-                            />
-                        </div>
-                    )}
-                {this.studyStore.cancerStudies.isPending && (
-                    <span style={{ textAlign: 'center' }}>
-                        <LoadingIndicator isLoading={true} small={true} />
-                    </span>
-                )}
-            </div>
-        ) : null;
-    }
+    // public getDataSetsSection() {
+    //     return AppConfig.serverConfig.skin_right_nav_show_data_sets ? (
+    //         <div className="rightBarSection">
+    //             <h3>Cancer Studies</h3>
+    //             {this.studyStore.cancerStudies.isComplete &&
+    //                 this.studyStore.cancerTypes.isComplete && (
+    //                     <div>
+    //                         <p>
+    //                             The portal contains{' '}
+    //                             {this.studyStore.cancerStudies.result.length}{' '}
+    //                             cancer studies{' '}
+    //                             <Link to={'/datasets'}>(details)</Link>
+    //                         </p>
+    //
+    //                         <BarGraph
+    //                             data={this.CancerTypeDescendantStudies(
+    //                                 this.CancerTypeList()
+    //                             )}
+    //                             openStudy={studyId => {
+    //                                 redirectToStudyView(studyId);
+    //                             }}
+    //                         />
+    //                     </div>
+    //                 )}
+    //             {this.studyStore.cancerStudies.isPending && (
+    //                 <span style={{ textAlign: 'center' }}>
+    //                     <LoadingIndicator isLoading={true} small={true} />
+    //                 </span>
+    //             )}
+    //         </div>
+    //     ) : null;
+    // }
 
     render() {
         return (
             <div>
                 {this.getWhatsNew()}
-                {this.getInstallationMap()}
-                {this.getDataSetsSection()}
                 {this.getExampleSection()}
+                {this.getInstallationMap()}
                 {this.getTestimonialsSection()}
             </div>
         );

--- a/src/shared/components/rightbar/RightBar.tsx
+++ b/src/shared/components/rightbar/RightBar.tsx
@@ -157,6 +157,30 @@ export default class RightBar extends React.Component<
         }
     }
 
+    private getInstallationMap() {
+        const installations_url = AppConfig.serverConfig.installation_map_url;
+        return !installations_url ? null : (
+            <div className="rightBarSection">
+                <h3>cBioPortal Installations</h3>
+                <a href="/installations" style={{ display: 'block' }}>
+                    <iframe
+                        frameBorder="0"
+                        height={200}
+                        width={300}
+                        scrolling="no"
+                        src={`${installations_url}?small=1`}
+                        style={{ pointerEvents: 'none' }}
+                    />
+                </a>
+                <a href="https://docs.google.com/forms/d/e/1FAIpQLSflQdN956q7Xh5caO8z8jIaF6uMLBkKrSxFvPi8OhNBWB247w/viewform">
+                    Are you running a local instance of cBioPortal, public or
+                    private? Complete the survey here to add your installation
+                    to the map.
+                </a>
+            </div>
+        );
+    }
+
     public getExampleSection() {
         if (AppConfig.serverConfig.skin_right_nav_show_examples) {
             if (
@@ -289,6 +313,7 @@ export default class RightBar extends React.Component<
         return (
             <div>
                 {this.getWhatsNew()}
+                {this.getInstallationMap()}
                 {this.getDataSetsSection()}
                 {this.getExampleSection()}
                 {this.getTestimonialsSection()}


### PR DESCRIPTION
Resolves [#8003](https://github.com/cBioPortal/cbioportal/issues/8003)

Describe changes proposed in this pull request:
- Render clickable iframe that leads to offsite installation map
- Added server configurations for installation map URL, whether iframe should be rendered

## Any screenshots or GIFs?
Before (live site)
![image](https://user-images.githubusercontent.com/33106214/93620005-59d1d580-f9a7-11ea-9b80-aa8235df6bac.png)

After (local)
![after_links_to_map](https://user-images.githubusercontent.com/33106214/93772538-ed481800-fbec-11ea-83b9-aec59282fdc2.gif)
![after_demo](https://user-images.githubusercontent.com/33106214/93772570-f933da00-fbec-11ea-9a7a-0245c8b99c67.gif)
