### PR TITLE
Improve GSVA volcano plot selector layout

### DIFF
--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -684,8 +684,8 @@ function transitionTracks(
 
     // find the max and min GSVA score value in the next heatmap track group
     // max and min value is used to create a custom legend for the track group
-    const genesetScoreValueMax = _.max(genesetScoreProfileData) || undefined;
-    const genesetScoreValueMin = _.min(genesetScoreProfileData) || undefined;
+    const genesetScoreValueMax = _.max(genesetScoreProfileData);
+    const genesetScoreValueMin = _.min(genesetScoreProfileData);
 
     // Transition genetic tracks
     const prevGeneticTracks = _.keyBy(
@@ -763,8 +763,10 @@ function transitionTracks(
     );
     for (const track of nextProps.genesetHeatmapTracks) {
         // add geneset layout/formatting information to the track specs
-        track.maxProfileValue = genesetScoreValueMax;
-        track.minProfileValue = genesetScoreValueMin;
+        track.maxProfileValue =
+            genesetScoreValueMax === null ? undefined : genesetScoreValueMax;
+        track.minProfileValue =
+            genesetScoreValueMin === null ? undefined : genesetScoreValueMin;
 
         transitionGenesetHeatmapTrack(
             track,

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -178,6 +178,8 @@ export interface IGenesetHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     trackLinkUrl: string | undefined;
     expansionTrackList: IHeatmapTrackSpec[];
     expansionCallback: () => void;
+    maxProfileValue?: number;
+    minProfileValue?: number;
 }
 
 export const GENETIC_TRACK_GROUP_INDEX = 1;

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -397,12 +397,29 @@ export function getGenericAssayTrackRuleSetParams(
     };
 }
 
-export function getGenesetHeatmapTrackRuleSetParams() {
+export function getGenesetHeatmapTrackRuleSetParams(
+    trackSpec: IGenesetHeatmapTrackSpec
+): RuleSetParams {
+    let maxValue = trackSpec.maxProfileValue! || 1;
+    let minValue = trackSpec.minProfileValue! || -1;
+
+    // calculate value range and value stop points
+    const largestValue = Math.ceil(
+        Math.max(Math.abs(maxValue), Math.abs(minValue))
+    );
+    const value_range = [-largestValue, largestValue];
+    const interval = (largestValue * 2) / 10;
+    const value_stop_points = _.map(
+        _.range(11),
+        (n: number) => -largestValue + n * interval
+    );
+
     return {
         type: RuleSetType.GRADIENT,
         legend_label: 'Gene Set Heatmap',
         value_key: 'profile_data',
-        value_range: [-1, 1] as [number, number],
+        value_range: value_range,
+        value_stop_points: value_stop_points,
         /*
          * The PiYG colormap is based on color specifications and designs
          * developed by Cynthia Brewer (http://colorbrewer.org).
@@ -422,19 +439,6 @@ export function getGenesetHeatmapTrackRuleSetParams() {
             [197, 27, 125, 1],
             [142, 1, 82, 1],
         ] as [number, number, number, number][],
-        value_stop_points: [
-            -1,
-            -0.8,
-            -0.6,
-            -0.4,
-            -0.2,
-            0,
-            0.2,
-            0.4,
-            0.6,
-            0.8,
-            1,
-        ],
         null_color: 'rgba(224,224,224,1)',
     } as IGradientRuleSetParams;
 }

--- a/src/shared/components/query/GenesetsSelector.tsx
+++ b/src/shared/components/query/GenesetsSelector.tsx
@@ -175,7 +175,7 @@ export default class GenesetsSelector extends QueryStoreComponent<
                                 Select Gene Sets From Volcano Plot
                             </Modal.Title>
                         </Modal.Header>
-                        <Modal.Body>
+                        <Modal.Body style={{ height: '474px' }}>
                             <GenesetsVolcanoSelector
                                 initialSelection={this.store.genesetIds}
                                 data={this.store.volcanoPlotTableData.result}

--- a/src/shared/components/query/GenesetsVolcanoSelector.tsx
+++ b/src/shared/components/query/GenesetsVolcanoSelector.tsx
@@ -119,9 +119,14 @@ export default class GenesetsVolcanoSelector extends QueryStoreComponent<
         return (
             <div
                 className={styles.GenesetsVolcanoSelectorWindow}
-                style={{ height: '400px' }}
+                style={{
+                    height: '400px',
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    justifyContent: 'flex-end',
+                }}
             >
-                <div style={{ float: 'left' }} className="form-inline">
+                <div className="form-inline">
                     <label htmlFor="PercentileScoreCalculation">
                         Percentile for score calculation:
                     </label>
@@ -173,6 +178,7 @@ export default class GenesetsVolcanoSelector extends QueryStoreComponent<
                                             stroke: 'tomato',
                                             strokeWidth: 2,
                                         }}
+                                        responsive={false}
                                     />
                                 }
                             >
@@ -255,10 +261,9 @@ export default class GenesetsVolcanoSelector extends QueryStoreComponent<
                 </div>
                 <div
                     style={{
-                        float: 'right',
-                        height: '356.5px',
-                        overflowY: 'scroll',
-                        width: '650px',
+                        height: '400px',
+                        overflowY: 'auto',
+                        width: '800px',
                     }}
                 >
                     <LoadingIndicator

--- a/src/shared/components/query/styles/styles.module.scss
+++ b/src/shared/components/query/styles/styles.module.scss
@@ -616,8 +616,7 @@ div.GenesetsSelectorWindow {
 
 div.GenesetsVolcanoSelectorWindow {
     div:global(.modal-dialog) {
-        width: 1200px;
-        height: 500px;
+        width: 1350px;
     }
     div.GenesetsSelectionArea {
         padding: 10px 15px;


### PR DESCRIPTION
Small fixes to GSVA volcano-plot selector component include:
- Hiding y scrollbar when not needed
- Making the modal a tad wider
- Using flex for more consistent layout 

# Before
![image](https://user-images.githubusercontent.com/745885/97203456-1f810280-17b5-11eb-9f75-1524ea023378.png)

# After
![image](https://user-images.githubusercontent.com/745885/97203336-f2cceb00-17b4-11eb-9f1b-2df000ccf984.png)
