### PR TITLE
remove build of image from fingerprint step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,13 @@ jobs:
           command: |
               source $PORTAL_SOURCE_DIR/env/custom.sh || true && \
               cd $TEST_HOME/local/runtime-config && \
-              ./setup_environment.sh && ./setup_environment.sh >> $BASH_ENV
+              ./setup_environment.sh && ./setup_environment.sh >> $BASH_ENV            
+      - run:
+          name: Build image
+          command: |
+              cd $TEST_HOME/local/docker && \
+              ./build_portal_image.sh
+          no_output_timeout: 25m
       - run:
           name: Generate checksum of data that populates the test database
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
               cd $TEST_HOME/local/runtime-config && \
               ./setup_environment.sh && ./setup_environment.sh >> $BASH_ENV            
       - run:
-          name: Build image
+          name: Build or pull backend image
           command: |
               cd $TEST_HOME/local/docker && \
               ./build_portal_image.sh

--- a/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
+++ b/end-to-end-test/local/runtime-config/db_content_fingerprint.sh
@@ -7,7 +7,6 @@ set -o pipefail
 DIR=$PWD
 
 cd $TEST_HOME/local/docker
-./build_portal_image.sh &> /dev/null
 MD5_ES_0=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'find /cbioportal/core/src/test/scripts/test_data/study_es_0/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//"')
 MD5_TEST_STUDIES=$(find $TEST_HOME/local/studies/ -type f -exec md5sum {} \; | md5sum | sed "s/\s.*$//")
 MD5_MIGRATION_SQL=$(docker run --rm $BACKEND_IMAGE_NAME sh -c 'md5sum /cbioportal/db-scripts/src/main/resources/migration.sql | sed "s/\s.*$//"')


### PR DESCRIPTION
Move build image step before fingerprinting so we can see the output of building the image