### PR TITLE
Remove empty treatment filters from study view bookmark URL

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -2542,8 +2542,6 @@ export class StudyViewPageStore {
             this.sampleTreatmentFilters.filters.length > 0
         ) {
             filters.sampleTreatmentFilters = this.sampleTreatmentFilters;
-        } else {
-            filters.sampleTreatmentFilters = { filters: [] };
         }
 
         if (
@@ -2551,8 +2549,6 @@ export class StudyViewPageStore {
             this.patientTreatmentFilters.filters.length > 0
         ) {
             filters.patientTreatmentFilters = this.patientTreatmentFilters;
-        } else {
-            filters.patientTreatmentFilters = { filters: [] };
         }
 
         let sampleIdentifiersFilterSets = Array.from(


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Empty treatment filters were being added to the study view filters
- These were being ignored by the backend anyways
- This just cleans up the bookmark url a bit
