### PR TITLE
Upgrade mobx and mobx-utils and make necessary changes everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
     "node": "8.12.0",
     "yarn": "1.22.4"
   },
+  "resolutions": {
+    "mobx": "^6.0.0",
+    "mobx-react": "^6.0.0"
+  },
   "author": "",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
@@ -183,12 +187,12 @@
     "memoize-weak-decorator": "^1.0.3",
     "mini-css-extract-plugin": "^0.6.0",
     "mixpanel-browser": "^2.18.0",
-    "mobx": "^3.1.7",
-    "mobx-react": "^4.1.3",
-    "mobx-react-devtools": "^4.2.11",
-    "mobx-react-lite": "^2.0.7",
-    "mobx-react-router": "^3.1.2",
-    "mobx-utils": "^2.0.1",
+    "mobx": "6.0.1",
+    "mobx-react": "6.0.0",
+    "mobx-react-devtools": "6.1.1",
+    "mobx-react-lite": "3.0.1",
+    "mobx-react-router": "4.1.0",
+    "mobx-utils": "6.0.1",
     "mobxpromise": "github:cbioportal/mobxpromise#v1.0.2",
     "node-sass": "^4.9.3",
     "numeral": "^2.0.6",

--- a/packages/cbioportal-clinical-timeline/package.json
+++ b/packages/cbioportal-clinical-timeline/package.json
@@ -31,7 +31,7 @@
     "test:watch": "yarn run test --watch"
   },
   "peerDependencies": {
-    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0",
+    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "mobx-react": "^4.0.0 || ^5.0.0",
     "mobx-react-lite": "^2.0.0",
     "react": "^15.0.0 || ^16.0.0",

--- a/packages/cbioportal-clinical-timeline/src/TimelineStore.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineStore.tsx
@@ -91,7 +91,7 @@ export class TimelineStore {
     }
 
     private tooltipUidCounter = 0;
-    private tooltipModelsByUid = observable.map<TooltipModel>();
+    private tooltipModelsByUid = observable.map<string, TooltipModel>();
     @observable private _lastHoveredTooltipUid: string | null = null;
     @action
     public setHoveredTooltipUid(uid: string | null) {
@@ -104,7 +104,7 @@ export class TimelineStore {
         ) {
             return this._lastHoveredTooltipUid;
         } else if (this.tooltipModelsByUid.size === 1) {
-            return this.tooltipModelsByUid.keys()[0];
+            return this.tooltipModelsByUid.keys().next().value; // equivalent of keys()[0] with Iterators
         } else {
             return null;
         }
@@ -117,7 +117,7 @@ export class TimelineStore {
     }
 
     @computed get tooltipModels() {
-        return this.tooltipModelsByUid.entries();
+        return Array.from(this.tooltipModelsByUid.entries());
     }
 
     @autobind
@@ -148,7 +148,7 @@ export class TimelineStore {
 
     @action
     removeAllTooltipsExcept(tooltipUid: string) {
-        const uids = this.tooltipModelsByUid.keys();
+        const uids = Array.from(this.tooltipModelsByUid.keys());
         for (const uid of uids) {
             if (uid !== tooltipUid) {
                 this.tooltipModelsByUid.delete(uid);

--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -31,7 +31,7 @@
     "test:watch": "yarn run test --watch"
   },
   "peerDependencies": {
-    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0",
+    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "mobx-react": "^4.0.0 || ^5.0.0",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"

--- a/packages/cbioportal-utils/package.json
+++ b/packages/cbioportal-utils/package.json
@@ -29,7 +29,7 @@
     "test:watch": "yarn run test -- --watch"
   },
   "peerDependencies": {
-    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0"
+    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "genome-nexus-ts-api-client": "^1.1.9",

--- a/packages/react-mutation-mapper/package.json
+++ b/packages/react-mutation-mapper/package.json
@@ -31,7 +31,7 @@
     "test:watch": "yarn run test --watch"
   },
   "peerDependencies": {
-    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0",
+    "mobx": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "mobx-react": "^4.0.0 || ^5.0.0",
     "prop-types": "^15.5.4",
     "react": "^15.0.0 || ^16.0.0",

--- a/packages/react-mutation-mapper/src/cache/DefaultStringQueryCache.ts
+++ b/packages/react-mutation-mapper/src/cache/DefaultStringQueryCache.ts
@@ -1,10 +1,10 @@
 import { action, observable } from 'mobx';
-
 import { CacheData, MobxCache } from 'cbioportal-utils';
+import _ from 'lodash';
 
 export abstract class DefaultStringQueryCache<D>
     implements MobxCache<D, string> {
-    protected _cache = observable.shallowMap<CacheData>();
+    protected _cache = observable.map<string, CacheData>({}, { deep: false });
 
     @action
     public get(query: string) {
@@ -26,6 +26,6 @@ export abstract class DefaultStringQueryCache<D>
     public abstract fetch(query: string): Promise<D>;
 
     public get cache() {
-        return this._cache.toJS();
+        return _.fromPairs(this._cache.toJSON());
     }
 }

--- a/packages/react-mutation-mapper/src/component/dataTable/DataTable.tsx
+++ b/packages/react-mutation-mapper/src/component/dataTable/DataTable.tsx
@@ -296,7 +296,11 @@ export default class DataTable<T> extends React.Component<
     protected createExpanderResetReaction(dataStore: DataStore) {
         return reaction(
             () => [dataStore.selectionFilters, dataStore.dataFilters],
-            (filters: DataFilter[][], disposer: IReactionPublic) => {
+            (
+                filters: DataFilter[][],
+                prev: DataFilter[][],
+                disposer: IReactionPublic
+            ) => {
                 if (filters.length > 0) {
                     this.resetExpander();
                 }

--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -1,4 +1,4 @@
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import {
     addServiceErrorHandler,
     getBrowserWindow,
@@ -17,6 +17,7 @@ export type SiteError = {
 
 export class AppStore {
     constructor() {
+        makeObservable<AppStore, '_appReady'>(this);
         getBrowserWindow().me = this;
         addServiceErrorHandler((error: any) => {
             try {

--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -29,7 +29,6 @@ import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { AppStore } from './AppStore';
 import { handleLongUrls } from 'shared/lib/handleLongUrls';
 import 'shared/polyfill/canvasToBlob';
-import mobx from 'mobx';
 import { setCurrentURLHeader } from 'shared/lib/extraHeader';
 
 superagentCache(superagent);
@@ -50,10 +49,6 @@ if (!window.hasOwnProperty('$')) {
 
 if (!window.hasOwnProperty('jQuery')) {
     window.jQuery = $;
-}
-
-if (!window.hasOwnProperty('mobx')) {
-    window.mobx = mobx;
 }
 
 // write browser name, version to brody tag

--- a/src/pages/groupComparison/GroupComparisonLoading.tsx
+++ b/src/pages/groupComparison/GroupComparisonLoading.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import LoadingIndicator from '../../shared/components/loadingIndicator/LoadingIndicator';
 import { AppStore } from '../../AppStore';
-import { computed, observable } from 'mobx';
+import { computed, observable, makeObservable } from 'mobx';
 import { getStudySummaryUrl } from '../../shared/api/urls';
 
 export interface IGroupComparisonLoadingProps {
@@ -32,6 +32,8 @@ export default class GroupComparisonLoading extends React.Component<
 
     constructor(props: IGroupComparisonLoadingProps) {
         super(props);
+
+        makeObservable(this);
 
         (window as any).ping = () => {
             this.pingedFromStudyView = true;

--- a/src/pages/groupComparison/GroupComparisonPage.tsx
+++ b/src/pages/groupComparison/GroupComparisonPage.tsx
@@ -21,6 +21,7 @@ import {
     IReactionDisposer,
     observable,
     reaction,
+    makeObservable,
 } from 'mobx';
 import autobind from 'autobind-decorator';
 import { AppStore } from '../../AppStore';
@@ -57,6 +58,7 @@ export default class GroupComparisonPage extends React.Component<
 
     constructor(props: IGroupComparisonPageProps) {
         super(props);
+        makeObservable<GroupComparisonPage, 'store'>(this);
         this.urlWrapper = new GroupComparisonURLWrapper(props.routing);
         this.queryReaction = reaction(
             () => this.urlWrapper.query.sessionId,

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -8,7 +8,7 @@ import {
 import { GroupComparisonTab } from './GroupComparisonTabs';
 import { remoteData, stringListToIndexSet } from 'cbioportal-frontend-commons';
 import { SampleFilter, CancerStudy } from 'cbioportal-ts-api-client';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import client from '../../shared/api/cbioportalClientInstance';
 import comparisonClient from '../../shared/api/comparisonGroupClientInstance';
 import _ from 'lodash';
@@ -40,6 +40,14 @@ export default class GroupComparisonStore extends ComparisonStore {
         private urlWrapper: GroupComparisonURLWrapper
     ) {
         super(appStore);
+
+        makeObservable<
+            GroupComparisonStore,
+            | '_currentTabId'
+            | 'sessionId'
+            | 'updateUnselectedGroups'
+            | 'saveAndGoToSession'
+        >(this);
 
         this.sessionId = sessionId;
     }

--- a/src/pages/groupComparison/GroupComparisonURLWrapper.ts
+++ b/src/pages/groupComparison/GroupComparisonURLWrapper.ts
@@ -1,6 +1,6 @@
 import URLWrapper from '../../shared/lib/URLWrapper';
 import ExtendedRouterStore from '../../shared/lib/ExtendedRouterStore';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { getTabId } from './GroupComparisonUtils';
 import { GroupComparisonTab } from './GroupComparisonTabs';
 import autobind from 'autobind-decorator';
@@ -25,6 +25,7 @@ export default class GroupComparisonURLWrapper extends URLWrapper<
             overlapStrategy: { isSessionProp: false },
             patientEnrichments: { isSessionProp: false },
         });
+        makeObservable(this);
     }
 
     @computed public get tabId() {

--- a/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManager.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManager.tsx
@@ -83,7 +83,7 @@ export default class ComparisonGroupManager extends React.Component<
         this.addGroupPanelOpen = true;
         this._inputGroupName = getDefaultGroupName(
             this.props.store.filters,
-            this.props.store.customChartFilterSet.toJS(),
+            _.fromPairs(this.props.store.customChartFilterSet.toJSON()),
             this.props.store.clinicalAttributeIdToDataType.result!
         );
     }

--- a/src/pages/groupComparison/groupSelector/GroupSelectorButton.tsx
+++ b/src/pages/groupComparison/groupSelector/GroupSelectorButton.tsx
@@ -18,7 +18,7 @@ import { TOOLTIP_MOUSE_ENTER_DELAY_MS } from 'cbioportal-frontend-commons';
 import * as ReactDOM from 'react-dom';
 import { Popover, Overlay } from 'react-bootstrap';
 import classnames from 'classnames';
-import { action, observable } from 'mobx';
+import { action, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import { ButtonHTMLAttributes } from 'react';
 
@@ -40,6 +40,11 @@ class GroupSelectorButton extends React.Component<
     @observable hovered = false;
     @observable.ref button: HTMLButtonElement | null;
     private hoverTimeout: any = null;
+
+    constructor(props: IGroupSelectorButtonProps) {
+        super(props);
+        makeObservable(this);
+    }
 
     @autobind
     @action

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer, inject, Observer } from 'mobx-react';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import Chart from 'chart.js';
 import AppConfig from 'appConfig';
 import 'react-select1/dist/react-select.css';
@@ -49,6 +49,7 @@ export default class HomePage extends React.Component<
 
     constructor(props: IResultsViewPageProps) {
         super(props);
+        makeObservable(this);
     }
 
     componentWillMount() {

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -27,7 +27,7 @@ import ClinicalInformationSamples from './clinicalInformation/ClinicalInformatio
 import { inject, Observer, observer } from 'mobx-react';
 import { getSpanElementsFromCleanData } from './clinicalInformation/lib/clinicalAttributesUtil.js';
 import CopyNumberTableWrapper from './copyNumberAlterations/CopyNumberTableWrapper';
-import { action, computed, observable, reaction } from 'mobx';
+import { action, computed, observable, reaction, makeObservable } from 'mobx';
 import Timeline from './timeline/Timeline';
 import { default as PatientViewMutationTable } from './mutation/PatientViewMutationTable';
 import PathologyReport from './pathologyReport/PathologyReport';
@@ -122,6 +122,17 @@ export default class PatientViewPage extends React.Component<
 
     constructor(props: IPatientViewPageProps) {
         super(props);
+        makeObservable<
+            PatientViewPage,
+            | 'mutationTableColumnVisibility'
+            | 'cnaTableColumnVisibility'
+            | 'onCnaTableColumnVisibilityToggled'
+            | 'onMutationTableColumnVisibilityToggled'
+            | 'shouldShowResources'
+            | 'shouldShowPathologyReport'
+            | 'hideTissueImageTab'
+            | 'shouldShowTrialMatch'
+        >(this);
         this.urlWrapper = new PatientViewUrlWrapper(props.routing);
         this.patientViewPageStore = new PatientViewPageStore(
             this.props.appStore

--- a/src/pages/patientView/PatientViewUrlWrapper.ts
+++ b/src/pages/patientView/PatientViewUrlWrapper.ts
@@ -1,7 +1,7 @@
 import URLWrapper from 'shared/lib/URLWrapper';
 import ExtendedRouterStore from 'shared/lib/ExtendedRouterStore';
 import { PagePath } from 'shared/enums/PagePaths';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { PatientViewPageTabs } from './PatientViewPageTabs';
 
 export type PatientViewUrlQuery = {
@@ -50,6 +50,7 @@ export default class PatientViewUrlWrapper extends URLWrapper<
                 },
             },
         });
+        makeObservable(this);
     }
 
     public setActiveTab(tab: string): void {

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -19,7 +19,13 @@ import {
 } from 'cbioportal-ts-api-client';
 import client from '../../../shared/api/cbioportalClientInstance';
 import internalClient from '../../../shared/api/cbioportalInternalClientInstance';
-import { computed, observable, action, runInAction } from 'mobx';
+import {
+    computed,
+    observable,
+    action,
+    runInAction,
+    makeObservable,
+} from 'mobx';
 import {
     getBrowserWindow,
     remoteData,
@@ -160,6 +166,7 @@ import {
 } from 'shared/lib/oql/AccessorsForOqlFilter';
 
 type PageMode = 'patient' | 'sample';
+type ResourceId = string;
 
 export async function checkForTissueImage(patientId: string): Promise<boolean> {
     if (/TCGA/.test(patientId) === false) {
@@ -261,6 +268,10 @@ function transformClinicalInformationToStoreShape(
 
 export class PatientViewPageStore {
     constructor(private appStore: AppStore) {
+        makeObservable<
+            PatientViewPageStore,
+            '_patientId' | '_patientIdsInCohort'
+        >(this);
         labelMobxPromises(this);
         this.internalClient = internalClient;
     }
@@ -284,7 +295,7 @@ export class PatientViewPageStore {
 
     @observable _sampleId = '';
 
-    private openResourceTabMap = observable.map<boolean>();
+    private openResourceTabMap = observable.map<ResourceId, boolean>();
     @autobind
     public isResourceTabOpen(resourceId: string) {
         return !!this.openResourceTabMap.get(resourceId);

--- a/src/pages/patientView/clinicalInformation/SampleGeneCache.ts
+++ b/src/pages/patientView/clinicalInformation/SampleGeneCache.ts
@@ -1,4 +1,4 @@
-import { observable, action } from 'mobx';
+import { observable, action, makeObservable } from 'mobx';
 import Immutable from 'seamless-immutable';
 import * as _ from 'lodash';
 import accumulatingDebounce from '../../../shared/lib/accumulatingDebounce';
@@ -40,6 +40,7 @@ export default class SampleGeneCache<
     private debouncedPopulate: (sampleId: string, entrezGeneId: number) => void;
 
     constructor(sampleIds: string[], ...dependencies: any[]) {
+        makeObservable<SampleGeneCache<T>, '_cache' | 'updateCache'>(this);
         this.dependencies = dependencies;
         this.initCache(sampleIds);
         this._pending = {};

--- a/src/pages/patientView/genomicOverview/GenomicOverview.tsx
+++ b/src/pages/patientView/genomicOverview/GenomicOverview.tsx
@@ -10,7 +10,7 @@ import {
 } from 'cbioportal-ts-api-client';
 import SampleManager from '../SampleManager';
 import { MutationFrequenciesBySample } from '../vafPlot/VAFPlot';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import {
     sampleIdToIconData,
     IKeyedIconData,
@@ -38,6 +38,7 @@ export default class GenomicOverview extends React.Component<
 > {
     constructor(props: IGenomicOverviewProps) {
         super(props);
+        makeObservable(this);
     }
 
     @computed get frequencies() {

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import {
     IMutationTableProps,
@@ -43,6 +43,7 @@ export default class PatientViewMutationTable extends MutationTable<
 > {
     constructor(props: IPatientViewMutationTableProps) {
         super(props);
+        makeObservable<PatientViewMutationTable, 'hasUncalledMutations'>(this);
     }
 
     public static defaultProps = {

--- a/src/pages/patientView/mutation/PatientViewMutationsDataStore.ts
+++ b/src/pages/patientView/mutation/PatientViewMutationsDataStore.ts
@@ -1,6 +1,6 @@
 import { SimpleGetterLazyMobXTableApplicationDataStore } from '../../../shared/lib/ILazyMobXTableApplicationDataStore';
 import { Mutation } from 'cbioportal-ts-api-client';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import _ from 'lodash';
 import PatientViewUrlWrapper from '../PatientViewUrlWrapper';
 
@@ -15,11 +15,13 @@ function mutationIdKey(m: Mutation) {
     return `{ "proteinChange": "${m.proteinChange}", "hugoGeneSymbol": "${m.gene.hugoGeneSymbol}" }`;
 }
 
+type MutationIdKey = string;
+
 export default class PatientViewMutationsDataStore extends SimpleGetterLazyMobXTableApplicationDataStore<
     Mutation[]
 > {
     @observable mouseOverMutation: Readonly<Mutation> | null = null;
-    private selectedMutationsMap = observable.map<Mutation>();
+    private selectedMutationsMap = observable.map<string, Mutation>();
 
     public get onlyShowSelectedInTable() {
         return (
@@ -77,7 +79,7 @@ export default class PatientViewMutationsDataStore extends SimpleGetterLazyMobXT
     }
 
     @computed public get selectedMutations(): Readonly<Mutation[]> {
-        return this.selectedMutationsMap.entries().map(x => x[1]);
+        return Array.from(this.selectedMutationsMap.values());
     }
 
     public isMutationSelected(m: Mutation) {
@@ -110,6 +112,10 @@ export default class PatientViewMutationsDataStore extends SimpleGetterLazyMobXT
         private urlWrapper: PatientViewUrlWrapper
     ) {
         super(getData);
+
+        makeObservable<PatientViewMutationsDataStore, 'mouseOverMutation'>(
+            this
+        );
 
         this.dataHighlighter = (mergedMutation: Mutation[]) => {
             const highlightedMutations = [];

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
@@ -16,7 +16,13 @@ import {
 } from './MutationOncoprintUtils';
 import LoadingIndicator from '../../../../shared/components/loadingIndicator/LoadingIndicator';
 import ErrorMessage from '../../../../shared/components/ErrorMessage';
-import { computed, IReactionDisposer, observable, reaction } from 'mobx';
+import {
+    computed,
+    IReactionDisposer,
+    observable,
+    reaction,
+    makeObservable,
+} from 'mobx';
 import OncoprintJS, {
     ColumnId,
     ColumnLabel,
@@ -119,6 +125,8 @@ export default class MutationOncoprint extends React.Component<
 
     constructor(props: IMutationOncoprintProps) {
         super(props);
+
+        makeObservable<MutationOncoprint, 'horzZoomSliderState'>(this);
 
         (window as any).mutationOncoprint = this;
         this.minZoomUpdater = setInterval(() => {

--- a/src/pages/patientView/timeline2/VAFChart.tsx
+++ b/src/pages/patientView/timeline2/VAFChart.tsx
@@ -233,7 +233,8 @@ export default class VAFChart extends React.Component<IVAFChartProps, {}> {
             highlightedMutations.push(mouseOverMutation);
         }
         if (highlightedMutations.length > 0) {
-            return highlightedMutations.map(highlightedMutation => {
+            return (
+                <>{highlightedMutations.map(highlightedMutation => {
                 const points = this.mutationToDataPoints.get({
                     proteinChange: highlightedMutation.proteinChange,
                     hugoGeneSymbol: highlightedMutation.gene.hugoGeneSymbol,
@@ -287,7 +288,7 @@ export default class VAFChart extends React.Component<IVAFChartProps, {}> {
                         {pointPaths}
                     </g>
                 );
-            });
+            })}</>);
         } else {
             return <g />;
         }

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -3,7 +3,14 @@ import * as _ from 'lodash';
 import $ from 'jquery';
 import URL from 'url';
 import { inject, observer } from 'mobx-react';
-import { action, computed, observable, reaction, runInAction } from 'mobx';
+import {
+    action,
+    computed,
+    observable,
+    reaction,
+    runInAction,
+    makeObservable,
+} from 'mobx';
 import { ResultsViewPageStore } from './ResultsViewPageStore';
 import CancerSummaryContainer from 'pages/resultsView/cancerSummary/CancerSummaryContainer';
 import Mutations from './mutation/Mutations';
@@ -110,6 +117,8 @@ export default class ResultsViewPage extends React.Component<
 
     constructor(props: IResultsViewPageProps) {
         super(props);
+
+        makeObservable<ResultsViewPage, 'tabs'>(this);
 
         this.urlWrapper = new ResultsViewURLWrapper(props.routing);
 

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -34,7 +34,14 @@ import {
 } from 'cbioportal-ts-api-client';
 import client from 'shared/api/cbioportalClientInstance';
 import { remoteData, stringListToSet } from 'cbioportal-frontend-commons';
-import { action, computed, observable, ObservableMap, reaction } from 'mobx';
+import {
+    action,
+    computed,
+    observable,
+    ObservableMap,
+    reaction,
+    makeObservable,
+} from 'mobx';
 import {
     getProteinPositionFromProteinChange,
     IHotspotIndex,
@@ -447,7 +454,7 @@ export type DriverAnnotationSettings = {
     cosmicCountThreshold: number;
     customBinary: boolean;
     customTiersDefault: boolean;
-    driverTiers: ObservableMap<boolean>;
+    driverTiers: ObservableMap<string, boolean>;
     hotspots: boolean;
     oncoKb: boolean;
     driversAnnotated: boolean;
@@ -464,6 +471,7 @@ export type ModifyQueryParams = {
 /* tslint:disable: member-ordering */
 export class ResultsViewPageStore {
     constructor(private appStore: AppStore, urlWrapper: ResultsViewURLWrapper) {
+        makeObservable(this);
         labelMobxPromises(this);
 
         this.urlWrapper = urlWrapper;
@@ -480,7 +488,7 @@ export class ResultsViewPageStore {
             cbioportalCountThreshold: 0,
             cosmicCount: false,
             cosmicCountThreshold: 0,
-            driverTiers: observable.map<boolean>(),
+            driverTiers: observable.map<string, boolean>(),
 
             _hotspots: false,
             _oncoKb: false,
@@ -732,7 +740,10 @@ export class ResultsViewPageStore {
         this.driverAnnotationSettings.cbioportalCountThreshold = 10;
         this.driverAnnotationSettings.cosmicCount = false;
         this.driverAnnotationSettings.cosmicCountThreshold = 10;
-        this.driverAnnotationSettings.driverTiers = observable.map<boolean>();
+        this.driverAnnotationSettings.driverTiers = observable.map<
+            string,
+            boolean
+        >();
         (this.driverAnnotationSettings as any)._oncoKb = !!AppConfig
             .serverConfig.oncoprint_oncokb_default;
         this.driverAnnotationSettings.hotspots = !!AppConfig.serverConfig

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -428,7 +428,10 @@ describe('ResultsViewPageStoreUtils', () => {
                 false
             );
 
-            assert.deepEqual(mutationAnnotationSettings.driverTiers.toJS(), {});
+            assert.deepEqual(
+                _.fromPairs(mutationAnnotationSettings.driverTiers.toJSON()),
+                {}
+            );
         });
 
         it.skip('initializes selection for given tiers', () => {
@@ -447,7 +450,7 @@ describe('ResultsViewPageStoreUtils', () => {
             );
 
             assert.deepEqual(
-                mutationAnnotationSettings.driverTiers.toJS(),
+                _.fromPairs(mutationAnnotationSettings.driverTiers.toJSON()),
                 { a: false, b: false, c: false },
                 'initialized to false'
             );
@@ -463,7 +466,7 @@ describe('ResultsViewPageStoreUtils', () => {
             );
 
             assert.deepEqual(
-                mutationAnnotationSettings.driverTiers.toJS(),
+                _.fromPairs(mutationAnnotationSettings.driverTiers.toJSON()),
                 { a: true, b: true, c: true },
                 'initialized to true'
             );

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -1,6 +1,6 @@
 import URLWrapper from '../../shared/lib/URLWrapper';
 import ExtendedRouterStore from '../../shared/lib/ExtendedRouterStore';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
     oldTabToNewTabRoute,
@@ -188,6 +188,7 @@ export default class ResultsViewURLWrapper extends URLWrapper<
                 ? parseInt(AppConfig.serverConfig.session_url_length_threshold)
                 : undefined
         );
+        makeObservable(this);
     }
 
     pathContext = '/results';

--- a/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
@@ -15,7 +15,7 @@ import {
     IAlterationData,
     ICancerSummaryChartData,
 } from './CancerSummaryContent';
-import { observable, computed, action } from 'mobx';
+import { observable, computed, action, makeObservable } from 'mobx';
 import { observer, Observer } from 'mobx-react';
 import { CSSProperties } from 'react';
 import autobind from 'autobind-decorator';
@@ -124,6 +124,14 @@ export class CancerSummaryChart extends React.Component<
 
     constructor(props: CancerSummaryChartProps) {
         super(props);
+        makeObservable<
+            CancerSummaryChart,
+            | 'barPlotTooltipModel'
+            | 'scatterPlotTooltipModel'
+            | 'barToolTipCounter'
+            | 'isBarPlotTooltipHovered'
+            | 'shouldUpdatePosition'
+        >(this);
     }
 
     @autobind

--- a/src/pages/resultsView/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { MSKTabs, MSKTab } from 'shared/components/MSKTabs/MSKTabs';
 import { CancerSummaryContent, IAlterationData } from './CancerSummaryContent';
@@ -40,6 +40,13 @@ export default class CancerSummaryContainer extends React.Component<
 
     constructor(props: ICancerSummaryContainerProps) {
         super(props);
+        makeObservable<
+            CancerSummaryContainer,
+            | 'activeTab'
+            | 'resultsViewPageWidth'
+            | 'groupAlterationsBy_userSelection'
+            | 'tabs'
+        >(this);
         this.handleTabClick = this.handleTabClick.bind(this);
         this.pivotData = this.pivotData.bind(this);
         this.mapStudyIdToShortName = this.mapStudyIdToShortName.bind(this);

--- a/src/pages/resultsView/cancerSummary/CancerSummaryContent.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Checkbox, ButtonGroup, Radio } from 'react-bootstrap';
-import { computed, observable, action } from 'mobx';
+import { computed, observable, action, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import Slider from 'react-rangeslider';
 import { ControlLabel, FormControl } from 'react-bootstrap';
@@ -155,6 +155,25 @@ export class CancerSummaryContent extends React.Component<
 
     constructor(props: ICancerSummaryContentProps) {
         super(props);
+        makeObservable<
+            CancerSummaryContent,
+            | 'tempAltCasesInputValue'
+            | 'tempTotalCasesInputValue'
+            | 'pngAnchor'
+            | 'pdf'
+            | 'showControls'
+            | 'hideGenomicAlterations'
+            | 'xAxis'
+            | 'viewCountsByCancerSubType'
+            | 'totalCasesMax'
+            | 'totalCasesMin'
+            | 'hasAlterations'
+            | 'totalCaseChanged'
+            | 'altCaseChanged'
+            | 'showStudyTooltipLinks'
+            | 'handleTotalInputKeyPress'
+            | 'initializeSliderValue'
+        >(this);
         this.handleYAxisChange = this.handleYAxisChange.bind(this);
         this.handleXAxisChange = this.handleXAxisChange.bind(this);
         this.handleGenomicCheckboxChange = this.handleGenomicCheckboxChange.bind(

--- a/src/pages/resultsView/cnSegments/CNSegments.tsx
+++ b/src/pages/resultsView/cnSegments/CNSegments.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import MobxPromise from 'mobxpromise';
 import autobind from 'autobind-decorator';
 import { Nav, NavItem } from 'react-bootstrap';
@@ -42,6 +42,7 @@ export default class CNSegments extends React.Component<
 
     constructor(props: { store: ResultsViewPageStore }) {
         super(props);
+        makeObservable(this);
         this.segmentTrackMaxHeight = WindowStore.size.height * 0.7;
     }
 

--- a/src/pages/resultsView/coExpression/CoExpressionTab.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MolecularProfile, Sample } from 'cbioportal-ts-api-client';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import { observer, Observer } from 'mobx-react';
 import {
     AlterationTypeConstants,
@@ -130,6 +130,8 @@ export default class CoExpressionTab extends React.Component<
 
     constructor(props: ICoExpressionTabProps) {
         super(props);
+
+        makeObservable<CoExpressionTab, 'plotState'>(this);
 
         (window as any).resultsViewCoExpressionTab = this; // for testing
 

--- a/src/pages/resultsView/comparison/ComparisonTab.tsx
+++ b/src/pages/resultsView/comparison/ComparisonTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import { MakeMobxView } from '../../../shared/components/MobxView';
 import { MSKTab, MSKTabs } from '../../../shared/components/MSKTabs/MSKTabs';
@@ -48,6 +48,7 @@ export default class ComparisonTab extends React.Component<
 
     constructor(props: IComparisonTabProps) {
         super(props);
+        makeObservable<ComparisonTab, 'store'>(this);
         (window as any).comparisonTab = this;
         this.store = new ResultsViewComparisonStore(
             this.props.appStore,

--- a/src/pages/resultsView/comparison/ResultsViewComparisonStore.ts
+++ b/src/pages/resultsView/comparison/ResultsViewComparisonStore.ts
@@ -1,4 +1,4 @@
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import { ResultsViewComparisonSubTab } from '../ResultsViewPageHelpers';
 import ComparisonStore, {
     OverlapStrategy,
@@ -42,6 +42,10 @@ export default class ResultsViewComparisonStore extends ComparisonStore {
         protected resultsViewStore: ResultsViewPageStore
     ) {
         super(appStore, resultsViewStore);
+        makeObservable<
+            ResultsViewComparisonStore,
+            '_currentTabId' | 'updateSelectedGroups' | 'saveAndGoToSession'
+        >(this);
     }
 
     @action public updateOverlapStrategy(strategy: OverlapStrategy) {

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { computed, observable, action } from 'mobx';
+import { computed, observable, action, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import fileDownload from 'react-file-download';
 import {
@@ -83,6 +83,8 @@ export default class DownloadTab extends React.Component<
 > {
     constructor(props: IDownloadTabProps) {
         super(props);
+
+        makeObservable<DownloadTab, 'handleQueryButtonClick'>(this);
 
         this.handleMutationDownload = this.handleMutationDownload.bind(this);
         this.handleTransposedMutationDownload = this.handleTransposedMutationDownload.bind(

--- a/src/pages/resultsView/expression/ExpressionWrapper.tsx
+++ b/src/pages/resultsView/expression/ExpressionWrapper.tsx
@@ -8,7 +8,7 @@ import {
     NumericGeneMolecularData,
     MolecularProfile,
 } from 'cbioportal-ts-api-client';
-import { computed, observable } from 'mobx';
+import { computed, observable, makeObservable } from 'mobx';
 import {
     ExpressionStyle,
     expressionTooltip,
@@ -92,6 +92,7 @@ export default class ExpressionWrapper extends React.Component<
 > {
     constructor(props: ExpressionWrapperProps) {
         super(props);
+        makeObservable<ExpressionWrapper, '_rnaSeqVersion'>(this);
         this.selectedGene = props.genes[0];
         (window as any).box = this;
     }

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -5,7 +5,7 @@ import { ResultsViewPageStore } from '../ResultsViewPageStore';
 import ResultsViewMutationMapper from './ResultsViewMutationMapper';
 import { convertToMutationMapperProps } from 'shared/components/mutationMapper/MutationMapperConfig';
 import MutationMapperUserSelectionStore from 'shared/components/mutationMapper/MutationMapperUserSelectionStore';
-import { computed, action } from 'mobx';
+import { computed, action, makeObservable } from 'mobx';
 import AppConfig from 'appConfig';
 import OqlStatusBanner from '../../../shared/components/banners/OqlStatusBanner';
 import autobind from 'autobind-decorator';
@@ -55,6 +55,7 @@ export default class Mutations extends React.Component<
 
     constructor(props: IMutationsPageProps) {
         super(props);
+        makeObservable(this);
         this.handleTabChange.bind(this);
         this.userSelectionStore = new MutationMapperUserSelectionStore();
     }

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -2,7 +2,7 @@ import autobind from 'autobind-decorator';
 import * as React from 'react';
 import { DataFilterType, onFilterOptionSelect } from 'react-mutation-mapper';
 import { observer } from 'mobx-react';
-import { action, computed } from 'mobx';
+import { action, computed, makeObservable } from 'mobx';
 
 import { getRemoteDataGroupStatus } from 'cbioportal-utils';
 import { EnsemblTranscript } from 'genome-nexus-ts-api-client';
@@ -36,6 +36,7 @@ export default class ResultsViewMutationMapper extends MutationMapper<
 > {
     constructor(props: IResultsViewMutationMapperProps) {
         super(props);
+        makeObservable(this);
     }
 
     @computed get mutationStatusFilter() {

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
@@ -25,7 +25,7 @@ import MutationMapperStore, {
     IMutationMapperStoreConfig,
 } from 'shared/components/mutationMapper/MutationMapperStore';
 import { IServerConfig } from '../../../config/IAppConfig';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 
 export default class ResultsViewMutationMapperStore extends MutationMapperStore {
     constructor(
@@ -85,6 +85,8 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
             genomenexusClient,
             genomenexusInternalClient
         );
+
+        makeObservable(this);
 
         labelMobxPromises(this);
     }

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityTab.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityTab.tsx
@@ -4,7 +4,7 @@ import MutualExclusivityTable from './MutualExclusivityTable';
 import { observer } from 'mobx-react';
 import { Checkbox } from 'react-bootstrap';
 import styles from './styles.module.scss';
-import { computed, observable } from 'mobx';
+import { computed, observable, makeObservable } from 'mobx';
 import { MutualExclusivity } from '../../../shared/model/MutualExclusivity';
 import { ResultsViewPageStore } from '../ResultsViewPageStore';
 import DiscreteCNACache from '../../../shared/cache/DiscreteCNACache';
@@ -41,6 +41,7 @@ export default class MutualExclusivityTab extends React.Component<
 
     constructor(props: IMutualExclusivityTabProps) {
         super(props);
+        makeObservable<MutualExclusivityTab, 'notEnoughDataError'>(this);
         this.mutualExclusivityFilterChange = this.mutualExclusivityFilterChange.bind(
             this
         );

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityTable.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityTable.tsx
@@ -5,7 +5,7 @@ import LazyMobXTable, {
 } from '../../../shared/components/lazyMobXTable/LazyMobXTable';
 import { MutualExclusivity } from '../../../shared/model/MutualExclusivity';
 import { observer } from 'mobx-react';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import { Badge } from 'react-bootstrap';
 import {
     formatPValue,
@@ -54,6 +54,7 @@ export default class MutualExclusivityTable extends React.Component<
 
     constructor(props: IMutualExclusivityTableProps) {
         super(props);
+        makeObservable<MutualExclusivityTable, '_columns'>(this);
         this._columns = {};
         this.generateColumns();
     }

--- a/src/pages/resultsView/pathwayMapper/PathwayMapperTable.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathwayMapperTable.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react';
 import LazyMobXTable, {
     Column,
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import { Radio } from 'react-bootstrap';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import {
@@ -79,6 +79,7 @@ export default class PathwayMapperTable extends React.Component<
 
     constructor(props: IPathwayMapperTableProps) {
         super(props);
+        makeObservable<PathwayMapperTable, '_columns'>(this);
         this._columns = {};
         this.generateColumns();
     }

--- a/src/pages/resultsView/pathwayMapper/ResultsViewPathwayMapper.tsx
+++ b/src/pages/resultsView/pathwayMapper/ResultsViewPathwayMapper.tsx
@@ -12,6 +12,7 @@ import {
     action,
     reaction,
     IReactionDisposer,
+    makeObservable,
 } from 'mobx';
 import { Row } from 'react-bootstrap';
 
@@ -83,6 +84,13 @@ export default class ResultsViewPathwayMapper extends React.Component<
 
     constructor(props: IResultsViewPathwayMapperProps) {
         super(props);
+        makeObservable<
+            ResultsViewPathwayMapper,
+            | 'selectedPathway'
+            | 'newGenesFromPathway'
+            | 'activeToasts'
+            | 'addGenomicData'
+        >(this);
         this.activeToasts = [];
         this.accumulatedValidGenes = {};
         this.accumulatedAlterationFrequencyDataForNonQueryGenes = [];

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { toJS, action, computed, observable, runInAction } from 'mobx';
+import {
+    toJS,
+    action,
+    computed,
+    observable,
+    runInAction,
+    makeObservable,
+} from 'mobx';
 import { Observer, observer } from 'mobx-react';
 import './styles.scss';
 import {
@@ -284,9 +291,10 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
     @observable searchCase: string = '';
     @observable searchMutation: string = '';
     @observable plotExists = false;
-    @observable highlightedLegendItems = observable.shallowMap<
+    @observable highlightedLegendItems = observable.map<
+        string,
         LegendDataWithId
-    >();
+    >({}, { deep: false });
 
     @autobind
     @action
@@ -656,6 +664,8 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
 
     constructor(props: IPlotsTabProps) {
         super(props);
+
+        makeObservable(this);
 
         this.horzSelection = this.initAxisMenuSelection(false);
         this.vertSelection = this.initAxisMenuSelection(true);
@@ -3003,9 +3013,9 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
         };
         const highlightFunctions = [
             searchHighlight,
-            ...this.highlightedLegendItems
-                .values()
-                .map(x => x.highlighting!.isDatumHighlighted),
+            ...Array.from(this.highlightedLegendItems.values()).map(
+                x => x.highlighting!.isDatumHighlighted
+            ),
         ];
         return (d: IPlotSampleData) => {
             return _.some(highlightFunctions, f => f(d));

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -384,7 +384,7 @@ export function scatterPlotLegendData(
     cnaDataExists: MobxPromise<boolean>,
     driversAnnotated: boolean,
     limitValueTypes: string[],
-    highlightedLegendItems?: ObservableMap<LegendDataWithId>,
+    highlightedLegendItems?: ObservableMap<string, LegendDataWithId>,
     highlight?: (d: IPlotSampleData) => boolean,
     coloringClinicalDataCacheEntry?: ClinicalDataCacheEntry,
     coloringClinicalDataLogScale?: boolean,

--- a/src/pages/resultsView/settings/DriverAnnotationControls.tsx
+++ b/src/pages/resultsView/settings/DriverAnnotationControls.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import ErrorIcon from '../../../shared/components/ErrorIcon';
-import { IObservableObject, ObservableMap } from 'mobx';
+import { ObservableMap } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
     EditableSpan,
@@ -30,7 +30,7 @@ export interface IDriverAnnotationControlsState {
     customDriverAnnotationBinaryMenuLabel?: string;
     customDriverAnnotationTiersMenuLabel?: string;
     customDriverAnnotationTiers?: string[];
-    selectedCustomDriverAnnotationTiers?: ObservableMap<boolean>;
+    selectedCustomDriverAnnotationTiers?: ObservableMap<string, boolean>;
     annotateCustomDriverBinary?: boolean;
 }
 
@@ -47,7 +47,7 @@ export interface IDriverAnnotationControlsHandlers {
 }
 
 export interface IDriverAnnotationControlsProps {
-    state: IDriverAnnotationControlsState & IObservableObject;
+    state: IDriverAnnotationControlsState;
     handlers: IDriverAnnotationControlsHandlers;
 }
 

--- a/src/pages/resultsView/settings/ResultsPageSettings.tsx
+++ b/src/pages/resultsView/settings/ResultsPageSettings.tsx
@@ -6,7 +6,6 @@ import DriverAnnotationControls, {
     IDriverAnnotationControlsHandlers,
     IDriverAnnotationControlsState,
 } from './DriverAnnotationControls';
-import { IObservableObject } from 'mobx';
 import {
     boldedTabList,
     buildDriverAnnotationControlsHandlers,
@@ -35,8 +34,7 @@ export default class ResultsPageSettings extends React.Component<
     IResultsPageSettingsProps,
     {}
 > {
-    private driverSettingsState: IDriverAnnotationControlsState &
-        IObservableObject;
+    private driverSettingsState: IDriverAnnotationControlsState;
     private driverSettingsHandlers: IDriverAnnotationControlsHandlers;
 
     constructor(props: IResultsPageSettingsProps) {

--- a/src/pages/resultsView/survival/SurvivalChart.tsx
+++ b/src/pages/resultsView/survival/SurvivalChart.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import { PatientSurvival } from '../../../shared/model/PatientSurvival';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import Slider from 'react-rangeslider';
 import { Popover } from 'react-bootstrap';
 import styles from './styles.module.scss';
@@ -277,6 +277,7 @@ export default class SurvivalChart
 
     constructor(props: ISurvivalChartProps) {
         super(props);
+        makeObservable(this);
         this.tooltipMouseEnter = this.tooltipMouseEnter.bind(this);
         this.tooltipMouseLeave = this.tooltipMouseLeave.bind(this);
     }

--- a/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
+++ b/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
@@ -13,7 +13,7 @@ import { filterNumericalColumn } from 'shared/components/lazyMobXTable/utils';
 import _ from 'lodash';
 import { toggleColumnVisibility } from 'cbioportal-frontend-commons';
 import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls/ColumnVisibilityControls';
-import { observable, computed } from 'mobx';
+import { observable, computed, makeObservable } from 'mobx';
 import AppConfig from 'appConfig';
 
 export interface ISurvivalPrefixTableProps {
@@ -178,6 +178,7 @@ export default class SurvivalPrefixTable extends React.Component<
 
     constructor(props: ISurvivalPrefixTableProps) {
         super(props);
+        makeObservable<SurvivalPrefixTable, 'columnVisibility'>(this);
         this.dataStore = new SurvivalPrefixTableStore(
             () => this.props.survivalPrefixes,
             this.props.getSelectedPrefix

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { inject, observer } from 'mobx-react';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import { Collapse } from 'react-collapse';
 import {
@@ -60,6 +60,8 @@ export default class MutationMapperTool extends React.Component<
 
     constructor(props: IMutationMapperToolProps) {
         super(props);
+
+        makeObservable(this);
 
         this.userSelectionStore = new MutationMapperUserSelectionStore();
         // set genomenexus url to grch38 instance if "show_mutation_mapper_tool_grch38" is true and choose "GRCh38", otherwise use default url

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -1,4 +1,4 @@
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import * as _ from 'lodash';
 import { cached } from 'mobxpromise';
 import {
@@ -87,6 +87,10 @@ export default class MutationMapperToolStore {
         },
         undefined
     );
+
+    constructor() {
+        makeObservable(this);
+    }
 
     @computed get isoformOverrideSource(): string {
         return AppConfig.serverConfig.isoformOverrideSource;

--- a/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
+++ b/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer, Observer } from 'mobx-react';
-import { action, computed, IObservableObject, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import Oncoprint from '../../../../shared/components/oncoprint/Oncoprint';
 import OncoprintControls, {
     IOncoprintControlsHandlers,
@@ -53,12 +53,14 @@ export default class Oncoprinter extends React.Component<
     @observable renderingComplete = true;
 
     private controlsHandlers: IOncoprintControlsHandlers;
-    private controlsState: IOncoprintControlsState & IObservableObject;
+    private controlsState: IOncoprintControlsState;
 
     @observable.ref public oncoprint: OncoprintJS;
 
     constructor(props: IOncoprinterProps) {
         super(props);
+
+        makeObservable<Oncoprinter, 'initializeOncoprint'>(this);
 
         (window as any).oncoprinter = this;
 

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
@@ -1,5 +1,5 @@
 import { DriverAnnotationSettings } from '../../../resultsView/ResultsViewPageStore';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import AppConfig from 'appConfig';
 import {
     annotateGeneticTrackData,
@@ -78,6 +78,7 @@ export default class OncoprinterStore {
     @observable customDriverWarningHidden: boolean;
 
     constructor() {
+        makeObservable(this);
         this.initialize();
     }
 

--- a/src/pages/staticPages/webAPI/WebAPIPage.tsx
+++ b/src/pages/staticPages/webAPI/WebAPIPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
 import './styles.scss';
 import Helmet from 'react-helmet';
@@ -19,6 +19,7 @@ export class UserDataAccessToken {
         expirationDate: string,
         username: string
     ) {
+        makeObservable(this);
         this.token = token;
         this.creationDate = creationDate;
         this.expirationDate = expirationDate;

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { inject, Observer, observer } from 'mobx-react';
 import { MSKTab, MSKTabs } from '../../shared/components/MSKTabs/MSKTabs';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import {
     CustomChart,
     StudyViewPageStore,
@@ -117,6 +117,11 @@ export default class StudyViewPage extends React.Component<
 
     constructor(props: IStudyViewPageProps) {
         super(props);
+
+        makeObservable<
+            StudyViewPage,
+            'toolbarLeft' | 'showReturnToDefaultChartListModal'
+        >(this);
 
         this.urlWrapper = new StudyViewURLWrapper(this.props.routing);
 

--- a/src/pages/studyView/StudyViewURLWrapper.ts
+++ b/src/pages/studyView/StudyViewURLWrapper.ts
@@ -1,7 +1,7 @@
 import URLWrapper from '../../shared/lib/URLWrapper';
 import { StudyViewPageTabKey, StudyViewURLQuery } from './StudyViewPageStore';
 import { PagePath } from '../../shared/enums/PagePaths';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { PatientViewPageTabs } from '../patientView/PatientViewPageTabs';
 import { StudyViewPageTabKeyEnum } from './StudyViewPageTabs';
 import ExtendedRouterStore from '../../shared/lib/ExtendedRouterStore';
@@ -14,6 +14,7 @@ export default class StudyViewURLWrapper extends URLWrapper<
             tab: { isSessionProp: false },
             resourceUrl: { isSessionProp: false },
         });
+        makeObservable(this);
     }
 
     public setTab(tab: string): void {

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -128,7 +128,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
             this.groupedChartMetaByDataType[ChartMetaDataTypeEnum.GENOMIC] ||
                 [],
             this.selectedAttrs,
-            this.props.store.chartsType.toJS()
+            _.fromPairs(this.props.store.chartsType.toJSON())
         );
 
         if (this.props.currentTab === StudyViewPageTabKeyEnum.CLINICAL_DATA) {
@@ -149,7 +149,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 ChartMetaDataTypeEnum.GENE_SPECIFIC
             ] || [],
             this.selectedAttrs,
-            this.props.store.chartsType.toJS()
+            _.fromPairs(this.props.store.chartsType.toJSON())
         );
         if (this.props.currentTab === StudyViewPageTabKeyEnum.CLINICAL_DATA) {
             return genomicDataOptions.filter(
@@ -168,7 +168,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
             this.groupedChartMetaByDataType[ChartMetaDataTypeEnum.CLINICAL] ||
                 [],
             this.selectedAttrs,
-            this.props.store.chartsType.toJS()
+            _.fromPairs(this.props.store.chartsType.toJSON())
         );
     }
 
@@ -179,7 +179,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 ChartMetaDataTypeEnum.CUSTOM_DATA
             ] || [],
             this.selectedAttrs,
-            this.props.store.chartsType.toJS()
+            _.fromPairs(this.props.store.chartsType.toJSON())
         );
     }
 

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from './styles.module.scss';
 import { observer } from 'mobx-react';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import _ from 'lodash';
 import {
     ChartControls,
@@ -148,6 +148,8 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
 
     constructor(props: IChartContainerProps) {
         super(props);
+
+        makeObservable<ChartContainer, 'selectedRowsKeys'>(this);
 
         this.chartType = this.props.chartType;
 

--- a/src/pages/studyView/charts/barChart/BarChart.tsx
+++ b/src/pages/studyView/charts/barChart/BarChart.tsx
@@ -6,7 +6,7 @@ import {
     VictoryChart,
     VictorySelectionContainer,
 } from 'victory';
-import { computed, observable } from 'mobx';
+import { computed, observable, makeObservable } from 'mobx';
 import _ from 'lodash';
 import { ClinicalDataBin, DataFilterValue } from 'cbioportal-ts-api-client';
 import { AbstractChart } from 'pages/studyView/charts/ChartContainer';
@@ -70,6 +70,10 @@ export default class BarChart extends React.Component<IBarChartProps, {}>
 
     constructor(props: IBarChartProps) {
         super(props);
+        makeObservable<
+            BarChart,
+            'mousePosition' | 'currentBarIndex' | 'toolTipModel'
+        >(this);
     }
 
     @autobind

--- a/src/pages/studyView/charts/barChart/CustomBinsModal.tsx
+++ b/src/pages/studyView/charts/barChart/CustomBinsModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { ChartMeta, customBinsAreValid } from 'pages/studyView/StudyViewUtils';
 import autobind from 'autobind-decorator';
-import { observable, computed } from 'mobx';
+import { observable, computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { Modal, Button } from 'react-bootstrap';
 
@@ -24,6 +24,7 @@ export default class CustomBinsModal extends React.Component<
 
     constructor(props: Readonly<ICustomBinsProps>) {
         super(props);
+        makeObservable<CustomBinsModal, 'currentBinsValue'>(this);
         if (this.props.currentBins) {
             this.currentBinsValue = _.sortBy(this.props.currentBins).join(
                 `${this.binSeparator} `

--- a/src/pages/studyView/charts/pieChart/PieChart.tsx
+++ b/src/pages/studyView/charts/pieChart/PieChart.tsx
@@ -7,7 +7,7 @@ import {
     VictoryLegend,
     VictoryPie,
 } from 'victory';
-import { action, computed, observable, toJS } from 'mobx';
+import { action, computed, observable, toJS, makeObservable } from 'mobx';
 import _ from 'lodash';
 import {
     getFrequencyStr,
@@ -46,6 +46,7 @@ export default class PieChart extends React.Component<IPieChartProps, {}>
 
     constructor(props: IPieChartProps) {
         super(props);
+        makeObservable(this);
     }
 
     @computed

--- a/src/pages/studyView/studyPageHeader/StudyPageHeader.tsx
+++ b/src/pages/studyView/studyPageHeader/StudyPageHeader.tsx
@@ -6,6 +6,7 @@ import StudySummary from './studySummary/StudySummary';
 import UserSelections from '../UserSelections';
 import * as _ from 'lodash';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import { computed, makeObservable } from 'mobx';
 
 export interface IStudyPageHeaderProps {
     store: StudyViewPageStore;
@@ -17,6 +18,14 @@ export default class StudyPageHeader extends React.Component<
     IStudyPageHeaderProps,
     {}
 > {
+    constructor(props: IStudyPageHeaderProps) {
+        super(props);
+        makeObservable(this);
+    }
+    @computed get customChartsFilter() {
+        return _.fromPairs(this.props.store.customChartFilterSet.toJSON());
+    }
+
     render() {
         return (
             <div className={'headBlock'} data-test="study-view-header">
@@ -61,7 +70,7 @@ export default class StudyPageHeader extends React.Component<
                             this.props.store
                                 .numberOfSelectedSamplesInCustomSelection
                         }
-                        customChartsFilter={this.props.store.customChartFilterSet.toJS()}
+                        customChartsFilter={this.customChartsFilter}
                         attributesMetaSet={
                             this.props.store.chartMetaSetWithChartType
                         }

--- a/src/pages/studyView/table/FixedHeaderTable.tsx
+++ b/src/pages/studyView/table/FixedHeaderTable.tsx
@@ -13,7 +13,7 @@ import {
     TableHeaderProps,
 } from 'react-virtualized';
 import 'react-virtualized/styles.css';
-import { action, computed, observable, toJS } from 'mobx';
+import { action, computed, observable, toJS, makeObservable } from 'mobx';
 import styles from './tables.module.scss';
 import * as _ from 'lodash';
 import { Observer, observer } from 'mobx-react';
@@ -69,6 +69,7 @@ export class FixedHeaderTableDataStore extends SimpleGetterLazyMobXTableApplicat
 > {
     constructor(getData: () => any[], fixedTopRowsData: any[]) {
         super(getData);
+        makeObservable(this);
         this.fixedTopRowsData = fixedTopRowsData;
     }
 
@@ -114,6 +115,7 @@ export default class FixedHeaderTable<T> extends React.Component<
 
     constructor(props: IFixedHeaderTableProps<T>) {
         super(props);
+        makeObservable<FixedHeaderTable<T>, '_sortBy' | '_sortDirection'>(this);
         this._sortBy = props.sortBy!;
         const sortByColumn = _.find(
             this.props.columns,

--- a/src/pages/studyView/table/MultiSelectionTable.tsx
+++ b/src/pages/studyView/table/MultiSelectionTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import * as _ from 'lodash';
 import FixedHeaderTable, { IFixedHeaderTableProps } from './FixedHeaderTable';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
     Column,
@@ -129,6 +129,10 @@ export class MultiSelectionTable extends React.Component<
 
     constructor(props: MultiSelectionTableProps, context: any) {
         super(props, context);
+        makeObservable<
+            MultiSelectionTable,
+            'sortBy' | 'sortDirection' | 'modalSettings' | '_selectionType'
+        >(this);
         this.sortBy = this.props.defaultSortBy;
     }
 

--- a/src/pages/studyView/table/treatments/PatientTreatmentsTable.tsx
+++ b/src/pages/studyView/table/treatments/PatientTreatmentsTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import * as _ from 'lodash';
 import FixedHeaderTable, { IFixedHeaderTableProps } from '../FixedHeaderTable';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
     Column,
@@ -78,6 +78,7 @@ export class PatientTreatmentsTable extends TreatmentsTable<
 
     constructor(props: PatientTreatmentsTableProps, context: any) {
         super(props, context);
+        makeObservable<PatientTreatmentsTable, 'sortBy'>(this);
         this.sortBy = this.props.defaultSortBy;
     }
 

--- a/src/pages/studyView/table/treatments/SampleTreatmentsTable.tsx
+++ b/src/pages/studyView/table/treatments/SampleTreatmentsTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import * as _ from 'lodash';
 import FixedHeaderTable, { IFixedHeaderTableProps } from '../FixedHeaderTable';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
     Column,
@@ -77,6 +77,7 @@ export class SampleTreatmentsTable extends TreatmentsTable<
 
     constructor(props: SampleTreatmentsTableProps, context: any) {
         super(props, context);
+        makeObservable<SampleTreatmentsTable, 'sortBy'>(this);
         this.sortBy = this.props.defaultSortBy;
     }
 

--- a/src/pages/studyView/tabs/CNSegments.tsx
+++ b/src/pages/studyView/tabs/CNSegments.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 
 import { CopyNumberSeg } from 'cbioportal-ts-api-client';
@@ -31,6 +31,7 @@ export default class CNSegments extends React.Component<
 
     constructor(props: { store: StudyViewPageStore }) {
         super(props);
+        makeObservable(this);
         this.segmentTrackMaxHeight = WindowStore.size.height * 0.7;
     }
 

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -5,7 +5,7 @@ import {
     ChartContainer,
     IChartContainerProps,
 } from 'pages/studyView/charts/ChartContainer';
-import { observable, toJS } from 'mobx';
+import { observable, toJS, makeObservable } from 'mobx';
 import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import {
     DataFilterValue,
@@ -54,6 +54,7 @@ export class StudySummaryTab extends React.Component<
 
     constructor(props: IStudySummaryTabProps) {
         super(props);
+        makeObservable(this);
         this.store = props.store;
 
         this.handlers = {

--- a/src/shared/api/LazyCache.ts
+++ b/src/shared/api/LazyCache.ts
@@ -1,10 +1,13 @@
-import { observable, action } from 'mobx';
+import { observable, action, makeObservable } from 'mobx';
 
 export default class LazyCache {
     @observable.ref protected _cache: any;
     protected dependencies: any[];
 
     constructor(..._dependencies: any[]) {
+        makeObservable<LazyCache, '_cache' | 'redefineCacheToTriggerMobX'>(
+            this
+        );
         this._cache = {};
         this.dependencies = _dependencies;
     }

--- a/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
+++ b/src/shared/components/GeneSelectionBox/OQLTextArea.tsx
@@ -10,6 +10,7 @@ import {
     action,
     reaction,
     IReactionDisposer,
+    makeObservable,
 } from 'mobx';
 import { Gene } from 'cbioportal-ts-api-client';
 import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
@@ -123,6 +124,15 @@ export default class OQLTextArea extends React.Component<
 
     constructor(props: IGeneSelectionBoxProps) {
         super(props);
+        makeObservable<
+            OQLTextArea,
+            | '_geneQuery'
+            | 'geneQueryIsValid'
+            | 'queryToBeValidated'
+            | 'isFocused'
+            | 'skipGenesValidation'
+            | 'textAreaClasses'
+        >(this);
         this.geneQuery = this.props.inputGeneQuery || '';
         this.queryToBeValidated = this.geneQuery;
         if (!this.props.validateInputGeneQuery) {

--- a/src/shared/components/TextExpander.tsx
+++ b/src/shared/components/TextExpander.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { If, Else, Then } from 'react-if';
 import TextTruncate from 'react-text-truncate';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 
 export interface ITextExpanderProps {
     text?: string | JSX.Element | null;
@@ -28,6 +28,8 @@ export default class TextExpander extends React.Component<
 
     constructor(props: ITextExpanderProps) {
         super(props);
+
+        makeObservable<TextExpander, 'isTextTruncated'>(this);
 
         this.toggleText = this.toggleText.bind(this);
     }

--- a/src/shared/components/UsageAgreement.tsx
+++ b/src/shared/components/UsageAgreement.tsx
@@ -27,7 +27,7 @@ export default class UsageAgreement extends React.Component<
     @observable
     modalShow: boolean = false;
 
-    @observable checkedItems = observable.map<boolean>();
+    @observable checkedItems = observable.map<string, boolean>();
 
     @computed get expirationInSeconds() {
         return this.props.expirationInDays
@@ -45,8 +45,11 @@ export default class UsageAgreement extends React.Component<
     @computed get isAgreementComplete(): boolean {
         return (
             this.useCheckboxes === false ||
-            (this.checkedItems.entries().length === this.props.clauses.length &&
-                _.every(this.checkedItems.values(), val => val === true))
+            (this.checkedItems.size === this.props.clauses.length &&
+                _.every(
+                    Array.from(this.checkedItems.values()),
+                    val => val === true
+                ))
         );
     }
 

--- a/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
@@ -3,7 +3,7 @@ import { Modal, Button } from 'react-bootstrap';
 import { ThreeBounce } from 'better-react-spinkit';
 import { If } from 'react-if';
 import fileDownload from 'react-file-download';
-import { action, observable } from 'mobx';
+import { action, observable, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 const Clipboard = require('clipboard');
 
@@ -52,6 +52,12 @@ export class CopyDownloadControls extends React.Component<
 
     constructor(props: IAsyncCopyDownloadControlsProps) {
         super(props);
+        makeObservable<
+            CopyDownloadControls,
+            | 'handleModalClose'
+            | 'triggerDownloadError'
+            | 'showSimpleCopyMessage'
+        >(this);
         this.handleDownload = this.handleDownload.bind(this);
         this.handleCopy = this.handleCopy.bind(this);
         this.handleModalClose = this.handleModalClose.bind(this);

--- a/src/shared/components/copyDownloadControls/SimpleCopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/SimpleCopyDownloadControls.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import fileDownload from 'react-file-download';
 import { observer } from 'mobx-react';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import { CopyDownloadLinks } from './CopyDownloadLinks';
 import { CopyDownloadButtons } from './CopyDownloadButtons';
 import { ICopyDownloadControlsProps } from './ICopyDownloadControls';
@@ -41,6 +41,8 @@ export class SimpleCopyDownloadControls extends React.Component<
 
     constructor(props: ISimpleCopyDownloadControlsProps) {
         super(props);
+
+        makeObservable<SimpleCopyDownloadControls, 'showCopyMessage'>(this);
 
         this.handleDownload = this.handleDownload.bind(this);
         this.copyLinkRef = this.copyLinkRef.bind(this);

--- a/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
+++ b/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import { AppStore } from '../../../AppStore';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
 import { observer } from 'mobx-react';
-import { observable, computed } from 'mobx';
+import { observable, computed, makeObservable } from 'mobx';
 import { buildCBioPortalPageUrl } from '../../api/urls';
 
 export class UserDataAccessToken {
@@ -18,6 +18,7 @@ export class UserDataAccessToken {
         expirationDate: string,
         username: string
     ) {
+        makeObservable(this);
         this.token = token;
         this.creationDate = creationDate;
         this.expirationDate = expirationDate;
@@ -44,6 +45,7 @@ export class DataAccessTokensDropdown extends React.Component<
 
     constructor(props: IDataAccessTokensProps) {
         super(props);
+        makeObservable(this);
     }
 
     @computed get getDatDropdownList(): any {

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -6,6 +6,7 @@ import {
     IReactionDisposer,
     observable,
     reaction,
+    makeObservable,
 } from 'mobx';
 import { observer, Observer } from 'mobx-react';
 import './styles.scss';
@@ -733,6 +734,16 @@ export class LazyMobXTableStore<T> {
     }
 
     constructor(lazyMobXTableProps: LazyMobXTableProps<T>) {
+        makeObservable<
+            LazyMobXTableStore<T>,
+            | '_itemsLabel'
+            | '_itemsLabelPlural'
+            | 'onRowClick'
+            | 'onRowMouseEnter'
+            | 'onRowMouseLeave'
+            | '_columnVisibility'
+            | '_columnVisibilityOverride'
+        >(this);
         this.sortColumn = lazyMobXTableProps.initialSortColumn || '';
         this.sortAscending = lazyMobXTableProps.initialSortDirection !== 'desc'; // default ascending
         this.setProps(lazyMobXTableProps);
@@ -822,6 +833,7 @@ export default class LazyMobXTable<T> extends React.Component<
 
     constructor(props: LazyMobXTableProps<T>) {
         super(props);
+        makeObservable(this);
         this.store = new LazyMobXTableStore<T>(props);
 
         this.handlers = {

--- a/src/shared/components/mutationMapper/MutationMapperDataStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperDataStore.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
     applyDataFiltersOnDatum,
@@ -196,6 +196,8 @@ export default class MutationMapperDataStore
         groupFilters: { group: string; filter: DataFilter }[] = []
     ) {
         super(data);
+
+        makeObservable(this);
 
         this.dataFilters = dataFilters;
         this.selectionFilters = selectionFilters;

--- a/src/shared/components/mutationMapper/MutationMapperStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperStore.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import MobxPromise, { cached, labelMobxPromises } from 'mobxpromise';
 
 import {
@@ -96,6 +96,11 @@ export default class MutationMapperStore extends DefaultMutationMapperStore {
             getMutations,
             getTranscriptId
         );
+
+        makeObservable<
+            MutationMapperStore,
+            'mutationsGroupedByProteinImpactType'
+        >(this);
 
         const unnormalizedGetMutations = this.getMutations;
         this.getMutations = () =>

--- a/src/shared/components/mutationMapper/MutationMapperUserSelectionStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUserSelectionStore.ts
@@ -1,4 +1,4 @@
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import {
     initDefaultTrackVisibility,
     TrackVisibility,
@@ -8,6 +8,7 @@ export default class MutationMapperUserSelectionStore {
     @observable trackVisibility: TrackVisibility;
 
     constructor() {
+        makeObservable(this);
         this.trackVisibility = initDefaultTrackVisibility();
     }
 }

--- a/src/shared/components/mutationMapper/PdbChainDataStore.ts
+++ b/src/shared/components/mutationMapper/PdbChainDataStore.ts
@@ -1,6 +1,6 @@
 import { SimpleLazyMobXTableApplicationDataStore } from '../../../shared/lib/ILazyMobXTableApplicationDataStore';
 import { IPdbChain } from '../../../shared/model/Pdb';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 export default class PdbChainDataStore extends SimpleLazyMobXTableApplicationDataStore<
     IPdbChain
 > {
@@ -36,6 +36,7 @@ export default class PdbChainDataStore extends SimpleLazyMobXTableApplicationDat
 
     constructor(data: IPdbChain[]) {
         super(data);
+        makeObservable(this);
         this.selectedUid = '';
         this.dataSelector = (d: IPdbChain) =>
             this.getChainUid(d) === this.selectedUid;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { observable, computed } from 'mobx';
+import { observable, computed, makeObservable } from 'mobx';
 import * as _ from 'lodash';
 import {
     default as LazyMobXTable,
@@ -254,6 +254,10 @@ export default class MutationTable<
 
     constructor(props: P) {
         super(props);
+        makeObservable<
+            MutationTable<P>,
+            '_columns' | 'orderedColumns' | 'columns'
+        >(this);
         this._columns = {};
         this.generateColumns();
     }

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -9,7 +9,7 @@ import OncoprintJS, {
 } from 'oncoprintjs';
 import { GenePanelData, MolecularProfile } from 'cbioportal-ts-api-client';
 import { observer } from 'mobx-react';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { transition } from './DeltaUtils';
 import _ from 'lodash';
 import {
@@ -247,6 +247,8 @@ export default class Oncoprint extends React.Component<IOncoprintProps, {}> {
     constructor(props: IOncoprintProps) {
         super(props);
 
+        makeObservable(this);
+
         this.trackSpecKeyToTrackId = {};
         this.divRefHandler = this.divRefHandler.bind(this);
         this.refreshOncoprint = _.debounce(this.refreshOncoprint.bind(this), 0);
@@ -321,10 +323,6 @@ export default class Oncoprint extends React.Component<IOncoprintProps, {}> {
 
     componentWillReceiveProps(nextProps: IOncoprintProps) {
         this.refreshOncoprint(nextProps);
-    }
-
-    shouldComponentUpdate() {
-        return false;
     }
 
     componentDidMount() {

--- a/src/shared/components/oncoprint/OncoprintUtils.spec.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.spec.ts
@@ -140,7 +140,7 @@ describe('OncoprintUtils', () => {
             sequencedSampleKeysByGene: {},
             sequencedPatientKeysByGene: { BRCA1: [], PTEN: [], TP53: [] },
             selectedMolecularProfiles: [],
-            expansionIndexMap: observable.map<number[]>(),
+            expansionIndexMap: observable.map<string, number[]>(),
             hideGermlineMutations: false,
             oncoprint: {} as any,
         });
@@ -406,9 +406,12 @@ describe('OncoprintUtils', () => {
             })(queryData, trackIndex).key;
             const postExpandStoreProperties = {
                 ...preExpandStoreProperties,
-                expansionIndexMap: observable.shallowMap({
-                    [trackKey]: [0, 1],
-                } as IKeyValueMap<number[]>),
+                expansionIndexMap: observable.map<string, number[]>(
+                    {
+                        [trackKey]: [0, 1],
+                    } as IKeyValueMap<number[]>,
+                    { deep: false }
+                ),
             };
             // when
             const trackFunction = makeGeneticTrackWith({
@@ -427,7 +430,7 @@ describe('OncoprintUtils', () => {
             const trackIndex = MINIMAL_TRACK_INDEX + 8;
             const storeProperties = {
                 ...makeMinimal3Patient3GeneStoreProperties(),
-                expansionIndexMap: observable.map<number[]>({
+                expansionIndexMap: observable.map<string, number[]>({
                     UNRELATED_TRACK_1: [8, 9, 10],
                     [parentKey]: [3, trackIndex, 15],
                 }),

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -87,7 +87,7 @@ function makeGenesetHeatmapExpandHandler(
                 molecularProfileId: zScoreGeneticProfileId,
             })
         );
-        runInAction('genesetHeatmapExpansion', () => {
+        runInAction(() => {
             const list =
                 oncoprint.expansionsByGenesetHeatmapTrackKey.get(track_key) ||
                 [];
@@ -595,7 +595,7 @@ interface IGeneticTrackAppState {
     sequencedSampleKeysByGene: any;
     sequencedPatientKeysByGene: any;
     selectedMolecularProfiles: MolecularProfile[];
-    expansionIndexMap: ObservableMap<number[]>;
+    expansionIndexMap: ObservableMap<string, number[]>;
 }
 
 function isAltered(d: GeneticTrackDatum) {
@@ -842,8 +842,9 @@ export function makeClinicalTracksMobxPromise(
                 oncoprint.props.store.clinicalAttributeIdToClinicalAttribute
                     .isComplete
             ) {
-                const attributes = oncoprint.selectedClinicalAttributeIds
-                    .keys()
+                const attributes = Array.from(
+                    oncoprint.selectedClinicalAttributeIds.keys()
+                )
                     .map(attrId => {
                         return oncoprint.props.store
                             .clinicalAttributeIdToClinicalAttribute.result![
@@ -858,11 +859,12 @@ export function makeClinicalTracksMobxPromise(
             return ret;
         },
         invoke: async () => {
-            if (oncoprint.selectedClinicalAttributeIds.keys().length === 0) {
+            if (oncoprint.selectedClinicalAttributeIds.size === 0) {
                 return [];
             }
-            const attributes = oncoprint.selectedClinicalAttributeIds
-                .keys()
+            const attributes = Array.from(
+                oncoprint.selectedClinicalAttributeIds.keys()
+            )
                 .map(attrId => {
                     return oncoprint.props.store
                         .clinicalAttributeIdToClinicalAttribute.result![attrId];
@@ -1260,9 +1262,9 @@ export function makeGenesetHeatmapExpansionsMobxPromise(
                 entrezGeneId: number;
                 molecularProfileId: string;
             }[] = _.flatten(
-                expansionsByGenesetTrack
-                    .values()
-                    .map(mobxArray => mobxArray.slice())
+                Array.from(expansionsByGenesetTrack.values()).map(mobxArray =>
+                    mobxArray.slice()
+                )
             ).map(({ entrezGeneId, molecularProfileId }) => ({
                 entrezGeneId,
                 molecularProfileId,
@@ -1272,7 +1274,7 @@ export function makeGenesetHeatmapExpansionsMobxPromise(
             const tracksByGenesetTrack: {
                 [genesetTrackKey: string]: IHeatmapTrackSpec[];
             } = {};
-            expansionsByGenesetTrack.entries().forEach(([gsTrack, genes]) => {
+            expansionsByGenesetTrack.toJSON().forEach(([gsTrack, genes]) => {
                 tracksByGenesetTrack[gsTrack] = genes.map(
                     ({
                         entrezGeneId,

--- a/src/shared/components/oncoprint/controls/CustomDropdown.tsx
+++ b/src/shared/components/oncoprint/controls/CustomDropdown.tsx
@@ -3,7 +3,7 @@ import { Button, Dropdown, ButtonProps } from 'react-bootstrap';
 import { RootCloseWrapper } from 'react-overlays';
 import classNames from 'classnames';
 import { observer } from 'mobx-react';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 
 export interface ICustomDropdownProps extends ButtonProps {
     title: string;
@@ -48,6 +48,7 @@ export default class CustomDropdown extends React.Component<
 
     constructor(props: ButtonProps) {
         super(props);
+        makeObservable<CustomDropdown, 'open'>(this);
         this.toggle = () => {
             this.open = !this.open;
         };

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -8,11 +8,11 @@ import { MobxPromise } from 'mobxpromise';
 import {
     action,
     computed,
-    IObservableObject,
     observable,
     ObservableMap,
     reaction,
     toJS,
+    makeObservable,
 } from 'mobx';
 import _ from 'lodash';
 import { SortMode } from '../ResultsViewOncoprint';
@@ -139,7 +139,7 @@ export interface IOncoprintControlsState {
     customDriverAnnotationBinaryMenuLabel?: string;
     customDriverAnnotationTiersMenuLabel?: string;
     customDriverAnnotationTiers?: string[];
-    selectedCustomDriverAnnotationTiers?: ObservableMap<boolean>;
+    selectedCustomDriverAnnotationTiers?: ObservableMap<string, boolean>;
     annotateCustomDriverBinary?: boolean;
 
     columnMode?: OncoprintAnalysisCaseType;
@@ -150,7 +150,7 @@ export interface IOncoprintControlsState {
 export interface IOncoprintControlsProps {
     store?: ResultsViewPageStore;
     handlers: IOncoprintControlsHandlers;
-    state: IOncoprintControlsState & IObservableObject;
+    state: IOncoprintControlsState;
     oncoprinterMode?: boolean;
     molecularProfileIdToMolecularProfile?: {
         [molecularProfileId: string]: MolecularProfile;
@@ -222,6 +222,11 @@ export default class OncoprintControls extends React.Component<
 
     constructor(props: IOncoprintControlsProps) {
         super(props);
+
+        makeObservable<
+            OncoprintControls,
+            '_selectedGenericAssayEntityIds' | '_genericAssaySearchText'
+        >(this);
 
         this.getHeatmapMenu = this.getHeatmapMenu.bind(this);
         this.getClinicalTracksMenu = this.getClinicalTracksMenu.bind(this);

--- a/src/shared/components/proteinChainPanel/ProteinChainPanel.tsx
+++ b/src/shared/components/proteinChainPanel/ProteinChainPanel.tsx
@@ -8,6 +8,7 @@ import {
     action,
     IReactionDisposer,
     reaction,
+    makeObservable,
 } from 'mobx';
 import { ProteinChainSpec } from './ProteinChainView';
 import { Collapse } from 'react-collapse';
@@ -57,6 +58,16 @@ export default class ProteinChainPanel extends React.Component<
 
     constructor(props: ProteinChainPanelProps) {
         super(props);
+
+        makeObservable<
+            ProteinChainPanel,
+            | 'isExpanded'
+            | 'pdbChainTableShown'
+            | 'hoveredChain'
+            | 'selectChain'
+            | 'isOpen'
+            | 'displayChains'
+        >(this);
 
         this.handlers = {
             onMouseEnter: action(() => {

--- a/src/shared/components/proteinChainPanel/ProteinChainView.tsx
+++ b/src/shared/components/proteinChainPanel/ProteinChainView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { computed, observable, action } from 'mobx';
+import { computed, observable, action, makeObservable } from 'mobx';
 import HotspotSet from '../../lib/HotspotSet';
 import * as _ from 'lodash';
 import { SyntheticEvent } from 'react';
@@ -58,6 +58,7 @@ export default class ProteinChainView extends React.Component<
 
     constructor(props: ProteinChainViewProps) {
         super(props);
+        makeObservable<ProteinChainView, 'rowHeight' | 'rowPadding'>(this);
         this.onMouseOver = this.onMouseOver.bind(this);
         this.positionToX = this.positionToX.bind(this);
     }

--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -7,7 +7,14 @@ import styles from './styles/styles.module.scss';
 import classNames from 'classnames';
 import StudyList from './studyList/StudyList';
 import { observer, Observer } from 'mobx-react';
-import { action, computed, expr, IReactionDisposer, reaction } from 'mobx';
+import {
+    action,
+    computed,
+    IReactionDisposer,
+    reaction,
+    makeObservable,
+} from 'mobx';
+import { expr } from 'mobx-utils';
 import memoize from 'memoize-weak-decorator';
 import { If, Then, Else } from 'react-if';
 import { QueryStore } from './QueryStore';
@@ -61,6 +68,7 @@ export default class CancerStudySelector extends React.Component<
 
     constructor(props: ICancerStudySelectorProps) {
         super(props);
+        makeObservable(this);
         this.store = this.props.queryStore;
     }
 

--- a/src/shared/components/query/GenesetsHierarchyFilterForm.tsx
+++ b/src/shared/components/query/GenesetsHierarchyFilterForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import ReactSelect from 'react-select1';
 
@@ -31,6 +31,7 @@ export default class GenesetsHierarchyFilterForm extends React.Component<
     ];
     constructor(props: GenesetsHierarchyFilterFormProps) {
         super(props);
+        makeObservable(this);
         this.percentileChange = this.percentileChange.bind(this);
         this.applyFilter = this.applyFilter.bind(this);
     }

--- a/src/shared/components/query/GenesetsHierarchySelector.tsx
+++ b/src/shared/components/query/GenesetsHierarchySelector.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ObservableMap, observable } from 'mobx';
+import { ObservableMap, observable, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import GenesetsJsTree from './GenesetsJsTree';
 import GenesetsHierarchyFilterForm, {
@@ -10,7 +10,7 @@ export interface GenesetsHierarchySelectorProps {
     initialSelection: string[];
     gsvaProfile: string;
     sampleListId: string | undefined;
-    onSelect: (map_geneSet_selected: ObservableMap<boolean>) => void;
+    onSelect: (map_geneSet_selected: ObservableMap<string, boolean>) => void;
 }
 
 @observer
@@ -25,6 +25,7 @@ export default class GenesetsHierarchySelector extends React.Component<
 
     constructor(props: GenesetsHierarchySelectorProps) {
         super(props);
+        makeObservable(this);
         this.updateSelectionParameters = this.updateSelectionParameters.bind(
             this
         );

--- a/src/shared/components/query/GenesetsJsTree.tsx
+++ b/src/shared/components/query/GenesetsJsTree.tsx
@@ -10,7 +10,7 @@ import CBioPortalAPIInternal, {
     GenesetHierarchyInfo,
 } from 'cbioportal-ts-api-client';
 import { observer } from 'mobx-react';
-import { observable, ObservableMap } from 'mobx';
+import { observable, ObservableMap, makeObservable } from 'mobx';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 
 export interface GenesetsJsTreeProps {
@@ -21,7 +21,7 @@ export interface GenesetsJsTreeProps {
     gsvaProfile: string;
     sampleListId: string | undefined;
     searchValue: string;
-    onSelect: (map_geneSet_selected: ObservableMap<boolean>) => void;
+    onSelect: (map_geneSet_selected: ObservableMap<string, boolean>) => void;
 }
 
 type JSNode = {
@@ -36,10 +36,14 @@ export default class GenesetsJsTree extends React.Component<
     tree: Element | null;
     @observable isLoading = true;
     promisedTree: Promise<Element>;
-    private readonly map_geneSets_selected = new ObservableMap<boolean>();
+    private readonly map_geneSets_selected = new ObservableMap<
+        string,
+        boolean
+    >();
 
     constructor(props: GenesetsJsTreeProps) {
         super(props);
+        makeObservable(this);
         this.map_geneSets_selected.replace(
             props.initialSelection.map(geneSet => [geneSet, true])
         );

--- a/src/shared/components/query/GenesetsSelectorStore.spec.ts
+++ b/src/shared/components/query/GenesetsSelectorStore.spec.ts
@@ -73,7 +73,10 @@ describe('GenesetsSelectorStore', () => {
             assert.equal(minYValue, 0.0736);
         });
         it('builds the data for the volcano plot graph with the correct values', () => {
-            const map_genesets_selected_volcano = new ObservableMap<boolean>();
+            const map_genesets_selected_volcano = new ObservableMap<
+                string,
+                boolean
+            >();
             map_genesets_selected_volcano.set('AKT_UP.V1_DN', true);
             const graphData = getVolcanoPlotData(
                 genesets,
@@ -109,7 +112,10 @@ describe('GenesetsSelectorStore', () => {
             assert.equal(minYValue, undefined);
         });
         it('returns undefined for volcano plot data graph if the table data is an empty array', () => {
-            const map_genesets_selected_volcano = new ObservableMap<boolean>();
+            const map_genesets_selected_volcano = new ObservableMap<
+                string,
+                boolean
+            >();
             map_genesets_selected_volcano.set('AKT_UP.V1_DN', true);
             const graphDataUndefined = getVolcanoPlotData(
                 [],

--- a/src/shared/components/query/GenesetsSelectorStore.tsx
+++ b/src/shared/components/query/GenesetsSelectorStore.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Geneset, GenesetHierarchyInfo } from 'cbioportal-ts-api-client';
 import * as _ from 'lodash';
-import { ObservableMap } from 'mobx/lib/mobx';
+import { ObservableMap } from 'mobx';
 
 export function getGenesetsFromHierarchy(
     hierarchyData: GenesetHierarchyInfo[]
@@ -30,7 +30,7 @@ export function getVolcanoPlotMinYValue(
 
 export function getVolcanoPlotData(
     genesetsData: Geneset[],
-    map_genesets_selected_volcano: ObservableMap<boolean>
+    map_genesets_selected_volcano: ObservableMap<string, boolean>
 ): { x: number; y: number; fill: string }[] | undefined {
     if (genesetsData.length > 0) {
         const volcanoPlotData = genesetsData.map(

--- a/src/shared/components/query/GenesetsVolcanoSelector.tsx
+++ b/src/shared/components/query/GenesetsVolcanoSelector.tsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import LabeledCheckbox from '../labeledCheckbox/LabeledCheckbox';
 import styles from './styles/styles.module.scss';
-import { action, computed, ObservableMap } from 'mobx';
+import { action, computed, ObservableMap, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import LazyMobXTable from 'shared/components/lazyMobXTable/LazyMobXTable';
 import { Geneset } from 'cbioportal-ts-api-client';
@@ -27,7 +27,7 @@ export interface GenesetsVolcanoSelectorProps {
     data: Geneset[] | undefined;
     plotData: { x: number; y: number; fill: string }[] | undefined;
     maxY: number | undefined;
-    onSelect: (map_genesets_selected: ObservableMap<boolean>) => void;
+    onSelect: (map_genesets_selected: ObservableMap<string, boolean>) => void;
 }
 
 @observer
@@ -42,6 +42,7 @@ export default class GenesetsVolcanoSelector extends QueryStoreComponent<
     ];
     constructor(props: GenesetsVolcanoSelectorProps) {
         super(props);
+        makeObservable(this);
         this.percentileChange = this.percentileChange.bind(this);
         this.updateSelectionFromPlot = this.updateSelectionFromPlot.bind(this);
     }

--- a/src/shared/components/query/GisticGeneSelector.tsx
+++ b/src/shared/components/query/GisticGeneSelector.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import styles from './styles/styles.module.scss';
-import { ObservableMap, expr, toJS, computed, observable } from 'mobx';
+import {
+    ObservableMap,
+    toJS,
+    computed,
+    observable,
+    makeObservable,
+} from 'mobx';
+import { expr } from 'mobx-utils';
 import { observer, Observer } from 'mobx-react';
 import { Gistic } from 'cbioportal-ts-api-client';
 import EnhancedReactTable from '../enhancedReactTable/EnhancedReactTable';
@@ -18,7 +25,7 @@ class GisticTable extends EnhancedReactTable<Gistic> {}
 export interface GisticGeneSelectorProps {
     initialSelection: string[];
     data: Gistic[];
-    onSelect: (map_geneSymbol_selected: ObservableMap<boolean>) => void;
+    onSelect: (map_geneSymbol_selected: ObservableMap<string, boolean>) => void;
 }
 
 @observer
@@ -33,7 +40,7 @@ export default class GisticGeneSelector extends React.Component<
         );
     }
 
-    map_geneSymbol_selected = observable.map<boolean>();
+    map_geneSymbol_selected = observable.map<string, boolean>();
 
     private columns: IColumnDefMap = {
         amp: {
@@ -190,10 +197,21 @@ export default class GisticGeneSelector extends React.Component<
 
 @observer
 class GisticGeneToggles extends React.Component<
-    { gistic?: Gistic; map_geneSymbol_selected: ObservableMap<boolean> },
+    {
+        gistic?: Gistic;
+        map_geneSymbol_selected: ObservableMap<string, boolean>;
+    },
     {}
 > {
     @observable showAll = false;
+
+    constructor(props: {
+        gistic?: Gistic;
+        map_geneSymbol_selected: ObservableMap<string, boolean>;
+    }) {
+        super(props);
+        makeObservable(this);
+    }
 
     renderGeneToggles(genes: string[]) {
         return genes.map(gene => (

--- a/src/shared/components/query/MutSigGeneSelector.tsx
+++ b/src/shared/components/query/MutSigGeneSelector.tsx
@@ -2,7 +2,15 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import LabeledCheckbox from '../labeledCheckbox/LabeledCheckbox';
 import styles from './styles/styles.module.scss';
-import { action, ObservableMap, expr, toJS, computed, observable } from 'mobx';
+import {
+    action,
+    ObservableMap,
+    toJS,
+    computed,
+    observable,
+    makeObservable,
+} from 'mobx';
+import { expr } from 'mobx-utils';
 import { observer, Observer } from 'mobx-react';
 import EnhancedReactTable from '../enhancedReactTable/EnhancedReactTable';
 import { MutSig } from 'cbioportal-ts-api-client';
@@ -16,7 +24,7 @@ class MutSigTable extends EnhancedReactTable<MutSig> {}
 export interface MutSigGeneSelectorProps {
     initialSelection: string[];
     data: MutSig[];
-    onSelect: (map_geneSymbol_selected: ObservableMap<boolean>) => void;
+    onSelect: (map_geneSymbol_selected: ObservableMap<string, boolean>) => void;
 }
 
 @observer
@@ -26,12 +34,16 @@ export default class MutSigGeneSelector extends React.Component<
 > {
     constructor(props: MutSigGeneSelectorProps) {
         super(props);
+        makeObservable(this);
         this.map_geneSymbol_selected.replace(
             props.initialSelection.map(geneSymbol => [geneSymbol, true])
         );
     }
 
-    private readonly map_geneSymbol_selected = observable.map<boolean>();
+    private readonly map_geneSymbol_selected = observable.map<
+        string,
+        boolean
+    >();
 
     @computed get allGenes() {
         return _.uniq(this.props.data.map(mutSig => mutSig.hugoGeneSymbol));

--- a/src/shared/components/query/QueryAndDownloadTabs.tsx
+++ b/src/shared/components/query/QueryAndDownloadTabs.tsx
@@ -3,7 +3,7 @@ import styles from './styles/styles.module.scss';
 import { observer } from 'mobx-react';
 import QueryContainer from './QueryContainer';
 import { QueryStore } from './QueryStore';
-import { observable, action } from 'mobx';
+import { observable, action, makeObservable } from 'mobx';
 import { MSKTab, MSKTabs } from '../MSKTabs/MSKTabs';
 import QuickSearch from './quickSearch/QuickSearch';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
@@ -35,6 +35,8 @@ export default class QueryAndDownloadTabs extends React.Component<
 > {
     constructor(props: IQueryAndDownloadTabsProps) {
         super(props);
+
+        makeObservable(this);
 
         if (
             props.showQuickSearchTab &&

--- a/src/shared/components/query/QueryContainer.tsx
+++ b/src/shared/components/query/QueryContainer.tsx
@@ -14,7 +14,7 @@ import CaseSetSelector from './CaseSetSelector';
 import UnknownStudiesWarning from '../unknownStudies/UnknownStudiesWarning';
 import classNames from 'classnames';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
-import { computed, observable } from 'mobx';
+import { computed, observable, makeObservable } from 'mobx';
 import { Else, If, Then } from 'react-if';
 import autobind from 'autobind-decorator';
 import SectionHeader from 'shared/components/sectionHeader/SectionHeader';
@@ -63,6 +63,7 @@ export default class QueryContainer extends React.Component<
 
     constructor(props: QueryContainerProps) {
         super(props);
+        makeObservable(this);
         this.handleSubmit = this.handleSubmit.bind(this);
     }
 

--- a/src/shared/components/query/StudyListLogic.ts
+++ b/src/shared/components/query/StudyListLogic.ts
@@ -9,7 +9,7 @@ import {
     CancerStudy,
 } from 'cbioportal-ts-api-client';
 import { QueryStore } from './QueryStore';
-import { computed, action } from 'mobx';
+import { computed, action, makeObservable } from 'mobx';
 import {
     parse_search_query,
     perform_search_single,
@@ -22,7 +22,9 @@ import memoize from 'memoize-weak-decorator';
 export const PAN_CAN_SIGNATURE = 'pan_can_atlas';
 
 export default class StudyListLogic {
-    constructor(private readonly store: QueryStore) {}
+    constructor(private readonly store: QueryStore) {
+        makeObservable(this);
+    }
 
     @cached get map_node_filterByDepth() {
         let map_node_filter = new Map<CancerTreeNode, boolean>();
@@ -193,7 +195,9 @@ export class FilteredCancerTreeView {
     constructor(
         private store: QueryStore,
         private filters: Pick<Map<CancerTreeNode, boolean>, 'get'>[]
-    ) {}
+    ) {
+        makeObservable(this);
+    }
 
     nodeFilter = (node: CancerTreeNode): boolean => {
         return this.filters.every(map => !!map.get(node));

--- a/src/shared/components/query/StudySelectorStats.tsx
+++ b/src/shared/components/query/StudySelectorStats.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { QueryStore } from 'shared/components/query/QueryStore';
 import { Observer, observer } from 'mobx-react';
-import { expr } from 'mobx';
+import { expr } from 'mobx-utils';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 
 export const StudySelectorStats: React.FunctionComponent<{

--- a/src/shared/components/structureViewer/StructureViewerPanel.tsx
+++ b/src/shared/components/structureViewer/StructureViewerPanel.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { FormControl, Checkbox, Button, ButtonGroup } from 'react-bootstrap';
 import { If, Else, Then } from 'react-if';
 import { ThreeBounce } from 'better-react-spinkit';
-import { observable, computed } from 'mobx';
+import { observable, computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import Draggable from 'react-draggable';
 import fileDownload from 'react-file-download';
@@ -64,6 +64,17 @@ export default class StructureViewerPanel extends React.Component<
 
     constructor(props: IStructureViewerPanelProps) {
         super(props);
+
+        makeObservable<
+            StructureViewerPanel,
+            | 'isCollapsed'
+            | 'isIncreasedSize'
+            | 'proteinScheme'
+            | 'proteinColor'
+            | 'sideChain'
+            | 'mutationColor'
+            | 'displayBoundMolecules'
+        >(this);
 
         this.containerRefHandler = this.containerRefHandler.bind(this);
         this.toggleCollapse = this.toggleCollapse.bind(this);

--- a/src/shared/components/structureViewer/StructureVisualizer3D.ts
+++ b/src/shared/components/structureViewer/StructureVisualizer3D.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import $ from 'jquery';
-import { observable, computed, reaction, action } from 'mobx';
+import { observable, computed, reaction, action, makeObservable } from 'mobx';
 import {
     default as StructureVisualizer,
     ProteinScheme,
@@ -116,6 +116,11 @@ export default class StructureVisualizer3D extends StructureVisualizer {
         _3dMol?: any
     ) {
         super();
+
+        makeObservable<
+            StructureVisualizer3D,
+            'props' | '_prevProps' | 'state' | '_prevState'
+        >(this);
 
         this._3dMol = _3dMol || $3Dmol;
         this._3dMolDiv = div;

--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -23,7 +23,7 @@
 
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { observable } from 'mobx';
+import { observable, makeObservable } from 'mobx';
 import { JsonToTable } from 'react-json-to-table';
 import './StudyTagsTooltip.scss';
 import { DefaultTooltip, remoteData } from 'cbioportal-frontend-commons';
@@ -59,6 +59,11 @@ class StudyInfoOverlay extends React.Component<
             console.error('Error on getting study tags.', error);
         },
     });
+
+    constructor(props: StudyInfoOverlayTooltipProps) {
+        super(props);
+        makeObservable(this);
+    }
 
     addHTMLDescription(description: string) {
         return { __html: description };

--- a/src/shared/components/testimonials/Testimonials.tsx
+++ b/src/shared/components/testimonials/Testimonials.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { observable, action } from 'mobx';
+import { observable, action, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { Link } from 'react-router';
 
@@ -20,6 +20,7 @@ export class TestimonialStore {
     }
 
     constructor() {
+        makeObservable(this);
         this.testimonialIndex = 0;
         this.testimonials = [
             {

--- a/src/shared/components/userMessager/UserMessage.tsx
+++ b/src/shared/components/userMessager/UserMessage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import { remoteData, isWebdriver } from 'cbioportal-frontend-commons';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
 import * as _ from 'lodash';
 import styles from './styles.module.scss';
@@ -54,6 +54,7 @@ export default class UserMessager extends React.Component<
 > {
     constructor(props: IUserMessagerProps) {
         super(props);
+        makeObservable(this);
         this.messageData = remoteData<IUserMessage[]>(async () => {
             return Promise.resolve(props.messages || MESSAGE_DATA);
         });

--- a/src/shared/lib/ILazyMobXTableApplicationDataStore.ts
+++ b/src/shared/lib/ILazyMobXTableApplicationDataStore.ts
@@ -1,5 +1,5 @@
 import { SortMetric } from './ISortMetric';
-import { observable, computed, action } from 'mobx';
+import { observable, computed, action, makeObservable } from 'mobx';
 import { lazyMobXTableSort } from '../components/lazyMobXTable/LazyMobXTable';
 import { SHOW_ALL_PAGE_SIZE as PAGINATION_SHOW_ALL } from 'shared/components/paginationControls/PaginationControls';
 
@@ -157,6 +157,10 @@ export class SimpleGetterLazyMobXTableApplicationDataStore<T>
     }
 
     constructor(private getData: () => T[]) {
+        makeObservable<
+            SimpleGetterLazyMobXTableApplicationDataStore<T>,
+            'dataFilter' | 'dataSelector'
+        >(this);
         this.filterString = '';
         this.dataHighlighter = () => false;
         this.dataSelector = () => false;

--- a/src/shared/lib/LazyMobXCache.spec.ts
+++ b/src/shared/lib/LazyMobXCache.spec.ts
@@ -4,7 +4,6 @@ import lolex from 'lolex';
 import { Clock } from 'lolex';
 import { default as LazyMobXCache, CacheData } from './LazyMobXCache';
 import mobx from 'mobx';
-import { whyRun } from 'mobx';
 
 // We have to use 'done' rather than fake clock because for some reason fake clock isn't working with async/await
 //  in LazyMobXCache.populate

--- a/src/shared/lib/LazyMobXCache.ts
+++ b/src/shared/lib/LazyMobXCache.ts
@@ -1,6 +1,6 @@
 import Immutable from 'seamless-immutable'; // need to use immutables so mobX can observe the cache shallowly
 import accumulatingDebounce from './accumulatingDebounce';
-import { observable, action, reaction } from 'mobx';
+import { observable, action, reaction, makeObservable } from 'mobx';
 import { AccumulatingDebouncedFunction } from './accumulatingDebounce';
 
 export type CacheData<D, M = any> =
@@ -65,6 +65,10 @@ export default class LazyMobXCache<Data, Query, Metadata = any> {
         ) => Promise<FetchResult<Data, Metadata>>,
         ...staticDependencies: any[]
     ) {
+        makeObservable<
+            LazyMobXCache<Data, Query, Metadata>,
+            '_cache' | 'updateCache'
+        >(this);
         this.init();
         this.staticDependencies = staticDependencies;
         this.debouncedPopulate = accumulatingDebounce<

--- a/src/shared/lib/PromisePlus.ts
+++ b/src/shared/lib/PromisePlus.ts
@@ -1,4 +1,10 @@
-import { action, computed, observable, runInAction } from 'mobx';
+import {
+    action,
+    computed,
+    observable,
+    runInAction,
+    makeObservable,
+} from 'mobx';
 
 type PromisePlusStatus = 'complete' | 'pending' | 'error';
 
@@ -24,6 +30,7 @@ export default class PromisePlus<T> {
     }
 
     constructor(private _promise: Promise<T>) {
+        makeObservable<PromisePlus<T>, '_status' | '_result' | '_error'>(this);
         runInAction(() => {
             this._status = 'pending';
 

--- a/src/shared/lib/URLWrapper.ts
+++ b/src/shared/lib/URLWrapper.ts
@@ -9,6 +9,7 @@ import {
     reaction,
     runInAction,
     toJS,
+    makeObservable,
 } from 'mobx';
 import ExtendedRouterStore, {
     getRemoteSession,
@@ -62,6 +63,10 @@ export default class URLWrapper<
         public sessionEnabled = false,
         public urlCharThresholdForSession = 1500
     ) {
+        makeObservable<
+            URLWrapper<QueryParamsType>,
+            'updateRoute' | 'syncAllProperties' | 'trySyncProperty'
+        >(this);
         this.properties = _.entries(this.propertiesMap).map(entry => ({
             name: entry[0],
             ...entry[1],

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -32,7 +32,14 @@ import {
     Sample,
     SampleFilter,
 } from 'cbioportal-ts-api-client';
-import { action, autorun, computed, IReactionDisposer, observable } from 'mobx';
+import {
+    action,
+    autorun,
+    computed,
+    IReactionDisposer,
+    observable,
+    makeObservable,
+} from 'mobx';
 import client from '../../api/cbioportalClientInstance';
 import comparisonClient from '../../api/comparisonGroupClientInstance';
 import _ from 'lodash';
@@ -90,7 +97,8 @@ export enum OverlapStrategy {
 }
 
 export default abstract class ComparisonStore {
-    private tabHasBeenShown = observable.map<boolean>();
+    private tabHasBeenShown = observable.map<GroupComparisonTab, boolean>();
+
     private tabHasBeenShownReactionDisposer: IReactionDisposer;
     @observable public newSessionPending = false;
 
@@ -98,6 +106,15 @@ export default abstract class ComparisonStore {
         protected appStore: AppStore,
         protected resultsViewStore?: ResultsViewPageStore
     ) {
+        makeObservable<
+            ComparisonStore,
+            | '_mutationEnrichmentProfileMap'
+            | '_copyNumberEnrichmentProfileMap'
+            | '_mRNAEnrichmentProfileMap'
+            | '_proteinEnrichmentProfileMap'
+            | '_methylationEnrichmentProfileMap'
+            | '_genericAssayEnrichmentProfileMapGroupByGenericAssayType'
+        >(this);
         setTimeout(() => {
             this.tabHasBeenShownReactionDisposer = autorun(() => {
                 this.tabHasBeenShown.set(
@@ -1325,7 +1342,7 @@ export default abstract class ComparisonStore {
     }
 
     @computed get showSurvivalTab() {
-        return (
+        return !!(
             this.survivalTabShowable ||
             (this.activeGroups.isComplete &&
                 this.activeGroups.result!.length === 0 &&
@@ -1350,7 +1367,7 @@ export default abstract class ComparisonStore {
     }
 
     @computed get showMutationsTab() {
-        return (
+        return !!(
             this.mutationsTabShowable ||
             (this.activeGroups.isComplete &&
                 this.activeGroups.result!.length === 0 &&
@@ -1381,7 +1398,7 @@ export default abstract class ComparisonStore {
     }
 
     @computed get showCopyNumberTab() {
-        return (
+        return !!(
             this.copyNumberTabShowable ||
             (this.activeGroups.isComplete &&
                 this.activeGroups.result!.length === 0 &&
@@ -1405,7 +1422,7 @@ export default abstract class ComparisonStore {
     }
 
     @computed get showMRNATab() {
-        return (
+        return !!(
             this.mRNATabShowable ||
             (this.activeGroups.isComplete &&
                 this.activeGroups.result!.length === 0 &&
@@ -1431,7 +1448,7 @@ export default abstract class ComparisonStore {
     }
 
     @computed get showProteinTab() {
-        return (
+        return !!(
             this.proteinTabShowable ||
             (this.activeGroups.isComplete &&
                 this.activeGroups.result!.length === 0 &&
@@ -1457,7 +1474,7 @@ export default abstract class ComparisonStore {
     }
 
     @computed get showMethylationTab() {
-        return (
+        return !!(
             this.methylationTabShowable ||
             (this.activeGroups.isComplete &&
                 this.activeGroups.result!.length === 0 &&
@@ -1487,7 +1504,7 @@ export default abstract class ComparisonStore {
     }
 
     @computed get showGenericAssayTab() {
-        return (
+        return !!(
             this.genericAssayTabShowable ||
             (this.activeGroups.isComplete &&
                 this.activeGroups.result!.length === 0 &&

--- a/src/shared/lib/onMobxPromise.spec.ts
+++ b/src/shared/lib/onMobxPromise.spec.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { remoteData } from 'cbioportal-frontend-commons';
 import onMobxPromise from './onMobxPromise';
-import { extras, IReactionDisposer, observable } from 'mobx';
+import { IReactionDisposer, observable } from 'mobx';
 
 describe('onMobxPromise', () => {
     it('executes the given callback with the result when the mobx promise completes', done => {
@@ -62,7 +62,7 @@ describe('onMobxPromise', () => {
         let promiseResultIncrementerDisposer: IReactionDisposer;
         let promise = remoteData({
             invoke: async () => {
-                lastInvokedPromiseResult = promiseResult.get();
+                lastInvokedPromiseResult = promiseResult;
                 return lastInvokedPromiseResult;
             },
         });
@@ -75,7 +75,7 @@ describe('onMobxPromise', () => {
                     'promise invoked with result = lastInvokedPromiseResult'
                 );
                 handlerInvokeCount += 1;
-                promiseResult.set(promiseResult.get() + 1);
+                promiseResult = promiseResult + 1;
             },
             5,
             () => {
@@ -87,7 +87,7 @@ describe('onMobxPromise', () => {
                             5,
                             'never invoked again'
                         );
-                        promiseResult.set(promiseResult.get() + 1);
+                        promiseResult = promiseResult + 1;
                     },
                     10,
                     () => {
@@ -104,7 +104,7 @@ describe('onMobxPromise', () => {
         let promiseResultIncrementerDisposer: IReactionDisposer;
         let promise = remoteData({
             invoke: async () => {
-                lastInvokedPromiseResult = promiseResult.get();
+                lastInvokedPromiseResult = promiseResult;
                 return lastInvokedPromiseResult;
             },
         });
@@ -115,7 +115,7 @@ describe('onMobxPromise', () => {
                 (result: number) => {
                     assert.equal(result, 0, 'promise invoked with result = 0');
                     handlerInvokeCount += 1;
-                    promiseResult.set(promiseResult.get() + 1);
+                    promiseResult = promiseResult + 1;
                 },
                 1,
                 () => {
@@ -127,7 +127,7 @@ describe('onMobxPromise', () => {
                                 1,
                                 'never invoked again'
                             );
-                            promiseResult.set(promiseResult.get() + 1);
+                            promiseResult = promiseResult + 1;
                         },
                         10,
                         () => {

--- a/src/shared/lib/reactionWithPrev.spec.ts
+++ b/src/shared/lib/reactionWithPrev.spec.ts
@@ -10,9 +10,9 @@ describe('reactionWithPrev', () => {
         let argumentIndex = observable(-1);
         let indexesWhereEffectCalled: { [index: number]: boolean } = {};
 
-        let dataFn = () => values[argumentIndex.get()];
+        let dataFn = () => values[argumentIndex];
         let effectFn = (data: number, prevData?: number) => {
-            if (argumentIndex.get() === values.length) {
+            if (argumentIndex === values.length) {
                 assert.isTrue(indexesWhereEffectCalled[0], '0');
                 assert.isTrue(indexesWhereEffectCalled[1], '1');
                 assert.isTrue(indexesWhereEffectCalled[2], '2');
@@ -23,22 +23,22 @@ describe('reactionWithPrev', () => {
                 assert.isTrue(indexesWhereEffectCalled[7], '7');
                 done();
             } else {
-                indexesWhereEffectCalled[argumentIndex.get()] = true;
-                assert.equal(data, values[argumentIndex.get()]);
-                if (argumentIndex.get() > 0) {
-                    assert.equal(prevData, values[argumentIndex.get() - 1]);
+                indexesWhereEffectCalled[argumentIndex] = true;
+                assert.equal(data, values[argumentIndex]);
+                if (argumentIndex > 0) {
+                    assert.equal(prevData, values[argumentIndex - 1]);
                 }
             }
         };
         dispose = reactionWithPrev<number>(dataFn, effectFn);
-        argumentIndex.set(0);
-        argumentIndex.set(1);
-        argumentIndex.set(2);
-        argumentIndex.set(3);
-        argumentIndex.set(4);
-        argumentIndex.set(5);
-        argumentIndex.set(6);
-        argumentIndex.set(7);
-        argumentIndex.set(8);
+        argumentIndex = 0;
+        argumentIndex = 1;
+        argumentIndex = 2;
+        argumentIndex = 3;
+        argumentIndex = 4;
+        argumentIndex = 5;
+        argumentIndex = 6;
+        argumentIndex = 7;
+        argumentIndex = 8;
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15121,37 +15121,47 @@ mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0
   dependencies:
     minimist "0.0.8"
 
-mobx-react-devtools@^4.2.11:
-  version "4.2.15"
-  resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-4.2.15.tgz#881c038fb83db4dffd1e72bbaf5374d26b2fdebb"
-  integrity sha1-iBwDj7g9tN/9HnK7r1N00msv3rs=
+mobx-react-devtools@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-6.1.1.tgz#a462b944085cf11ff96fc937d12bf31dab4c8984"
+  integrity sha512-nc5IXLdEUFLn3wZal65KF3/JFEFd+mbH4KTz/IG5BOPyw7jo8z29w/8qm7+wiCyqVfUIgJ1gL4+HVKmcXIOgqA==
 
-mobx-react-lite@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.0.7.tgz#1bfb3b4272668e288047cf0c7940b14e91cba284"
-  integrity sha512-YKAh2gThC6WooPnVZCoC+rV1bODAKFwkhxikzgH18wpBjkgTkkR9Sb0IesQAH5QrAEH/JQVmy47jcpQkf2Au3Q==
+mobx-react-lite@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.4.0.tgz#193beb5fdddf17ae61542f65ff951d84db402351"
+  integrity sha512-5xCuus+QITQpzKOjAOIQ/YxNhOl/En+PlNJF+5QU4Qxn9gnNMJBbweAdEW3HnuVQbfqDYEUnkGs5hmkIIStehg==
 
-mobx-react-router@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/mobx-react-router/-/mobx-react-router-3.1.2.tgz#83328b108393017148d86fea17f611de2d2aacdc"
-  integrity sha1-gzKLEIOTAXFI2G/qF/YR3i0qrNw=
+mobx-react-lite@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.0.1.tgz#417f54a819d1e3e00c073077f29373399c95b005"
+  integrity sha512-Ue8uGgT5iOjMyNf5ptoFW7BTvyLIwggzIkoFpwORrqf73TPqu47iLpz/DNvaba3v40kSsEpp050qYroMNuA1xw==
 
-mobx-react@^4.1.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-4.4.3.tgz#baa9ec41165ee35ae7b9df19bca10190f36f117e"
-  integrity sha1-uqnsQRZe41rnud8ZvKEBkPNvEX4=
+mobx-react-lite@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz#87c217dc72b4e47b22493daf155daf3759f868a6"
+  integrity sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg==
+
+mobx-react-router@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-router/-/mobx-react-router-4.1.0.tgz#de014848207d8aa32f6a4e67ed861bd2cb6516e5"
+  integrity sha512-2knsbDqVorWLngZWbdO8tr7xcZXaLpVFsFlCaGaoyZ+EP9erVGRxnlWGqKyFObs3EH1JPLyTDOJ2LPTxb/lB6Q==
+
+mobx-react@6.0.0, mobx-react@^6.0.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.3.1.tgz#204f9756e42e19d91cb6598837063b7e7de87c52"
+  integrity sha512-IOxdJGnRSNSJrL2uGpWO5w9JH5q5HoxEqwOF4gye1gmZYdjoYkkMzSGMDnRCUpN/BNzZcFoMdHXrjvkwO7KgaQ==
   dependencies:
-    hoist-non-react-statics "^2.3.1"
+    mobx-react-lite "^2.2.0"
 
-mobx-utils@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/mobx-utils/-/mobx-utils-2.0.2.tgz#c12c9cc69be8020e30c7b6417f14b4ea38ba9723"
-  integrity sha1-wSycxpvoAg4wx7ZBfxS06ji6lyM=
+mobx-utils@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/mobx-utils/-/mobx-utils-6.0.1.tgz#bc16c2c62794a48498685f3663e6162d42fb6106"
+  integrity sha512-0p5xqHDt/arz3cswVcEHYKY/BwL+fifsNroT3Gjkz9lNC7ZDsJm3IuGsmYlvFcVRJRr1rwlFZGuZXrt/MhHEJQ==
 
-mobx@^3.1.7:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.6.2.tgz#fb9f5ff5090539a1ad54e75dc4c098b602693320"
-  integrity sha512-Dq3boJFLpZEvuh5a/MbHLUIyN9XobKWIb0dBfkNOJffNkE3vtuY0C9kSDVpfH8BB0BPkVw8g22qCv7d05LEhKg==
+mobx@6.0.1, mobx@^3.1.7, mobx@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.0.1.tgz#ec23520848527bf7834d7b4c0b54b2a8eb6e7c14"
+  integrity sha512-Pk6uJXZ34yqd661yRmS6z/9avm4FOGXpFpVjnEfiYYOsZXnAxv1fpYjxTCEZ9tuwk0Xe1qnUUlgm+rJtGe0YJA==
 
 "mobxpromise@github:cbioportal/mobxpromise#v1.0.2":
   version "1.3.1"


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/7976

Main changes are the following:

(1) using mobx tool, auto-migrate code to use `makeObservable` in observer constructors
(2) `ObservableMap` type signature now has two generic types: key and value: `ObservableMap<Key, Value>`, so it's no longer necessary to index using strings, probably because of using `Map` in the implementation
(3) `ObservableMap::keys()`, `::values()`, and `::entries()` now return iterators instead of arrays, so they have to be handled differently. Sometimes we can use `ObservableMap::size` instead to save work when only the length is needed. Otherwise, `Array.from(iterator)` and `[...iterator]` work to get into array form.
(4) `ObservableMap::toJS()` is no longer a method. Instead, I substituted `_.fromPairs(myMap.toJSON())`, where `toJSON()` now returns non-observable [key, value] pairs.