### PR TITLE
Timeline - allow fallback to default tooltip

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/TimelineStore.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineStore.tsx
@@ -183,10 +183,14 @@ export class TimelineStore {
 
     public getTooltipContent(uid: string, tooltipModel: TooltipModel) {
         const activeItem = tooltipModel.events[tooltipModel.index];
-        let content;
+        let content = null;
         if (tooltipModel.track.renderTooltip) {
             content = tooltipModel.track.renderTooltip(activeItem);
-        } else {
+        }
+
+        if (content === null) {
+            // Show default tooltip if there's no custom track tooltip renderer,
+            //  or if the track renderer returns `null`
             content = <EventTooltipContent event={activeItem} />;
         }
 

--- a/packages/cbioportal-clinical-timeline/src/types.ts
+++ b/packages/cbioportal-clinical-timeline/src/types.ts
@@ -17,7 +17,7 @@ export interface TimelineTrackSpecification {
     label?: string;
     tracks?: TimelineTrackSpecification[];
     renderEvents?: (e: TimelineEvent[]) => JSX.Element | string;
-    renderTooltip?: (e: TimelineEvent) => JSX.Element | string;
+    renderTooltip?: (e: TimelineEvent) => JSX.Element | string | null; // null means use default tooltip
     sortSimultaneousEvents?: (e: TimelineEvent[]) => TimelineEvent[];
     trackType?: TimelineTrackType;
     getLineChartValue?: (e: TimelineEvent) => number | null;

--- a/src/pages/patientView/timeline2/TimelineWrapper.tsx
+++ b/src/pages/patientView/timeline2/TimelineWrapper.tsx
@@ -227,14 +227,8 @@ const TimelineWrapper: React.FunctionComponent<ITimeline2Props> = observer(
                                     (att: any) => att.key === 'SAMPLE_ID'
                                 );
 
-                                const errorDiv = (
-                                    <div>
-                                        Error. Cannot find data for sample.
-                                    </div>
-                                );
-
                                 if (!hoveredSample || !hoveredSample.value) {
-                                    return errorDiv;
+                                    return null;
                                 }
 
                                 const sampleWithClinicalData = sampleManager.samples.find(
@@ -288,7 +282,7 @@ const TimelineWrapper: React.FunctionComponent<ITimeline2Props> = observer(
                                         </table>
                                     );
                                 } else {
-                                    return errorDiv;
+                                    return null;
                                 }
                             };
 


### PR DESCRIPTION
- If custom tooltip returns null, then show default tooltip
- Use this to handle case in sample tracks where sample doesn't exist

Fixes https://github.com/cBioPortal/cbioportal/issues/7880

![image](https://user-images.githubusercontent.com/636232/93638440-4df50c00-f9c5-11ea-861f-1adcd9e76ce4.png)
