### PR TITLE
Update mutation-mapper and variant-view to add germline biallelic 

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/signal/MutationTumorTypeFrequencyTable.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/signal/MutationTumorTypeFrequencyTable.tsx
@@ -31,6 +31,9 @@ class MutationTumorTypeFrequencyTable extends React.Component<
                 FrequencyTableColumnEnum.VARIANT_COUNT
             ],
             FREQUENCY_COLUMNS_DEFINITION[
+                FrequencyTableColumnEnum.NUMBER_OF_GERMLINE_HOMOZYGOUS
+            ],
+            FREQUENCY_COLUMNS_DEFINITION[
                 FrequencyTableColumnEnum.PREVALENCE_FREQUENCY
             ],
             FREQUENCY_COLUMNS_DEFINITION[

--- a/packages/cbioportal-frontend-commons/src/components/signal/SignalHelper.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/signal/SignalHelper.tsx
@@ -22,6 +22,8 @@ export enum FrequencyTableColumnEnum {
     MEDIAN_HRD_LST = 'lst',
     MEDIAN_HRD_NTELOMERIC_AI = 'ntelomericAi',
     MEDIAN_HRD_FRACTION_LOH = 'fractionLoh',
+    OVERALL_NUMBER_OF_GERMLINE_HOMOZYGOUS = 'overallNumberOfGermlineHomozygous',
+    NUMBER_OF_GERMLINE_HOMOZYGOUS = 'numberOfGermlineHomozygous',
 }
 
 export function columnHeader(
@@ -56,6 +58,10 @@ export const FREQUENCY_TABLE_HEADER_COMPONENT: { [id: string]: JSX.Element } = {
     [FrequencyTableColumnEnum.VARIANT_COUNT]: columnHeader(
         <strong className="table-header"># Carriers</strong>,
         'Total number of patients harboring a germline pathogenic variant'
+    ),
+    [FrequencyTableColumnEnum.NUMBER_OF_GERMLINE_HOMOZYGOUS]: columnHeader(
+        <strong className="table-header"># Germline Homozygous</strong>,
+        'Number of germline homozygous'
     ),
     [FrequencyTableColumnEnum.PREVALENCE_FREQUENCY]: columnHeader(
         <strong className="table-header">% Prevalence</strong>,
@@ -147,6 +153,29 @@ export const FREQUENCY_COLUMNS_DEFINITION = {
                 0
             );
             return <strong className="pull-right">{variantCount}</strong>;
+        },
+    },
+    [FrequencyTableColumnEnum.NUMBER_OF_GERMLINE_HOMOZYGOUS]: {
+        id: FrequencyTableColumnEnum.NUMBER_OF_GERMLINE_HOMOZYGOUS,
+        Cell: renderNumber,
+        Header:
+            FREQUENCY_TABLE_HEADER_COMPONENT[
+                FrequencyTableColumnEnum.NUMBER_OF_GERMLINE_HOMOZYGOUS
+            ],
+        accessor: FrequencyTableColumnEnum.NUMBER_OF_GERMLINE_HOMOZYGOUS,
+        sortMethod: defaultSortMethod,
+        minWidth: 100,
+        Footer: (col: any) => {
+            const numberOfGermlineHomozygous = col.data.reduce(
+                (sum: any, row: ISignalTumorTypeDecomposition) =>
+                    sum + row.numberOfGermlineHomozygous,
+                0
+            );
+            return (
+                <strong className="pull-right">
+                    {numberOfGermlineHomozygous}
+                </strong>
+            );
         },
     },
     [FrequencyTableColumnEnum.PREVALENCE_FREQUENCY]: {
@@ -286,7 +315,7 @@ export function renderPercentage(cellProps: any, styles?: any) {
 
 export function renderNumber(cellProps: any, fractionDigits?: number) {
     let displayValue;
-    if (cellProps.value !== null) {
+    if (cellProps.value !== undefined && cellProps.value !== null) {
         if (fractionDigits) {
             displayValue = cellProps.value.toFixed(fractionDigits);
         } else {

--- a/packages/cbioportal-utils/src/model/SignalMutation.ts
+++ b/packages/cbioportal-utils/src/model/SignalMutation.ts
@@ -15,6 +15,7 @@ export interface ISignalTumorTypeDecomposition extends CountByTumorType {
     tmb: number | null;
     biallelicTumorCount: number | null;
     qcPassTumorCount: number | null;
+    numberOfGermlineHomozygous: number | null;
 }
 
 export interface IExtendedSignalMutation extends SignalMutation {

--- a/packages/cbioportal-utils/src/signal/SignalMutationUtils.ts
+++ b/packages/cbioportal-utils/src/signal/SignalMutationUtils.ts
@@ -163,6 +163,10 @@ export function generateTumorTypeDecomposition(
             qcPassTumorMap && qcPassTumorMap[counts.tumorType]
                 ? qcPassTumorMap[counts.tumorType].variantCount
                 : null,
+        numberOfGermlineHomozygous:
+            statsTumorMap && statsTumorMap[counts.tumorType]
+                ? statsTumorMap[counts.tumorType].numberOfGermlineHomozygous
+                : null,
     }));
 }
 


### PR DESCRIPTION
Part of: https://github.com/knowledgesystems/signal/issues/112
Changes in this PR:
- [x] Add `# Germline Biallelic` column in mutation mapper table and variant view
Mutation mapper table:
![image](https://user-images.githubusercontent.com/16869603/112250954-b781fb80-8c30-11eb-863f-2cba52730a1b.png)
Variant view:
![image](https://user-images.githubusercontent.com/16869603/112251446-9ec61580-8c31-11eb-93b3-77e056d12906.png)
