### PR TITLE
Fix bugs in survival types table and add median survival columns

### DIFF
--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -363,6 +363,7 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
             const patientSurvivals = this.props.store.patientSurvivals.result!;
             const analysisGroups = this.analysisGroupsComputations.result!
                 .analysisGroups;
+            const uidToAnalysisGroup = _.keyBy(analysisGroups, g => g.value);
             const patientToAnalysisGroups = this.analysisGroupsComputations
                 .result!.patientToAnalysisGroups;
             const pValues = this.pValuesByPrefix.result!;
@@ -389,12 +390,14 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
 
                                 for (const s of patientSurvivals[prefix]) {
                                     // count the number of patients in each active group
-                                    const groups =
+                                    const groupUids =
                                         patientToAnalysisGroups[
                                             s.uniquePatientKey
                                         ] || [];
-                                    for (const groupName of groups) {
-                                        numPatientsPerGroup[groupName] += 1;
+                                    for (const uid of groupUids) {
+                                        numPatientsPerGroup[
+                                            uidToAnalysisGroup[uid].name
+                                        ] += 1;
                                     }
                                 }
                                 return {

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -408,10 +408,10 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                                     numPatients: _.sumBy(
                                         patientSurvivals[prefix],
                                         s =>
-                                            +(
-                                                s.uniquePatientKey in
-                                                patientToAnalysisGroups
-                                            )
+                                            s.uniquePatientKey in
+                                            patientToAnalysisGroups
+                                                ? 1
+                                                : 0
                                     ),
                                     numPatientsPerGroup: _.mapValues(
                                         patientSurvivalsPerGroup,

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -332,6 +332,8 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                                         marginTop: 15,
                                         minWidth: 475,
                                         maxWidth: 475,
+                                        height: 'fit-content',
+                                        overflowX: 'scroll',
                                     }}
                                 >
                                     {this.survivalPrefixTable.component}

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -403,8 +403,14 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                                 return {
                                     prefix,
                                     displayText,
-                                    numPatients:
-                                        patientSurvivals[prefix].length,
+                                    numPatients: _.sumBy(
+                                        patientSurvivals[prefix],
+                                        s =>
+                                            +(
+                                                s.uniquePatientKey in
+                                                patientToAnalysisGroups
+                                            )
+                                    ),
                                     numPatientsPerGroup,
                                     pValue: pValues[prefix],
                                     qValue: qValues[prefix],


### PR DESCRIPTION
Fixes  https://github.com/cBioPortal/cbioportal/issues/7952

[Link1](https://www.cbioportal.org/results/comparison?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=brca_tcga_pan_can_atlas_2018&case_set_id=brca_tcga_pan_can_atlas_2018_cnaseq&comparison_subtab=survival&data_priority=0&gene_list=TP53&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=brca_tcga_pan_can_atlas_2018_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=brca_tcga_pan_can_atlas_2018_mutations&profileFilter=0&tab_index=tab_visualize)
[Link2](https://genie-private.cbioportal.org/results/comparison?Action=Submit&cancer_study_list=nsclc_genie_bpc&case_set_id=nsclc_genie_bpc_all&gene_list=TP53&tab_index=tab_visualize&comparison_subtab=survival)
