### PR TITLE
Fix Cancer Type Summary tooltips

### DIFF
--- a/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
@@ -145,9 +145,9 @@ export class CancerSummaryChart extends React.Component<
         } else {
             const profiledCount = this.scatterPlotTooltipModel.datum
                 .profiledCount as number;
-            let tooltopMessage = 'Not profiled';
+            let tooltipMessage = 'Not profiled';
             if (profiledCount > 0) {
-                tooltopMessage = `${profiledCount} ${pluralize(
+                tooltipMessage = `${profiledCount} ${pluralize(
                     'sample',
                     profiledCount
                 )}  profiled`;
@@ -177,7 +177,7 @@ export class CancerSummaryChart extends React.Component<
                     }}
                     placement={tooltipPlacement}
                 >
-                    <div style={{ whiteSpace: 'normal' }}>{tooltopMessage}</div>
+                    <div style={{ whiteSpace: 'normal' }}>{tooltipMessage}</div>
                 </Popover>,
                 document.body
             );
@@ -527,6 +527,26 @@ export class CancerSummaryChart extends React.Component<
                                 target: 'data',
                                 mutation: () => {
                                     self.scatterPlotTooltipModel = null;
+                                },
+                            },
+                        ];
+                    },
+                    onMouseEnter: () => {
+                        return [
+                            {
+                                target: 'data',
+                                mutation: () => {
+                                    self.shouldUpdatePosition = true;
+                                },
+                            },
+                        ];
+                    },
+                    onMouseLeave: () => {
+                        return [
+                            {
+                                target: 'data',
+                                mutation: () => {
+                                    self.shouldUpdatePosition = false;
                                 },
                             },
                         ];


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7662
## Describe changes proposed in this pull request:
- Fixed hovering over plus signs in scatter plot underneath bar plot so they update the tooltip position

### To do:
- Look into horizontal scrollbar for plot

## Any screenshots or GIFs?
### Before
![cts_plus_hover_before](https://user-images.githubusercontent.com/33106214/95348829-6b164f80-088c-11eb-8f48-9910eef667f1.gif)

### After
![cts_plus_hover_after](https://user-images.githubusercontent.com/33106214/95348787-60f45100-088c-11eb-8979-82998e96c620.gif)
