### PR TITLE
fix frequency formatting in signal table

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/signal/SignalHelper.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/signal/SignalHelper.tsx
@@ -175,12 +175,12 @@ export const FREQUENCY_COLUMNS_DEFINITION = {
                     sum + row.variantCount,
                 0
             );
-            const frequency =
-                (formatNumberValueInSignificantDigits(
-                    variantCount / tumorTypeCount,
+            const percent =
+                formatNumberValueInSignificantDigits(
+                    (variantCount * 100) / tumorTypeCount,
                     2
-                ) || 0) * 100;
-            return <strong className="pull-right">{frequency}</strong>;
+                ) || 0;
+            return <strong className="pull-right">{percent}</strong>;
         },
     },
     [FrequencyTableColumnEnum.BIALLELIC_RATIO]: {
@@ -202,12 +202,12 @@ export const FREQUENCY_COLUMNS_DEFINITION = {
                 (sum: any, row: any) => sum + row._original.qcPassTumorCount,
                 0
             );
-            const frequency =
-                (formatNumberValueInSignificantDigits(
-                    biallelicTumorCount / qcPassTumorCount,
+            const percent =
+                formatNumberValueInSignificantDigits(
+                    (biallelicTumorCount * 100) / qcPassTumorCount,
                     2
-                ) || 0) * 100;
-            return <strong className="pull-right">{frequency}</strong>;
+                ) || 0;
+            return <strong className="pull-right">{percent}</strong>;
         },
     },
     [FrequencyTableColumnEnum.MEDIAN_AGE_AT_DX]: {


### PR DESCRIPTION
Fix: https://github.com/knowledgesystems/signal/issues/107

Reason: floating-point
https://stackoverflow.com/questions/1458633/how-to-deal-with-floating-point-number-precision-in-javascript

`formatNumberValueInSignificantDigits` will handle floating-point. So to avoid this formatting issue, apply `* 100` inside `formatNumberValueInSignificantDigits`.