### PR TITLE
Comparison tab performance improvements

### DIFF
--- a/src/pages/groupComparison/GroupComparisonUtils.tsx
+++ b/src/pages/groupComparison/GroupComparisonUtils.tsx
@@ -247,24 +247,29 @@ export function getStudyIds(groups: Pick<SessionGroupData, 'studies'>[]) {
     );
 }
 
+/**
+ * Gets all unique sample identifiers from the groups
+ * provided. A unique key can be generated for a sample
+ * by appending the sample's study id to the sample's sample id, separated
+ * by a character not allowed in either id- in this case a newline symbol.
+ */
 export function getSampleIdentifiers(
     groups: Pick<SessionGroupData, 'studies'>[]
 ) {
-    return _.uniqWith(
-        _.flattenDeep<SampleIdentifier>(
-            groups.map(group =>
-                group.studies.map(study => {
-                    const studyId = study.id;
-                    return study.samples.map(sampleId => ({
-                        studyId,
-                        sampleId,
-                    }));
-                })
-            )
-        ),
-        (id1, id2) =>
-            id1.sampleId === id2.sampleId && id1.studyId === id2.studyId
-    );
+    const sampleIds: { [key: string]: SampleIdentifier } = {};
+
+    groups.forEach(group => {
+        group.studies.forEach(study => {
+            study.samples.forEach(sample => {
+                sampleIds[study.id + '\n' + sample] = {
+                    studyId: study.id,
+                    sampleId: sample,
+                };
+            });
+        });
+    });
+
+    return Object.values(sampleIds);
 }
 
 export function getNumSamples(

--- a/src/pages/studyView/StudyViewUtils.spec.ts
+++ b/src/pages/studyView/StudyViewUtils.spec.ts
@@ -55,6 +55,7 @@ import {
     updateSavedUserPreferenceChartIds,
     getNonZeroUniqueBins,
     DataBin,
+    getPatientIdentifiers,
 } from 'pages/studyView/StudyViewUtils';
 import {
     Sample,
@@ -3440,6 +3441,110 @@ describe('StudyViewUtils', () => {
                 30,
                 40,
             ]);
+        });
+    });
+
+    describe('getPatientIdentifiers', () => {
+        it('should return all identifiers for 1 group and 1 study', () => {
+            const groups = [
+                {
+                    studies: [
+                        {
+                            id: 'S01',
+                            samples: [],
+                            patients: ['P01', 'P02', 'P03'],
+                        },
+                    ],
+                },
+            ];
+
+            const actual = getPatientIdentifiers(groups);
+            const expected = [
+                { studyId: 'S01', patientId: 'P01' },
+                { studyId: 'S01', patientId: 'P02' },
+                { studyId: 'S01', patientId: 'P03' },
+            ];
+
+            assert.deepEqual(actual.sort(), expected.sort());
+        });
+
+        it('should return all identifiers for 1 group and 2 studies', () => {
+            const groups = [
+                {
+                    studies: [
+                        {
+                            id: 'S01',
+                            samples: [],
+                            patients: ['P01', 'P02', 'P03'],
+                        },
+                        {
+                            id: 'S02',
+                            samples: [],
+                            patients: ['P01', 'P02', 'P03'],
+                        },
+                    ],
+                },
+            ];
+
+            const actual = getPatientIdentifiers(groups);
+            const expected = [
+                { studyId: 'S01', patientId: 'P01' },
+                { studyId: 'S01', patientId: 'P02' },
+                { studyId: 'S01', patientId: 'P03' },
+                { studyId: 'S02', patientId: 'P01' },
+                { studyId: 'S02', patientId: 'P02' },
+                { studyId: 'S02', patientId: 'P03' },
+            ];
+
+            assert.deepEqual(actual.sort(), expected.sort());
+        });
+
+        it('should return all identifiers for 2 groups and 3 studies', () => {
+            const groups = [
+                {
+                    studies: [
+                        {
+                            id: 'S01',
+                            samples: [],
+                            patients: ['P01', 'P02', 'P03'],
+                        },
+                        {
+                            id: 'S02',
+                            samples: [],
+                            patients: ['P01', 'P02', 'P03'],
+                        },
+                    ],
+                },
+                {
+                    studies: [
+                        {
+                            id: 'S01',
+                            samples: [],
+                            patients: ['P01', 'P02', 'P03'],
+                        },
+                        {
+                            id: 'S03',
+                            samples: [],
+                            patients: ['P01', 'P02', 'P03'],
+                        },
+                    ],
+                },
+            ];
+
+            const actual = getPatientIdentifiers(groups);
+            const expected = [
+                { studyId: 'S01', patientId: 'P01' },
+                { studyId: 'S01', patientId: 'P02' },
+                { studyId: 'S01', patientId: 'P03' },
+                { studyId: 'S02', patientId: 'P01' },
+                { studyId: 'S02', patientId: 'P02' },
+                { studyId: 'S02', patientId: 'P03' },
+                { studyId: 'S03', patientId: 'P01' },
+                { studyId: 'S03', patientId: 'P02' },
+                { studyId: 'S03', patientId: 'P03' },
+            ];
+
+            assert.deepEqual(actual.sort(), expected.sort());
         });
     });
 });

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -2300,24 +2300,29 @@ export function getSelectedGroupNames(
     }
 }
 
+/**
+ * Gets all unique patient identifiers from the groups
+ * provided. A unique key can be generated for a patient
+ * by appending the patient's study id to the patient's patient id, separated
+ * by a character not allowed in either id- in this case a newline symbol.
+ */
 export function getPatientIdentifiers(
     groups: Pick<StudyViewComparisonGroup, 'studies'>[]
 ) {
-    return _.uniqWith(
-        _.flattenDeep<PatientIdentifier>(
-            groups.map(group =>
-                group.studies.map(study => {
-                    const studyId = study.id;
-                    return study.patients.map(patientId => ({
-                        studyId,
-                        patientId,
-                    }));
-                })
-            )
-        ),
-        (id1, id2) =>
-            id1.patientId === id2.patientId && id1.studyId === id2.studyId
-    );
+    const patientIdentifiers: { [key: string]: PatientIdentifier } = {};
+
+    groups.forEach(group => {
+        group.studies.forEach(study => {
+            study.patients.forEach(patientId => {
+                patientIdentifiers[study.id + '\n' + patientId] = {
+                    studyId: study.id,
+                    patientId: patientId,
+                };
+            });
+        });
+    });
+
+    return Object.values(patientIdentifiers);
 }
 
 export function isSpecialChart(chartMeta: ChartMeta) {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8287

**Problem**:
- For the GENIE dataset, the coparison page was taking
20+ minutes to load from when the spinner appears

**Solution**:
- Added tests for `StudyViewUtils.getPatientIdentifiers`
- Modified `StudyViewUtils.getPatientIdentifiers` to add objects
to a set rather than constructing and then filtering a list
- Modified `GroupCompairsonUtils.getSampleIdentifiers` in the
same manner
  - This method was already well covered, so no tests were added

**Result**:
- Spinner time down to ~38 seconds on my local.