### PR TITLE
Fix bug when creating comparison session from study view

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -1078,14 +1078,6 @@ export class StudyViewPageStore {
                     const groups: SessionGroupData[] = _.chain(
                         clinicalAttributeValues
                     )
-                        .sortBy(attrVal => -attrVal.count)
-                        // do not slice for comparison on cancer studies chart
-                        .slice(
-                            0,
-                            doesChartHaveComparisonGroupsLimit(chartMeta)
-                                ? MAX_GROUPS_IN_SESSION
-                                : undefined
-                        )
                         .filter(attrVal => {
                             const lcValue = attrVal.value.toLowerCase();
                             const sampleIdentifiers =
@@ -1095,6 +1087,15 @@ export class StudyViewPageStore {
                                 sampleIdentifiers.length > 0
                             );
                         })
+                        .sortBy(attrVal => -attrVal.count)
+                        // slice max number of groups
+                        // do not slice for comparison on cancer studies chart
+                        .slice(
+                            0,
+                            doesChartHaveComparisonGroupsLimit(chartMeta)
+                                ? MAX_GROUPS_IN_SESSION
+                                : undefined
+                        )
                         .map(attrVal => {
                             const lcValue = attrVal.value.toLowerCase();
                             const sampleIdentifiers =

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -290,51 +290,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                                     .result! as ClinicalDataCountSummary[],
                             }
                         );
-                    const values = this.props.promise
-                        .result! as ClinicalDataCountSummary[];
-                    if (
-                        doesChartHaveComparisonGroupsLimit(
-                            this.props.chartMeta
-                        ) &&
-                        values.length > MAX_GROUPS_IN_SESSION
-                    ) {
-                        this.props.setComparisonConfirmationModal(hideModal => {
-                            return (
-                                <Modal
-                                    show={true}
-                                    onHide={() => {}}
-                                    backdrop="static"
-                                >
-                                    <Modal.Body>
-                                        Group comparisons are limited to 20
-                                        groups. Click OK to compare the 20
-                                        largest groups in this chart. Or, select
-                                        up to 20 specific groups in the chart to
-                                        compare.
-                                    </Modal.Body>
-                                    <Modal.Footer>
-                                        <button
-                                            className="btn btn-md btn-primary"
-                                            onClick={() => {
-                                                openComparison();
-                                                hideModal();
-                                            }}
-                                        >
-                                            OK
-                                        </button>
-                                        <button
-                                            className="btn btn-md btn-default"
-                                            onClick={hideModal}
-                                        >
-                                            Cancel
-                                        </button>
-                                    </Modal.Footer>
-                                </Modal>
-                            );
-                        });
-                    } else {
-                        openComparison();
-                    }
+                    openComparison();
                     break;
                 default:
                     this.props.store.openComparisonPage(


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/8103

Gets rid of warning when trying to make a group comparison session with more than 20 groups. The reason for this is that the code cannot at that time determine how many groups there will be. 

Discussion: Should we show that notification once the user arrives at the group comparison page?
@jjgao @schultzn @alisman 