### PR TITLE
Make NA label font consistent with tick label font

### DIFF
--- a/src/pages/studyView/charts/barChart/BarChart.tsx
+++ b/src/pages/studyView/charts/barChart/BarChart.tsx
@@ -302,9 +302,14 @@ export default class BarChart extends React.Component<IBarChartProps, {}>
                 .join(', ');
             return (
                 <VictoryLabel
-                    text={`n/a: ${labelNA}`}
+                    text={`NA: ${labelNA}`}
                     textAnchor="end"
                     datum={{ x: this.maximumX, y: this.maximumY }}
+                    style={{
+                        fontFamily:
+                            VICTORY_THEME.axis.style.tickLabels.fontFamily,
+                        fontSize: VICTORY_THEME.axis.style.tickLabels.fontSize,
+                    }}
                 />
             );
         }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8346

Describe changes proposed in this pull request:
- Changed 'n/a' to 'NA' 
- Changed font-family and font-size to that of tick label's

Note: Font-weight is set by default and not defined in cBioPortal theme for tick labels

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

### Before
![image](https://user-images.githubusercontent.com/33106214/108256841-f8678b80-712b-11eb-97cd-304f5a1ed934.png)

### After
![image](https://user-images.githubusercontent.com/33106214/108256776-e1289e00-712b-11eb-80bb-636430ecff95.png)


[Link](http://localhost:3000/study/summary?id=hnsc_tcga) tested
