### PR TITLE
Independent display logic for sample treatments chart

### DIFF
--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI-docs.json
@@ -5108,12 +5108,12 @@
         "deprecated": false
       }
     },
-    "/treatments/display": {
+    "/treatments/display-patient": {
       "post": {
         "tags": [
           "Treatments"
         ],
-        "summary": "Should sample level treatments be displayed",
+        "summary": "Should patient level treatments be displayed",
         "operationId": "getContainsTreatmentDataUsingPOST",
         "consumes": [
           "application/json"
@@ -5124,11 +5124,52 @@
         "parameters": [
           {
             "in": "body",
-            "name": "studyViewFilter",
-            "description": "Study view filter",
+            "name": "studyIds",
+            "description": "List of Study IDs",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/StudyViewFilter"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/treatments/display-sample": {
+      "post": {
+        "tags": [
+          "Treatments"
+        ],
+        "summary": "Should sample level treatments be displayed",
+        "operationId": "getContainsSampleTreatmentDataUsingPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "studyIds",
+            "description": "List of Study IDs",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -6854,8 +6895,7 @@
           "type": "string",
           "enum": [
             "Pre",
-            "Post",
-            "Unknown"
+            "Post"
           ]
         },
         "treatment": {
@@ -6881,8 +6921,7 @@
           "type": "string",
           "enum": [
             "Pre",
-            "Post",
-            "Unknown"
+            "Post"
           ]
         },
         "treatment": {

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI.ts
@@ -715,7 +715,7 @@ export type SampleMolecularIdentifier = {
 
 };
 export type SampleTreatmentFilter = {
-    'time': "Pre" | "Post" | "Unknown"
+    'time': "Pre" | "Post"
 
         'treatment': string
 
@@ -725,7 +725,7 @@ export type SampleTreatmentRow = {
 
         'samples': Array < ClinicalEventSample >
 
-        'time': "Pre" | "Post" | "Unknown"
+        'time': "Pre" | "Post"
 
         'treatment': string
 
@@ -8803,11 +8803,87 @@ export default class CBioPortalAPI {
         });
     };
     getContainsTreatmentDataUsingPOSTURL(parameters: {
-        'studyViewFilter': StudyViewFilter,
+        'studyIds': Array < string > ,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
-        let path = '/treatments/display';
+        let path = '/treatments/display-patient';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Should patient level treatments be displayed
+     * @method
+     * @name CBioPortalAPI#getContainsTreatmentDataUsingPOST
+     * @param {} studyIds - List of Study IDs
+     */
+    getContainsTreatmentDataUsingPOSTWithHttpInfo(parameters: {
+        'studyIds': Array < string > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/treatments/display-patient';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['studyIds'] !== undefined) {
+                body = parameters['studyIds'];
+            }
+
+            if (parameters['studyIds'] === undefined) {
+                reject(new Error('Missing required  parameter: studyIds'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Should patient level treatments be displayed
+     * @method
+     * @name CBioPortalAPI#getContainsTreatmentDataUsingPOST
+     * @param {} studyIds - List of Study IDs
+     */
+    getContainsTreatmentDataUsingPOST(parameters: {
+        'studyIds': Array < string > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < boolean > {
+        return this.getContainsTreatmentDataUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+    getContainsSampleTreatmentDataUsingPOSTURL(parameters: {
+        'studyIds': Array < string > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/treatments/display-sample';
 
         if (parameters.$queryParameters) {
             Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
@@ -8822,18 +8898,18 @@ export default class CBioPortalAPI {
     /**
      * Should sample level treatments be displayed
      * @method
-     * @name CBioPortalAPI#getContainsTreatmentDataUsingPOST
-     * @param {} studyViewFilter - Study view filter
+     * @name CBioPortalAPI#getContainsSampleTreatmentDataUsingPOST
+     * @param {} studyIds - List of Study IDs
      */
-    getContainsTreatmentDataUsingPOSTWithHttpInfo(parameters: {
-        'studyViewFilter': StudyViewFilter,
+    getContainsSampleTreatmentDataUsingPOSTWithHttpInfo(parameters: {
+        'studyIds': Array < string > ,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < request.Response > {
         const domain = parameters.$domain ? parameters.$domain : this.domain;
         const errorHandlers = this.errorHandlers;
         const request = this.request;
-        let path = '/treatments/display';
+        let path = '/treatments/display-sample';
         let body: any;
         let queryParameters: any = {};
         let headers: any = {};
@@ -8842,12 +8918,12 @@ export default class CBioPortalAPI {
             headers['Accept'] = 'application/json';
             headers['Content-Type'] = 'application/json';
 
-            if (parameters['studyViewFilter'] !== undefined) {
-                body = parameters['studyViewFilter'];
+            if (parameters['studyIds'] !== undefined) {
+                body = parameters['studyIds'];
             }
 
-            if (parameters['studyViewFilter'] === undefined) {
-                reject(new Error('Missing required  parameter: studyViewFilter'));
+            if (parameters['studyIds'] === undefined) {
+                reject(new Error('Missing required  parameter: studyIds'));
                 return;
             }
 
@@ -8866,15 +8942,15 @@ export default class CBioPortalAPI {
     /**
      * Should sample level treatments be displayed
      * @method
-     * @name CBioPortalAPI#getContainsTreatmentDataUsingPOST
-     * @param {} studyViewFilter - Study view filter
+     * @name CBioPortalAPI#getContainsSampleTreatmentDataUsingPOST
+     * @param {} studyIds - List of Study IDs
      */
-    getContainsTreatmentDataUsingPOST(parameters: {
-        'studyViewFilter': StudyViewFilter,
+    getContainsSampleTreatmentDataUsingPOST(parameters: {
+        'studyIds': Array < string > ,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < boolean > {
-        return this.getContainsTreatmentDataUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+        return this.getContainsSampleTreatmentDataUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });
     };

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
@@ -3741,8 +3741,7 @@
           "type": "string",
           "enum": [
             "Pre",
-            "Post",
-            "Unknown"
+            "Post"
           ]
         },
         "treatment": {

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -595,7 +595,7 @@ export type SampleIdentifier = {
 
 };
 export type SampleTreatmentFilter = {
-    'time': "Pre" | "Post" | "Unknown"
+    'time': "Pre" | "Post"
 
         'treatment': string
 

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -3832,7 +3832,7 @@ export class StudyViewPageStore {
             _chartMetaSet
         );
 
-        if (this.displayTreatments.result) {
+        if (this.displaySampleTreatments.result) {
             _chartMetaSet['SAMPLE_TREATMENTS'] = {
                 uniqueKey: 'SAMPLE_TREATMENTS',
                 dataType: ChartMetaDataTypeEnum.CLINICAL,
@@ -3845,7 +3845,9 @@ export class StudyViewPageStore {
                 description:
                     'List of treatments and the corresponding number of samples acquired before treatment or after/on treatment',
             };
+        }
 
+        if (this.displayPatientTreatments.result) {
             _chartMetaSet['PATIENT_TREATMENTS'] = {
                 uniqueKey: 'PATIENT_TREATMENTS',
                 dataType: ChartMetaDataTypeEnum.CLINICAL,
@@ -4039,7 +4041,7 @@ export class StudyViewPageStore {
             this.cnaProfiles.isPending ||
             this.structuralVariantProfiles.isPending ||
             this.survivalClinicalAttributesPrefix.isPending ||
-            this.displayTreatments.isPending;
+            this.displayPatientTreatments.isPending;
 
         if (
             this.clinicalAttributes.isComplete &&
@@ -4326,7 +4328,7 @@ export class StudyViewPageStore {
             }
         }
 
-        if (this.displayTreatments.result) {
+        if (this.displayPatientTreatments.result) {
             this.changeChartVisibility(
                 SpecialChartsUniqueKeyEnum.SAMPLE_TREATMENTS,
                 true
@@ -6913,16 +6915,21 @@ export class StudyViewPageStore {
         },
     });
 
-    @computed
-    public get displayTreatments() {
-        return remoteData({
-            invoke: () => {
-                return defaultClient.getContainsTreatmentDataUsingPOST({
-                    studyViewFilter: this.initialFilters,
-                });
-            },
-        });
-    }
+    public readonly displayPatientTreatments = remoteData({
+        invoke: () => {
+            return defaultClient.getContainsTreatmentDataUsingPOST({
+                studyIds: this.studyIds,
+            });
+        },
+    });
+
+    public readonly displaySampleTreatments = remoteData({
+        invoke: () => {
+            return defaultClient.getContainsSampleTreatmentDataUsingPOST({
+                studyIds: this.studyIds,
+            });
+        },
+    });
 
     // a row represents a list of samples that ether have or have not recieved
     // a specific treatment

--- a/src/pages/studyView/table/treatments/treatmentsTableUtil.tsx
+++ b/src/pages/studyView/table/treatments/treatmentsTableUtil.tsx
@@ -47,7 +47,7 @@ export function toSampleTreatmentFilter(
     const split = uniqueKey.split('::');
     return {
         treatment: split[0],
-        time: split[1] as 'Pre' | 'Post' | 'Unknown',
+        time: split[1] as 'Pre' | 'Post',
     };
 }
 


### PR DESCRIPTION
Backend changes here: https://github.com/cBioPortal/cbioportal/pull/7960

Fix cBioPortal/cbioportal#7928

Describe changes proposed in this pull request:
- Sample treatments sometimes should not be shown when patient treatments
are shown
- This PR uses a new API endpoint to determine when sample treatments should be shown
- Also, unknown treatments are no longer shows on the frontend

