### PR TITLE
Survival prefix table - use slider for setting min patient threshold

### DIFF
--- a/src/pages/resultsView/survival/SurvivalChart.tsx
+++ b/src/pages/resultsView/survival/SurvivalChart.tsx
@@ -83,6 +83,7 @@ export interface ISurvivalChartProps {
     xAxisTickCount?: number;
 }
 
+const MIN_GROUP_SIZE_FOR_LOGRANK = 10;
 // Start to down sampling when there are more than 1000 dots in the plot.
 const SURVIVAL_DOWN_SAMPLING_THRESHOLD = 1000;
 
@@ -287,7 +288,15 @@ export default class SurvivalChart
     }
 
     @computed get logRankTestPVal(): number | null {
-        if (this.analysisGroupsWithData.length > 1) {
+        if (
+            this.analysisGroupsWithData.length > 1 &&
+            _.every(
+                this.analysisGroupsWithData,
+                group =>
+                    this.props.sortedGroupedSurvivals[group.value].length >
+                    MIN_GROUP_SIZE_FOR_LOGRANK
+            )
+        ) {
             return logRankTest(
                 ...this.analysisGroupsWithData.map(group => {
                     return this.props.sortedGroupedSurvivals[group.value];

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -85,8 +85,10 @@ type LazyMobXTableProps<T> = {
     initialFilterString?: string;
     showFilter?: boolean;
     showFilterClearButton?: boolean;
+    filterBoxWidth?: number;
     showCopyDownload?: boolean;
     copyDownloadProps?: ICopyDownloadControlsProps;
+    headerComponent?: JSX.Element;
     showPagination?: boolean;
     // used only when showPagination === true (show pagination at bottom otherwise)
     showPaginationAtTop?: boolean;
@@ -757,6 +759,7 @@ export default class LazyMobXTable<T> extends React.Component<
     public static defaultProps = {
         showFilter: true,
         showFilterClearButton: false,
+        filterBoxWidth: 200,
         showCopyDownload: true,
         showPagination: true,
         showColumnVisibility: true,
@@ -945,6 +948,7 @@ export default class LazyMobXTable<T> extends React.Component<
     private getTopToolbar() {
         return (
             <div>
+                {this.props.headerComponent}
                 {this.props.showCountHeader && this.countHeader}
                 <ButtonToolbar
                     style={{ marginLeft: 0 }}
@@ -965,7 +969,7 @@ export default class LazyMobXTable<T> extends React.Component<
                                 type="text"
                                 onInput={this.handlers.onFilterTextChange}
                                 className="form-control tableSearchInput"
-                                style={{ width: 200 }}
+                                style={{ width: this.props.filterBoxWidth }}
                             />
                             {this.props.showFilterClearButton &&
                             this.store.filterString ? (


### PR DESCRIPTION
Also only show p-value for survival when all groups have at least 10 cases.

Fixes https://github.com/cBioPortal/cbioportal/issues/8381
![8381-survival-slider](https://user-images.githubusercontent.com/636232/109546341-102e0080-7a98-11eb-9419-e90275964fcc.gif)

