### PR TITLE
fix empty lollipop specs error

### DIFF
--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -228,8 +228,8 @@ export default class LollipopMutationPlot<
             group,
             placement
         );
-
-        const noLabelsAreShown = specs.every(spec => !spec.label!.show);
+        const noLabelsAreShown =
+            !_.isEmpty(specs) && specs.every(spec => !spec.label!.show);
         if (noLabelsAreShown) {
             this.labelOneLollipopByDefault(
                 this.getRemainingDomains(positionMutations),


### PR DESCRIPTION
Related to: https://github.com/knowledgesystems/signal/issues/112
Page will crash when `spec` is empty, for example: https://www.signaldb.org/gene/ABL1 (This link won't crash because it's not using the latest mutation mapper package, but will crash when using local latest package)
![image](https://user-images.githubusercontent.com/16869603/112252370-60c9f100-8c33-11eb-98cd-f19d21a2a74b.png)
In this example, it has `somatic` and `germline`. `somatic` has data but `germline` is empty, the spec will be `[]` for germline. If no data available it shouldn't label any lollipop, but in this example - `noLabelsAreShown` will still be `true` and enter `labelOneLollipopByDefault`, and will break on `specs[candidateIndex].label!.show = true;`