### PR TITLE
fix mutation mapper tool test

### DIFF
--- a/end-to-end-test/remote/specs/core/mutationMapperTool.spec.js
+++ b/end-to-end-test/remote/specs/core/mutationMapperTool.spec.js
@@ -40,11 +40,11 @@ describe('Mutation Mapper Tool', function() {
                 60000
             );
 
-            const mutationsT790M = browser.getText(
-                './/*[text()[contains(.,"T790M")]]'
-            );
+            // Waiting for Annotation column sorting
+            browser.waitForText('.//*[text()[contains(.,"T790M")]]');
+
             assert.equal(
-                mutationsT790M.length,
+                browser.getText('.//*[text()[contains(.,"T790M")]]').length,
                 2,
                 'there should be two samples with a T790M mutation'
             );
@@ -327,11 +327,11 @@ describe('Mutation Mapper Tool', function() {
                 60000
             );
 
-            const mutationsT790M = browser.getText(
-                './/*[text()[contains(.,"T790M")]]'
-            );
+            // Waiting for Annotation column sorting
+            browser.waitForText('.//*[text()[contains(.,"T790M")]]');
+
             assert.equal(
-                mutationsT790M.length,
+                browser.getText('.//*[text()[contains(.,"T790M")]]').length,
                 2,
                 'there should be two samples with a T790M mutation'
             );

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -178,6 +178,7 @@ import {
 } from 'shared/lib/oql/AccessorsForOqlFilter';
 import {
     CLINICAL_ATTRIBUTE_ID_ENUM,
+    GENOME_NEXUS_ARG_FIELD_ENUM,
     MSI_H_THRESHOLD,
     TMB_H_THRESHOLD,
 } from 'shared/constants';
@@ -995,7 +996,13 @@ export class PatientViewPageStore {
                         this.mutationData,
                         this.uncalledMutationData
                     ),
-                    ['annotation_summary', 'hotspots', 'signal'],
+                    [
+                        GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
+                        GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
+                        AppConfig.serverConfig.show_signal
+                            ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
+                            : '',
+                    ].filter(f => f),
                     AppConfig.serverConfig.isoformOverrideSource,
                     this.genomeNexusClient
                 ),
@@ -1016,7 +1023,7 @@ export class PatientViewPageStore {
                     this.mutationData,
                     this.uncalledMutationData
                 ),
-                ['my_variant_info'],
+                [GENOME_NEXUS_ARG_FIELD_ENUM.MY_VARIANT_INFO],
                 AppConfig.serverConfig.isoformOverrideSource,
                 this.genomeNexusClient
             );
@@ -2051,7 +2058,7 @@ export class PatientViewPageStore {
     @cached @computed get genomeNexusCache() {
         return new GenomeNexusCache(
             createVariantAnnotationsByMutationFetcher(
-                ['annotation_summary'],
+                [GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY],
                 this.genomeNexusClient
             )
         );
@@ -2060,7 +2067,10 @@ export class PatientViewPageStore {
     @cached @computed get genomeNexusMutationAssessorCache() {
         return new GenomeNexusMutationAssessorCache(
             createVariantAnnotationsByMutationFetcher(
-                ['annotation_summary', 'mutation_assessor'],
+                [
+                    GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
+                    GENOME_NEXUS_ARG_FIELD_ENUM.MUTATION_ASSESSOR,
+                ],
                 this.genomeNexusClient
             )
         );

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -4544,8 +4544,10 @@ export class ResultsViewPageStore {
                           [
                               GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                               GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
-                              GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL,
-                          ],
+                              AppConfig.serverConfig.show_signal
+                                  ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
+                                  : '',
+                          ].filter(f => f),
                           AppConfig.serverConfig.isoformOverrideSource,
                           this.genomeNexusClient
                       )

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -50,6 +50,7 @@ import defaultGenomeNexusClient from 'shared/api/genomeNexusClientInstance';
 import defaultGenomeNexusInternalClient from 'shared/api/genomeNexusInternalClientInstance';
 import autobind from 'autobind-decorator';
 import { getGenomeNexusHgvsgUrl } from 'shared/api/urls';
+import { GENOME_NEXUS_ARG_FIELD_ENUM } from 'shared/constants';
 
 export default class MutationMapperToolStore {
     @observable mutationData: Partial<MutationInput>[] | undefined;
@@ -219,7 +220,13 @@ export default class MutationMapperToolStore {
             invoke: async () =>
                 await fetchVariantAnnotationsIndexedByGenomicLocation(
                     this.rawMutations,
-                    ['annotation_summary', 'hotspots', 'signal'],
+                    [
+                        GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
+                        GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
+                        AppConfig.serverConfig.show_signal
+                            ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
+                            : '',
+                    ].filter(f => f),
                     AppConfig.serverConfig.isoformOverrideSource,
                     this.genomeNexusClient
                 ),
@@ -414,7 +421,7 @@ export default class MutationMapperToolStore {
     @cached @computed get genomeNexusCache() {
         return new GenomeNexusCache(
             createVariantAnnotationsByMutationFetcher(
-                ['annotation_summary'],
+                [GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY],
                 this.genomeNexusClient
             )
         );
@@ -423,7 +430,10 @@ export default class MutationMapperToolStore {
     @cached @computed get genomeNexusMutationAssessorCache() {
         return new GenomeNexusMutationAssessorCache(
             createVariantAnnotationsByMutationFetcher(
-                ['annotation_summary', 'mutation_assessor'],
+                [
+                    GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
+                    GENOME_NEXUS_ARG_FIELD_ENUM.MUTATION_ASSESSOR,
+                ],
                 this.genomeNexusClient
             )
         );

--- a/src/shared/cache/GenomeNexusCache.ts
+++ b/src/shared/cache/GenomeNexusCache.ts
@@ -5,6 +5,7 @@ import { extractGenomicLocation } from 'cbioportal-utils';
 import { Mutation } from 'cbioportal-ts-api-client';
 import LazyMobXCache, { CacheData } from 'shared/lib/LazyMobXCache';
 import AppConfig from 'appConfig';
+import { GENOME_NEXUS_ARG_FIELD_ENUM } from 'shared/constants';
 
 export type GenomeNexusCacheDataType = CacheData<VariantAnnotation>;
 
@@ -14,7 +15,7 @@ export function defaultGNFetch(
     if (queries.length > 0) {
         return fetchVariantAnnotationsByMutation(
             queries,
-            ['annotation_summary'],
+            [GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY],
             AppConfig.serverConfig.isoformOverrideSource
         );
     } else {

--- a/src/shared/cache/GenomeNexusMutationAssessorCache.ts
+++ b/src/shared/cache/GenomeNexusMutationAssessorCache.ts
@@ -5,6 +5,7 @@ import LazyMobXCache, { CacheData } from 'shared/lib/LazyMobXCache';
 import AppConfig from 'appConfig';
 import { VariantAnnotation } from 'genome-nexus-ts-api-client';
 import { extractGenomicLocation } from 'cbioportal-utils';
+import { GENOME_NEXUS_ARG_FIELD_ENUM } from 'shared/constants';
 
 export type GenomeNexusCacheDataType = CacheData<VariantAnnotation>;
 
@@ -14,7 +15,10 @@ export function defaultGNFetch(
     if (queries.length > 0) {
         return fetchVariantAnnotationsByMutation(
             queries,
-            ['annotation_summary', 'mutation_assessor'],
+            [
+                GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
+                GENOME_NEXUS_ARG_FIELD_ENUM.MUTATION_ASSESSOR,
+            ],
             AppConfig.serverConfig.isoformOverrideSource
         );
     } else {

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -64,6 +64,7 @@ import { IGisticData } from 'shared/model/Gistic';
 import { IMutSigData } from 'shared/model/MutSig';
 import {
     CLINICAL_ATTRIBUTE_ID_ENUM,
+    GENOME_NEXUS_ARG_FIELD_ENUM,
     MOLECULAR_PROFILE_MUTATIONS_SUFFIX,
     MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX,
 } from 'shared/constants';
@@ -147,7 +148,7 @@ export async function fetchMutationData(
 
 export async function fetchVariantAnnotationsByMutation(
     mutations: Mutation[],
-    fields: string[] = ['annotation_summary'],
+    fields: string[] = [GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY],
     isoformOverrideSource: string = 'uniprot',
     client: GenomeNexusAPI = genomeNexusClient
 ) {
@@ -161,7 +162,7 @@ export async function fetchVariantAnnotationsByMutation(
 
 export async function fetchVariantAnnotationsIndexedByGenomicLocation(
     mutations: Mutation[],
-    fields: string[] = ['annotation_summary'],
+    fields: string[] = [GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY],
     isoformOverrideSource: string = 'uniprot',
     client: GenomeNexusAPI = genomeNexusClient
 ) {


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/8283
Reason:
Query `signal` data makes it a little slower than before.

Solution:
- Only fetch `signal` when it's enabled
- Add waiting time

Changes in this pr:
- Fix mutation mapper tool test
- Using `GENOME_NEXUS_ARG_FIELD_ENUM` on query fields

Fix tests:
1. `should show all transcripts when using combination of genomic and protein changes`
2. `should correctly annotate the genomic changes example with GRCh38 and display the results`