### PR TITLE
Speedup e2e-localdb tests for custom backends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,9 @@ jobs:
       - restore_cache:
           keys:
           - v5-e2e-database-files-{{ checksum "/tmp/db_data_md5key" }}
+          - maven-repo-v1-{{ .Branch }}-{{ checksum "pom.xml" }}
+          - maven-repo-v1-{{ .Branch }}-
+          - maven-repo-v1-
       - run:
           name: Create MySQL data directory when no cache found
           command: |
@@ -291,6 +294,10 @@ jobs:
           paths:
             - /tmp/mysql
           key: v5-e2e-database-files-{{ checksum "/tmp/db_data_md5key" }}
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: maven-repo-v1-{{ .Branch }}-{{ checksum "pom.xml" }}
       - run:
           name: Run end-2-end tests with studies in local database
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,7 @@ jobs:
           destination: /imageCompare.html
     environment:
         PORTAL_SOURCE_DIR: /tmp/repo
+        BACKEND_SOURCE_DIR: /tmp/cbioportal
         TEST_HOME: /tmp/repo/end-to-end-test
         FRONTEND_TEST_USE_LOCAL_DIST: true
         NO_PARALLEL: true

--- a/end-to-end-test/local/docker/build_portal_image.sh
+++ b/end-to-end-test/local/docker/build_portal_image.sh
@@ -7,9 +7,14 @@ set -o pipefail
 # rc, master and tagged releases (e.g. 3.0.1) of cbioportal are available as prebuilt images
 # build a image of a specified backend if no prebuilt image exists
 if [[ $BACKEND_IMAGE_NAME == $CUSTOM_BACKEND_IMAGE_NAME ]]; then
-    docker build https://github.com/$BACKEND_PROJECT_USERNAME/cbioportal.git#$BACKEND_BRANCH \
-        -f docker/web-and-data/Dockerfile \
-        -t $BACKEND_IMAGE_NAME
+   dir=$PWD
+   git clone "https://github.com/$BACKEND_PROJECT_USERNAME/cbioportal.git"
+   cd $BACKEND_SOURCE_DIR
+   git fetch --all
+   git checkout -b $BACKEND_BRANCH origin/$BACKEND_BRANCH
+   mvn clean install -DskipTests
+   unzip $BACKEND_SOURCE_DIR/portal/target/cbioportal*.war -d $BACKEND_SOURCE_DIR/portal/target/war-exploded
+   cd $PWD
 else
     docker pull $BACKEND_IMAGE_NAME
 fi

--- a/end-to-end-test/local/docker/build_portal_image.sh
+++ b/end-to-end-test/local/docker/build_portal_image.sh
@@ -7,6 +7,7 @@ set -o pipefail
 # rc, master and tagged releases (e.g. 3.0.1) of cbioportal are available as prebuilt images
 # build a image of a specified backend if no prebuilt image exists
 if [[ $BACKEND_IMAGE_NAME == $CUSTOM_BACKEND_IMAGE_NAME ]]; then
+	echo "Building custom backend ..."
    dir=$PWD
    git clone "https://github.com/$BACKEND_PROJECT_USERNAME/cbioportal.git"
    cd $BACKEND_SOURCE_DIR
@@ -15,6 +16,5 @@ if [[ $BACKEND_IMAGE_NAME == $CUSTOM_BACKEND_IMAGE_NAME ]]; then
    mvn clean install -DskipTests
    unzip $BACKEND_SOURCE_DIR/portal/target/cbioportal*.war -d $BACKEND_SOURCE_DIR/portal/target/war-exploded
    cd $PWD
-else
-    docker pull $BACKEND_IMAGE_NAME
 fi
+docker pull $BACKEND_IMAGE_NAME

--- a/end-to-end-test/local/docker/setup_docker_containers.sh
+++ b/end-to-end-test/local/docker/setup_docker_containers.sh
@@ -82,6 +82,8 @@ run_cbioportal_container() {
 
 	if [[ $BACKEND_IMAGE_NAME == $CUSTOM_BACKEND_IMAGE_NAME ]]; then
 
+		echo "Running with custom backend"
+
 		if [ ! -e "$BACKEND_SOURCE_DIR/portal/target/war-exploded" ]; then
 			echo "Compiled resources for backend cannot be found."
 			echo "Please run 'mvn install' and unzip te war file in '/portal/target/war-exploded'"
@@ -97,10 +99,12 @@ run_cbioportal_container() {
 			-v "$BACKEND_SOURCE_DIR/portal/target/war-exploded:/cbioportal-webapp:ro" \
 			-e JAVA_OPTS="-Xms2g -Xmx4g -Dauthenticate=false -Dapp.name=localdbe2e" \
 			-p 8081:8080 \
-			cbioportal/cbioportal:latest \
+			$BACKEND_IMAGE_NAME \
 			/bin/sh -c 'java ${JAVA_OPTS} -jar webapp-runner.jar /cbioportal-webapp'
 
 	else
+		echo "Running with $BACKEND_IMAGE_NAME backend"
+
 		# run from dockerhub image
 		docker run -d --restart=always \
 		   --name=$E2E_CBIOPORTAL_HOST_NAME \


### PR DESCRIPTION
Rather than building a docker image of the backend for custom backends, the backend is built locally and mounted in a dockerhub-based container. Maven dependencies are cached to reduce the build time. 