### PR TITLE
(Patient View) Validate mutational signatures data after fetching

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -197,6 +197,7 @@ import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericA
 import {
     MutationalSignaturesVersion,
     MutationalSignatureStableIdKeyWord,
+    validateMutationalSignatureRawData,
 } from 'shared/lib/GenericAssayUtils/MutationalSignaturesUtils';
 
 type PageMode = 'patient' | 'sample';
@@ -459,7 +460,7 @@ export class PatientViewPageStore {
                 this.samples,
                 this.mutationalSignatureMolecularProfiles,
             ],
-            invoke: () => {
+            invoke: async () => {
                 const mutationalSignatureMolecularProfileIds = this.mutationalSignatureMolecularProfiles.result.map(
                     profile => profile.molecularProfileId
                 );
@@ -475,13 +476,18 @@ export class PatientViewPageStore {
                             });
                         }
                     );
-                    return client.fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
+                    const genericAssayRawData = await client.fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
                         {
                             genericAssayDataMultipleStudyFilter: {
                                 sampleMolecularIdentifiers,
                             } as GenericAssayDataMultipleStudyFilter,
                         }
                     );
+                    if (
+                        validateMutationalSignatureRawData(genericAssayRawData)
+                    ) {
+                        return Promise.resolve(genericAssayRawData);
+                    }
                 }
                 return Promise.resolve([]);
             },

--- a/src/shared/lib/GenericAssayUtils/MutationalSignaturesUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/MutationalSignaturesUtils.spec.ts
@@ -1,0 +1,127 @@
+import { assert } from 'chai';
+import { GenericAssayData } from 'cbioportal-ts-api-client';
+import { validateMutationalSignatureRawData } from './MutationalSignaturesUtils';
+
+describe('MutationalSignaturesUtils', () => {
+    describe('validateMutationalSignatureRawData()', () => {
+        it('single version: data come from single profile is not valid', () => {
+            const genericAssayData = [
+                {
+                    molecularProfileId: 'study1_contribution_v2',
+                },
+            ];
+
+            assert.isFalse(
+                validateMutationalSignatureRawData(
+                    genericAssayData as GenericAssayData[]
+                )
+            );
+        });
+
+        it('single version: data come from paired profiles is valid', () => {
+            const genericAssayData = [
+                {
+                    molecularProfileId: 'study1_contribution_v2',
+                },
+                {
+                    molecularProfileId: 'study1_pvalue_v2',
+                },
+            ];
+
+            assert.isTrue(
+                validateMutationalSignatureRawData(
+                    genericAssayData as GenericAssayData[]
+                )
+            );
+        });
+
+        it('single version: data come from paired profiles is valid, have other profiles', () => {
+            const genericAssayData = [
+                {
+                    molecularProfileId: 'study1_contribution_v2',
+                },
+                {
+                    molecularProfileId: 'study1_pvalue_v2',
+                },
+                {
+                    molecularProfileId: 'study1_category_v2',
+                },
+            ];
+
+            assert.isTrue(
+                validateMutationalSignatureRawData(
+                    genericAssayData as GenericAssayData[]
+                )
+            );
+        });
+
+        it('multiple version: data come from single profile is not valid', () => {
+            const genericAssayData = [
+                {
+                    molecularProfileId: 'study1_contribution_v2',
+                },
+                {
+                    molecularProfileId: 'study1_contribution_v3',
+                },
+            ];
+
+            assert.isFalse(
+                validateMutationalSignatureRawData(
+                    genericAssayData as GenericAssayData[]
+                )
+            );
+        });
+
+        it('multiple version: data come from paired profiles is valid', () => {
+            const genericAssayData = [
+                {
+                    molecularProfileId: 'study1_contribution_v2',
+                },
+                {
+                    molecularProfileId: 'study1_pvalue_v2',
+                },
+                {
+                    molecularProfileId: 'study1_contribution_v3',
+                },
+                {
+                    molecularProfileId: 'study1_pvalue_v3',
+                },
+            ];
+
+            assert.isTrue(
+                validateMutationalSignatureRawData(
+                    genericAssayData as GenericAssayData[]
+                )
+            );
+        });
+
+        it('multiple version: data come from paired profiles is valid, have other profiles', () => {
+            const genericAssayData = [
+                {
+                    molecularProfileId: 'study1_contribution_v2',
+                },
+                {
+                    molecularProfileId: 'study1_pvalue_v2',
+                },
+                {
+                    molecularProfileId: 'study1_category_v2',
+                },
+                {
+                    molecularProfileId: 'study1_contribution_v3',
+                },
+                {
+                    molecularProfileId: 'study1_pvalue_v3',
+                },
+                {
+                    molecularProfileId: 'study1_category_v3',
+                },
+            ];
+
+            assert.isTrue(
+                validateMutationalSignatureRawData(
+                    genericAssayData as GenericAssayData[]
+                )
+            );
+        });
+    });
+});


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8295

Describe changes proposed in this pull request:
- validate data will show up in pair (has both `contribution` and `pvalue`)

Testing:
https://triage.cbioportal.mskcc.org/patient?studyId=msk_impact_2021&caseId=P-0035874

set `localStorage.netlify ="deploy-preview-3599--cbioportalfrontend"` for testing.