### PR TITLE
Genomic evolution feature: highlight only partially works when splitt…

### DIFF
--- a/src/pages/patientView/timeline2/VAFChartWrapper.tsx
+++ b/src/pages/patientView/timeline2/VAFChartWrapper.tsx
@@ -387,12 +387,6 @@ export default class VAFChartWrapper extends React.Component<
         let sampleGroups: { [groupIndex: number]: string[] } = {};
         this.sampleIds.forEach((sampleId, i) => {
             // check the group value of this sample id
-            console.info(
-                'Sample id ' +
-                    sampleId +
-                    ' is in group ' +
-                    this.sampleIdToClinicalValue[sampleId]
-            );
             if (
                 sampleGroups[
                     this.clinicalValuesForGrouping.indexOf(


### PR DESCRIPTION
Fix cbioportal/cbioportal#8058

Modified highlighting logic to take into account that there can be multiple lines (instead of only one) for one mutation when groupBy functionality is used.