### PR TITLE
OncoKB Card minor changes

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/svg/getSvg.ts
+++ b/packages/cbioportal-clinical-timeline/src/svg/getSvg.ts
@@ -3,7 +3,7 @@ import {CustomTrackSpecification} from "../CustomTrack";
 import {EXPORT_TRACK_HEADER_BORDER_CLASSNAME, getTrackHeadersG} from "../TrackHeader";
 import {TICK_AXIS_COLOR} from "../TickAxis";
 import jQuery from "jquery";
-import {REMOVE_FOR_DOWNLOAD_CLASSNAME} from "..";
+import {REMOVE_FOR_DOWNLOAD_CLASSNAME} from "../lib/helpers";
 
 export default function getSvg(
     store: TimelineStore,

--- a/packages/cbioportal-clinical-timeline/src/svg/renderStack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/svg/renderStack.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TIMELINE_TRACK_HEIGHT } from '..';
+import {TIMELINE_TRACK_HEIGHT} from "../lib/helpers";
 
 const HEIGHT_OVER_WIDTH = 0.52
 const SHEET_STROKE_WIDTH = 0.2;

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardTitle.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbCardTitle.tsx
@@ -12,7 +12,11 @@ export const OncoKbCardTitle: React.FunctionComponent<OncoKbCardDefaultTitleProp
     props: OncoKbCardDefaultTitleProps
 ) => {
     const titleContent = [];
-    if (props.hugoSymbol && props.hugoSymbol !== OTHER_BIOMARKER_HUGO_SYMBOL) {
+    if (
+        props.hugoSymbol &&
+        props.hugoSymbol !== OTHER_BIOMARKER_HUGO_SYMBOL &&
+        (!props.variant || !props.variant.includes(props.hugoSymbol))
+    ) {
         titleContent.push(props.hugoSymbol);
     }
     if (props.variant) {

--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbHelper.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbHelper.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { defaultArraySortMethod, defaultSortMethod } from '../..';
 import {
     normalizeLevel,
     levelIconClassNames,
@@ -8,7 +7,12 @@ import {
 } from '../../util/OncoKbUtils';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import _ from 'lodash';
-import { LEVELS, OncoKbCardDataType } from 'cbioportal-utils';
+import {
+    defaultArraySortMethod,
+    defaultSortMethod,
+    LEVELS,
+    OncoKbCardDataType,
+} from 'cbioportal-utils';
 
 export default class OncoKbHelper {
     public static get TX_LEVELS(): string[] {
@@ -144,7 +148,7 @@ export default class OncoKbHelper {
             case 'level':
                 return {
                     id: 'level',
-                    Header: <span>Level</span>,
+                    Header: <div style={{ textAlign: 'center' }}>Level</div>,
                     accessor: 'level',
                     maxWidth: 45,
                     sortMethod: (a: string, b: string) =>

--- a/packages/react-mutation-mapper/src/component/oncokb/oncokb.scss
+++ b/packages/react-mutation-mapper/src/component/oncokb/oncokb.scss
@@ -46,4 +46,9 @@
         min-height: 50px;
         position: relative;
     }
+
+    // Default left align all react-table headers under oncokb-card-tabs
+    .rt-thead .rt-resizable-header-content {
+        text-align: left;
+    }
 }

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -82,14 +82,6 @@ import TimelineWrapper from './timeline2/TimelineWrapper';
 import { isFusion } from '../../shared/lib/MutationUtils';
 import { Mutation } from 'cbioportal-ts-api-client';
 import ClinicalEventsTables from './timeline2/ClinicalEventsTables';
-import { OncoKB } from 'react-mutation-mapper';
-import {
-    getSampleNumericalClinicalDataValue,
-    OTHER_BIOMARKERS_CLINICAL_ATTR,
-} from 'shared/lib/StoreUtils';
-import { CLINICAL_ATTRIBUTE_ID_ENUM } from 'shared/constants';
-import { OtherBiomarkersQueryType } from 'react-mutation-mapper';
-import { OtherBiomarkerAnnotation } from 'pages/patientView/oncokb/OtherBiomarkerAnnotation';
 import MutationalSignaturesContainer from './mutationalSignatures/MutationalSignaturesContainer';
 import SampleSummaryList from './sampleHeader/SampleSummaryList';
 


### PR DESCRIPTION
- Do not show hugo symbol when the alteration includes it. Example: ABL1, ABL1-BCR Fusion, we only want to show ABL1-BCR Fusion in the title

- Center align the headers in the all tables by default.

- fix some importing circular references issues. Example: defaultArraySortMethod, defaultSortMethod } from '../..';

This fixes https://github.com/oncokb/oncokb/issues/2429