### PR TITLE
Use MSI_TYPE to determine the MSI-H annotation in patient view

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -101,6 +101,7 @@ import {
     generateUniqueSampleKeyToTumorTypeMap,
     getGenomeNexusUrl,
     getOtherBiomarkersQueryId,
+    getSampleClinicalDataMapByKeywords,
     getSampleClinicalDataMapByThreshold,
     getSampleTumorTypeMap,
     groupBySampleId,
@@ -178,6 +179,7 @@ import {
 } from 'shared/lib/oql/AccessorsForOqlFilter';
 import {
     CLINICAL_ATTRIBUTE_ID_ENUM,
+    MIS_TYPE_VALUE,
     GENOME_NEXUS_ARG_FIELD_ENUM,
     MSI_H_THRESHOLD,
     TMB_H_THRESHOLD,
@@ -2360,10 +2362,10 @@ export class PatientViewPageStore {
     }
 
     @computed get sampleMsiHInfo() {
-        return getSampleClinicalDataMapByThreshold(
+        return getSampleClinicalDataMapByKeywords(
             this.clinicalDataForSamples.result,
-            CLINICAL_ATTRIBUTE_ID_ENUM.MSI_SCORE,
-            MSI_H_THRESHOLD
+            CLINICAL_ATTRIBUTE_ID_ENUM.MSI_TYPE,
+            [MIS_TYPE_VALUE.INSTABLE]
         );
     }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -25,7 +25,12 @@ export const enum CLINICAL_ATTRIBUTE_ID_ENUM {
     ASCN_PURITY = 'ASCN_PURITY',
     ASCN_WGD = 'ASCN_WGD',
     MSI_SCORE = 'MSI_SCORE',
+    MSI_TYPE = 'MSI_TYPE',
     TMB_SCORE = 'CVR_TMB_SCORE',
+}
+
+export const enum MIS_TYPE_VALUE {
+    INSTABLE = 'Instable',
 }
 
 export const MSI_H_THRESHOLD = 10;

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1628,6 +1628,25 @@ export function getSampleClinicalDataMapByThreshold(
     );
 }
 
+export function getSampleClinicalDataMapByKeywords(
+    clinicalData: ClinicalData[],
+    clinicalAttributeId: string,
+    keywords: string[]
+) {
+    return _.reduce(
+        clinicalData,
+        (acc: { [key: string]: ClinicalData }, next) => {
+            if (next.clinicalAttributeId === clinicalAttributeId) {
+                if (keywords.includes(next.value)) {
+                    acc[next.sampleId] = next;
+                }
+            }
+            return acc;
+        },
+        {}
+    );
+}
+
 export function getNumericalClinicalDataValue(
     clinicalData: ClinicalData
 ): number | undefined {


### PR DESCRIPTION
This is to fix https://github.com/cBioPortal/cbioportal/issues/8100

There are only two studies at the moment having MSI_TYPE attribute.
The mskimpact has the following values `Stable`, `Instable`, `Do not report`, `Indeterminate`, `NA`
The coadread_vakianie_impact_cmo_2018 has the following values `Yes`, `No`, `Stable`, `Do not report`, `Indeterminate`
Note: the clinical attribute MSI_TYPE does not have controlled vocabulary.

We could map value `Instable` to OncoKB MSI-H.
The value `No` from coadread_vakianie_impact_cmo_2018 study is correspoding to MSI-H, but I don't think the value itself is generic enough to be used to map to MSI-H. Thoughts? @inodb @jjgao 