### PR TITLE
comparison urls should not be relative

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -140,7 +140,7 @@ export function getPatientViewUrl(
 }
 
 export function getComparisonUrl(params: Partial<GroupComparisonURLQuery>) {
-    return buildCBioPortalPageUrl('comparison', params);
+    return buildCBioPortalPageUrl('/comparison', params);
 }
 
 export function redirectToComparisonPage(
@@ -155,7 +155,7 @@ export function redirectToComparisonPage(
 export function getComparisonLoadingUrl(
     params?: Partial<GroupComparisonLoadingParams>
 ) {
-    return buildCBioPortalPageUrl('loading/comparison', params || {});
+    return buildCBioPortalPageUrl('/loading/comparison', params || {});
 }
 
 export function getPubMedUrl(pmid: string) {


### PR DESCRIPTION
Comparison urls weren't working in localdev (or in portals hosted inside subdirectories)

Fixes https://github.com/cbioportal/cbioportal/issues/7893