### PR TITLE
Fix group checkbox wrap issue

### DIFF
--- a/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
@@ -21,10 +21,7 @@ import {
     CLI_YES_COLOR,
     DARK_GREY,
 } from '../../../shared/lib/Colors';
-import {
-    DefaultTooltip,
-    EllipsisTextTooltip,
-} from 'cbioportal-frontend-commons';
+import { DefaultTooltip, TruncatedText } from 'cbioportal-frontend-commons';
 import classnames from 'classnames';
 import { ColorPickerIcon } from 'pages/groupComparison/comparisonGroupManager/ColorPickerIcon';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
@@ -93,8 +90,14 @@ export default class GroupCheckbox extends React.Component<
 
     @computed get label() {
         return (
-            <span style={{ display: 'flex', alignItems: 'center' }}>
-                <EllipsisTextTooltip text={this.props.group.name} />
+            <span
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                <TruncatedText text={this.props.group.name} maxLength={30} />
                 &nbsp;(
                 {caseCounts(
                     getNumSamples(this.props.group),


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8507

Describe changes proposed in this pull request:
- Added `nowrap` to the span style.
- Replaced `EllipsisTextTooltip` with `TruncatedText` since `EllipsisTextTooltip` does not play well with `nowrap`.


## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!