### PR TITLE
Remove gene panel data calls for mutations tab

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -168,89 +168,6 @@ export default class ResultsViewPage extends React.Component<
         const store = this.resultsViewPageStore;
 
         const tabMap: ITabConfiguration[] = [
-            {
-                id: ResultsViewTab.ONCOPRINT,
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={0}
-                            id={ResultsViewTab.ONCOPRINT}
-                            linkText="OncoPrint"
-                        >
-                            <ResultsViewOncoprint
-                                divId={'oncoprintDiv'}
-                                store={store}
-                                urlWrapper={store.urlWrapper}
-                                key={store.hugoGeneSymbols.join(',')}
-                                addOnBecomeVisibleListener={
-                                    addOnBecomeVisibleListener
-                                }
-                            />
-                        </MSKTab>
-                    );
-                },
-            },
-
-            {
-                id: ResultsViewTab.CANCER_TYPES_SUMMARY,
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={1}
-                            id={ResultsViewTab.CANCER_TYPES_SUMMARY}
-                            linkText="Cancer Types Summary"
-                        >
-                            <CancerSummaryContainer store={store} />
-                        </MSKTab>
-                    );
-                },
-            },
-
-            {
-                id: ResultsViewTab.MUTUAL_EXCLUSIVITY,
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={5}
-                            id={ResultsViewTab.MUTUAL_EXCLUSIVITY}
-                            linkText="Mutual Exclusivity"
-                        >
-                            <MutualExclusivityTab
-                                store={store}
-                                isSampleAlteredMap={store.isSampleAlteredMap}
-                            />
-                        </MSKTab>
-                    );
-                },
-                hide: () => {
-                    // we are using the size of isSampleAlteredMap as a proxy for the number of things we have to compare
-                    return (
-                        !this.resultsViewPageStore.isSampleAlteredMap
-                            .isComplete ||
-                        _.size(
-                            this.resultsViewPageStore.isSampleAlteredMap.result
-                        ) < 2
-                    );
-                },
-            },
-
-            {
-                id: ResultsViewTab.PLOTS,
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={12}
-                            id={ResultsViewTab.PLOTS}
-                            linkText={'Plots'}
-                        >
-                            <PlotsTab
-                                store={store}
-                                urlWrapper={this.urlWrapper}
-                            />
-                        </MSKTab>
-                    );
-                },
-            },
 
             {
                 id: ResultsViewTab.MUTATIONS,
@@ -266,173 +183,6 @@ export default class ResultsViewPage extends React.Component<
                                 appStore={this.props.appStore}
                                 urlWrapper={this.urlWrapper}
                             />
-                        </MSKTab>
-                    );
-                },
-            },
-
-            {
-                id: ResultsViewTab.COEXPRESSION,
-                hide: () => {
-                    if (
-                        !this.resultsViewPageStore.isThereDataForCoExpressionTab
-                            .isComplete ||
-                        !this.resultsViewPageStore.studies.isComplete
-                    ) {
-                        return true;
-                    } else {
-                        const tooManyStudies =
-                            this.resultsViewPageStore.studies.result!.length >
-                            1;
-                        const noData = !this.resultsViewPageStore
-                            .isThereDataForCoExpressionTab.result;
-                        return tooManyStudies || noData;
-                    }
-                },
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={7}
-                            id={ResultsViewTab.COEXPRESSION}
-                            linkText={'Co-expression'}
-                        >
-                            <CoExpressionTab store={store} />
-                        </MSKTab>
-                    );
-                },
-            },
-
-            {
-                id: ResultsViewTab.COMPARISON,
-                hide: () => {
-                    return this.resultsViewPageStore.survivalClinicalDataExists
-                        .isPending;
-                },
-                getTab: () => {
-                    const text = this.resultsViewPageStore
-                        .survivalClinicalDataExists.result
-                        ? 'Comparison/Survival'
-                        : 'Comparison';
-                    return (
-                        <MSKTab
-                            key={10}
-                            id={ResultsViewTab.COMPARISON}
-                            linkText={text}
-                        >
-                            <ComparisonTab
-                                urlWrapper={this.urlWrapper}
-                                appStore={this.props.appStore}
-                                store={this.resultsViewPageStore}
-                            />
-                        </MSKTab>
-                    );
-                },
-            },
-            {
-                id: ResultsViewTab.CN_SEGMENTS,
-                hide: () => {
-                    return (
-                        !this.resultsViewPageStore.studies.isComplete ||
-                        !this.resultsViewPageStore.genes.isComplete ||
-                        !this.resultsViewPageStore.referenceGenes.isComplete ||
-                        !doesQueryHaveCNSegmentData(
-                            this.resultsViewPageStore.samples.result
-                        )
-                    );
-                },
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={6}
-                            id={ResultsViewTab.CN_SEGMENTS}
-                            linkText="CN Segments"
-                        >
-                            <CNSegments store={store} />
-                        </MSKTab>
-                    );
-                },
-            },
-
-            {
-                id: ResultsViewTab.NETWORK,
-                hide: () => {
-                    return true;
-                },
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={9}
-                            id={ResultsViewTab.NETWORK}
-                            linkText={'Network'}
-                        >
-                            <div className="alert alert-info">
-                                The Network tab has been retired. For similar
-                                functionality, please visit{' '}
-                                <a
-                                    href="http://www.pathwaycommons.org/pcviz/"
-                                    target="_blank"
-                                >
-                                    http://www.pathwaycommons.org/pcviz/
-                                </a>
-                            </div>
-                        </MSKTab>
-                    );
-                },
-            },
-            {
-                id: ResultsViewTab.PATHWAY_MAPPER,
-                hide: () =>
-                    browser.name === 'Internet Explorer' ||
-                    !AppConfig.serverConfig.show_pathway_mapper ||
-                    !this.resultsViewPageStore.studies.isComplete,
-                getTab: () => {
-                    const showPM =
-                        store.filteredSequencedSampleKeysByGene.isComplete &&
-                        store.oqlFilteredCaseAggregatedDataByOQLLine
-                            .isComplete &&
-                        store.genes.isComplete &&
-                        store.samples.isComplete &&
-                        store.patients.isComplete &&
-                        store.coverageInformation.isComplete &&
-                        store.filteredSequencedSampleKeysByGene.isComplete &&
-                        store.filteredSequencedPatientKeysByGene.isComplete &&
-                        store.selectedMolecularProfiles.isComplete &&
-                        store.oqlFilteredCaseAggregatedDataByUnflattenedOQLLine
-                            .isComplete;
-
-                    return (
-                        <MSKTab
-                            key={13}
-                            id={ResultsViewTab.PATHWAY_MAPPER}
-                            linkText={'Pathways'}
-                        >
-                            {showPM ? (
-                                <ResultsViewPathwayMapper
-                                    store={store}
-                                    appStore={this.props.appStore}
-                                    urlWrapper={this.urlWrapper}
-                                />
-                            ) : (
-                                <LoadingIndicator
-                                    isLoading={true}
-                                    size={'big'}
-                                    center={true}
-                                />
-                            )}
-                        </MSKTab>
-                    );
-                },
-            },
-            {
-                id: ResultsViewTab.DOWNLOAD,
-                getTab: () => {
-                    return (
-                        <MSKTab
-                            key={11}
-                            id={ResultsViewTab.DOWNLOAD}
-                            linkText={'Download'}
-                        >
-                            <DownloadTab store={store} />
                         </MSKTab>
                     );
                 },
@@ -611,28 +361,6 @@ export default class ResultsViewPage extends React.Component<
         } else {
             return (
                 <>
-                    {// if query invalid(we only check gene count * sample count < 1,000,000 for now), return error page
-                    this.resultsViewPageStore.isQueryInvalid && (
-                        <div
-                            className="alert alert-danger queryInvalid"
-                            style={{ marginBottom: '40px' }}
-                            role="alert"
-                        >
-                            <GeneSymbolValidationError
-                                sampleCount={
-                                    this.resultsViewPageStore.samples.result
-                                        .length
-                                }
-                                queryProductLimit={
-                                    AppConfig.serverConfig.query_product_limit
-                                }
-                                email={
-                                    AppConfig.serverConfig.skin_email_contact
-                                }
-                            />
-                        </div>
-                    )}
-
                     {this.userMessages.isComplete &&
                         this.userMessages.result.length > 0 && (
                             <UserMessager messages={this.userMessages.result} />
@@ -657,6 +385,7 @@ export default class ResultsViewPage extends React.Component<
                                 </title>
                             </Helmet>
                             <div>
+                                {/*
                                 <div className={'headBlock'}>
                                     <QuerySummary
                                         routingStore={this.props.routing}
@@ -700,13 +429,9 @@ export default class ResultsViewPage extends React.Component<
                                         </div>
                                     )}
                                 </div>
+                                */}
                                 {// we don't show the result tabs if we don't have valid query
-                                this.showTabs &&
-                                    !this.resultsViewPageStore.genesInvalid &&
-                                    !this.resultsViewPageStore.isQueryInvalid &&
-                                    this.resultsViewPageStore
-                                        .customDriverAnnotationReport
-                                        .isComplete && (
+                                this.showTabs && (
                                         <MSKTabs
                                             key={this.urlWrapper.hash}
                                             activeTabId={

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -3275,9 +3275,7 @@ export class ResultsViewPageStore {
         await: () => [
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
-            this.mutationsReportByGene,
-            this.filteredSampleKeyToSample,
-            this.structuralVariantsReportByGene,
+            this.mutationsReportByGene
         ],
         invoke: () => {
             const mutationsByGene = _.mapValues(
@@ -3306,97 +3304,9 @@ export class ResultsViewPageStore {
                         this.mutationsTabFilteringSettings.excludeVus,
                         this.mutationsTabFilteringSettings.excludeGermline
                     );
-                    if (this.hideUnprofiledSamples) {
-                        // filter unprofiled samples
-                        const sampleMap = this.filteredSampleKeyToSample
-                            .result!;
-                        return filteredMutations.filter(
-                            m => m.uniqueSampleKey in sampleMap
-                        );
-                    } else {
-                        return filteredMutations;
-                    }
+                    return filteredMutations;
                 }
             );
-
-            //TODO: remove once SV/Fusion tab is merged
-            _.forEach(
-                this.structuralVariantsReportByGene.result,
-                (structuralVariantsGroups, hugoGeneSymbol) => {
-                    if (mutationsByGene[hugoGeneSymbol] === undefined) {
-                        mutationsByGene[hugoGeneSymbol] = [];
-                    }
-
-                    if (
-                        this.mutationsTabFilteringSettings.useOql &&
-                        this.queryContainsMutationOql
-                    ) {
-                        // use oql filtering in mutations tab only if query contains mutation oql
-                        structuralVariantsGroups = _.mapValues(
-                            structuralVariantsGroups,
-                            structuralVariants =>
-                                filterCBioPortalWebServiceData(
-                                    this.oqlText,
-                                    structuralVariants,
-                                    new AccessorsForOqlFilter(
-                                        this.selectedMolecularProfiles.result!
-                                    ),
-                                    this.defaultOQLQuery.result!
-                                )
-                        );
-                    }
-                    let filteredStructuralVariants = compileStructuralVariants(
-                        structuralVariantsGroups,
-                        this.mutationsTabFilteringSettings.excludeVus,
-                        this.mutationsTabFilteringSettings.excludeGermline
-                    );
-                    if (this.hideUnprofiledSamples) {
-                        // filter unprofiled samples
-                        const sampleMap = this.filteredSampleKeyToSample
-                            .result!;
-                        filteredStructuralVariants = filteredStructuralVariants.filter(
-                            m => m.uniqueSampleKey in sampleMap
-                        );
-                    }
-
-                    filteredStructuralVariants.forEach(structuralVariant => {
-                        const mutation = {
-                            center: structuralVariant.center,
-                            chr: structuralVariant.site1Chromosome,
-                            entrezGeneId: structuralVariant.site1EntrezGeneId,
-                            keyword: structuralVariant.comments,
-                            molecularProfileId:
-                                structuralVariant.molecularProfileId,
-                            mutationType: CanonicalMutationType.FUSION,
-                            ncbiBuild: structuralVariant.ncbiBuild,
-                            patientId: structuralVariant.patientId,
-                            proteinChange: structuralVariant.eventInfo,
-                            sampleId: structuralVariant.sampleId,
-                            startPosition: structuralVariant.site1Position,
-                            studyId: structuralVariant.studyId,
-                            uniquePatientKey:
-                                structuralVariant.uniquePatientKey,
-                            uniqueSampleKey: structuralVariant.uniqueSampleKey,
-                            variantType: structuralVariant.variantClass,
-                            gene: {
-                                entrezGeneId:
-                                    structuralVariant.site1EntrezGeneId,
-                                hugoGeneSymbol:
-                                    structuralVariant.site1HugoSymbol,
-                            },
-                            hugoGeneSymbol: structuralVariant.site1HugoSymbol,
-                            putativeDriver: structuralVariant.putativeDriver,
-                            oncoKbOncogenic: structuralVariant.oncoKbOncogenic,
-                            isHotspot: structuralVariant.isHotspot,
-                            simplifiedMutationType:
-                                CanonicalMutationType.FUSION,
-                        } as AnnotatedMutation;
-
-                        mutationsByGene[hugoGeneSymbol].push(mutation);
-                    });
-                }
-            );
-            //TODO: remove once SV/Fusion tab is merged
 
             return Promise.resolve(mutationsByGene);
         },

--- a/src/pages/resultsView/mutation/MutationRateSummary.tsx
+++ b/src/pages/resultsView/mutation/MutationRateSummary.tsx
@@ -85,8 +85,8 @@ export default class MutationRateSummary extends React.Component<
                     filter={this.props.mutationStatusFilter}
                     onSelect={this.props.onMutationStatusSelect}
                     rates={{
-                        Germline: this.germlineMutationRate,
-                        Somatic: this.somaticMutationRate,
+                        Germline: 1,
+                        Somatic: 1,
                     }}
                     somaticContent={{
                         title: 'Somatic Mutation Frequency',

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -167,35 +167,6 @@ export default class Mutations extends React.Component<
             )!;
             return (
                 <div>
-                    <div className={'tabMessageContainer'}>
-                        <OqlStatusBanner
-                            className="mutations-oql-status-banner"
-                            store={this.props.store}
-                            tabReflectsOql={
-                                this.props.store.mutationsTabFilteringSettings
-                                    .useOql
-                            }
-                            isUnaffected={
-                                !this.props.store.queryContainsMutationOql
-                            }
-                            onToggle={this.onToggleOql}
-                        />
-                        <AlterationFilterWarning
-                            store={this.props.store}
-                            mutationsTabModeSettings={{
-                                excludeVUS: this.props.store
-                                    .mutationsTabFilteringSettings.excludeVus,
-                                excludeGermline: this.props.store
-                                    .mutationsTabFilteringSettings
-                                    .excludeGermline,
-                                toggleExcludeVUS: this.onToggleVUS,
-                                toggleExcludeGermline: this.onToggleGermline,
-                                hugoGeneSymbol: this.selectedGene
-                                    .hugoGeneSymbol,
-                            }}
-                        />
-                        <CaseFilterWarning store={this.props.store} />
-                    </div>
                     <ResultsViewMutationMapper
                         {...convertToMutationMapperProps({
                             ...AppConfig.serverConfig,

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -79,13 +79,10 @@ export default class ResultsViewMutationMapper extends MutationMapper<
     protected get isMutationTableDataLoading() {
         return (
             getRemoteDataGroupStatus(
-                this.props.store.clinicalDataForSamples,
-                this.props.store.studiesForSamplesWithoutCancerTypeClinicalData,
                 this.props.store.canonicalTranscript,
                 this.props.store.mutationData,
                 this.props.store.indexedVariantAnnotations,
                 this.props.store.activeTranscript,
-                this.props.store.clinicalDataGroupedBySampleMap
             ) === 'pending'
         );
     }

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -345,6 +345,7 @@ export default class QuerySummary extends React.Component<
                                 this.cohortAndGeneSummary.component!}
                         </div>
 
+                        {/*
                         <div className="query-summary__rightItems">
                             <div className="query-summary__alterationData">
                                 {loadingComplete && (
@@ -362,6 +363,7 @@ export default class QuerySummary extends React.Component<
                                 urlWrapper={this.props.store.urlWrapper}
                             />
                         </div>
+                            */}
                     </div>
 
                     {this.queryFormVisible && this.queryForm}

--- a/src/shared/components/mutationMapper/MutationMapper.tsx
+++ b/src/shared/components/mutationMapper/MutationMapper.tsx
@@ -579,7 +579,6 @@ export default class MutationMapper<
 
                             <div className="mutationMapperMetaColumn">
                                 {this.geneSummary}
-                                {this.mutationRateSummary}
                                 {this.mutationFilterPanel}
                                 {this.view3dButton}
                             </div>

--- a/src/shared/lib/GenePanelUtils.ts
+++ b/src/shared/lib/GenePanelUtils.ts
@@ -166,6 +166,7 @@ export async function getCoverageInformation(
     // query for gene panel data using sample molecular identifiers
     let genePanelData: GenePanelData[];
     if (sampleMolecularIdentifiers.length && genes.result!.length) {
+        debugger;
         genePanelData = await client.fetchGenePanelDataInMultipleMolecularProfilesUsingPOST(
             {
                 sampleMolecularIdentifiers,


### PR DESCRIPTION
Should only be mutation rate really that's relying on gene panel data but there were a bunch of different things that had the same dependency (e.g. SVs and some warning related to showing only profiled cases).

Note: this also disables a lot of the other tabs. This is not really meant for review but pure for hackathon example

See also https://docs.google.com/presentation/d/16yEuaNJu0mmvxOvF481402lDtUjHtER_s6HL9pDRrEg/edit#slide=id.gd6f8e9ff63_0_0

Further ideas:

- only need clinical sample information (cancer type) for samples with mutations. Don't need detailed samples projection

    <img width="1343" alt="Screen Shot 2021-05-03 at 5 13 46 PM" src="https://user-images.githubusercontent.com/1334004/116934513-13c63b00-ac33-11eb-9184-5ac11b3ff0f7.png">
