### PR TITLE
Results page: settings button should never wrap

### DIFF
--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -292,7 +292,7 @@ export default class QuerySummary extends React.Component<
                     <div className="query-summary">
                         <div className="query-summary__leftItems">
                             {!this.isQueryOrGeneInvalid && (
-                                <div>
+                                <div style={{ display: 'flex' }}>
                                     <button
                                         id="modifyQueryBtn"
                                         onClick={this.toggleQueryFormVisibility}


### PR DESCRIPTION
Fixes: https://github.com/cbioportal/cbioportal/issues/8082

No:
![image](https://user-images.githubusercontent.com/186521/102650950-a4472780-4139-11eb-97f0-797f4a71ed84.png)
