### PR TITLE
Allow '_SURVIVAL' word to occur in custom survival clin vars

### DIFF
--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -315,7 +315,7 @@ export class StudySummaryTab extends React.Component<
                     ? this.store.survivalDescriptions.result![
                           chartMeta.uniqueKey.substring(
                               0,
-                              chartMeta.uniqueKey.indexOf('_SURVIVAL')
+                              chartMeta.uniqueKey.lastIndexOf('_SURVIVAL')
                           )
                       ][0]
                     : undefined;


### PR DESCRIPTION
# Problem
Clinical variable name _OVERALL_SURVIVAL_ for survival data is not accepted.

# Cause
Frontend code creates a unique key for this by appending __SURVIVAL_ to the name. The original is back translated by removing the __SURVIVAL_ element. When the __SURVIVAL_ word occurs in the name of the clinical var this results in an incorrect name.

# Solution
The correct name is obtained when using `lastIndexOf('_SURVIVAL')` instead of `indexOf('_SURVIVAL')`.