### PR TITLE
Support initial multi column sort for DataTable

### DIFF
--- a/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { ReactNode } from 'react';
 import { TableProps } from 'react-table';
 
-import { MobxCache, Mutation } from 'cbioportal-utils';
+import { MobxCache, Mutation, RemoteData } from 'cbioportal-utils';
 
 import { DefaultPubMedCache } from '../../cache/DefaultPubMedCache';
 import { MutationAlignerCache } from '../../cache/MutationAlignerCache';
@@ -18,7 +18,7 @@ import { DefaultLollipopPlotControlsConfig } from '../../store/DefaultLollipopPl
 import DefaultMutationMapperStore from '../../store/DefaultMutationMapperStore';
 import { initDefaultTrackVisibility } from '../../util/TrackUtils';
 import { getDefaultWindowInstance } from '../../util/DefaultWindowInstance';
-import { ColumnSortDirection, DataTableColumn } from '../dataTable/DataTable';
+import { ColumnSort, DataTableColumn } from '../dataTable/DataTable';
 import DefaultMutationRateSummary, {
     MutationRate,
 } from './DefaultMutationRateSummary';
@@ -65,8 +65,8 @@ export type MutationMapperProps = {
     plotVizHeight?: number;
     customControls?: JSX.Element;
     mutationTable?: JSX.Element;
-    mutationTableInitialSortColumn?: string;
-    mutationTableInitialSortDirection?: ColumnSortDirection;
+    mutationTableInitialSort?: ColumnSort[];
+    mutationTableInitialSortRemoteData?: (RemoteData<any> | undefined)[];
     mutationRates?: MutationRate[];
     pubMedCache?: MobxCache;
     mutationAlignerCache?: MobxCache;
@@ -281,11 +281,9 @@ export default class MutationMapper<
                 <DefaultMutationTable
                     dataStore={this.store.dataStore}
                     columns={columns}
-                    initialSortColumn={
-                        this.props.mutationTableInitialSortColumn
-                    }
-                    initialSortDirection={
-                        this.props.mutationTableInitialSortDirection
+                    initialSort={this.props.mutationTableInitialSort}
+                    initialSortRemoteData={
+                        this.props.mutationTableInitialSortRemoteData
                     }
                     reactTableProps={this.props.customMutationTableProps}
                     hotspotData={this.store.indexedHotspotData}

--- a/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
@@ -65,7 +65,7 @@ export default class DefaultMutationTable extends React.Component<
     {}
 > {
     public static defaultProps = {
-        initialSortColumn: MutationColumn.ANNOTATION,
+        initialSort: [{ column: MutationColumn.ANNOTATION }],
         appendColumns: true,
     };
 
@@ -122,8 +122,8 @@ export default class DefaultMutationTable extends React.Component<
     }
 
     @computed
-    get initialSortColumnData() {
-        return this.props.initialSortColumnData || this.annotationColumnData;
+    get initialSortRemoteData() {
+        return this.props.initialSortRemoteData || this.annotationColumnData;
     }
 
     protected getDefaultColumnAccessor(columnKey: MutationColumn) {
@@ -229,7 +229,7 @@ export default class DefaultMutationTable extends React.Component<
             <DefaultMutationTableComponent
                 {...this.props}
                 columns={this.columns}
-                initialSortColumnData={this.initialSortColumnData}
+                initialSortRemoteData={this.initialSortRemoteData}
                 onSearch={this.onSearch}
                 className="default-mutation-table"
             />


### PR DESCRIPTION
Related to knowledgesystems/signal/issues/66

Describe changes proposed in this pull request:
- Just expose the existing functionality of the underlying table lib (`react-table`)
- There will be another PR for Signal frontend once we release the latest `react-mutation-mapper`

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!