### PR TITLE
By default, hide new installation map on homepage

### DIFF
--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -167,9 +167,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
         'TREATMENT_RESPONSE:Treatment Response,MUTATIONAL_SIGNATURE:Mutational Signature',
 
     saml_logout_local: false,
-    patient_view_use_legacy_timeline: false,
-
-    installation_map_url: null,
+    patient_view_use_legacy_timeline: false
 };
 
 export default ServerConfigDefaults;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -169,7 +169,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     saml_logout_local: false,
     patient_view_use_legacy_timeline: false,
 
-    installation_map_url: 'https://installationmap.netlify.app/',
+    installation_map_url: null,
 };
 
 export default ServerConfigDefaults;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -167,7 +167,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
         'TREATMENT_RESPONSE:Treatment Response,MUTATIONAL_SIGNATURE:Mutational Signature',
 
     saml_logout_local: false,
-    patient_view_use_legacy_timeline: false
+    patient_view_use_legacy_timeline: false,
 };
 
 export default ServerConfigDefaults;


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/8034

The installation map url should not have a default.

Needs backend https://github.com/cBioPortal/cbioportal/pull/8036 to work for public portal