### PR TITLE
Performance improvements for initial oncoprint load

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -4796,13 +4796,16 @@ export class ResultsViewPageStore {
                     getOncoKbMutationAnnotationForOncoprint(mutation);
 
                 const isHotspotDriver =
+                    this.driverAnnotationSettings.hotspots &&
                     !(this.isHotspotForOncoprint.result instanceof Error) &&
                     this.isHotspotForOncoprint.result!(mutation);
                 const cbioportalCountExceeded =
+                    this.driverAnnotationSettings.cbioportalCount &&
                     this.getCBioportalCount.isComplete &&
                     this.getCBioportalCount.result!(mutation) >=
                         this.driverAnnotationSettings.cbioportalCountThreshold;
                 const cosmicCountExceeded =
+                    this.driverAnnotationSettings.cosmicCount &&
                     this.getCosmicCount.isComplete &&
                     this.getCosmicCount.result!(mutation) >=
                         this.driverAnnotationSettings.cosmicCountThreshold;

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -255,6 +255,7 @@ import {
     ANNOTATED_PROTEIN_IMPACT_FILTER_TYPE,
     createAnnotatedProteinImpactTypeFilter,
 } from 'shared/lib/MutationUtils';
+import ComplexKeyCounter from 'shared/lib/complexKeyDataStructures/ComplexKeyCounter';
 
 type Optional<T> =
     | { isApplicable: true; value: T }
@@ -5130,21 +5131,28 @@ export class ResultsViewPageStore {
             ),
     });
 
-    readonly cbioportalMutationCountData = remoteData<
-        MutationCountByPosition[]
-    >({
+    readonly cbioportalMutationCountData = remoteData<{
+        [mutationCountByPositionKey: string]: number;
+    }>({
         await: () => [this.mutations],
-        invoke: () => {
+        invoke: async () => {
             const mutationPositionIdentifiers = _.values(
                 countMutations(this.mutations.result!)
             );
 
             if (mutationPositionIdentifiers.length > 0) {
-                return internalClient.fetchMutationCountsByPositionUsingPOST({
-                    mutationPositionIdentifiers,
-                });
+                const data = await internalClient.fetchMutationCountsByPositionUsingPOST(
+                    {
+                        mutationPositionIdentifiers,
+                    }
+                );
+                return _.mapValues(
+                    _.groupBy(data, mutationCountByPositionKey),
+                    (counts: MutationCountByPosition[]) =>
+                        _.sumBy(counts, c => c.count)
+                );
             } else {
-                return Promise.resolve([]);
+                return {};
             }
         },
     });
@@ -5154,27 +5162,16 @@ export class ResultsViewPageStore {
     > = remoteData({
         await: () => [this.cbioportalMutationCountData],
         invoke: () => {
-            const countsMap = _.groupBy(
-                this.cbioportalMutationCountData.result!,
-                count => mutationCountByPositionKey(count)
-            );
             return Promise.resolve((mutation: Mutation): number => {
                 const key = mutationCountByPositionKey(mutation);
-                const counts = countsMap[key];
-                if (counts) {
-                    return counts.reduce((count, next) => {
-                        return count + next.count;
-                    }, 0);
-                } else {
-                    return -1;
-                }
+                return this.cbioportalMutationCountData.result![key] || -1;
             });
         },
     });
     //COSMIC count
-    readonly cosmicCountData = remoteData<CosmicMutation[]>({
+    readonly cosmicCountsByKeywordAndStart = remoteData<ComplexKeyCounter>({
         await: () => [this.mutations],
-        invoke: () => {
+        invoke: async () => {
             const keywords = _.uniq(
                 this.mutations
                     .result!.filter((m: Mutation) => {
@@ -5187,11 +5184,27 @@ export class ResultsViewPageStore {
             );
 
             if (keywords.length > 0) {
-                return internalClient.fetchCosmicCountsUsingPOST({
+                const data = await internalClient.fetchCosmicCountsUsingPOST({
                     keywords,
                 });
+                const map = new ComplexKeyCounter();
+                for (const d of data) {
+                    const position = getProteinPositionFromProteinChange(
+                        d.proteinChange
+                    );
+                    if (position) {
+                        map.add(
+                            {
+                                keyword: d.keyword,
+                                start: position.start,
+                            },
+                            d.count
+                        );
+                    }
+                }
+                return map;
             } else {
-                return Promise.resolve([]);
+                return new ComplexKeyCounter();
             }
         },
     });
@@ -5199,31 +5212,21 @@ export class ResultsViewPageStore {
     readonly getCosmicCount: MobxPromise<
         (mutation: Mutation) => number
     > = remoteData({
-        await: () => [this.cosmicCountData],
+        await: () => [this.cosmicCountsByKeywordAndStart],
         invoke: () => {
-            const countMap = _.groupBy(
-                this.cosmicCountData.result!,
-                d => d.keyword
-            );
             return Promise.resolve((mutation: Mutation): number => {
-                const keyword = mutation.keyword;
-                const counts = countMap[keyword];
                 const targetPosObj = getProteinPositionFromProteinChange(
                     mutation.proteinChange
                 );
-                if (counts && targetPosObj) {
-                    const targetPos = targetPosObj.start;
-                    return counts.reduce((count, next: CosmicMutation) => {
-                        const pos = getProteinPositionFromProteinChange(
-                            next.proteinChange
-                        );
-                        if (pos && pos.start === targetPos) {
-                            // only tally cosmic entries with same keyword and same start position
-                            return count + next.count;
-                        } else {
-                            return count;
+                if (targetPosObj) {
+                    const keyword = mutation.keyword;
+                    const cosmicCount = this.cosmicCountsByKeywordAndStart.result!.get(
+                        {
+                            keyword,
+                            start: targetPosObj.start,
                         }
-                    }, 0);
+                    );
+                    return cosmicCount;
                 } else {
                     return -1;
                 }

--- a/src/shared/lib/complexKeyDataStructures/ComplexKeyCounter.spec.ts
+++ b/src/shared/lib/complexKeyDataStructures/ComplexKeyCounter.spec.ts
@@ -25,15 +25,16 @@ describe('ComplexKeyCounter', () => {
         counter.increment({ k: 'aaidsopjfap' });
         counter.increment({ k: 'aaidsopjfap' });
         counter.increment({ k: 'aaidsopjfap' });
+        counter.add({ k: 'aaidsopjfap' }, 6);
         counter.increment({ 'kjaspdoijfp134u13!@@#$!$$': 'sdf0913' });
         counter.increment({ 'kjaspdoijfp134u13!@@#$!$$': 'sdf0913' });
-        assert.equal(counter.get({ k: 'aaidsopjfap' }), 5);
+        assert.equal(counter.get({ k: 'aaidsopjfap' }), 11);
         assert.equal(
             counter.get({ 'kjaspdoijfp134u13!@@#$!$$': 'sdf0913' }),
             2
         );
         assert.deepEqual(counter.entries(), [
-            { key: { k: 'aaidsopjfap' }, value: 5 },
+            { key: { k: 'aaidsopjfap' }, value: 11 },
             { key: { 'kjaspdoijfp134u13!@@#$!$$': 'sdf0913' }, value: 2 },
         ]);
     });

--- a/src/shared/lib/complexKeyDataStructures/ComplexKeyCounter.ts
+++ b/src/shared/lib/complexKeyDataStructures/ComplexKeyCounter.ts
@@ -3,8 +3,12 @@ import ComplexKeyMap, { ComplexKey } from './ComplexKeyMap';
 export default class ComplexKeyCounter {
     private map: ComplexKeyMap<number> = new ComplexKeyMap<number>();
 
+    public add(key: ComplexKey, amount: number) {
+        this.map.set(key, (this.map.get(key) || 0) + amount);
+    }
+
     public increment(key: ComplexKey) {
-        this.map.set(key, (this.map.get(key) || 0) + 1);
+        this.add(key, 1);
     }
 
     public get(key: ComplexKey) {

--- a/src/shared/lib/oql/oqlfilter.ts
+++ b/src/shared/lib/oql/oqlfilter.ts
@@ -79,7 +79,7 @@ export type OQLLineFilterOutput<T> = {
     gene: string;
     parsed_oql_line: SingleGeneQuery;
     oql_line: string;
-    data: T[];
+    data: Readonly<T>[];
 };
 
 export type MergedTrackLineFilterOutput<T> = {
@@ -814,7 +814,6 @@ function filterData<T extends Datum>(
      *    * If opt_by_oql_line is false or absent, then the result is
      *      a flat list of the data that is wanted by at least one oql line.
      */
-    data = $.extend(true, [], data); // deep copy, because of any modifications it will make during filtration
     var null_fn = function() {
         return null;
     };


### PR DESCRIPTION
### Results

Genie query with EGFR loading time goes from ~56s to ~46s, and without the backwards-progress-in-loading phenomenon

### Details 
1) Fix issue that was causing unnecessary delay on initial oncoprint load, loading data that isn't necessary yet as per default mutation annotation settings

2) Dont do unnecessary data copying in OQL filter code, which was costly for large data 

3) Optimize annotation with cosmic and cbio count - turn O(n^2) into O(n) for some parts of the code