### PR TITLE
Treatment counts display correctly on GENIE

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -7304,11 +7304,34 @@ export class StudyViewPageStore {
                     );
                 }
 
+                const calculateSampleCount = (
+                    result:
+                        | (SampleTreatmentRow | PatientTreatmentRow)[]
+                        | undefined
+                ) => {
+                    if (!result) {
+                        return 0;
+                    }
+
+                    return result
+                        .map(row => row.samples)
+                        .reduce((allSamples, samples) => {
+                            samples.forEach(s =>
+                                allSamples.add(s.sampleId + '::' + s.studyId)
+                            );
+                            return allSamples;
+                        }, new Set<String>()).size;
+                };
+
                 if (!_.isEmpty(this.sampleTreatments.result)) {
-                    ret['SAMPLE_TREATMENTS'] = 1;
+                    ret['SAMPLE_TREATMENTS'] = calculateSampleCount(
+                        this.sampleTreatments.result
+                    );
                 }
                 if (!_.isEmpty(this.patientTreatments.result)) {
-                    ret['PATIENT_TREATMENTS'] = 1;
+                    ret['PATIENT_TREATMENTS'] = calculateSampleCount(
+                        this.patientTreatments.result
+                    );
                 }
 
                 if (!_.isEmpty(this.structuralVariantProfiles.result)) {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8288

Describe changes proposed in this pull request:
- The counts for treatments in the chart select were not calculated
correctly... or at all. How this is working on the public portal
is a mystery to me
- Made it so the counts are the number of unique sample id + study id
pairs in the respective treatment responses.

## Any screenshots or GIFs?
![Screenshot from 2021-01-20 14-03-49](https://user-images.githubusercontent.com/20069833/105223394-b85fb980-5b29-11eb-9eea-84209bda8643.png)
