### PR TITLE
Label 1 lollipop by default for diagrams that originally have no lollipops

### DIFF
--- a/packages/react-mutation-mapper/src/component/lollipopPlot/Lollipop.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopPlot/Lollipop.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { computed, makeObservable, observable } from 'mobx';
 
-import { LollipopPlacement, LollipopSpec } from '../../model/LollipopSpec';
+import {
+    LollipopLabel,
+    LollipopPlacement,
+    LollipopSpec,
+} from '../../model/LollipopSpec';
 
 type LollipopProps = {
     x: number;
@@ -12,12 +16,7 @@ type LollipopProps = {
     hoverHeadRadius: number;
     headColor?: string;
     stickColor?: string;
-    label?: {
-        text: string;
-        textAnchor?: string;
-        fontSize?: number;
-        fontFamily?: string;
-    };
+    label?: LollipopLabel;
     hitzoneClassName?: string;
     spec: LollipopSpec;
 };
@@ -90,7 +89,7 @@ export default class Lollipop extends React.Component<LollipopProps, {}> {
                     x={this.props.x}
                     y={this.textY}
                 >
-                    {this.props.label.text}
+                    {this.props.label.show ? this.props.label.text : ''}
                 </text>
             );
         }

--- a/packages/react-mutation-mapper/src/model/LollipopSpec.ts
+++ b/packages/react-mutation-mapper/src/model/LollipopSpec.ts
@@ -8,12 +8,15 @@ export type LollipopSpec = {
     count: number;
     group?: string;
     placement?: LollipopPlacement;
-    label?: {
-        text: string;
-        textAnchor?: string;
-        fontSize?: number;
-        fontFamily?: string;
-    };
+    label?: LollipopLabel;
     color?: string;
     tooltip?: JSX.Element;
+};
+
+export type LollipopLabel = {
+    text: string;
+    textAnchor?: string;
+    fontSize?: number;
+    fontFamily?: string;
+    show: boolean;
 };

--- a/packages/react-mutation-mapper/src/util/LollipopPlotUtils.spec.ts
+++ b/packages/react-mutation-mapper/src/util/LollipopPlotUtils.spec.ts
@@ -2,7 +2,18 @@ import { assert } from 'chai';
 
 import { Mutation } from 'cbioportal-utils';
 
-import { lollipopLabelText } from './LollipopPlotUtils';
+import {
+    byMiddlemostPosition,
+    byMutationCount,
+    byWhetherExistsInADomain,
+    calcCountRange,
+    calcYMaxInput,
+    getCommonYAxisMaxSliderValue,
+    getYAxisMaxInputValue,
+    getYAxisMaxSliderValue,
+    lollipopLabelText,
+    lollipopLabelTextAnchor,
+} from './LollipopPlotUtils';
 
 describe('LollipopPlotUtils', () => {
     let mutationsAtPosition: Mutation[];
@@ -130,7 +141,6 @@ describe('LollipopPlotUtils', () => {
         });
     });
 
-    // TODO disabled for now due to an incompatibility with JEST
     //  See https://stackoverflow.com/questions/33269093/how-to-add-canvas-support-to-my-tests-in-jest
     // describe('lollipopLabelTextAnchor', () => {
     //     it ('determines anchor position wrt protein change position and label length', () => {
@@ -158,4 +168,245 @@ describe('LollipopPlotUtils', () => {
     //             "end");
     //     });
     // });
+
+    describe('calcYMaxInput', () => {
+        it('gets the maximum y-axis value for the lollipop plot slider', () => {
+            assert.equal(calcYMaxInput(1, 0.1, [1, 5], [0, 0], true), 1);
+            assert.equal(calcYMaxInput(5, 0.1, [1, 5], [0, 0], true), 5);
+            assert.equal(calcYMaxInput(5, 0.1, [1, 5], [0, 0], false), 5);
+        });
+    });
+
+    describe('getCommonYAxisMaxSliderValue', () => {
+        it('gets the common y-axis max slider value based on the highest two minimums', () => {
+            assert.equal(
+                getCommonYAxisMaxSliderValue(0.1, [0, 0], [1, 5], undefined),
+                5
+            );
+        });
+    });
+
+    describe('getYAxisMaxSliderValue', () => {
+        it('gets the minimum y-axis max slider value between the default and user input', () => {
+            assert.equal(getYAxisMaxSliderValue(0.1, [1, 5], undefined), 5);
+            assert.equal(getYAxisMaxSliderValue(0.1, [1, 5], 3), 3);
+        });
+    });
+
+    describe('getYAxisMaxInputValue', () => {
+        it('gets the max input value', () => {
+            assert.equal(getYAxisMaxInputValue(0.1, '2'), 2);
+            assert.equal(getYAxisMaxInputValue(0.1, '0'), 0.1);
+        });
+    });
+
+    describe('calcCountRange', () => {
+        it('calculates the count range based on whether the lollipops exist', () => {
+            assert.deepEqual(
+                calcCountRange(
+                    [
+                        {
+                            codon: 223,
+                            count: 1,
+                        },
+                        {
+                            codon: 101,
+                            count: 1,
+                        },
+                        {
+                            codon: 182,
+                            count: 1,
+                        },
+                        {
+                            codon: 165,
+                            count: 1,
+                        },
+                    ],
+                    5,
+                    1
+                ),
+                [1, 5]
+            );
+        });
+    });
+
+    describe('byMiddlemostPosition', () => {
+        it('ranks lollipops by the smallest distance to average codon in descending order', () => {
+            assert.equal(
+                byMiddlemostPosition(162)(
+                    {
+                        codon: 182,
+                        count: 1,
+                    },
+                    {
+                        codon: 223,
+                        count: 1,
+                    }
+                ),
+                -1,
+                "if first lollipop is closer, don't pick the second"
+            );
+
+            assert.equal(
+                byMiddlemostPosition(162)(
+                    {
+                        codon: 223,
+                        count: 1,
+                    },
+                    {
+                        codon: 182,
+                        count: 1,
+                    }
+                ),
+                1,
+                "if second lollipop is closer, don't pick the first"
+            );
+
+            assert.equal(
+                byMiddlemostPosition(162)(
+                    {
+                        codon: 142,
+                        count: 1,
+                    },
+                    {
+                        codon: 182,
+                        count: 1,
+                    }
+                ),
+                0,
+                'if both lollipops are just as close, neither is preferred'
+            );
+        });
+    });
+
+    describe('byWhetherExistsInADomain', () => {
+        it('ranks lollipops by whether they exist in a domain', () => {
+            assert.equal(
+                byWhetherExistsInADomain([
+                    {
+                        pfamDomainEnd: 280,
+                        pfamDomainId: 'PF01852',
+                        pfamDomainStart: 78,
+                    },
+                ])(
+                    {
+                        codon: 182,
+                        count: 1,
+                    },
+                    {
+                        codon: 223,
+                        count: 1,
+                    }
+                ),
+                0,
+                'if both lollipops are in a domain, neither is preferred'
+            );
+
+            assert.equal(
+                byWhetherExistsInADomain([])(
+                    {
+                        codon: 366,
+                        count: 1,
+                    },
+                    {
+                        codon: 226,
+                        count: 1,
+                    }
+                ),
+                0,
+                'if both lollipops are not in a domain, neither is preferred'
+            );
+
+            assert.equal(
+                byWhetherExistsInADomain([
+                    {
+                        pfamDomainEnd: 200,
+                        pfamDomainId: 'PF01852',
+                        pfamDomainStart: 78,
+                    },
+                ])(
+                    {
+                        codon: 182,
+                        count: 1,
+                    },
+                    {
+                        codon: 223,
+                        count: 1,
+                    }
+                ),
+                -1,
+                "if the first lollipop is in a domain, don't pick the second"
+            );
+
+            assert.equal(
+                byWhetherExistsInADomain([
+                    {
+                        pfamDomainEnd: 200,
+                        pfamDomainId: 'PF01852',
+                        pfamDomainStart: 78,
+                    },
+                ])(
+                    {
+                        codon: 223,
+                        count: 1,
+                    },
+                    {
+                        codon: 182,
+                        count: 1,
+                    }
+                ),
+                1,
+                "if the second lollipop is in a domain, don't pick the first"
+            );
+        });
+    });
+
+    describe('byMutationCount', () => {
+        it('ranks lollipops in descending order of their count', () => {
+            assert.equal(
+                byMutationCount(
+                    {
+                        codon: 182,
+                        count: 1,
+                    },
+                    {
+                        codon: 223,
+                        count: 1,
+                    }
+                ),
+                0,
+                'if both lollipops have the same count, neither is preferred'
+            );
+
+            assert.equal(
+                byMutationCount(
+                    {
+                        codon: 182,
+                        count: 5,
+                    },
+                    {
+                        codon: 223,
+                        count: 1,
+                    }
+                ),
+                -1,
+                "if first lollipop has higher count, don't pick the second"
+            );
+
+            assert.equal(
+                byMutationCount(
+                    {
+                        codon: 182,
+                        count: 1,
+                    },
+                    {
+                        codon: 223,
+                        count: 5,
+                    }
+                ),
+                1,
+                "if second lollipop has higher count, don't pick the first"
+            );
+        });
+    });
 });


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8319

Describe changes proposed in this pull request:
- Label 1 lollipop for lollipops on the diagram based on the best candidate that:
  - has the highest mutation count
  - is in a domain (if at all)
  - is found in the middle-most position
- Added unit tests for existing and new functions in LollipopPlotUtils

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

### Before
#### Case 1
![image](https://user-images.githubusercontent.com/33106214/109879482-9a669800-7c43-11eb-937a-a05ca8cddb12.png)
#### Case 2
![image](https://user-images.githubusercontent.com/33106214/109847059-c884b180-7c1c-11eb-91f0-7aeb22aca34a.png)
#### Case 3
![image](https://user-images.githubusercontent.com/33106214/109847091-cf132900-7c1c-11eb-8056-eb1c2f34db26.png)

### After
#### Case 1
![image](https://user-images.githubusercontent.com/33106214/110374195-606c0c00-801e-11eb-8f80-bbbccf10ed4a.png)
#### Case 2
![image](https://user-images.githubusercontent.com/33106214/109847395-231e0d80-7c1d-11eb-8907-22638c188a84.png)
#### Case 3
![image](https://user-images.githubusercontent.com/33106214/109847432-2ca77580-7c1d-11eb-88ec-8a59ecf84c86.png)


## Links tested:
- [1](http://localhost:3000/results/mutations?cancer_study_list=metastatic_solid_tumors_mich_2017%2Cchol_msk_2018&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=0&case_set_id=all&gene_list=STAR&geneset_list=%20&tab_index=tab_visualize&Action=Submit&comparison_subtab=cna&mutations_gene=STAR)
- [2](http://localhost:3000/results/mutations?genetic_profile_ids_PROFILE_MUTATION_EXTENDED=msk_impact_2017_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=msk_impact_2017_cna&cancer_study_list=msk_impact_2017&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=0&case_set_id=msk_impact_2017_cnaseq&gene_list=EGFR&geneset_list=%20&tab_index=tab_visualize&Action=Submit&mutations_transcript_id=ENST00000420316)
- [3](http://localhost:3000/results/mutations?cancer_study_list=metastatic_solid_tumors_mich_2017%2Cchol_msk_2018&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=0&case_set_id=all&gene_list=CIR1&geneset_list=%20&tab_index=tab_visualize&Action=Submit&comparison_subtab=cna&mutations_gene=CIR1)
