### PR TITLE
Temporary fix for portals in nested folders 

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -1,6 +1,7 @@
 export interface IAppConfig {
     apiRoot?: string;
     baseUrl?: string;
+    basePath?: string;
     configurationServiceUrl?: string;
     frontendUrl?: string;
     serverConfig: IServerConfig;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
 import { inject } from 'mobx-react';
-import Container from 'appShell/App/Container';
+import AppConfig from 'appConfig';
 import {
     handleIndexDO,
     handleCaseDO,
@@ -10,6 +10,7 @@ import {
     handleLinkOut,
     handleEncodedRedirect,
     redirectTo,
+    correctBasePath as _correctBasePath,
 } from './shared/lib/redirectHelpers';
 import PageNotFound from './shared/components/pageNotFound/PageNotFound';
 
@@ -109,6 +110,7 @@ import { handleEncodedURLRedirect } from 'shared/lib/redirectHelpers';
 import { CLIN_ATTR_DATA_TYPE } from 'pages/resultsView/plots/PlotsTabUtils';
 import { SpecialAttribute } from 'shared/cache/ClinicalDataCache';
 import { AlterationTypeConstants } from 'pages/resultsView/ResultsViewPageStore';
+import ExtendedRouterStore from 'shared/lib/ExtendedRouterStore';
 
 function SuspenseWrapper(Component) {
     return props => (
@@ -226,6 +228,8 @@ var defaultRoute = window.defaultRoute || '/home';
 
 var restoreRoute = inject('routing')(restoreRouteAfterRedirect);
 
+var correctBasePath = inject('routing')(_correctBasePath);
+
 let getBlankPage = function(callback) {
     return props => {
         if (callback) {
@@ -267,6 +271,16 @@ export const makeRoutes = routing => {
             <Switch>
                 <Route exact path={'/'} component={ScrollToTop(Homepage)} />
                 <Route path="/restore" component={ScrollToTop(restoreRoute)} />
+
+                {['private.cbioportal.org', 'sclc.cbioportal.org'].includes(
+                    window.location.hostname
+                ) && (
+                    <Route
+                        path={`${AppConfig.basePath}`}
+                        component={correctBasePath}
+                    />
+                )}
+
                 <Route
                     path="/loading/comparison"
                     component={ScrollToTop(GroupComparisonLoading)}

--- a/src/shared/lib/redirectHelpers.ts
+++ b/src/shared/lib/redirectHelpers.ts
@@ -31,6 +31,18 @@ export function restoreRouteAfterRedirect(injected: {
     return null;
 }
 
+export function correctBasePath(injected: { routing: ExtendedRouterStore }) {
+    if (AppConfig.basePath) {
+        injected.routing.updateRoute(
+            {},
+            window.location.pathname.replace(AppConfig.basePath, ''),
+            false,
+            true
+        );
+    }
+    return null;
+}
+
 // harvest query data written to the page by JSP (or assigned by parent window) to support queries originating
 // from external posts
 export function handlePostedSubmission(urlWrapper: ResultsViewURLWrapper) {


### PR DESCRIPTION
React-router 5 no longer supports basePath.  This broke any portal in subfolder of domain. (e.g. /private)     This PR fixes things by re-directing user to non-nested route after page load.  This route exists only in frontend. 