### PR TITLE
Add signal additional columns back

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/signal/MutationTumorTypeFrequencyTable.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/signal/MutationTumorTypeFrequencyTable.tsx
@@ -36,7 +36,20 @@ class MutationTumorTypeFrequencyTable extends React.Component<
             FREQUENCY_COLUMNS_DEFINITION[
                 FrequencyTableColumnEnum.BIALLELIC_RATIO
             ],
-            // TODO: add more columns after having additional columns data for pathogenic variants
+            FREQUENCY_COLUMNS_DEFINITION[
+                FrequencyTableColumnEnum.MEDIAN_AGE_AT_DX
+            ],
+            FREQUENCY_COLUMNS_DEFINITION[FrequencyTableColumnEnum.MEDIAN_TMB],
+            FREQUENCY_COLUMNS_DEFINITION[FrequencyTableColumnEnum.MSI_SCORE],
+            FREQUENCY_COLUMNS_DEFINITION[
+                FrequencyTableColumnEnum.MEDIAN_HRD_LST
+            ],
+            FREQUENCY_COLUMNS_DEFINITION[
+                FrequencyTableColumnEnum.MEDIAN_HRD_NTELOMERIC_AI
+            ],
+            FREQUENCY_COLUMNS_DEFINITION[
+                FrequencyTableColumnEnum.MEDIAN_HRD_FRACTION_LOH
+            ],
         ],
     };
 

--- a/packages/react-mutation-mapper/src/component/column/Signal.tsx
+++ b/packages/react-mutation-mapper/src/component/column/Signal.tsx
@@ -135,6 +135,30 @@ export default class Signal extends React.Component<SignalProps, {}> {
                                                 FrequencyTableColumnEnum
                                                     .BIALLELIC_RATIO
                                             ],
+                                            FREQUENCY_COLUMNS_DEFINITION[
+                                                FrequencyTableColumnEnum
+                                                    .MEDIAN_AGE_AT_DX
+                                            ],
+                                            FREQUENCY_COLUMNS_DEFINITION[
+                                                FrequencyTableColumnEnum
+                                                    .MEDIAN_TMB
+                                            ],
+                                            FREQUENCY_COLUMNS_DEFINITION[
+                                                FrequencyTableColumnEnum
+                                                    .MSI_SCORE
+                                            ],
+                                            FREQUENCY_COLUMNS_DEFINITION[
+                                                FrequencyTableColumnEnum
+                                                    .MEDIAN_HRD_LST
+                                            ],
+                                            FREQUENCY_COLUMNS_DEFINITION[
+                                                FrequencyTableColumnEnum
+                                                    .MEDIAN_HRD_NTELOMERIC_AI
+                                            ],
+                                            FREQUENCY_COLUMNS_DEFINITION[
+                                                FrequencyTableColumnEnum
+                                                    .MEDIAN_HRD_FRACTION_LOH
+                                            ],
                                         ]}
                                     />
                                 }


### PR DESCRIPTION
Fix https://github.com/knowledgesystems/signal/issues/105

Adding additional signal columns back because we have new data for pathogenic variants. Please review and merge https://github.com/genome-nexus/genome-nexus-importer/pull/41 first

Will show new data after merging https://github.com/genome-nexus/genome-nexus-importer/pull/41 and update database.

![image](https://user-images.githubusercontent.com/16869603/111112853-41e2a500-8537-11eb-9796-7d317171434b.png)
https://www.signaldb.org/variant/17:g.7578263G%3EA