### PR TITLE
Skip annotating canonical transcript only for cBioPortal mutations

### DIFF
--- a/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
@@ -113,7 +113,8 @@ export function getMutationByTranscriptId(
     mutation: Mutation,
     ensemblTranscriptId: string,
     indexedVariantAnnotations: { [genomicLocation: string]: VariantAnnotation },
-    isCanonicalTranscript: boolean
+    isCanonicalTranscript: boolean = false,
+    skipAnnotationForCanonicalTranscript: boolean = false
 ): Mutation | undefined {
     const genomicLocation = extractGenomicLocation(mutation);
     const variantAnnotation = genomicLocation
@@ -128,7 +129,8 @@ export function getMutationByTranscriptId(
             (tc: TranscriptConsequenceSummary) =>
                 tc.transcriptId === ensemblTranscriptId
         );
-    if (isCanonicalTranscript) {
+
+    if (isCanonicalTranscript && skipAnnotationForCanonicalTranscript) {
         return mutation;
     }
     if (
@@ -141,7 +143,8 @@ export function getMutationByTranscriptId(
             mutation,
             variantAnnotation.annotation_summary,
             transcriptConsequenceSummary,
-            isCanonicalTranscript
+            isCanonicalTranscript,
+            !skipAnnotationForCanonicalTranscript
         );
         // do not ignore mutations that don't have a protein change
         // include silent mutations
@@ -218,7 +221,8 @@ export function getMutationsByTranscriptId(
     mutations: Mutation[],
     ensemblTranscriptId: string,
     indexedVariantAnnotations: { [genomicLocation: string]: VariantAnnotation },
-    isCanonicalTranscript: boolean
+    isCanonicalTranscript?: boolean,
+    skipAnnotationForCanonicalTranscript: boolean = false
 ): Mutation[] {
     const fusionMutation = getFusionMutations(mutations);
     // only non-fusion mutations need to get mutation with transcript id
@@ -230,7 +234,8 @@ export function getMutationsByTranscriptId(
                     mutation,
                     ensemblTranscriptId,
                     indexedVariantAnnotations,
-                    isCanonicalTranscript
+                    isCanonicalTranscript,
+                    skipAnnotationForCanonicalTranscript
                 )
             )
         ),

--- a/packages/react-mutation-mapper/src/store/DefaultMutationMapperStore.ts
+++ b/packages/react-mutation-mapper/src/store/DefaultMutationMapperStore.ts
@@ -921,11 +921,7 @@ class DefaultMutationMapperStore implements MutationMapperStore {
                     getMutationsByTranscriptId(
                         this.getMutations(),
                         t,
-                        this.indexedVariantAnnotations.result!,
-                        this.canonicalTranscript.result
-                            ? this.canonicalTranscript.result!.transcriptId ===
-                                  t
-                            : false
+                        this.indexedVariantAnnotations.result!
                     ),
                 ])
             );

--- a/src/shared/components/mutationMapper/MutationMapperStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperStore.ts
@@ -288,7 +288,8 @@ export default class MutationMapperStore extends DefaultMutationMapperStore {
                         this.canonicalTranscript.result
                             ? this.canonicalTranscript.result!.transcriptId ===
                                   t
-                            : false
+                            : false,
+                        true
                     ),
                 ])
             );


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8019. MutationMapper is used in multiple projects (cBioPortal, Genome Nexus & SIGNAL). In cBioPortal the mutations are pre-annotated for the canonical transcripts, which is why we only annotate mutations for non-canonical transcripts. In other projects where this component is used we do want to annotate the canonical transcript using Genome Nexus. This introduces a property `skipAnnotationForCanonicalTranscript` to allow developers that use this package to choose to enable/disable annotation of the canonical transcript.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!