### PR TITLE
(Download tab) Enable generic assay download by selected entities

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -135,11 +135,6 @@ export default class ResultsViewPage extends React.Component<
     }
 
     @autobind
-    private handleTabChange(id: string, replace?: boolean) {
-        this.urlWrapper.updateURL({}, `results/${id}`, false, replace);
-    }
-
-    @autobind
     private customTabCallback(
         div: HTMLDivElement,
         tab: any,
@@ -712,7 +707,9 @@ export default class ResultsViewPage extends React.Component<
                                             }
                                             unmountOnHide={false}
                                             onTabClick={(id: string) =>
-                                                this.handleTabChange(id)
+                                                this.resultsViewPageStore.handleTabChange(
+                                                    id
+                                                )
                                             }
                                             className="mainTabs"
                                             getTabHref={this.getTabHref}
@@ -744,7 +741,10 @@ export default class ResultsViewPage extends React.Component<
             !this.resultsViewPageStore.tabId
         ) {
             setTimeout(() => {
-                this.handleTabChange(this.resultsViewPageStore.tabId, true);
+                this.resultsViewPageStore.handleTabChange(
+                    this.resultsViewPageStore.tabId,
+                    true
+                );
             });
             return null;
         } else {

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -617,6 +617,10 @@ export class ResultsViewPageStore {
         return getMolecularProfiles(this.urlWrapper.query);
     }
 
+    public handleTabChange(id: string, replace?: boolean) {
+        this.urlWrapper.updateURL({}, `results/${id}`, false, replace);
+    }
+
     @computed get tabId() {
         return this.urlWrapper.tabId || ResultsViewTab.ONCOPRINT;
     }
@@ -4172,15 +4176,15 @@ export class ResultsViewPageStore {
                             .genericAssayEntityStableIdsGroupByProfileIdSuffix
                             .result![profileIdSuffix];
 
-                        const sampleMolecularIdentifiers = _.flatten(
-                            _.map(molecularIds, molecularId =>
+                        const sampleMolecularIdentifiers = _.flatMap(
+                            molecularIds,
+                            molecularId =>
                                 _.map(this.samples.result, sample => {
                                     return {
                                         molecularProfileId: molecularId,
                                         sampleId: sample.sampleId,
                                     } as SampleMolecularIdentifier;
                                 })
-                            )
                         );
 
                         if (

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -12,6 +12,7 @@ import {
     DiscreteCopyNumberFilter,
     Gene,
     GenericAssayData,
+    GenericAssayDataMultipleStudyFilter,
     GenericAssayMeta,
     Geneset,
     GenesetDataFilterCriteria,
@@ -199,6 +200,8 @@ import {
     fetchGenericAssayDataByStableIdsAndMolecularIds,
     fetchGenericAssayMetaByMolecularProfileIdsGroupByGenericAssayType,
     fetchGenericAssayMetaByMolecularProfileIdsGroupByMolecularProfileId,
+    COMMON_GENERIC_ASSAY_PROPERTY,
+    getGenericAssayMetaPropertyOrDefault,
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { createVariantAnnotationsByMutationFetcher } from 'shared/components/mutationMapper/MutationMapperUtils';
 import { getGenomeNexusHgvsgUrl } from 'shared/api/urls';
@@ -1508,7 +1511,6 @@ export class ResultsViewPageStore {
             this.studyToDataQueryFilter,
             this.genes,
             this.genesets,
-            this.genericAssayEntitiesGroupByGenericAssayType,
         ],
         invoke: async () => {
             const ret: MolecularProfile[] = [];
@@ -4055,10 +4057,13 @@ export class ResultsViewPageStore {
                         const linkMap: { [stableId: string]: string } = {};
                         genericAssayEntities.forEach(entity => {
                             // if entity meta contains reference url, add the link into map
-                            linkMap[entity.stableId] =
-                                'URL' in entity.genericEntityMetaProperties
-                                    ? entity.genericEntityMetaProperties['URL']
-                                    : '';
+                            linkMap[
+                                entity.stableId
+                            ] = getGenericAssayMetaPropertyOrDefault(
+                                entity,
+                                COMMON_GENERIC_ASSAY_PROPERTY.URL,
+                                ''
+                            );
                         });
                         return linkMap;
                     }
@@ -4066,6 +4071,24 @@ export class ResultsViewPageStore {
             } else {
                 return {};
             }
+        },
+    });
+
+    readonly genericAssayStableIdToMeta = remoteData<{
+        [genericAssayStableId: string]: GenericAssayMeta;
+    }>({
+        await: () => [this.genericAssayEntitiesGroupByMolecularProfileId],
+        invoke: () => {
+            return Promise.resolve(
+                _.chain(
+                    this.genericAssayEntitiesGroupByMolecularProfileId.result
+                )
+                    .values()
+                    .flatten()
+                    .uniqBy(meta => meta.stableId)
+                    .keyBy(meta => meta.stableId)
+                    .value()
+            );
         },
     });
 
@@ -4101,10 +4124,7 @@ export class ResultsViewPageStore {
     readonly genericAssayEntityStableIdsGroupByProfileIdSuffix = remoteData<{
         [profileIdSuffix: string]: string[];
     }>({
-        await: () => [
-            this.genericAssayEntitiesGroupByMolecularProfileId,
-            this.genericAssayProfilesGroupByProfileIdSuffix,
-        ],
+        await: () => [this.genericAssayProfilesGroupByProfileIdSuffix],
         invoke: () => {
             return Promise.resolve(
                 _.mapValues(
@@ -4114,12 +4134,13 @@ export class ResultsViewPageStore {
                             .map(
                                 profile =>
                                     this
-                                        .genericAssayEntitiesGroupByMolecularProfileId
-                                        .result![profile.molecularProfileId]
+                                        .selectedGenericAssayEntitiesGroupByMolecularProfileId[
+                                        profile.molecularProfileId
+                                    ]
                             )
                             .flatten()
-                            .map(entity => entity.stableId)
                             .uniq()
+                            .compact()
                             .value();
                     }
                 )
@@ -4151,14 +4172,36 @@ export class ResultsViewPageStore {
                             .genericAssayEntityStableIdsGroupByProfileIdSuffix
                             .result![profileIdSuffix];
 
-                        return fetchGenericAssayDataByStableIdsAndMolecularIds(
-                            stableIds,
-                            molecularIds
-                        ).then(genericAssayData => {
-                            genericAssayDataGroupByProfileIdSuffix[
-                                profileIdSuffix
-                            ] = genericAssayData;
-                        });
+                        const sampleMolecularIdentifiers = _.flatten(
+                            _.map(molecularIds, molecularId =>
+                                _.map(this.samples.result, sample => {
+                                    return {
+                                        molecularProfileId: molecularId,
+                                        sampleId: sample.sampleId,
+                                    } as SampleMolecularIdentifier;
+                                })
+                            )
+                        );
+
+                        if (
+                            !_.isEmpty(stableIds) &&
+                            !_.isEmpty(sampleMolecularIdentifiers)
+                        ) {
+                            return client
+                                .fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
+                                    {
+                                        genericAssayDataMultipleStudyFilter: {
+                                            genericAssayStableIds: stableIds,
+                                            sampleMolecularIdentifiers,
+                                        } as GenericAssayDataMultipleStudyFilter,
+                                    } as any
+                                )
+                                .then(genericAssayData => {
+                                    genericAssayDataGroupByProfileIdSuffix[
+                                        profileIdSuffix
+                                    ] = genericAssayData;
+                                });
+                        }
                     }
                 )
             );

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -71,6 +71,7 @@ import { Alteration } from 'shared/lib/oql/oql-parser';
 import autobind from 'autobind-decorator';
 import FontAwesome from 'react-fontawesome';
 import CaseFilterWarning from '../../../shared/components/banners/CaseFilterWarning';
+import { If, Then, Else } from 'react-if';
 
 export interface IDownloadTabProps {
     store: ResultsViewPageStore;
@@ -272,6 +273,7 @@ export default class DownloadTab extends React.Component<
             this.props.store.genericAssayEntityStableIdsGroupByProfileIdSuffix,
             this.props.store.genericAssayDataGroupByProfileIdSuffix,
             this.props.store.genericAssayProfilesGroupByProfileIdSuffix,
+            this.props.store.genericAssayStableIdToMeta,
         ],
         invoke: () => {
             const genericAssayProfileDataGroupByProfileIdSuffix = _.mapValues(
@@ -301,7 +303,8 @@ export default class DownloadTab extends React.Component<
                             this.props.store.samples.result!,
                             this.props.store
                                 .genericAssayEntityStableIdsGroupByProfileIdSuffix
-                                .result![profileIdSuffix]
+                                .result![profileIdSuffix],
+                            this.props.store.genericAssayStableIdToMeta.result!
                         );
                     }
                 )
@@ -633,9 +636,8 @@ export default class DownloadTab extends React.Component<
             this.props.store
                 .nonSelectedDownloadableMolecularProfilesGroupByName,
             this.props.store.studies,
-            this.props.store.selectedMolecularProfiles
-            // disable generic assay download for now
-            // this.props.store.genericAssayDataGroupByProfileIdSuffix
+            this.props.store.selectedMolecularProfiles,
+            this.props.store.genericAssayDataGroupByProfileIdSuffix
         );
 
         switch (status) {
@@ -718,17 +720,24 @@ export default class DownloadTab extends React.Component<
                                                 .nonSelectedDownloadableMolecularProfilesGroupByName
                                                 .result!
                                         )}
-                                    {/* disable generic assay download for now */}
-                                    {/* {!_.isEmpty(
-                                        this.props.store
-                                            .genericAssayProfilesGroupByProfileIdSuffix
-                                            .result
-                                    ) &&
+                                    {/* Generic Assay Download only available for single study */}
+                                    {this.props.store.studies.result!.length ===
+                                        1 &&
+                                        !_.isEmpty(
+                                            this.props.store
+                                                .genericAssayProfilesGroupByProfileIdSuffix
+                                                .result
+                                        ) &&
                                         this.genericAssayProfileDownloadRows(
                                             this.props.store
                                                 .genericAssayProfilesGroupByProfileIdSuffix
-                                                .result!
-                                        )} */}
+                                                .result!,
+                                            _.keys(
+                                                this.props.store
+                                                    .genericAssayDataGroupByProfileIdSuffix
+                                                    .result
+                                            )
+                                        )}
                                 </tbody>
                             </table>
                         </div>
@@ -925,7 +934,8 @@ export default class DownloadTab extends React.Component<
     private genericAssayProfileDownloadRows(
         genericAssayProfilesGroupByProfileIdSuffix: _.Dictionary<
             MolecularProfile[]
-        >
+        >,
+        selectedSuffix: string[]
     ) {
         const allProfileOptions = _.map(
             genericAssayProfilesGroupByProfileIdSuffix,
@@ -966,35 +976,47 @@ export default class DownloadTab extends React.Component<
                 </td>
                 <td>
                     <div>
-                        <a
-                            onClick={() =>
-                                this.handleGenericAssayProfileDownload(
-                                    option.name,
-                                    option.profileIdSuffix
-                                )
-                            }
+                        <If
+                            condition={selectedSuffix.includes(
+                                option.profileIdSuffix
+                            )}
                         >
-                            <i
-                                className="fa fa-cloud-download"
-                                style={{ marginRight: 5 }}
-                            />
-                            Tab Delimited Format
-                        </a>
-                        <span style={{ margin: '0px 10px' }}>|</span>
-                        <a
-                            onClick={() =>
-                                this.handleTransposedGenericAssayProfileDownload(
-                                    option.name,
-                                    option.profileIdSuffix
-                                )
-                            }
-                        >
-                            <i
-                                className="fa fa-cloud-download"
-                                style={{ marginRight: 5 }}
-                            />
-                            Transposed Matrix
-                        </a>
+                            <Then>
+                                <a
+                                    onClick={() =>
+                                        this.handleGenericAssayProfileDownload(
+                                            option.name,
+                                            option.profileIdSuffix
+                                        )
+                                    }
+                                >
+                                    <i
+                                        className="fa fa-cloud-download"
+                                        style={{ marginRight: 5 }}
+                                    />
+                                    Tab Delimited Format
+                                </a>
+                                <span style={{ margin: '0px 10px' }}>|</span>
+                                <a
+                                    onClick={() =>
+                                        this.handleTransposedGenericAssayProfileDownload(
+                                            option.name,
+                                            option.profileIdSuffix
+                                        )
+                                    }
+                                >
+                                    <i
+                                        className="fa fa-cloud-download"
+                                        style={{ marginRight: 5 }}
+                                    />
+                                    Transposed Matrix
+                                </a>
+                            </Then>
+                            <Else>
+                                Only entities selected in OncoPrint tab can be
+                                download at here. Please select entities first.
+                            </Else>
+                        </If>
                     </div>
                 </td>
             </tr>

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -72,6 +72,7 @@ import autobind from 'autobind-decorator';
 import FontAwesome from 'react-fontawesome';
 import CaseFilterWarning from '../../../shared/components/banners/CaseFilterWarning';
 import { If, Then, Else } from 'react-if';
+import { ResultsViewTab } from '../ResultsViewPageHelpers';
 
 export interface IDownloadTabProps {
     store: ResultsViewPageStore;
@@ -1013,8 +1014,17 @@ export default class DownloadTab extends React.Component<
                                 </a>
                             </Then>
                             <Else>
-                                Only entities selected in OncoPrint tab can be
-                                download at here. Please select entities first.
+                                Heatmap tracks added in the&nbsp;
+                                <a
+                                    onClick={() =>
+                                        this.props.store.handleTabChange(
+                                            ResultsViewTab.ONCOPRINT
+                                        )
+                                    }
+                                >
+                                    OncoPrint tab
+                                </a>
+                                &nbsp;can be downloaded here.
                             </Else>
                         </If>
                     </div>

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -108,7 +108,11 @@ import { SpecialAttribute } from '../../../shared/cache/ClinicalDataCache';
 import LabeledCheckbox from '../../../shared/components/labeledCheckbox/LabeledCheckbox';
 import CaseFilterWarning from '../../../shared/components/banners/CaseFilterWarning';
 import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
-import { makeGenericAssayOption } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import {
+    makeGenericAssayOption,
+    COMMON_GENERIC_ASSAY_PROPERTY,
+    getGenericAssayMetaPropertyOrDefault,
+} from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { getBoxWidth } from 'shared/lib/boxPlotUtils';
 
 enum EventKey {
@@ -3181,14 +3185,16 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
             const entity = this.genericEntitiesGroupByEntityId.result![
                 selectedGenericAssayEntityId
             ];
-            genericAssayDescription =
-                'DESCRIPTION' in entity.genericEntityMetaProperties
-                    ? entity.genericEntityMetaProperties['DESCRIPTION']
-                    : '';
-            genericAssayUrl =
-                'URL' in entity.genericEntityMetaProperties
-                    ? entity.genericEntityMetaProperties['URL']
-                    : '';
+            genericAssayDescription = getGenericAssayMetaPropertyOrDefault(
+                entity,
+                COMMON_GENERIC_ASSAY_PROPERTY.DESCRIPTION,
+                ''
+            );
+            genericAssayUrl = getGenericAssayMetaPropertyOrDefault(
+                entity,
+                COMMON_GENERIC_ASSAY_PROPERTY.URL,
+                ''
+            );
         }
 
         // generic assay options

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -60,8 +60,8 @@ import {
 import { RESERVED_CLINICAL_VALUE_COLORS } from 'shared/lib/Colors';
 import { ISelectOption } from './controls/OncoprintControls';
 import {
-    NOT_APPLICABLE_VALUE,
-    GenericAssayTypeConstants,
+    COMMON_GENERIC_ASSAY_PROPERTY,
+    getGenericAssayMetaPropertyOrDefault,
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import ifNotDefined from '../../lib/ifNotDefined';
 
@@ -1119,10 +1119,11 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
                     );
                     return _.keys(entry.entities).map(entityId => {
                         const entity = genericAssayEntitiesByEntityId[entityId];
-                        const entityName =
-                            'NAME' in entity.genericEntityMetaProperties
-                                ? entity.genericEntityMetaProperties['NAME']
-                                : entityId;
+                        const entityName = getGenericAssayMetaPropertyOrDefault(
+                            entity,
+                            COMMON_GENERIC_ASSAY_PROPERTY.NAME,
+                            entityId
+                        );
                         const description =
                             ('DESCRIPTION' in entity.genericEntityMetaProperties
                                 ? `${entityName} (${entity.genericEntityMetaProperties['DESCRIPTION']})`

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
@@ -1,6 +1,10 @@
 import { assert } from 'chai';
 import { GenericAssayMeta } from 'cbioportal-ts-api-client';
-import { makeGenericAssayOption } from './GenericAssayCommonUtils';
+import {
+    makeGenericAssayOption,
+    getGenericAssayMetaPropertyOrDefault,
+    COMMON_GENERIC_ASSAY_PROPERTY,
+} from './GenericAssayCommonUtils';
 
 describe('GenericAssayCommonUtils', () => {
     describe('makeGenericAssayOption()', () => {
@@ -101,6 +105,67 @@ describe('GenericAssayCommonUtils', () => {
             };
             assert.deepEqual(
                 makeGenericAssayOption(genericAssayEntity, true),
+                expect
+            );
+        });
+    });
+
+    describe('getGenericAssayMetaPropertyOrDefault()', () => {
+        it('property exist in meta', () => {
+            const genericAssayEntity: GenericAssayMeta = {
+                stableId: 'id_1',
+                entityType: 'GENERIC_ASSAY',
+                genericEntityMetaProperties: {
+                    NAME: 'name_1',
+                    DESCRIPTION: 'desc_1',
+                },
+            };
+
+            const expect = 'name_1';
+            assert.deepEqual(
+                getGenericAssayMetaPropertyOrDefault(
+                    genericAssayEntity,
+                    COMMON_GENERIC_ASSAY_PROPERTY.NAME
+                ),
+                expect
+            );
+        });
+
+        it('property not exist in meta, default value not given', () => {
+            const genericAssayEntity: GenericAssayMeta = {
+                stableId: 'id_1',
+                entityType: 'GENERIC_ASSAY',
+                genericEntityMetaProperties: {
+                    DESCRIPTION: 'desc_1',
+                },
+            };
+
+            const expect = 'NA';
+            assert.deepEqual(
+                getGenericAssayMetaPropertyOrDefault(
+                    genericAssayEntity,
+                    COMMON_GENERIC_ASSAY_PROPERTY.NAME
+                ),
+                expect
+            );
+        });
+
+        it('property not exist in meta, default value given', () => {
+            const genericAssayEntity: GenericAssayMeta = {
+                stableId: 'id_1',
+                entityType: 'GENERIC_ASSAY',
+                genericEntityMetaProperties: {
+                    DESCRIPTION: 'desc_1',
+                },
+            };
+
+            const expect = 'default';
+            assert.deepEqual(
+                getGenericAssayMetaPropertyOrDefault(
+                    genericAssayEntity,
+                    COMMON_GENERIC_ASSAY_PROPERTY.NAME,
+                    'default'
+                ),
                 expect
             );
         });

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
@@ -11,6 +11,11 @@ import _ from 'lodash';
 import { IDataQueryFilter } from '../StoreUtils';
 
 export const NOT_APPLICABLE_VALUE = 'NA';
+export const COMMON_GENERIC_ASSAY_PROPERTY = {
+    NAME: 'NAME',
+    DESCRIPTION: 'DESCRIPTION',
+    URL: 'URL',
+};
 
 export const GenericAssayTypeConstants: { [s: string]: string } = {
     TREATMENT_RESPONSE: 'TREATMENT_RESPONSE',
@@ -172,14 +177,14 @@ export function makeGenericAssayOption(
     // When not provided in the data file, these fields are assigned the
     // value of the entity_stable_id. The code below hides fields when
     // indentical to the entity_stable_id.
-    const name =
-        'NAME' in meta.genericEntityMetaProperties
-            ? meta.genericEntityMetaProperties['NAME']
-            : NOT_APPLICABLE_VALUE;
-    const description =
-        'DESCRIPTION' in meta.genericEntityMetaProperties
-            ? meta.genericEntityMetaProperties['DESCRIPTION']
-            : NOT_APPLICABLE_VALUE;
+    const name = getGenericAssayMetaPropertyOrDefault(
+        meta,
+        COMMON_GENERIC_ASSAY_PROPERTY.NAME
+    );
+    const description = getGenericAssayMetaPropertyOrDefault(
+        meta,
+        COMMON_GENERIC_ASSAY_PROPERTY.DESCRIPTION
+    );
     const uniqueName = name !== meta.stableId;
     const uniqueDesc = description !== meta.stableId && description !== name;
     // set stableId as default label
@@ -198,14 +203,29 @@ export function makeGenericAssayOption(
         return {
             value: meta.stableId,
             label: label,
-            plotAxisLabel:
-                'NAME' in meta.genericEntityMetaProperties
-                    ? meta.genericEntityMetaProperties['NAME']
-                    : meta.stableId,
+            plotAxisLabel: getGenericAssayMetaPropertyOrDefault(
+                meta,
+                COMMON_GENERIC_ASSAY_PROPERTY.NAME,
+                meta.stableId
+            ),
         };
     }
     return {
         value: meta.stableId,
         label: label,
     };
+}
+
+export function getGenericAssayMetaPropertyOrDefault(
+    meta: GenericAssayMeta,
+    property: string,
+    defaultValue: string = NOT_APPLICABLE_VALUE
+): string {
+    if (property in meta.genericEntityMetaProperties) {
+        return (meta.genericEntityMetaProperties as {
+            [property: string]: string;
+        })[property];
+    } else {
+        return defaultValue;
+    }
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#7851

This pr can only let users to download generic assay data in single study query since heatmap feature is only enabled for single study. Will extended to multiple query in the future.

[Example download tab link(without heatmap selection)](https://deploy-preview-3506--cbioportalfrontend.netlify.app/results/download?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=lusc_tcga_pan_can_atlas_2018&case_set_id=lusc_tcga_pan_can_atlas_2018_cnaseq&data_priority=0&gene_list=TP53%2520EGFR%2520KRAS&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=lusc_tcga_pan_can_atlas_2018_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=lusc_tcga_pan_can_atlas_2018_mutations&profileFilter=0&tab_index=tab_visualize)
[Example download tab link(with heatmap selection)](https://deploy-preview-3506--cbioportalfrontend.netlify.app/results/download?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=lusc_tcga_pan_can_atlas_2018&case_set_id=lusc_tcga_pan_can_atlas_2018_cnaseq&data_priority=0&gene_list=TP53%2520EGFR%2520KRAS&generic_assay_groups=lusc_tcga_pan_can_atlas_2018_microbiome_signature%2CPrasinovirus%2CSfi1unalikevirus%2CSimplexvirus&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=lusc_tcga_pan_can_atlas_2018_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=lusc_tcga_pan_can_atlas_2018_mutations&heatmap_track_groups=lusc_tcga_pan_can_atlas_2018_microbiome_signature%2CPrasinovirus%2CSfi1unalikevirus%2CSimplexvirus&profileFilter=0&tab_index=tab_visualize)

Describe changes proposed in this pull request:
- Select generic assay entities from OncoPrint tab then download from download tab
when no selection:
![image](https://user-images.githubusercontent.com/15748980/100020908-a2927a00-2dae-11eb-82c7-eeb1b7a6edd1.png)
after select:
![image](https://user-images.githubusercontent.com/15748980/99558094-5f40a180-2991-11eb-937f-cf3f6e4250b7.png)
download file example:
![image](https://user-images.githubusercontent.com/15748980/99558314-98791180-2991-11eb-90b0-00540a8e83b6.png)

- New utils function for getting generic assay meta property clearly `getGenericAssayMetaPropertyOrDefault`
- Unit tests for `getGenericAssayMetaPropertyOrDefault` function