### PR TITLE
Timeline line-chart track recognition is broken when value=0 exists in track data

### DIFF
--- a/src/pages/patientView/timeline2/TimelineWrapper.tsx
+++ b/src/pages/patientView/timeline2/TimelineWrapper.tsx
@@ -19,7 +19,7 @@ import {
     buildBaseConfig,
     configureGenieTimeline,
     sortTracks,
-} from 'pages/patientView/timeline2/helpers';
+} from 'pages/patientView/timeline2/timeline_helpers';
 import { downloadZippedTracks } from './timelineDataUtils';
 
 export interface ISampleMetaDeta {

--- a/src/pages/patientView/timeline2/VAFChartWrapper.tsx
+++ b/src/pages/patientView/timeline2/VAFChartWrapper.tsx
@@ -24,7 +24,7 @@ import {
     buildBaseConfig,
     configureGenieTimeline,
     sortTracks,
-} from 'pages/patientView/timeline2/helpers';
+} from 'pages/patientView/timeline2/timeline_helpers';
 import { CustomTrackSpecification } from 'cbioportal-clinical-timeline/dist/CustomTrack';
 import { computed } from 'mobx';
 import {

--- a/src/pages/patientView/timeline2/timeline_helpers.spec.tsx
+++ b/src/pages/patientView/timeline2/timeline_helpers.spec.tsx
@@ -1,0 +1,53 @@
+import { allResultValuesAreNumerical } from 'pages/patientView/timeline2/timeline_helpers';
+import { assert } from 'chai';
+import { TimelineEvent } from 'cbioportal-clinical-timeline';
+
+describe('#allResultValuesAreNumerical', () => {
+    var events = [] as TimelineEvent[];
+
+    beforeEach(() => {
+        events = [
+            {
+                event: {
+                    attributes: [{ key: 'RESULT', value: '0.6' }],
+                },
+            },
+            {
+                event: {
+                    attributes: [{ key: 'RESULT', value: '10' }],
+                },
+            },
+        ] as TimelineEvent[];
+    });
+
+    it('catches all numerical condition', () => {
+        assert.isTrue(allResultValuesAreNumerical(events));
+    });
+
+    it('catches non numerical', () => {
+        events.push({
+            event: {
+                attributes: [{ key: 'RESULT', value: 'S' }],
+            },
+        } as TimelineEvent);
+        assert.isFalse(allResultValuesAreNumerical(events));
+    });
+
+    it('handles zero as numeric', () => {
+        events.push({
+            event: {
+                attributes: [{ key: 'RESULT', value: '0' }],
+            },
+        } as TimelineEvent);
+        assert.isTrue(allResultValuesAreNumerical(events));
+    });
+
+    it('catches missing RESULT attribute', () => {
+        events.push({
+            event: {
+                attributes: [],
+            },
+        } as TimelineEvent);
+        assert.isFalse(allResultValuesAreNumerical(events));
+    });
+});

--- a/src/pages/patientView/timeline2/timeline_helpers.tsx
+++ b/src/pages/patientView/timeline2/timeline_helpers.tsx
@@ -475,11 +475,7 @@ function getNumericalAttrVal(name: string, e: TimelineEvent) {
 }
 function configureLABTESTSubTrack(track: TimelineTrackSpecification) {
     if (track.items.length) {
-        const doAllEventsHaveNumericalValue = _.every(track.items, e => {
-            const val = getNumericalAttrVal('RESULT', e);
-            return !!(val && !isNaN(val));
-        });
-        if (doAllEventsHaveNumericalValue) {
+        if (allResultValuesAreNumerical(track.items)) {
             track.trackType = TimelineTrackType.LINE_CHART;
             track.getLineChartValue = e => getNumericalAttrVal('RESULT', e);
         }
@@ -488,4 +484,11 @@ function configureLABTESTSubTrack(track: TimelineTrackSpecification) {
             track.tracks.forEach(configureLABTESTSubTrack);
         }
     }
+}
+
+export function allResultValuesAreNumerical(events: TimelineEvent[]) {
+    return _.every(events, e => {
+        const val = getNumericalAttrVal('RESULT', e);
+        return !!(val !== null && !isNaN(val));
+    });
 }


### PR DESCRIPTION
We treat as a line-chart any track with where all RESULT attributes have numerical values.  This detection was breaking when any value was equal 0.  