### PR TITLE
Make sure we use es5 version of pako to ensure compatibility with ie11

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -121,6 +121,9 @@ var config = {
             styles: join(src, 'styles'),
             pages: join(src, 'pages'),
             shared: join(src, 'shared'),
+            pako: join(
+                path.join(__dirname + '/node_modules/pako/dist/pako.es5.js')
+            ),
             appConfig: path.join(
                 __dirname + '/src',
                 'config',


### PR DESCRIPTION
Will fix ie tests (and application in IE11

fixes https://github.com/cbioportal/cbioportal/issues/8223