### PR TITLE
Remove makeObservable call from ProteinImpactTypeBadgeSelector

### DIFF
--- a/packages/react-mutation-mapper/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
+++ b/packages/react-mutation-mapper/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
@@ -1,6 +1,4 @@
 import { Option, ProteinImpactType } from 'cbioportal-frontend-commons';
-import _ from 'lodash';
-import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { CSSProperties } from 'react';
@@ -63,8 +61,8 @@ export class ProteinImpactTypeBadgeSelector<
 > extends React.Component<P, {}> {
     constructor(props: any) {
         super(props);
-        makeObservable(this);
     }
+
     public static defaultProps: Partial<ProteinImpactTypeBadgeSelectorProps> = {
         colors: DEFAULT_PROTEIN_IMPACT_TYPE_COLORS,
         alignColumns: true,


### PR DESCRIPTION
When trying to update to the latest `react-mutation-mapper` this isse causes `Signal` to crash in dev mode (and potentially in prod mode).

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!