### PR TITLE
Fix comparison tab alterations tab layout

### DIFF
--- a/src/pages/groupComparison/GroupComparisonPage.tsx
+++ b/src/pages/groupComparison/GroupComparisonPage.tsx
@@ -183,18 +183,25 @@ export default class GroupComparisonPage extends React.Component<
                                     : ''
                             }
                         >
-                            <AlterationEnrichmentTypeSelector
-                                store={this.store}
-                                handlers={
-                                    this
-                                        .alterationEnrichmentTypeSelectorHandlers!
-                                }
-                                showMutations={
-                                    this.store.hasMutationEnrichmentData
-                                }
-                                showCnas={this.store.hasCnaEnrichmentData}
-                                showFusions={this.store.hasFusionEnrichmentData}
-                            />
+                            {this.store.activeGroups.isComplete &&
+                                this.store.activeGroups.result.length > 1 && (
+                                    <AlterationEnrichmentTypeSelector
+                                        store={this.store}
+                                        handlers={
+                                            this
+                                                .alterationEnrichmentTypeSelectorHandlers!
+                                        }
+                                        showMutations={
+                                            this.store.hasMutationEnrichmentData
+                                        }
+                                        showCnas={
+                                            this.store.hasCnaEnrichmentData
+                                        }
+                                        showFusions={
+                                            this.store.hasFusionEnrichmentData
+                                        }
+                                    />
+                                )}
                             <AlterationEnrichments store={this.store} />
                         </MSKTab>
                     )}


### PR DESCRIPTION
We should not show the alterations menu when we only have one group selected 

broken:
![image](https://user-images.githubusercontent.com/186521/109861605-7b5d0b80-7c2d-11eb-9b7b-d79fa8b4a31d.png)

fixed:
![image](https://user-images.githubusercontent.com/186521/109863268-70a37600-7c2f-11eb-92b5-27f54a7c1295.png)

