### PR TITLE
oncoprint - add support for categorical generic assay tracks

### DIFF
--- a/end-to-end-test/local/specs/core/oncoprint.screenshot.spec.js
+++ b/end-to-end-test/local/specs/core/oncoprint.screenshot.spec.js
@@ -1,0 +1,20 @@
+var {
+    goToUrlAndSetLocalStorage,
+    assertScreenShotMatch,
+    waitForOncoprint,
+    checkOncoprintElement,
+} = require('../../../shared/specUtils');
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+
+describe('oncoprint', function() {
+    describe('generic assay categorical tracks', () => {
+        it('shows binary and multiple category tracks', () => {
+            var url = `${CBIOPORTAL_URL}/results/oncoprint?genetic_profile_ids_PROFILE_MUTATION_EXTENDED=lgg_ucsf_2014_test_generic_assay_mutations&cancer_study_list=lgg_ucsf_2014_test_generic_assay&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=0&case_set_id=lgg_ucsf_2014_test_generic_assay_sequenced&gene_list=IDH1&geneset_list=%20&tab_index=tab_visualize&Action=Submit&show_samples=true&generic_assay_groups=lgg_ucsf_2014_test_generic_assay_mutational_signature_binary_v2%2Cmutational_signature_binary_2%2Cmutational_signature_binary_1%3Blgg_ucsf_2014_test_generic_assay_mutational_signature_category_v2%2Cmutational_signature_category_6%2Cmutational_signature_category_8%2Cmutational_signature_category_9`;
+            goToUrlAndSetLocalStorage(url, true);
+            waitForOncoprint(10000);
+            var res = checkOncoprintElement();
+            assertScreenShotMatch(res);
+        });
+    });
+});

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
@@ -708,6 +708,7 @@ export default class MutationOncoprint extends React.Component<
                             clinicalTracks={[]}
                             geneticTracks={[]}
                             genesetHeatmapTracks={[]}
+                            categoricalTracks={[]}
                             heatmapTracks={this.heatmapTracks.result!}
                             heatmapTracksOrder={this.heatmapTracksOrder.result}
                             divId="MutationHeatmap"

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -3523,6 +3523,7 @@ export class ResultsViewPageStore
             () => this.discreteCNACache,
             this.studyToMolecularProfileDiscreteCna.result!,
             this.studyIdToStudy,
+            this.queriedStudies,
             this.molecularProfileIdToMolecularProfile,
             this.clinicalDataForSamples,
             this.studiesForSamplesWithoutCancerTypeClinicalData,

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
@@ -68,6 +68,7 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
             [studyId: string]: MolecularProfile;
         },
         public studyIdToStudy: MobxPromise<{ [studyId: string]: CancerStudy }>,
+        public queriedStudies: MobxPromise<CancerStudy[]>,
         public molecularProfileIdToMolecularProfile: MobxPromise<{
             [molecularProfileId: string]: MolecularProfile;
         }>,

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -71,10 +71,10 @@ export default class QuerySummary extends React.Component<
                     submitToStudyViewPage(
                         this.props.store.queriedStudies.result,
                         this.props.store.filteredSamples.result!,
-                        this.props.store.queriedVirtualStudies.result.length >
-                            0,
                         this.props.store.filteredSamples.result!.length <
                             this.props.store.samples.result!.length,
+                        this.props.store.queriedVirtualStudies.result.length >
+                            0,
                         this.props.store.sampleLists.result
                     );
                 }}

--- a/src/pages/resultsView/querySummary/QuerySummaryUtils.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummaryUtils.tsx
@@ -6,16 +6,20 @@ import { buildCBioPortalPageUrl } from '../../../shared/api/urls';
 
 export function getPatientSampleSummary(samples: any[], patients: any[]) {
     if (samples.length !== patients.length) {
+        const patientUnits = patients.length === 1 ? 'patient' : 'patients';
+        const sampleUnits = samples.length === 1 ? 'sample' : 'samples';
         return (
             <span>
-                <strong>{patients.length}</strong> patients /{' '}
-                <strong>{samples.length}</strong> samples
+                <strong>{patients.length}</strong> {patientUnits} /{' '}
+                <strong>{samples.length}</strong> {sampleUnits}
             </span>
         );
     } else {
+        const units =
+            samples.length === 1 ? 'patient/sample' : 'patients/samples';
         return (
             <span>
-                <strong>{samples.length}</strong> patients/samples
+                <strong>{samples.length}</strong> {units}
             </span>
         );
     }
@@ -84,8 +88,8 @@ export function getAlterationSummary(
 export function submitToStudyViewPage(
     queriedStudies: Pick<CancerStudy, 'studyId'>[],
     samples: Pick<Sample, 'sampleId' | 'studyId'>[],
-    hasVirtualStudies: boolean,
     samplesAreFiltered: boolean,
+    hasVirtualStudies?: boolean,
     sampleLists?: Pick<SampleList, 'category'>[]
 ) {
     const hasAllCaseLists = _.some(

--- a/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
+++ b/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
@@ -436,6 +436,7 @@ export default class Oncoprinter extends React.Component<
                                 geneticTracks={
                                     this.props.store.geneticTracks.result
                                 }
+                                categoricalTracks={[]} // TODO: allow import of generic assay categorical tracks
                                 geneticTracksOrder={
                                     this.props.store.geneOrder &&
                                     this.props.store.geneOrder.map(

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -59,9 +59,11 @@ export function buildCBioPortalPageUrl(
         typeof pathnameOrParams === 'string'
             ? { pathname: pathnameOrParams, query, hash }
             : pathnameOrParams;
+
+    // AppConfig.frontendUrl format is '//url/', hence the specified slice to get just 'url'
     return URL.format({
         protocol: window.location.protocol,
-        host: AppConfig.baseUrl,
+        host: AppConfig.baseUrl || AppConfig.frontendUrl?.slice(2, -1),
         ...params,
     });
 }

--- a/src/shared/components/mutationMapper/MutationMapperDataStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperDataStore.ts
@@ -196,6 +196,19 @@ export default class MutationMapperDataStore
         return countDuplicateMutations(this.tableDataGroupedByPatients);
     }
 
+    @computed
+    get tableDataSamples() {
+        return _.uniqBy(_.flatten(this.tableData), m => m.sampleId).map(m => ({
+            sampleId: m.sampleId,
+            studyId: m.studyId,
+        }));
+    }
+
+    @computed
+    get tableDataPatients() {
+        return _.uniq(_.flatten(this.tableData).map(m => m.patientId));
+    }
+
     constructor(
         data: Mutation[][],
         customFilterApplier?: FilterApplier,

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -14,8 +14,10 @@ import {
     Mutation,
     Patient,
     Sample,
+    GenericAssayData,
 } from 'cbioportal-ts-api-client';
 import {
+    CategoricalTrackDatum,
     ClinicalTrackDatum,
     GeneticTrackDatum,
     GeneticTrackDatum_Data,
@@ -494,6 +496,79 @@ function selectRepresentingDataPoint(
     } else {
         return selData[0];
     }
+}
+
+function fillCategoricalTrackDatum(
+    newDatum: Partial<CategoricalTrackDatum>,
+    data: GenericAssayData[],
+    entityId: string,
+    profile: MolecularProfile
+) {
+    newDatum.profile_name = profile.name;
+    newDatum.study_id = profile.studyId;
+    newDatum.entity = entityId;
+
+    newDatum.attr_val_counts = _.countBy(data, d => d.value);
+    const attr_vals = Object.keys(newDatum.attr_val_counts);
+    switch (attr_vals.length) {
+        case 0:
+            newDatum.na = true;
+            break;
+        case 1:
+            newDatum.attr_val = attr_vals[0];
+            break;
+        default:
+            newDatum.attr_val = 'Mixed';
+            break;
+    }
+}
+
+export function makeCategoricalTrackData(
+    profile: MolecularProfile,
+    entityId: string,
+    cases: Sample[] | Patient[],
+    data: GenericAssayData[]
+) {
+    let ret: CategoricalTrackDatum[];
+    let keyToData: { [uniqueKey: string]: GenericAssayData[] };
+    if (isSampleList(cases)) {
+        // if sample list, then make one oncoprint datum per sample
+        keyToData = _.groupBy(data, (d: GenericAssayData) => d.uniqueSampleKey);
+        ret = cases.map(c => {
+            const trackDatum: Partial<CategoricalTrackDatum> = {};
+            trackDatum.sample = c.sampleId;
+            trackDatum.patient = c.patientId;
+            trackDatum.uid = c.uniqueSampleKey;
+            fillCategoricalTrackDatum(
+                trackDatum,
+                keyToData[c.uniqueSampleKey],
+                entityId,
+                profile
+            );
+
+            return trackDatum as CategoricalTrackDatum;
+        });
+    } else {
+        // if patient list, then make one oncoprint datum per patient
+        keyToData = _.groupBy(
+            data,
+            (d: GenericAssayData) => d.uniquePatientKey
+        );
+        ret = cases.map(c => {
+            const trackDatum: Partial<CategoricalTrackDatum> = {};
+            trackDatum.patient = c.patientId;
+            trackDatum.uid = c.uniquePatientKey;
+            fillCategoricalTrackDatum(
+                trackDatum,
+                keyToData[c.uniquePatientKey],
+                entityId,
+                profile
+            );
+
+            return trackDatum as CategoricalTrackDatum;
+        });
+    }
+    return ret;
 }
 
 export function makeHeatmapTrackData<

--- a/src/shared/components/oncoprint/DeltaUtils.spec.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.spec.ts
@@ -100,6 +100,7 @@ describe('Oncoprint DeltaUtils', () => {
             clinicalTracks: [],
             geneticTracks: [],
             genesetHeatmapTracks: [],
+            categoricalTracks: [],
             heatmapTracks: [],
             divId: 'myDomId',
             width: 1000,
@@ -873,6 +874,7 @@ describe('Oncoprint DeltaUtils', () => {
             geneticTracks: [],
             genesetHeatmapTracks: [],
             heatmapTracks: [],
+            categoricalTracks: [],
             divId: 'myDomId',
             width: 1000,
         });
@@ -994,6 +996,7 @@ describe('Oncoprint DeltaUtils', () => {
             geneticTracks: [],
             genesetHeatmapTracks: [],
             heatmapTracks: [],
+            categoricalTracks: [],
             divId: 'myDomId',
             width: 1000,
         });

--- a/src/shared/components/oncoprint/DeltaUtils.spec.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.spec.ts
@@ -6,6 +6,7 @@ import {
     transition,
     transitionTrackGroupSortPriority,
     transitionHeatmapTrack,
+    transitionCategoricalTrack,
 } from './DeltaUtils';
 
 import { spy, SinonStub, match, createStubInstance } from 'sinon';
@@ -15,9 +16,11 @@ import { MolecularProfile, CancerStudy } from 'cbioportal-ts-api-client';
 import {
     CLINICAL_TRACK_GROUP_INDEX,
     GENETIC_TRACK_GROUP_INDEX,
+    ICategoricalTrackSpec,
     IHeatmapTrackSpec,
     IOncoprintProps,
 } from './Oncoprint';
+import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 
 describe('Oncoprint DeltaUtils', () => {
     describe('numTracksWhoseDataChanged', () => {
@@ -1051,7 +1054,7 @@ describe('Oncoprint DeltaUtils', () => {
 
         it('when is new track and ruleSetId is undefined, the new trackId is set as ruleSetId', () => {
             const trackIdForRuleSetSharing = {
-                genericAssay: {} as { [m: string]: number },
+                genericAssayHeatmap: {} as { [m: string]: number },
             };
 
             (oncoprint.addTracks as SinonStub).returns([1]);
@@ -1068,11 +1071,16 @@ describe('Oncoprint DeltaUtils', () => {
             );
 
             assert.isFalse((oncoprint.shareRuleSet as SinonStub).called);
-            assert.equal(trackIdForRuleSetSharing.genericAssay['profile_1'], 1);
+            assert.equal(
+                trackIdForRuleSetSharing.genericAssayHeatmap['profile_1'],
+                1
+            );
         });
 
         it('when is new track and ruleSetId is defined, the new trackId is set as ruleSetId', () => {
-            const trackIdForRuleSetSharing = { genericAssay: { profile_1: 1 } };
+            const trackIdForRuleSetSharing = {
+                genericAssayHeatmap: { profile_1: 1 },
+            };
 
             (oncoprint.addTracks as SinonStub).returns([2]);
 
@@ -1088,11 +1096,16 @@ describe('Oncoprint DeltaUtils', () => {
             );
 
             assert.isFalse((oncoprint.shareRuleSet as SinonStub).called);
-            assert.equal(trackIdForRuleSetSharing.genericAssay['profile_1'], 2);
+            assert.equal(
+                trackIdForRuleSetSharing.genericAssayHeatmap['profile_1'],
+                2
+            );
         });
 
         it('when is existing track and ruleSetId is defined, the ruleset of existing track is updated to ruleSetId', () => {
-            const trackIdForRuleSetSharing = { genericAssay: { profile_1: 2 } };
+            const trackIdForRuleSetSharing = {
+                genericAssayHeatmap: { profile_1: 2 },
+            };
             const prevSpec = nextSpec;
 
             transitionHeatmapTrack(
@@ -1107,7 +1120,149 @@ describe('Oncoprint DeltaUtils', () => {
             );
 
             assert.isTrue((oncoprint.shareRuleSet as SinonStub).called);
-            assert.equal(trackIdForRuleSetSharing.genericAssay['profile_1'], 2);
+            assert.equal(
+                trackIdForRuleSetSharing.genericAssayHeatmap['profile_1'],
+                2
+            );
+        });
+    });
+    describe('transitionCategoricalTrack() for generic assay response profile', () => {
+        const molecularAlterationType = 'GENERIC_ASSAY';
+
+        const makeMinimalOncoprintProps = (): IOncoprintProps => ({
+            caseLinkOutInTooltips: false,
+            clinicalTracks: [],
+            geneticTracks: [],
+            genesetHeatmapTracks: [],
+            heatmapTracks: [],
+            categoricalTracks: [],
+            divId: 'myDomId',
+            width: 1000,
+        });
+
+        const nextSpec: ICategoricalTrackSpec = {
+            key: '',
+            label: '',
+            molecularProfileId: 'profile_1',
+            molecularAlterationType: molecularAlterationType,
+            molecularProfileName: 'Profile',
+            genericAssayType: GenericAssayTypeConstants.ARMLEVEL_CNA,
+            trackLinkUrl: '',
+            datatype: '',
+            trackGroupIndex: 1,
+            onRemove: () => {},
+            data: [
+                {
+                    entity: 'entity_1',
+                    profile_name: 'Profile',
+                    attr_val_counts: { '1': 1 },
+                    study_id: 'study1',
+                    uid: 'uid',
+                    patient: 'patient1',
+                },
+                {
+                    entity: 'entity_1',
+                    profile_name: 'Profile',
+                    attr_val_counts: { '2': 1 },
+                    study_id: 'study1',
+                    uid: 'uid',
+                    patient: 'patient1',
+                },
+                {
+                    entity: 'entity_1',
+                    profile_name: 'Profile',
+                    attr_val_counts: { '3': 1 },
+                    study_id: 'study1',
+                    uid: 'uid',
+                    patient: 'patient1',
+                },
+            ],
+        };
+
+        const prevSpec = undefined;
+
+        const trackspec2trackId = () => {
+            return {
+                GENERIC_ASSAY_TRACK_1: 1,
+                GENERIC_ASSAY_TRACK_2: 2,
+            };
+        };
+
+        const nextProps: IOncoprintProps = makeMinimalOncoprintProps();
+        const prevProps: IOncoprintProps = makeMinimalOncoprintProps();
+
+        const oncoprint: OncoprintJS = createStubInstance(OncoprintJS);
+
+        beforeEach(function() {
+            (oncoprint.shareRuleSet as SinonStub).resetHistory();
+        });
+
+        it('when is new track and ruleSetId is undefined, the new trackId is set as ruleSetId', () => {
+            const trackIdForRuleSetSharing = {
+                genericAssayCategorical: {} as { [m: string]: number },
+            };
+
+            (oncoprint.addTracks as SinonStub).returns([1]);
+
+            transitionCategoricalTrack(
+                nextSpec,
+                prevSpec,
+                trackspec2trackId,
+                oncoprint,
+                nextProps,
+                trackIdForRuleSetSharing
+            );
+
+            assert.isFalse((oncoprint.shareRuleSet as SinonStub).called);
+            assert.equal(
+                trackIdForRuleSetSharing.genericAssayCategorical['profile_1'],
+                1
+            );
+        });
+
+        it('when is new track and ruleSetId is defined, the new trackId is set as ruleSetId', () => {
+            const trackIdForRuleSetSharing = {
+                genericAssayCategorical: { profile_1: 1 },
+            };
+
+            (oncoprint.addTracks as SinonStub).returns([2]);
+
+            transitionCategoricalTrack(
+                nextSpec,
+                prevSpec,
+                trackspec2trackId,
+                oncoprint,
+                nextProps,
+                trackIdForRuleSetSharing
+            );
+
+            assert.isFalse((oncoprint.shareRuleSet as SinonStub).called);
+            assert.equal(
+                trackIdForRuleSetSharing.genericAssayCategorical['profile_1'],
+                2
+            );
+        });
+
+        it('when is existing track and ruleSetId is defined, the ruleset of existing track is updated to ruleSetId', () => {
+            const trackIdForRuleSetSharing = {
+                genericAssayCategorical: { profile_1: 2 },
+            };
+            const prevSpec = nextSpec;
+
+            transitionCategoricalTrack(
+                nextSpec,
+                prevSpec,
+                trackspec2trackId,
+                oncoprint,
+                nextProps,
+                trackIdForRuleSetSharing
+            );
+
+            assert.isTrue((oncoprint.shareRuleSet as SinonStub).called);
+            assert.equal(
+                trackIdForRuleSetSharing.genericAssayCategorical['profile_1'],
+                2
+            );
         });
     });
 });

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -4,13 +4,20 @@ import {
     GENETIC_TRACK_GROUP_INDEX,
     GeneticTrackSpec,
     IBaseHeatmapTrackDatum,
+    ICategoricalTrackSpec,
     IGenesetHeatmapTrackSpec,
     IHeatmapTrackSpec,
     IOncoprintProps,
 } from './Oncoprint';
-import OncoprintJS, { SortConfig, TrackId, UserTrackSpec } from 'oncoprintjs';
+import OncoprintJS, {
+    ICategoricalRuleSetParams,
+    SortConfig,
+    TrackId,
+    UserTrackSpec,
+} from 'oncoprintjs';
 import _ from 'lodash';
 import {
+    getCategoricalTrackRuleSetParams,
     getClinicalTrackRuleSetParams,
     getGenesetHeatmapTrackRuleSetParams,
     getGeneticTrackRuleSetParams,
@@ -20,9 +27,11 @@ import {
     getClinicalTrackSortComparator,
     getGeneticTrackSortComparator,
     heatmapTrackSortComparator,
+    categoricalTrackSortComparator,
 } from './SortUtils';
 import {
     linebreakGenesetId,
+    makeCategoricalTrackTooltip,
     makeClinicalTrackTooltip,
     makeGeneticTrackTooltip,
     makeHeatmapTrackTooltip,
@@ -30,6 +39,12 @@ import {
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import { AlterationTypeConstants } from 'pages/resultsView/ResultsViewPageStore';
 import ifNotDefined from '../../lib/ifNotDefined';
+
+// This file implements functions that call imperative OncoprintJS library
+//  methods in order to keep the oncoprint in a state consistent with the
+//  specified props. In essence, it's transforming declarative logic into
+//  imperative logic by executing "transitions" from the previous props
+//  to the new props.
 
 export function transition(
     nextProps: IOncoprintProps,
@@ -842,6 +857,34 @@ function transitionTracks(
         oncoprint,
         getTrackSpecKeyToTrackId
     );
+
+    // Transition categorical tracks
+    const prevCategoricalTracks = _.keyBy(
+        prevProps.categoricalTracks,
+        (track: ICategoricalTrackSpec) => track.key
+    );
+    for (const track of nextProps.categoricalTracks) {
+        transitionCategoricalTrack(
+            track,
+            prevCategoricalTracks[track.key],
+            getTrackSpecKeyToTrackId,
+            oncoprint,
+            nextProps
+        );
+        delete prevCategoricalTracks[track.key];
+    }
+    for (const track of prevProps.categoricalTracks || []) {
+        if (prevCategoricalTracks.hasOwnProperty(track.key)) {
+            // if its still there, then this track no longer exists
+            transitionCategoricalTrack(
+                undefined,
+                prevCategoricalTracks[track.key],
+                getTrackSpecKeyToTrackId,
+                oncoprint,
+                nextProps
+            );
+        }
+    }
 }
 
 function transitionGeneticTrackOrder(
@@ -1479,6 +1522,76 @@ export function transitionHeatmapTrack(
                     nextSpec,
                     nextProps.caseLinkOutInTooltips
                 )
+        );
+    }
+}
+
+function transitionCategoricalTrack(
+    nextSpec: ICategoricalTrackSpec | undefined,
+    prevSpec: ICategoricalTrackSpec | undefined,
+    getTrackSpecKeyToTrackId: () => { [key: string]: TrackId },
+    oncoprint: OncoprintJS,
+    nextProps: IOncoprintProps
+) {
+    const trackSpecKeyToTrackId = getTrackSpecKeyToTrackId();
+    if (tryRemoveTrack(nextSpec, prevSpec, trackSpecKeyToTrackId, oncoprint)) {
+        return;
+    } else if (nextSpec && !prevSpec) {
+        // Add track
+        const rule_set_params: ICategoricalRuleSetParams = getCategoricalTrackRuleSetParams(
+            nextSpec
+        );
+        rule_set_params.legend_label = nextSpec.label;
+        rule_set_params.na_legend_label = nextSpec.naLegendLabel;
+        const trackParams: UserTrackSpec<any> = {
+            rule_set_params,
+            data: nextSpec.data,
+            data_id_key: 'uid',
+            track_padding: 0,
+            label: nextSpec.label,
+            target_group: nextSpec.trackGroupIndex,
+            removable:
+                !!nextSpec.onRemove || !!nextSpec.onClickRemoveInTrackMenu,
+            removeCallback: () => {
+                delete getTrackSpecKeyToTrackId()[nextSpec.key];
+                nextSpec.onRemove && nextSpec.onRemove();
+            },
+            onClickRemoveInTrackMenu: () => {
+                nextSpec.onClickRemoveInTrackMenu &&
+                    nextSpec.onClickRemoveInTrackMenu();
+            },
+            sort_direction_changeable: true,
+            sortCmpFn: categoricalTrackSortComparator,
+            init_sort_direction: 0 as 0,
+            description: ifNotDefined(
+                nextSpec.description,
+                `${nextSpec.label} data from ${nextSpec.molecularProfileId}`
+            ),
+            link_url: nextSpec.trackLinkUrl,
+            tooltipFn: makeCategoricalTrackTooltip(
+                nextSpec,
+                nextProps.caseLinkOutInTooltips
+            ),
+            track_info: nextSpec.info || '',
+            onSortDirectionChange: nextProps.onTrackSortDirectionChange,
+        };
+        trackSpecKeyToTrackId[nextSpec.key] = oncoprint.addTracks([
+            trackParams,
+        ])[0];
+    } else if (nextSpec && prevSpec) {
+        // Transition track
+        const trackId = trackSpecKeyToTrackId[nextSpec.key];
+        if (nextSpec.data !== prevSpec.data) {
+            // shallow equality check
+            oncoprint.setTrackData(trackId, nextSpec.data, 'uid');
+        }
+        // set tooltip, its cheap
+        oncoprint.setTrackTooltipFn(
+            trackId,
+            makeCategoricalTrackTooltip(
+                nextSpec,
+                nextProps.caseLinkOutInTooltips
+            )
         );
     }
 }

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -103,10 +103,13 @@ function transitionTrackHeaders(
     oncoprint: OncoprintJS
 ) {
     if (
-        !_.isEqual(nextProps.heatmapTrackHeaders, prevProps.heatmapTrackHeaders)
+        !_.isEqual(
+            nextProps.additionalTrackGroupHeaders,
+            prevProps.additionalTrackGroupHeaders
+        )
     ) {
-        const nextHeaders = nextProps.heatmapTrackHeaders || {};
-        const prevHeaders = prevProps.heatmapTrackHeaders || {};
+        const nextHeaders = nextProps.additionalTrackGroupHeaders || {};
+        const prevHeaders = prevProps.additionalTrackGroupHeaders || {};
 
         const nextIndexes = Object.keys(nextHeaders).map(x => parseInt(x, 10));
         const prevIndexes = Object.keys(prevHeaders).map(x => parseInt(x, 10));

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -21,6 +21,18 @@ import {
 import './styles.scss';
 import { ShapeParams } from 'oncoprintjs/dist/js/oncoprintshape';
 
+export type CategoricalTrackDatum = {
+    entity: string;
+    profile_name: string;
+    study_id?: string;
+    sample?: string;
+    patient: string;
+    uid: string;
+    attr_val_counts: { [val: string]: number };
+    attr_val?: string | number | CategoricalTrackDatum['attr_val_counts'];
+    na?: boolean;
+};
+
 export type ClinicalTrackDatum = {
     attr_id: string;
     study_id?: string;
@@ -186,6 +198,24 @@ export interface IGenesetHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     expansionCallback: () => void;
 }
 
+export interface ICategoricalTrackSpec {
+    key: string;
+    label: string;
+    molecularProfileId: string;
+    molecularProfileName: string;
+    molecularAlterationType: MolecularProfile['molecularAlterationType'];
+    genericAssayType: string;
+    datatype: MolecularProfile['datatype'];
+    data: CategoricalTrackDatum[];
+    trackGroupIndex: number;
+    trackLinkUrl: string | undefined;
+    onRemove?: () => void;
+    onClickRemoveInTrackMenu?: () => void;
+    naLegendLabel?: string;
+    description?: string;
+    info?: string;
+}
+
 export const GENETIC_TRACK_GROUP_INDEX = 1;
 export const CLINICAL_TRACK_GROUP_INDEX = 0;
 
@@ -198,6 +228,7 @@ export interface IOncoprintProps {
     genesetHeatmapTracks: IGenesetHeatmapTrackSpec[];
     heatmapTracks: IHeatmapTrackSpec[];
     heatmapTracksOrder?: { [trackGroupIndex: number]: string[] }; // track keys
+    categoricalTracks: ICategoricalTrackSpec[];
     additionalTrackGroupHeaders?: {
         [trackGroupIndex: number]: TrackGroupHeader;
     };

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -198,7 +198,9 @@ export interface IOncoprintProps {
     genesetHeatmapTracks: IGenesetHeatmapTrackSpec[];
     heatmapTracks: IHeatmapTrackSpec[];
     heatmapTracksOrder?: { [trackGroupIndex: number]: string[] }; // track keys
-    heatmapTrackHeaders?: { [trackGroupIndex: number]: TrackGroupHeader };
+    additionalTrackGroupHeaders?: {
+        [trackGroupIndex: number]: TrackGroupHeader;
+    };
     divId: string;
     width: number;
     initParams?: InitParams;

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -975,11 +975,11 @@ export function makeHeatmapTracksMobxPromise(
         invoke: async () => {
             const molecularProfileIdToMolecularProfile = oncoprint.props.store
                 .molecularProfileIdToMolecularProfile.result!;
-            const molecularProfileIdToHeatmapTracks =
-                oncoprint.molecularProfileIdToHeatmapTracks;
+            const molecularProfileIdToAdditionalTracks =
+                oncoprint.molecularProfileIdToAdditionalTracks;
 
             const geneProfiles = _.filter(
-                _.values(molecularProfileIdToHeatmapTracks),
+                _.values(molecularProfileIdToAdditionalTracks),
                 d =>
                     d.molecularAlterationType !==
                     AlterationTypeConstants.GENERIC_ASSAY
@@ -1041,11 +1041,11 @@ export function makeHeatmapTracksMobxPromise(
                         data
                     ),
                     trackGroupIndex:
-                        molecularProfileIdToHeatmapTracks[molecularProfileId]
+                        molecularProfileIdToAdditionalTracks[molecularProfileId]
                             .trackGroupIndex,
                     onClickRemoveInTrackMenu: action(() => {
                         const trackGroup =
-                            oncoprint.molecularProfileIdToHeatmapTracks[
+                            oncoprint.molecularProfileIdToAdditionalTracks[
                                 molecularProfileId
                             ];
                         if (trackGroup) {
@@ -1097,11 +1097,11 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
         invoke: async () => {
             const molecularProfileIdToMolecularProfile = oncoprint.props.store
                 .molecularProfileIdToMolecularProfile.result!;
-            const molecularProfileIdToHeatmapTracks =
-                oncoprint.molecularProfileIdToHeatmapTracks;
+            const molecularProfileIdToAdditionalTracks =
+                oncoprint.molecularProfileIdToAdditionalTracks;
 
             const genericAssayProfiles = _.filter(
-                molecularProfileIdToHeatmapTracks,
+                molecularProfileIdToAdditionalTracks,
                 d =>
                     d.molecularAlterationType ===
                     AlterationTypeConstants.GENERIC_ASSAY
@@ -1205,12 +1205,12 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
                     pivotThreshold: pivotThreshold,
                     sortOrder: sortOrder,
                     trackLinkUrl: entityLinkMap[entityId],
-                    trackGroupIndex: molecularProfileIdToHeatmapTracks[
+                    trackGroupIndex: molecularProfileIdToAdditionalTracks[
                         molecularProfileId
                     ]!.trackGroupIndex,
                     onClickRemoveInTrackMenu: action(() => {
                         const trackGroup = oncoprint
-                            .molecularProfileIdToHeatmapTracks[
+                            .molecularProfileIdToAdditionalTracks[
                             molecularProfileId
                         ]!;
                         if (trackGroup) {

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -502,6 +502,7 @@ export function getCategoricalTrackRuleSetParams(
 ): ICategoricalRuleSetParams {
     return {
         type: RuleSetType.CATEGORICAL,
+        legend_label: track.molecularProfileName,
         category_key: 'attr_val',
         category_to_color: _.mapValues(
             RESERVED_CLINICAL_VALUE_COLORS,

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -1311,7 +1311,7 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
                             const newEntities = _.keys(
                                 trackGroup.entities
                             ).filter(entity => entity !== entityId);
-                            oncoprint.addHeatmapTracks(
+                            oncoprint.addGenericAssayTracks(
                                 molecularProfileId,
                                 newEntities
                             );

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -1079,7 +1079,7 @@ export function makeHeatmapTracksMobxPromise(
                                     molecularProfileId
                                 );
                             } else {
-                                oncoprint.addHeatmapTracks(
+                                oncoprint.setHeatmapTracks(
                                     molecularProfileId,
                                     newEntities
                                 );
@@ -1194,7 +1194,7 @@ export function makeGenericAssayProfileCategoricalTracksMobxPromise(
                             const newEntities = _.keys(
                                 trackGroup.entities
                             ).filter(entity => entity !== entityId);
-                            oncoprint.addGenericAssayTracks(
+                            oncoprint.setGenericAssayTracks(
                                 molecularProfileId,
                                 newEntities
                             );
@@ -1311,7 +1311,7 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
                             const newEntities = _.keys(
                                 trackGroup.entities
                             ).filter(entity => entity !== entityId);
-                            oncoprint.addGenericAssayTracks(
+                            oncoprint.setGenericAssayTracks(
                                 molecularProfileId,
                                 newEntities
                             );

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -47,7 +47,7 @@ import {
     makeHeatmapTracksMobxPromise,
 } from './OncoprintUtils';
 import _ from 'lodash';
-import onMobxPromise from 'shared/lib/onMobxPromise';
+import onMobxPromise, { toPromise } from 'shared/lib/onMobxPromise';
 import AppConfig from 'appConfig';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import OncoprintJS, { TrackGroupIndex, TrackId } from 'oncoprintjs';
@@ -81,6 +81,7 @@ import {
 import { buildCBioPortalPageUrl } from '../../api/urls';
 import '../../../globalStyles/oncoprintStyles.scss';
 import { GenericAssayTrackInfo } from 'pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection';
+import { GenericAssayDataType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 
 interface IResultsViewOncoprintProps {
     divId: string;
@@ -111,11 +112,11 @@ export interface IGenesetExpansionRecord {
 
 const CLINICAL_TRACK_KEY_PREFIX = 'CLINICALTRACK_';
 
-/*  Each heatmap track group can hold tracks of a single entity type.
+/*  Each additional track group can hold tracks of a single entity type.
     Implemented entity types are genes and generic assay entites. In the
-    HeatmapTrackGroupRecord type the `entities` member refers to
+    AdditionalTrackGroupRecord type the `entities` member refers to
     hugo_gene_symbols (for genes) or to entity_id's (for generic assay entities). */
-export type HeatmapTrackGroupRecord = {
+export type AdditionalTrackGroupRecord = {
     trackGroupIndex: number;
     molecularAlterationType: string;
     entities: { [entity: string]: boolean }; // map of hugo_gene_symbols or entity_id's
@@ -229,7 +230,7 @@ export default class ResultsViewOncoprint extends React.Component<
 
     private heatmapGeneInputValueUpdater: IReactionDisposer;
 
-    private molecularProfileIdToHeatmapTrackGroupIndex: {
+    private molecularProfileIdToTrackGroupIndex: {
         [molecularProfileId: string]: number;
     } = {};
 
@@ -277,13 +278,22 @@ export default class ResultsViewOncoprint extends React.Component<
         IGenesetExpansionRecord[]
     >();
 
-    @computed get molecularProfileIdToHeatmapTracks() {
-        // empty if no heatmap tracks param
+    @computed get molecularProfileIdToAdditionalTracks() {
+        // start with heatmap tracks param
         const groups = this.urlWrapper.query.heatmap_track_groups
             ? this.urlWrapper.query.heatmap_track_groups
                   .split(';')
                   .map((x: string) => x.split(','))
             : [];
+
+        if (this.urlWrapper.query.generic_assay_groups) {
+            // add generic assay tracks
+            groups.push(
+                ...this.urlWrapper.query.generic_assay_groups
+                    .split(';')
+                    .map((x: string) => x.split(','))
+            );
+        }
 
         const parsedGroups = groups.reduce(
             (acc: { [molecularProfileId: string]: string[] }, group) => {
@@ -294,17 +304,17 @@ export default class ResultsViewOncoprint extends React.Component<
         );
 
         const map: {
-            [molecularProfileId: string]: HeatmapTrackGroupRecord;
+            [molecularProfileId: string]: AdditionalTrackGroupRecord;
         } = {};
 
         let nextTrackGroupIndex: number;
-        // start next track group index based on existing heatmap track groups
-        if (_.isEmpty(this.molecularProfileIdToHeatmapTrackGroupIndex)) {
+        // start next track group index based on existing track groups
+        if (_.isEmpty(this.molecularProfileIdToTrackGroupIndex)) {
             nextTrackGroupIndex = 2;
         } else {
             nextTrackGroupIndex =
                 Math.max(
-                    ..._.values(this.molecularProfileIdToHeatmapTrackGroupIndex)
+                    ..._.values(this.molecularProfileIdToTrackGroupIndex)
                 ) + 1;
         }
         _.forEach(parsedGroups, (entities: string[], molecularProfileId) => {
@@ -316,18 +326,17 @@ export default class ResultsViewOncoprint extends React.Component<
                 if (
                     !(
                         profile.molecularProfileId in
-                        this.molecularProfileIdToHeatmapTrackGroupIndex
+                        this.molecularProfileIdToTrackGroupIndex
                     )
                 ) {
                     // set track group index if doesnt yet exist
-                    this.molecularProfileIdToHeatmapTrackGroupIndex[
+                    this.molecularProfileIdToTrackGroupIndex[
                         profile.molecularProfileId
                     ] = nextTrackGroupIndex;
                     nextTrackGroupIndex += 1;
                 }
-                const trackGroup: HeatmapTrackGroupRecord = {
-                    trackGroupIndex: this
-                        .molecularProfileIdToHeatmapTrackGroupIndex[
+                const trackGroup: AdditionalTrackGroupRecord = {
+                    trackGroupIndex: this.molecularProfileIdToTrackGroupIndex[
                         profile.molecularProfileId
                     ],
                     molecularProfileId: profile.molecularProfileId,
@@ -770,8 +779,7 @@ export default class ResultsViewOncoprint extends React.Component<
                 this.selectedGenericAssayProfileId = id;
             },
             onClickAddGenericAssays: (info: GenericAssayTrackInfo[]) => {
-                // TODO: currently, add all tracks as heatmap tracks, later on when we have the support of categorical tracks, change here.
-                this.addHeatmapTracks(
+                this.addGenericAssayTracks(
                     // selectedGenericAssayProfileId will be updated in GenericAssaySelection component
                     this.selectedGenericAssayProfileId!,
                     info.map(d => d.genericAssayEntityId)
@@ -1022,12 +1030,42 @@ export default class ResultsViewOncoprint extends React.Component<
         invoke: async () => getUnalteredUids(this.geneticTracks.result!),
     });
 
-    public addHeatmapTracks(molecularProfileId: string, entities: string[]) {
+    public addGenericAssayTracks(
+        molecularProfileId: string,
+        entities: string[]
+    ) {
+        const groups = this.urlWrapper.query.generic_assay_groups
+            ? this.urlWrapper.query.generic_assay_groups
+                .split(';')
+                .map((x: string) => x.split(','))
+            : [];
+
+        const targetGroup = groups.find(g => g[0] === molecularProfileId);
+
+        if (targetGroup) {
+            // if theres already a group for this profile, update entities
+            targetGroup.splice(1, targetGroup.length); // remove existing entities
+            targetGroup.push(...entities); // add new entities
+        } else {
+            // if not, add a group
+            groups.push([molecularProfileId, ...entities]);
+        }
+
+        const generic_assay_groups = groups
+            .map(group => group.join(','))
+            .join(';');
+
+        this.urlWrapper.updateURL({
+            generic_assay_groups,
+        });
+    }
+
+    public async addHeatmapTracks(molecularProfileId: string, entities: string[]) {
         const tracksMap = _.cloneDeep(
-            this.molecularProfileIdToHeatmapTracks
+            this.molecularProfileIdToAdditionalTracks
         ) as {
             [molecularProfileId: string]: Pick<
-                HeatmapTrackGroupRecord,
+                AdditionalTrackGroupRecord,
                 'entities' | 'molecularProfileId' | 'molecularAlterationType'
             >;
         };
@@ -1054,33 +1092,35 @@ export default class ResultsViewOncoprint extends React.Component<
             delete tracksMap[molecularProfileId];
         }
 
-        const heatmap_track_groups = _.map(
-            tracksMap,
-            (track, molecularProfileId) => {
+        const profileIdToProfile = await toPromise(
+            this.props.store.molecularProfileIdToMolecularProfile
+        );
+
+        const heatmap_track_groups = _.chain(tracksMap)
+            .filter((track, molecularProfileId) => {
+                const profile = profileIdToProfile[molecularProfileId];
+                if (
+                    profile.molecularAlterationType ===
+                    AlterationTypeConstants.GENERIC_ASSAY
+                ) {
+                    // only LIMIT-VALUE generic assay profiles are heatmap
+                    return (
+                        profile.datatype === GenericAssayDataType.LIMIT_VALUE
+                    );
+                } else {
+                    return true;
+                }
+            })
+            .map((track, molecularProfileId) => {
                 return `${molecularProfileId},${_.keys(track.entities).join(
                     ','
                 )}`;
-            }
-        ).join(';');
-
-        // derive generic assay from heatmap tracks since the only way to add generic assay entities right now
-        // is to use heatmap UI in oncoprint
-        const generic_assay_groups = _.filter(
-            tracksMap,
-            (x: HeatmapTrackGroupRecord) =>
-                x.molecularAlterationType ===
-                AlterationTypeConstants.GENERIC_ASSAY
-        )
-            .map(track => {
-                return `${track.molecularProfileId},${_.keys(
-                    track.entities
-                ).join(',')}`;
             })
+            .value()
             .join(';');
 
         this.urlWrapper.updateURL({
             heatmap_track_groups,
-            generic_assay_groups,
         });
     }
 
@@ -1349,7 +1389,7 @@ export default class ResultsViewOncoprint extends React.Component<
             if (clusteredHeatmapProfile === genesetHeatmapProfile) {
                 return this.genesetHeatmapTrackGroupIndex;
             } else {
-                const heatmapGroup = this.molecularProfileIdToHeatmapTracks[
+                const heatmapGroup = this.molecularProfileIdToAdditionalTracks[
                     clusteredHeatmapProfile
                 ];
                 return heatmapGroup && heatmapGroup.trackGroupIndex;
@@ -1382,7 +1422,7 @@ export default class ResultsViewOncoprint extends React.Component<
                     .molecularProfileId;
         } else {
             const heatmapTrackGroup = _.values(
-                this.molecularProfileIdToHeatmapTracks
+                this.molecularProfileIdToAdditionalTracks
             ).find(trackGroup => trackGroup.trackGroupIndex === index);
             molecularProfileId = heatmapTrackGroup
                 ? heatmapTrackGroup.molecularProfileId
@@ -1400,7 +1440,7 @@ export default class ResultsViewOncoprint extends React.Component<
     @action.bound
     private removeHeatmapByIndex(index: TrackGroupIndex) {
         const groupEntry = _.values(
-            this.molecularProfileIdToHeatmapTracks
+            this.molecularProfileIdToAdditionalTracks
         ).find(group => group.trackGroupIndex === index);
         if (groupEntry) {
             this.removeHeatmapByMolecularProfileId(
@@ -1411,20 +1451,18 @@ export default class ResultsViewOncoprint extends React.Component<
 
     @action.bound
     public removeHeatmapByMolecularProfileId(molecularProfileId: string) {
-        delete this.molecularProfileIdToHeatmapTrackGroupIndex[
-            molecularProfileId
-        ];
+        delete this.molecularProfileIdToTrackGroupIndex[molecularProfileId];
         this.addHeatmapTracks(molecularProfileId, []);
     }
 
-    readonly heatmapTrackHeaders = remoteData({
+    readonly additionalTrackGroupHeaders = remoteData({
         await: () => [this.props.store.molecularProfileIdToMolecularProfile],
         invoke: () => {
             return Promise.resolve(
                 makeTrackGroupHeaders(
                     this.props.store.molecularProfileIdToMolecularProfile
                         .result!,
-                    this.molecularProfileIdToHeatmapTracks,
+                    this.molecularProfileIdToAdditionalTracks,
                     this.genesetHeatmapTrackGroupIndex,
                     () => this.clusteredHeatmapTrackGroupIndex,
                     this.clusterHeatmapByIndex,
@@ -1483,7 +1521,7 @@ export default class ResultsViewOncoprint extends React.Component<
                 this.props.store.molecularProfileIdToMolecularProfile,
                 this.alterationTypesInQuery,
                 this.alteredKeys,
-                this.heatmapTrackHeaders
+                this.additionalTrackGroupHeaders
             ) === 'pending'
         );
     }
@@ -1718,8 +1756,8 @@ export default class ResultsViewOncoprint extends React.Component<
                                     this.alterationTypesInQuery.result
                                 }
                                 showSublabels={this.showOqlInLabels}
-                                heatmapTrackHeaders={
-                                    this.heatmapTrackHeaders.result!
+                                additionalTrackGroupHeaders={
+                                    this.additionalTrackGroupHeaders.result!
                                 }
                                 horzZoomToFitIds={this.alteredKeys.result}
                                 distinguishMutationType={

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -1104,28 +1104,27 @@ export default class ResultsViewOncoprint extends React.Component<
             this.props.store.molecularProfileIdToMolecularProfile
         );
 
-        const heatmap_track_groups = _.chain(tracksMap)
-            .filter((track, molecularProfileId) => {
-                const profile = profileIdToProfile[molecularProfileId];
-                if (
-                    profile.molecularAlterationType ===
-                    AlterationTypeConstants.GENERIC_ASSAY
-                ) {
-                    return isGenericAssayHeatmapProfile(profile);
-                } else {
-                    return true;
-                }
-            })
-            .map((track, molecularProfileId) => {
-                return `${molecularProfileId},${_.keys(track.entities).join(
-                    ','
-                )}`;
-            })
-            .value()
-            .join(';');
+        const heatmap_track_groups: string[] = [];
+
+        _.forEach(tracksMap, (track, molecularProfileId) => {
+            const profile = profileIdToProfile[molecularProfileId];
+            let shouldAdd = true;
+            if (
+                profile.molecularAlterationType ===
+                AlterationTypeConstants.GENERIC_ASSAY
+            ) {
+                shouldAdd = isGenericAssayHeatmapProfile(profile);
+            }
+
+            if (shouldAdd) {
+                heatmap_track_groups.push(
+                    `${molecularProfileId},${_.keys(track.entities).join(',')}`
+                );
+            }
+        });
 
         this.urlWrapper.updateURL({
-            heatmap_track_groups,
+            heatmap_track_groups: heatmap_track_groups.join(';'),
         });
     }
 

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -1465,8 +1465,11 @@ export default class ResultsViewOncoprint extends React.Component<
             this.molecularProfileIdToAdditionalTracks
         ).find(group => group.trackGroupIndex === index);
         if (groupEntry) {
-            if (isGenericAssayCategoricalProfile(groupEntry.molecularProfile)) {
-                this.removeCategoricalTracksByMolecularProfileId(
+            if (
+                isGenericAssayHeatmapProfile(groupEntry.molecularProfile) ||
+                isGenericAssayCategoricalProfile(groupEntry.molecularProfile)
+            ) {
+                this.removeGenericAssayTracksByMolecularProfileId(
                     groupEntry.molecularProfileId
                 );
             } else {
@@ -1478,7 +1481,7 @@ export default class ResultsViewOncoprint extends React.Component<
     }
 
     @action.bound
-    public removeCategoricalTracksByMolecularProfileId(
+    public removeGenericAssayTracksByMolecularProfileId(
         molecularProfileId: string
     ) {
         delete this.molecularProfileIdToTrackGroupIndex[molecularProfileId];

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -777,13 +777,13 @@ export default class ResultsViewOncoprint extends React.Component<
                 const genes = parseOQLQuery(
                     this.heatmapGeneInputValue.toUpperCase().trim()
                 ).map(q => q.gene);
-                this.addHeatmapTracks(this.selectedHeatmapProfileId, genes);
+                this.setHeatmapTracks(this.selectedHeatmapProfileId, genes);
             },
             onSelectGenericAssayProfile: (id: string) => {
                 this.selectedGenericAssayProfileId = id;
             },
             onClickAddGenericAssays: (info: GenericAssayTrackInfo[]) => {
-                this.addGenericAssayTracks(
+                this.setGenericAssayTracks(
                     // selectedGenericAssayProfileId will be updated in GenericAssaySelection component
                     this.selectedGenericAssayProfileId!,
                     info.map(d => d.genericAssayEntityId)
@@ -1034,7 +1034,7 @@ export default class ResultsViewOncoprint extends React.Component<
         invoke: async () => getUnalteredUids(this.geneticTracks.result!),
     });
 
-    public addGenericAssayTracks(
+    public setGenericAssayTracks(
         molecularProfileId: string,
         entities: string[]
     ) {
@@ -1065,7 +1065,7 @@ export default class ResultsViewOncoprint extends React.Component<
         });
     }
 
-    public async addHeatmapTracks(
+    public async setHeatmapTracks(
         molecularProfileId: string,
         entities: string[]
     ) {
@@ -1485,13 +1485,13 @@ export default class ResultsViewOncoprint extends React.Component<
         molecularProfileId: string
     ) {
         delete this.molecularProfileIdToTrackGroupIndex[molecularProfileId];
-        this.addGenericAssayTracks(molecularProfileId, []);
+        this.setGenericAssayTracks(molecularProfileId, []);
     }
 
     @action.bound
     public removeHeatmapTracksByMolecularProfileId(molecularProfileId: string) {
         delete this.molecularProfileIdToTrackGroupIndex[molecularProfileId];
-        this.addHeatmapTracks(molecularProfileId, []);
+        this.setHeatmapTracks(molecularProfileId, []);
     }
 
     readonly additionalTrackGroupHeaders = remoteData({

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -40,6 +40,7 @@ import {
     getAlteredUids,
     getUnalteredUids,
     makeClinicalTracksMobxPromise,
+    makeGenericAssayProfileCategoricalTracksMobxPromise,
     makeGenericAssayProfileHeatmapTracksMobxPromise,
     makeGenesetHeatmapExpansionsMobxPromise,
     makeGenesetHeatmapTracksMobxPromise,
@@ -61,6 +62,8 @@ import {
 import OqlStatusBanner from '../banners/OqlStatusBanner';
 import {
     getAnnotatingProgressMessage,
+    isGenericAssayCategoricalProfile,
+    isGenericAssayHeatmapProfile,
     makeTrackGroupHeaders,
 } from './ResultsViewOncoprintUtils';
 import ProgressIndicator, {
@@ -121,6 +124,7 @@ export type AdditionalTrackGroupRecord = {
     molecularAlterationType: string;
     entities: { [entity: string]: boolean }; // map of hugo_gene_symbols or entity_id's
     molecularProfileId: string;
+    molecularProfile: MolecularProfile;
 };
 
 /* fields and methods in the class below are ordered based on roughly
@@ -132,7 +136,6 @@ export default class ResultsViewOncoprint extends React.Component<
     {}
 > {
     @computed get columnMode() {
-        debugger;
         return this.urlWrapper.query.show_samples === 'true'
             ? 'sample'
             : 'patient';
@@ -339,6 +342,7 @@ export default class ResultsViewOncoprint extends React.Component<
                     trackGroupIndex: this.molecularProfileIdToTrackGroupIndex[
                         profile.molecularProfileId
                     ],
+                    molecularProfile: profile,
                     molecularProfileId: profile.molecularProfileId,
                     molecularAlterationType: profile.molecularAlterationType,
                     entities: {},
@@ -1036,8 +1040,8 @@ export default class ResultsViewOncoprint extends React.Component<
     ) {
         const groups = this.urlWrapper.query.generic_assay_groups
             ? this.urlWrapper.query.generic_assay_groups
-                .split(';')
-                .map((x: string) => x.split(','))
+                  .split(';')
+                  .map((x: string) => x.split(','))
             : [];
 
         const targetGroup = groups.find(g => g[0] === molecularProfileId);
@@ -1052,6 +1056,7 @@ export default class ResultsViewOncoprint extends React.Component<
         }
 
         const generic_assay_groups = groups
+            .filter(group => group.length > 1) // a group of length 1 only contains the molecularProfileId and no entities
             .map(group => group.join(','))
             .join(';');
 
@@ -1060,7 +1065,10 @@ export default class ResultsViewOncoprint extends React.Component<
         });
     }
 
-    public async addHeatmapTracks(molecularProfileId: string, entities: string[]) {
+    public async addHeatmapTracks(
+        molecularProfileId: string,
+        entities: string[]
+    ) {
         const tracksMap = _.cloneDeep(
             this.molecularProfileIdToAdditionalTracks
         ) as {
@@ -1103,10 +1111,7 @@ export default class ResultsViewOncoprint extends React.Component<
                     profile.molecularAlterationType ===
                     AlterationTypeConstants.GENERIC_ASSAY
                 ) {
-                    // only LIMIT-VALUE generic assay profiles are heatmap
-                    return (
-                        profile.datatype === GenericAssayDataType.LIMIT_VALUE
-                    );
+                    return isGenericAssayHeatmapProfile(profile);
                 } else {
                     return true;
                 }
@@ -1337,6 +1342,21 @@ export default class ResultsViewOncoprint extends React.Component<
             : this.patientGenericAssayHeatmapTracks;
     }
 
+    readonly sampleGenericAssayCategoricalTracks = makeGenericAssayProfileCategoricalTracksMobxPromise(
+        this,
+        true
+    );
+    readonly patientGenericAssayCategoricalTracks = makeGenericAssayProfileCategoricalTracksMobxPromise(
+        this,
+        false
+    );
+    @computed get genericAssayCategoricalTracks() {
+        return this.oncoprintAnalysisCaseType ===
+            OncoprintAnalysisCaseType.SAMPLE
+            ? this.sampleGenericAssayCategoricalTracks
+            : this.patientGenericAssayCategoricalTracks;
+    }
+
     @computed get genesetHeatmapTrackGroupIndex(): TrackGroupIndex | undefined {
         // check whether oncoprint should show a geneset trackgroup
         if (this.props.store.genesetIds.length > 0) {
@@ -1350,6 +1370,9 @@ export default class ResultsViewOncoprint extends React.Component<
                     ),
                     ...this.genericAssayHeatmapTracks.result.map(
                         hmTrack => hmTrack.trackGroupIndex
+                    ),
+                    ...this.genericAssayCategoricalTracks.result.map(
+                        track => track.trackGroupIndex
                     )
                 )
             );
@@ -1438,19 +1461,33 @@ export default class ResultsViewOncoprint extends React.Component<
     }
 
     @action.bound
-    private removeHeatmapByIndex(index: TrackGroupIndex) {
+    private removeAdditionalTrackSection(index: TrackGroupIndex) {
         const groupEntry = _.values(
             this.molecularProfileIdToAdditionalTracks
         ).find(group => group.trackGroupIndex === index);
         if (groupEntry) {
-            this.removeHeatmapByMolecularProfileId(
-                groupEntry.molecularProfileId
-            );
+            if (isGenericAssayCategoricalProfile(groupEntry.molecularProfile)) {
+                this.removeCategoricalTracksByMolecularProfileId(
+                    groupEntry.molecularProfileId
+                );
+            } else {
+                this.removeHeatmapTracksByMolecularProfileId(
+                    groupEntry.molecularProfileId
+                );
+            }
         }
     }
 
     @action.bound
-    public removeHeatmapByMolecularProfileId(molecularProfileId: string) {
+    public removeCategoricalTracksByMolecularProfileId(
+        molecularProfileId: string
+    ) {
+        delete this.molecularProfileIdToTrackGroupIndex[molecularProfileId];
+        this.addGenericAssayTracks(molecularProfileId, []);
+    }
+
+    @action.bound
+    public removeHeatmapTracksByMolecularProfileId(molecularProfileId: string) {
         delete this.molecularProfileIdToTrackGroupIndex[molecularProfileId];
         this.addHeatmapTracks(molecularProfileId, []);
     }
@@ -1467,7 +1504,7 @@ export default class ResultsViewOncoprint extends React.Component<
                     () => this.clusteredHeatmapTrackGroupIndex,
                     this.clusterHeatmapByIndex,
                     () => this.sortByData(),
-                    this.removeHeatmapByIndex
+                    this.removeAdditionalTrackSection
                 )
             );
         },
@@ -1516,6 +1553,7 @@ export default class ResultsViewOncoprint extends React.Component<
                 this.clinicalTracks,
                 this.geneticTracks,
                 this.genesetHeatmapTracks,
+                this.genericAssayCategoricalTracks,
                 this.genericAssayHeatmapTracks,
                 this.heatmapTracks,
                 this.props.store.molecularProfileIdToMolecularProfile,
@@ -1735,6 +1773,9 @@ export default class ResultsViewOncoprint extends React.Component<
                                         this.genericAssayHeatmapTracks.result
                                     )
                                     .concat(this.heatmapTracks.result)}
+                                categoricalTracks={
+                                    this.genericAssayCategoricalTracks.result
+                                }
                                 divId={this.props.divId}
                                 width={this.width}
                                 caseLinkOutInTooltips={true}

--- a/src/shared/components/oncoprint/ResultsViewOncoprintUtils.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprintUtils.tsx
@@ -11,9 +11,13 @@ import naturalSort from 'javascript-natural-sort';
 import { Group } from '../../api/ComparisonGroupClient';
 import * as React from 'react';
 import { ISelectOption } from './controls/OncoprintControls';
-import { makeGenericAssayOption } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import {
+    GenericAssayDataType,
+    makeGenericAssayOption,
+} from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { TrackGroupHeader, TrackGroupIndex } from 'oncoprintjs';
-import { HeatmapTrackGroupRecord } from 'shared/components/oncoprint/ResultsViewOncoprint';
+import { AdditionalTrackGroupRecord } from 'shared/components/oncoprint/ResultsViewOncoprint';
+import { AlterationTypeConstants } from 'pages/resultsView/ResultsViewPageStore';
 
 export const alterationTypeToProfiledForText: {
     [alterationType: string]: string;
@@ -248,7 +252,9 @@ export function genericAssayEntitiesToSelectOptionsGroupedByGenericAssayType(gen
 
 export function makeTrackGroupHeaders(
     molecularProfileIdToMolecularProfile: { [p: string]: MolecularProfile },
-    molecularProfileIdToHeatmapTracks: { [p: string]: HeatmapTrackGroupRecord },
+    molecularProfileIdToAdditionalTracks: {
+        [p: string]: AdditionalTrackGroupRecord;
+    },
     genesetHeatmapTrackGroupIndex: number | undefined,
     getClusteredTrackGroupIndex: () => number | undefined,
     onClickClusterCallback: (index: TrackGroupIndex) => void,
@@ -256,18 +262,32 @@ export function makeTrackGroupHeaders(
     onClickDeleteCallback: (index: TrackGroupIndex) => void
 ): { [trackGroupIndex: number]: TrackGroupHeader } {
     var headers = _.reduce(
-        molecularProfileIdToHeatmapTracks,
+        molecularProfileIdToAdditionalTracks,
         (headerMap, nextEntry) => {
+            let type: 'categorical' | 'heatmap';
+            const profile =
+                molecularProfileIdToMolecularProfile[
+                    nextEntry.molecularProfileId
+                ];
+            if (
+                profile.molecularAlterationType ===
+                    AlterationTypeConstants.GENERIC_ASSAY &&
+                profile.datatype !== GenericAssayDataType.LIMIT_VALUE
+            ) {
+                type = 'categorical';
+            } else {
+                type = 'heatmap';
+            }
             headerMap[nextEntry.trackGroupIndex] = makeTrackGroupHeader(
-                'heatmap',
+                type,
                 molecularProfileIdToMolecularProfile[
                     nextEntry.molecularProfileId
                 ].name,
                 nextEntry.trackGroupIndex,
+                onClickDeleteCallback,
                 getClusteredTrackGroupIndex,
                 onClickClusterCallback,
-                onClickDontClusterCallback,
-                onClickDeleteCallback
+                onClickDontClusterCallback
             );
             return headerMap;
         },
@@ -279,10 +299,10 @@ export function makeTrackGroupHeaders(
             'geneset',
             'GSVA Scores',
             genesetHeatmapTrackGroupIndex!,
+            onClickDeleteCallback,
             getClusteredTrackGroupIndex,
             onClickClusterCallback,
-            onClickDontClusterCallback,
-            onClickDeleteCallback
+            onClickDontClusterCallback
         );
     }
 
@@ -290,17 +310,20 @@ export function makeTrackGroupHeaders(
 }
 
 function makeTrackGroupHeader(
-    type: 'heatmap' | 'geneset',
+    type: 'heatmap' | 'geneset' | 'categorical',
     text: string,
     trackGroupIndex: number,
+    onClickDeleteCallback: (index: TrackGroupIndex) => void,
     getClusteredTrackGroupIndex: () => number | undefined,
-    onClickClusterCallback: (index: TrackGroupIndex) => void,
-    onClickDontClusterCallback: () => void,
-    onClickDeleteCallback: (index: TrackGroupIndex) => void
+    onClickClusterCallback?: (index: TrackGroupIndex) => void,
+    onClickDontClusterCallback?: () => void
 ): TrackGroupHeader {
     const header = {
         label: { text: text },
-        options: [
+        options: [],
+    } as TrackGroupHeader;
+    if (type !== 'categorical') {
+        header.options.push(
             {
                 label: 'Cluster',
                 onClick: onClickClusterCallback,
@@ -316,7 +339,7 @@ function makeTrackGroupHeader(
                 label: "Don't cluster",
                 onClick: () => {
                     if (getClusteredTrackGroupIndex() === trackGroupIndex) {
-                        onClickDontClusterCallback();
+                        onClickDontClusterCallback!();
                     }
                 },
                 weight: () => {
@@ -326,14 +349,16 @@ function makeTrackGroupHeader(
                         return 'bold';
                     }
                 },
-            },
-        ],
-    } as TrackGroupHeader;
+            }
+        );
+    }
 
     if (type !== 'geneset') {
-        header.options.push({
-            separator: true,
-        });
+        if (type !== 'categorical') {
+            header.options.push({
+                separator: true,
+            });
+        }
         header.options.push({
             label: 'Delete',
             onClick: onClickDeleteCallback,

--- a/src/shared/components/oncoprint/SortUtils.ts
+++ b/src/shared/components/oncoprint/SortUtils.ts
@@ -309,3 +309,11 @@ export const heatmapTrackSortComparator = (() => {
         mandatory: comparator,
     };
 })();
+
+export const categoricalTrackSortComparator = (() => {
+    const comparator = stringClinicalComparator;
+    return {
+        preferred: alphabeticalDefault(comparator),
+        mandatory: comparator,
+    };
+})();

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
@@ -33,6 +33,12 @@ export const RESERVED_CATEGORY_ORDER_DICT: Dictionary<string[]> = {
     ],
 };
 
+export enum GenericAssayDataType {
+    LIMIT_VALUE = 'LIMIT-VALUE',
+    CATEGORICAL = 'CATEGORICAL',
+    BINARY = 'BINARY',
+}
+
 export async function fetchGenericAssayMetaByMolecularProfileIdsGroupedByGenericAssayType(
     genericAssayProfiles: MolecularProfile[]
 ) {

--- a/src/shared/lib/onMobxPromise.ts
+++ b/src/shared/lib/onMobxPromise.ts
@@ -29,4 +29,10 @@ export function onMobxPromise<T>(
     return disposer;
 }
 
+export function toPromise<T>(promise: MobxPromise<T>): Promise<T> {
+    return new Promise(resolve => {
+        onMobxPromise(promise, resolve);
+    });
+}
+
 export default onMobxPromise;


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/8313

![image](https://user-images.githubusercontent.com/636232/114772697-1d4b3a00-9d3c-11eb-9b67-59d2182637ab.png)

**Test instruction:** 
1. Go to study view page: http://private.cbioportal.org/private/study/summary?id=acc_tcga_pan_can_atlas_2018
2. Set `localStorage.netlify ="deploy-preview-3711--cbioportalfrontend"` in browser console.
3. Query any gene, and go to result view page
4. Select OncoPrint tab
5. Click `Add Tracks`, then add tracks from `Armlevel Cna` tab