### PR TITLE
Add OncoKB MSI-H, TMB-H annotation

### DIFF
--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardBody.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardBody.tsx
@@ -39,6 +39,7 @@ export default class OncoKbCardBody extends React.Component<
             case OncoKbCardDataType.TX:
                 return (
                     <OncoKbCardTreatmentContent
+                        hugoSymbol={indicator.query.hugoSymbol}
                         variant={indicator.query.alteration}
                         oncogenicity={indicator.oncogenic}
                         mutationEffect={indicator.mutationEffect.knownEffect}

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardTitle.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardTitle.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import mainStyles from './main.module.scss';
+import { OTHER_BIOMARKER_HUGO_SYMBOL } from './constants';
 
 type OncoKbCardDefaultTitleProps = {
     hugoSymbol: string;
@@ -11,7 +12,7 @@ export const OncoKbCardTitle: React.FunctionComponent<OncoKbCardDefaultTitleProp
     props: OncoKbCardDefaultTitleProps
 ) => {
     const titleContent = [];
-    if (props.hugoSymbol) {
+    if (props.hugoSymbol && props.hugoSymbol !== OTHER_BIOMARKER_HUGO_SYMBOL) {
         titleContent.push(props.hugoSymbol);
     }
     if (props.variant) {

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardTreatmentContent.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardTreatmentContent.tsx
@@ -14,8 +14,10 @@ import SummaryWithRefs from './SummaryWithRefs';
 import mainStyles from './main.module.scss';
 import tabsStyles from './tabs.module.scss';
 import autobind from 'autobind-decorator';
+import { OTHER_BIOMARKER_HUGO_SYMBOL } from './constants';
 
 type OncoKbCardTreatmentContentProps = {
+    hugoSymbol: string;
     variant: string;
     oncogenicity: string;
     mutationEffect: string;
@@ -65,8 +67,49 @@ export default class OncoKbCardTreatmentContent extends React.Component<
 > {
     @observable activeTab: ActiveTabEnum = ActiveTabEnum.ONCOGENICITY;
 
+    getOncogenicityContent() {
+        return (
+            <>
+                <p>{this.props.geneSummary}</p>
+                <p>{this.props.variantSummary}</p>
+                {this.props.usingPublicOncoKbInstance ? (
+                    <p className={mainStyles.disclaimer}>
+                        Therapeutic levels are not available in this instance of
+                        cBioPortal.{' '}
+                        <DefaultTooltip
+                            overlayStyle={{
+                                maxWidth: 400,
+                            }}
+                            overlay={publicInstanceDisclaimerOverLay}
+                        >
+                            <i className={'fa fa-info-circle'}></i>
+                        </DefaultTooltip>
+                    </p>
+                ) : (
+                    <>
+                        <p>{this.props.tumorTypeSummary}</p>
+
+                        {this.props.treatments!.length > 0 && (
+                            <div
+                                style={{
+                                    marginTop: 10,
+                                }}
+                            >
+                                <OncoKbTreatmentTable
+                                    variant={this.props.variant || ''}
+                                    pmidData={this.props.pmidData!}
+                                    treatments={this.props.treatments!}
+                                />
+                            </div>
+                        )}
+                    </>
+                )}
+            </>
+        );
+    }
+
     // TODO we should replace the tabs with an actual ReactBootstrap Tab,
-    public render() {
+    getContentInTabs() {
         return (
             <div className={mainStyles['oncokb-card']} data-test="oncokb-card">
                 <div className={tabsStyles['tabs-wrapper']}>
@@ -135,50 +178,7 @@ export default class OncoKbCardTreatmentContent extends React.Component<
                                 className={classnames(tabsStyles['tab-pane'])}
                                 data-test={`${ActiveTabEnum.ONCOGENICITY}-pane`}
                             >
-                                <p>{this.props.geneSummary}</p>
-                                <p>{this.props.variantSummary}</p>
-                                {this.props.usingPublicOncoKbInstance ? (
-                                    <p className={mainStyles.disclaimer}>
-                                        Therapeutic levels are not available in
-                                        this instance of cBioPortal.{' '}
-                                        <DefaultTooltip
-                                            overlayStyle={{
-                                                maxWidth: 400,
-                                            }}
-                                            overlay={
-                                                publicInstanceDisclaimerOverLay
-                                            }
-                                        >
-                                            <i
-                                                className={'fa fa-info-circle'}
-                                            ></i>
-                                        </DefaultTooltip>
-                                    </p>
-                                ) : (
-                                    <>
-                                        <p>{this.props.tumorTypeSummary}</p>
-
-                                        {this.props.treatments!.length > 0 && (
-                                            <div
-                                                style={{
-                                                    marginTop: 10,
-                                                }}
-                                            >
-                                                <OncoKbTreatmentTable
-                                                    variant={
-                                                        this.props.variant || ''
-                                                    }
-                                                    pmidData={
-                                                        this.props.pmidData!
-                                                    }
-                                                    treatments={
-                                                        this.props.treatments!
-                                                    }
-                                                />
-                                            </div>
-                                        )}
-                                    </>
-                                )}
+                                {this.getOncogenicityContent()}
                             </div>
                         </div>
                     )}
@@ -241,6 +241,16 @@ export default class OncoKbCardTreatmentContent extends React.Component<
                     )}
                 </div>
             </div>
+        );
+    }
+
+    public render() {
+        return this.props.hugoSymbol === OTHER_BIOMARKER_HUGO_SYMBOL ? (
+            <div style={{ marginLeft: 10 }}>
+                {this.getOncogenicityContent()}
+            </div>
+        ) : (
+            this.getContentInTabs()
         );
     }
 

--- a/packages/react-mutation-mapper/src/component/oncokb/constants.ts
+++ b/packages/react-mutation-mapper/src/component/oncokb/constants.ts
@@ -1,0 +1,14 @@
+export enum OtherBiomarkersQueryType {
+    MSIH = 'MSIH',
+    TMBH = 'TMBI',
+}
+
+export const OTHER_BIOMARKER_HUGO_SYMBOL = 'Other Biomarkers';
+export const MSI_H_NAME = 'MSI-H';
+export const TMB_H_NAME = 'TMB-H';
+export const OTHER_BIOMARKER_NAME: {
+    [key in OtherBiomarkersQueryType]: string;
+} = {
+    [OtherBiomarkersQueryType.MSIH]: MSI_H_NAME,
+    [OtherBiomarkersQueryType.TMBH]: TMB_H_NAME,
+};

--- a/packages/react-mutation-mapper/src/index.tsx
+++ b/packages/react-mutation-mapper/src/index.tsx
@@ -152,3 +152,4 @@ export { default as DefaultMutationMapperDataFetcher } from './store/DefaultMuta
 export { default as DefaultMutationMapperDataStore } from './store/DefaultMutationMapperDataStore';
 export { default as DefaultMutationMapperFilterApplier } from './store/DefaultMutationMapperFilterApplier';
 export { default as DefaultMutationMapperStore } from './store/DefaultMutationMapperStore';
+export * from './component/oncokb/constants';

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -81,6 +81,17 @@ import TimelineWrapper from './timeline2/TimelineWrapper';
 import { isFusion } from '../../shared/lib/MutationUtils';
 import { Mutation } from 'cbioportal-ts-api-client';
 import ClinicalEventsTables from './timeline2/ClinicalEventsTables';
+import { OncoKB } from 'react-mutation-mapper';
+import {
+    getSampleNumericalClinicalDataValue,
+    OTHER_BIOMARKERS_CLINICAL_ATTR,
+} from 'shared/lib/StoreUtils';
+import { CLINICAL_ATTRIBUTE_ID_ENUM } from 'shared/constants';
+import {
+    OTHER_BIOMARKER_HUGO_SYMBOL,
+    OtherBiomarkersQueryType,
+} from 'react-mutation-mapper';
+import { OtherBiomarkerAnnotation } from 'pages/patientView/oncokb/OtherBiomarkerAnnotation';
 
 export interface IPatientViewPageProps {
     params: any; // react route
@@ -546,6 +557,35 @@ export default class PatientViewPage extends React.Component<
         this.urlWrapper.setResourceUrl(resource.url);
     }
 
+    getOncoKbOtherBiomarkerAnnotationComponent(
+        type: OtherBiomarkersQueryType,
+        sampleId: string
+    ) {
+        const numericalData = getSampleNumericalClinicalDataValue(
+            this.patientViewPageStore.clinicalDataForSamples.result,
+            sampleId,
+            OTHER_BIOMARKERS_CLINICAL_ATTR[type]
+        );
+
+        return this.patientViewPageStore.getOtherBiomarkersOncoKbData.result[
+            sampleId
+        ][type] && numericalData !== undefined ? (
+            <span>
+                ,{' '}
+                <OtherBiomarkerAnnotation
+                    type={type}
+                    isPublicOncoKbInstance={
+                        this.patientViewPageStore.usingPublicOncoKbInstance
+                    }
+                    annotation={
+                        this.patientViewPageStore.getOtherBiomarkersOncoKbData
+                            .result[sampleId][type]
+                    }
+                />
+            </span>
+        ) : null;
+    }
+
     @autobind
     @action
     private closeResourceTab(tabId: string) {
@@ -705,6 +745,22 @@ export default class PatientViewPage extends React.Component<
                                         uniqueSampleKey={sample.id}
                                     />
                                 )}
+
+                            {this.patientViewPageStore
+                                .getOtherBiomarkersOncoKbData.result[
+                                sample.id
+                            ] && (
+                                <>
+                                    {this.getOncoKbOtherBiomarkerAnnotationComponent(
+                                        OtherBiomarkersQueryType.MSIH,
+                                        sample.id
+                                    )}
+                                    {this.getOncoKbOtherBiomarkerAnnotationComponent(
+                                        OtherBiomarkersQueryType.TMBH,
+                                        sample.id
+                                    )}
+                                </>
+                            )}
                         </div>
                     );
                 }

--- a/src/pages/patientView/oncokb/OtherBiomarkerAnnotation.tsx
+++ b/src/pages/patientView/oncokb/OtherBiomarkerAnnotation.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {
+    OncoKB,
+    OTHER_BIOMARKER_HUGO_SYMBOL,
+    OtherBiomarkersQueryType,
+    OTHER_BIOMARKER_NAME,
+} from 'react-mutation-mapper';
+import { IndicatorQueryResp } from 'oncokb-ts-api-client';
+
+export const OtherBiomarkerAnnotation: React.FunctionComponent<{
+    type: OtherBiomarkersQueryType;
+    isPublicOncoKbInstance: boolean;
+    annotation: IndicatorQueryResp;
+}> = props => {
+    return (
+        <span className="clinical-spans">
+            {OTHER_BIOMARKER_NAME[props.type]}
+            <span
+                style={{
+                    marginLeft: 2,
+                    marginTop: -4,
+                }}
+            >
+                <OncoKB
+                    usingPublicOncoKbInstance={props.isPublicOncoKbInstance}
+                    isCancerGene={true}
+                    geneNotExist={false}
+                    hugoGeneSymbol={OTHER_BIOMARKER_HUGO_SYMBOL}
+                    status={'complete'}
+                    indicator={props.annotation}
+                />
+            </span>
+        </span>
+    );
+};

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -25,7 +25,12 @@ export const enum CLINICAL_ATTRIBUTE_ID_ENUM {
     CANCER_TYPE_DETAILED = 'CANCER_TYPE_DETAILED',
     ASCN_PURITY = 'ASCN_PURITY',
     ASCN_WGD = 'ASCN_WGD',
+    MSI_SCORE = 'MSI_SCORE',
+    TMB_SCORE = 'CVR_TMB_SCORE',
 }
+
+export const MSI_H_THRESHOLD = 10;
+export const TMB_H_THRESHOLD = 10;
 
 /* cbioportal api responses - clinical attribute fields and subfields */
 export const enum CLINICAL_ATTRIBUTE_FIELD_ENUM {


### PR DESCRIPTION
The following annotations will be added when sample has TMB, MSI scores.
The thresholds for both score are >=10.

#### Patient View Header
![Screen Shot 2020-10-27 at 7 55 21 PM](https://user-images.githubusercontent.com/5400599/97374335-71e22200-188e-11eb-8ab2-f1b6f05eed69.png)

#### MSI-H Annotation
![Screen Shot 2020-10-27 at 7 55 29 PM](https://user-images.githubusercontent.com/5400599/97374343-773f6c80-188e-11eb-8054-6fc0c00a73a4.png)

#### TMB-H Annotation
![Screen Shot 2020-10-27 at 7 55 40 PM](https://user-images.githubusercontent.com/5400599/97374351-7ad2f380-188e-11eb-88af-65ce529732b3.png)

Fix https://github.com/cBioPortal/cbioportal/issues/6862