### PR TITLE
Remove double info treatment chart

### DIFF
--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -342,11 +342,6 @@ export class StudySummaryTab extends React.Component<
                 break;
             }
             case ChartTypeEnum.SAMPLE_TREATMENTS_TABLE: {
-                props.description = {
-                    description: chartMeta.description,
-                    studyName: '',
-                    displayName: '',
-                };
                 props.filters = this.store.sampleTreatmentFiltersAsStrings;
                 props.promise = this.store.sampleTreatments;
                 props.onValueSelection = this.store.onSampleTreatmentSelection;
@@ -356,11 +351,6 @@ export class StudySummaryTab extends React.Component<
                 break;
             }
             case ChartTypeEnum.PATIENT_TREATMENTS_TABLE: {
-                props.description = {
-                    description: chartMeta.description,
-                    studyName: '',
-                    displayName: '',
-                };
                 props.filters = this.store.patientTreatmentFiltersAsStrings;
                 props.promise = this.store.patientTreatments;
                 props.onValueSelection = this.store.onPatientTreatmentSelection;


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7951

Removes double info icon for treatment charts. Not sure why it works, but it does :) 

**before:**

<img width="494" alt="Screen Shot 2020-10-09 at 5 17 22 PM" src="https://user-images.githubusercontent.com/840895/95629051-343b6780-0a4d-11eb-9035-8b522c31e324.png">

**after:**

<img width="494" alt="Screen Shot 2020-10-09 at 5 17 22 PM" src="https://user-images.githubusercontent.com/1334004/95632288-51733480-0a53-11eb-804e-b786d73370b5.png">