### PR TITLE
Frontend change to detect noauthsessionservice for e2e group tests

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -564,7 +564,9 @@ export class StudyViewPageStore {
             this._comparisonGroupsChangeCount;
             if (
                 this.studyIds.length > 0 &&
-                this.isLoggedIn &&
+                (this.isLoggedIn ||
+                    AppConfig.serverConfig.authenticationMethod ===
+                        'noauthsessionservice') &&
                 !this.pendingDecision.result
             ) {
                 const groups = await comparisonClient.getGroupsForStudies(


### PR DESCRIPTION
Added necessary change to frontend in order to have the e2e tests for groups working when noauthsessionservice is used.
This will allow frontend to call /groups/fetch after a group update even when noauthsessionservice is active.