### PR TITLE
download tab - label NS (not sequenced) and WT (wild type) for mutations, and NP (not profiled) for cna, mrna, prot when necessary

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -2855,6 +2855,26 @@ export class ResultsViewPageStore {
         },
     });
 
+    readonly studyToSelectedMolecularProfilesMap = remoteData<{
+        [studyId: string]: {
+            [molecularAlterationType: string]: MolecularProfile;
+        };
+    }>({
+        await: () => [this.selectedMolecularProfiles],
+        invoke: () => {
+            return Promise.resolve(
+                _.mapValues(
+                    _.groupBy(
+                        this.selectedMolecularProfiles.result!,
+                        p => p.studyId
+                    ),
+                    profiles =>
+                        _.keyBy(profiles, p => p.molecularAlterationType)
+                )
+            );
+        },
+    });
+
     readonly discreteCopyNumberAlterations = remoteData<
         DiscreteCopyNumberData[]
     >({

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -47,6 +47,7 @@ import {
     generateOtherMolecularProfileDownloadData,
     generateGenericAssayProfileData,
     generateGenericAssayProfileDownloadData,
+    makeIsSampleProfiledFunction,
 } from './DownloadUtils';
 
 import styles from './styles.module.scss';
@@ -175,13 +176,21 @@ export default class DownloadTab extends React.Component<
             this.mutationData,
             this.props.store.samples,
             this.props.store.genes,
+            this.props.store.coverageInformation,
+            this.props.store.studyToSelectedMolecularProfilesMap,
         ],
         invoke: () =>
             Promise.resolve(
                 generateMutationDownloadData(
                     this.mutationData.result!,
                     this.props.store.samples.result!,
-                    this.props.store.genes.result!
+                    this.props.store.genes.result!,
+                    makeIsSampleProfiledFunction(
+                        AlterationTypeConstants.MUTATION_EXTENDED,
+                        this.props.store.studyToSelectedMolecularProfilesMap
+                            .result!,
+                        this.props.store.coverageInformation.result!
+                    )
                 )
             ),
     });
@@ -250,6 +259,7 @@ export default class DownloadTab extends React.Component<
             this.allOtherMolecularProfileDataGroupByProfileName,
             this.props.store.samples,
             this.props.store.genes,
+            this.props.store.coverageInformation,
         ],
         invoke: () =>
             Promise.resolve(
@@ -328,13 +338,21 @@ export default class DownloadTab extends React.Component<
             this.mrnaData,
             this.props.store.samples,
             this.props.store.genes,
+            this.props.store.coverageInformation,
+            this.props.store.studyToSelectedMolecularProfilesMap,
         ],
         invoke: () =>
             Promise.resolve(
                 generateDownloadData(
                     this.mrnaData.result!,
                     this.props.store.samples.result!,
-                    this.props.store.genes.result!
+                    this.props.store.genes.result!,
+                    makeIsSampleProfiledFunction(
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                        this.props.store.studyToSelectedMolecularProfilesMap
+                            .result!,
+                        this.props.store.coverageInformation.result!
+                    )
                 )
             ),
     });
@@ -354,13 +372,21 @@ export default class DownloadTab extends React.Component<
             this.proteinData,
             this.props.store.samples,
             this.props.store.genes,
+            this.props.store.coverageInformation,
+            this.props.store.studyToSelectedMolecularProfilesMap,
         ],
         invoke: () =>
             Promise.resolve(
                 generateDownloadData(
                     this.proteinData.result!,
                     this.props.store.samples.result!,
-                    this.props.store.genes.result!
+                    this.props.store.genes.result!,
+                    makeIsSampleProfiledFunction(
+                        AlterationTypeConstants.PROTEIN_LEVEL,
+                        this.props.store.studyToSelectedMolecularProfilesMap
+                            .result!,
+                        this.props.store.coverageInformation.result!
+                    )
                 )
             ),
     });
@@ -380,13 +406,21 @@ export default class DownloadTab extends React.Component<
             this.cnaData,
             this.props.store.samples,
             this.props.store.genes,
+            this.props.store.coverageInformation,
+            this.props.store.studyToSelectedMolecularProfilesMap,
         ],
         invoke: () =>
             Promise.resolve(
                 generateDownloadData(
                     this.cnaData.result!,
                     this.props.store.samples.result!,
-                    this.props.store.genes.result!
+                    this.props.store.genes.result!,
+                    makeIsSampleProfiledFunction(
+                        AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+                        this.props.store.studyToSelectedMolecularProfilesMap
+                            .result!,
+                        this.props.store.coverageInformation.result!
+                    )
                 )
             ),
     });

--- a/src/pages/resultsView/download/DownloadUtils.spec.ts
+++ b/src/pages/resultsView/download/DownloadUtils.spec.ts
@@ -577,7 +577,14 @@ describe('DownloadUtils', () => {
             const downloadData = generateMutationDownloadData(
                 sampleAlterationDataByGene,
                 samples,
-                genes
+                genes,
+                (uniqueSampleKey: string, study: string, gene: string) => {
+                    return !(
+                        uniqueSampleKey ===
+                            'VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ' &&
+                        gene === 'PTEN'
+                    );
+                }
             );
 
             const expectedResult = [
@@ -585,11 +592,11 @@ describe('DownloadUtils', () => {
                 [
                     'msk_impact_2017',
                     'P-0000378-T01-IM3',
-                    'NA',
-                    'NA',
+                    'WT',
+                    'WT',
                     'G598A [germline] EGFR-intragenic G239C',
                 ],
-                ['skcm_tcga', 'TCGA-EE-A20C-06', 'NA', 'NA', 'NA'],
+                ['skcm_tcga', 'TCGA-EE-A20C-06', 'NS', 'WT', 'WT'],
             ];
 
             assert.deepEqual(
@@ -617,13 +624,20 @@ describe('DownloadUtils', () => {
             const downloadData = generateDownloadData(
                 sampleAlterationDataByGene,
                 samples,
-                genes
+                genes,
+                (uniqueSampleKey: string, study: string, gene: string) => {
+                    return !(
+                        uniqueSampleKey ===
+                            'VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ' &&
+                        gene === 'EGFR'
+                    );
+                }
             );
 
             const expectedResult = [
                 ['STUDY_ID', 'SAMPLE_ID', 'PTEN', 'TP53', 'EGFR'],
                 ['msk_impact_2017', 'P-0000378-T01-IM3', 'NA', 'NA', 'NA'],
-                ['skcm_tcga', 'TCGA-EE-A20C-06', '2.4745', 'NA', 'NA'],
+                ['skcm_tcga', 'TCGA-EE-A20C-06', '2.4745', 'NA', 'NP'],
             ];
 
             assert.deepEqual(
@@ -649,13 +663,20 @@ describe('DownloadUtils', () => {
             const downloadData = generateDownloadData(
                 sampleAlterationDataByGene,
                 samples,
-                genes
+                genes,
+                (uniqueSampleKey: string, study: string, gene: string) => {
+                    return !(
+                        uniqueSampleKey ===
+                            'VENHQS1FRS1BMjBDLTA2OnNrY21fdGNnYQ' &&
+                        gene === 'TP53'
+                    );
+                }
             );
 
             const expectedResult = [
                 ['STUDY_ID', 'SAMPLE_ID', 'PTEN', 'TP53', 'EGFR'],
                 ['msk_impact_2017', 'P-0000378-T01-IM3', 'NA', 'NA', 'NA'],
-                ['skcm_tcga', 'TCGA-EE-A20C-06', '2.5406', 'NA', 'NA'],
+                ['skcm_tcga', 'TCGA-EE-A20C-06', '2.5406', 'NP', 'NA'],
             ];
 
             assert.deepEqual(
@@ -681,12 +702,19 @@ describe('DownloadUtils', () => {
             const downloadData = generateDownloadData(
                 sampleAlterationDataByGene,
                 samples,
-                genes
+                genes,
+                (uniqueSampleKey: string, study: string, gene: string) => {
+                    return !(
+                        uniqueSampleKey ===
+                            'UC0wMDAwMzc4LVQwMS1JTTM6bXNrX2ltcGFjdF8yMDE3' &&
+                        gene !== 'PTEN'
+                    );
+                }
             );
 
             const expectedResult = [
                 ['STUDY_ID', 'SAMPLE_ID', 'PTEN', 'TP53', 'EGFR'],
-                ['msk_impact_2017', 'P-0000378-T01-IM3', 'NA', 'NA', 'NA'],
+                ['msk_impact_2017', 'P-0000378-T01-IM3', 'NA', 'NP', 'NP'],
                 ['skcm_tcga', 'TCGA-EE-A20C-06', 'NA', '-1', 'NA'],
             ];
 

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -34,6 +34,8 @@ import {
     MergedTrackLineFilterOutput,
 } from 'shared/lib/oql/oqlfilter';
 import { isNotGermlineMutation } from 'shared/lib/MutationUtils';
+import { coverageInformation } from 'pages/resultsView/expression/expressionHelpers.sample';
+import { isSampleProfiled } from 'shared/lib/isSampleProfiled';
 import {
     getGenericAssayMetaPropertyOrDefault,
     COMMON_GENERIC_ASSAY_PROPERTY,
@@ -43,6 +45,7 @@ export interface IDownloadFileRow {
     studyId: string;
     patientId: string;
     sampleId: string;
+    uniqueSampleKey: string;
     alterationData: { [gene: string]: string[] };
 }
 
@@ -239,14 +242,23 @@ export function generateMutationData(
 export function generateMutationDownloadData(
     sampleAlterationDataByGene: { [key: string]: ExtendedAlteration[] },
     samples: Sample[] = [],
-    genes: Gene[] = []
+    genes: Gene[] = [],
+    isSampleProfiledFunc: (
+        uniqueSampleKey: string,
+        studyId: string,
+        hugoGeneSymbol: string
+    ) => boolean
 ): string[][] {
     return sampleAlterationDataByGene
         ? generateDownloadData(
               sampleAlterationDataByGene,
               samples,
               genes,
-              extractMutationValue
+              isSampleProfiledFunc,
+              extractMutationValue,
+              undefined,
+              'WT',
+              'NS'
           )
         : [];
 }
@@ -327,7 +339,12 @@ export function generateOtherMolecularProfileDownloadData(
     genes: Gene[] = []
 ): string[][] {
     return sampleAlterationDataByGene
-        ? generateDownloadData(sampleAlterationDataByGene, samples, genes)
+        ? generateDownloadData(
+              sampleAlterationDataByGene,
+              samples,
+              genes,
+              () => true // dont deal with labeling not profiled
+          )
         : [];
 }
 
@@ -454,6 +471,7 @@ export function generateDownloadFileRows(
         const row: IDownloadFileRow = rows[sampleKey] || {
             studyId: sample.studyId,
             sampleId: sample.sampleId,
+            uniqueSampleKey: sample.uniqueSampleKey,
             patientId: sample.patientId,
             alterationData: {},
         };
@@ -518,12 +536,45 @@ export function generateGenericAssayRowsByUniqueSampleKey(
     return rows;
 }
 
+export function makeIsSampleProfiledFunction(
+    alterationType: string,
+    studyIdToMolecularProfilesMap: {
+        [studyId: string]: { [altType: string]: MolecularProfile };
+    },
+    coverageInformation: CoverageInformation
+) {
+    return (
+        uniqueSampleKey: string,
+        studyId: string,
+        hugoGeneSymbol: string
+    ) => {
+        const profile = studyIdToMolecularProfilesMap[studyId][alterationType];
+        if (profile) {
+            return isSampleProfiled(
+                uniqueSampleKey,
+                profile.molecularProfileId,
+                hugoGeneSymbol,
+                coverageInformation
+            );
+        } else {
+            return false;
+        }
+    };
+}
+
 export function generateDownloadData(
     sampleAlterationDataByGene: { [key: string]: ExtendedAlteration[] },
     samples: Sample[] = [],
     genes: Gene[] = [],
+    isSampleProfiledFunc: (
+        uniqueSampleKey: string,
+        studyId: string,
+        hugoGeneSymbol: string
+    ) => boolean,
     extractValue?: (alteration: ExtendedAlteration) => string,
-    formatData?: (data: string[]) => string
+    formatData?: (data: string[]) => string,
+    notAlteredString = 'NA',
+    notProfiledString = 'NP'
 ) {
     const geneSymbols = genes.map(gene => gene.hugoGeneSymbol);
 
@@ -554,10 +605,23 @@ export function generateDownloadData(
         row.push(rowData.sampleId);
 
         geneSymbols.forEach(gene => {
-            const formattedValue = formatData
-                ? formatData(rowData.alterationData[gene]) // if provided format with the custom data formatter
-                : rowData.alterationData[gene].join(' ') || 'NA'; // else, default format: space delimited join
-
+            let formattedValue: string;
+            if (
+                !isSampleProfiledFunc(
+                    rowData.uniqueSampleKey,
+                    rowData.studyId,
+                    gene
+                )
+            ) {
+                formattedValue = notProfiledString;
+            } else {
+                if (formatData) {
+                    formattedValue = formatData(rowData.alterationData[gene]); // if provided format with the custom data formatter
+                } else {
+                    formattedValue = rowData.alterationData[gene].join(' ');
+                }
+                formattedValue = formattedValue || notAlteredString; // else, default format: space delimited join
+            }
             row.push(formattedValue);
         });
 


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/3972

[Example link](https://www.cbioportal.org/results/download?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_id=coadread_tcga_pub&cancer_study_list=msk_impact_2017&case_ids=msk_impact_2017%3AP-0000004-T01-IM3%2Bmsk_impact_2017%3AP-0000015-T01-IM3%2Bmsk_impact_2017%3AP-0000023-T01-IM3%2Bmsk_impact_2017%3AP-0000024-T01-IM3&case_set_id=-1&data_priority=0&gene_list=OCA2%2520PTPN22%2520TP53&gene_set_choice=user-defined-list&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=msk_impact_2017_cna&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=msk_impact_2017_mutations&profileFilter=0&tab_index=tab_visualize)