### PR TITLE
Attempt to fix ErrorScreen for missing session service

### DIFF
--- a/src/shared/components/errorScreen/ErrorScreen.tsx
+++ b/src/shared/components/errorScreen/ErrorScreen.tsx
@@ -21,13 +21,20 @@ export default class ErrorScreen extends React.Component<
     {}
 > {
     @autobind
-    copyToClipRef(copyToClip: HTMLButtonElement | null) {
-        if (copyToClip) {
-            new Clipboard(copyToClip, {
+    copyToClipRef(copyToClipButton: HTMLButtonElement) {
+        this.copyToClipButton = copyToClipButton;
+    }
+
+    copyToClipButton: HTMLButtonElement | undefined = undefined;
+
+    componentDidMount() {
+        console.log('copytoclip', this.copyToClipButton);
+        if (this.copyToClipButton !== undefined) {
+            new Clipboard(this.copyToClipButton, {
                 text: function() {
                     return JSON.stringify(this.errorLog);
                 }.bind(this),
-                container: copyToClip,
+                container: this.copyToClipButton,
             });
         }
     }


### PR DESCRIPTION
There something very strange about session service error message.  It only fails for frontend.cbioportal.org or embedded frontend.  Not any other  netlify preview, local dev version etc. even when we alter the configuration frontend.url property so that loading takes place exactly as in production.  So it seems we need to merge something to master to more carefully debug it. 