### PR TITLE
Fix caution warning for session urls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
           command: "cat yarn.lock $(find src/ -type f | sort) $(find packages/ -type f | sort) webpack.config.js vendor-bundles.webpack.config.js > has_source_changed"
       - restore_cache:
           keys:
-          - v4-dependencies-plus-dist-{{ checksum "has_source_changed" }}
-          - v4-dependencies-{{ checksum "yarn.lock" }}
+          - v5-dependencies-plus-dist-{{ checksum "has_source_changed" }}
+          - v5-dependencies-{{ checksum "yarn.lock" }}
       # Download and cache dependencies
       - run: yarn
       - run: yarn buildModules
@@ -95,7 +95,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v4-dependencies-{{ checksum "yarn.lock" }}
+          key: v5-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: "Run build if no dist folder"
           command: 'ls dist || yarn run build'
@@ -107,7 +107,7 @@ jobs:
             - node_modules
             - dist
             - common-dist
-          key: v4-dependencies-plus-dist-{{ checksum "has_source_changed" }}
+          key: v5-dependencies-plus-dist-{{ checksum "has_source_changed" }}
       - persist_to_workspace:
           root: /tmp
           paths:

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -299,8 +299,8 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
             } else if (numActiveGroups === 0) {
                 content = <span>{SURVIVAL_NOT_ENOUGH_GROUPS_MSG}</span>;
             } else {
-                var isGenieBpcStudy = window.location.href.includes(
-                    'genie_bpc'
+                var isGenieBpcStudy = this.props.store.studies.result.find(s =>
+                    s.studyId.includes('genie_bpc')
                 );
 
                 content = (

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -299,7 +299,7 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
             } else if (numActiveGroups === 0) {
                 content = <span>{SURVIVAL_NOT_ENOUGH_GROUPS_MSG}</span>;
             } else {
-                var isGenieBpcStudy = this.props.store.studies.result.find(s =>
+                var isGenieBpcStudy = this.props.store.studies.result!.find(s =>
                     s.studyId.includes('genie_bpc')
                 );
 


### PR DESCRIPTION
The warning info wasn't working for session urls b/c it was looking for the study id in the url, see e.g.

https://genie-private.cbioportal.org/comparison/survival?sessionId=5ffc7a3be4b015b63e9d4256

Follow up to https://github.com/cBioPortal/cbioportal-frontend/pull/3570