### PR TITLE
Remove year related attributes from comparison

### DIFF
--- a/src/pages/groupComparison/ClinicalData.tsx
+++ b/src/pages/groupComparison/ClinicalData.tsx
@@ -204,11 +204,24 @@ export default class ClinicalData extends React.Component<
             const survivalAttributeIdsDict = createSurvivalAttributeIdsDict(
                 this.props.store.survivalClinicalAttributesPrefix.result || []
             );
+            // In addition remove a few more attributes from the comparison page
+            // for GENIE BPC related to years. In the future we might want to
+            // have a more elegant way to exclude clinical attributes from
+            // comparison. See also
+            // https://github.com/cBioPortal/cbioportal/issues/8445
+            const excludeGenieHardcodedAttributeIds = {
+                AGE_LAST_FU_YEARS: 'AGE_LAST_FU_YEARS',
+                BIRTH_YEAR: 'BIRTH_YEAR',
+            };
             return this.props.store.clinicalDataEnrichmentsWithQValues.result.filter(
                 d =>
                     !(
                         d.clinicalAttribute.clinicalAttributeId in
                         survivalAttributeIdsDict
+                    ) &&
+                    !(
+                        d.clinicalAttribute.clinicalAttributeId in
+                        excludeGenieHardcodedAttributeIds
                     )
             );
         },


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/8445. Decided to
hardcode removal of a few GENIE attributes. The stats team mentioned
that it does not make sense to compare on these year related attributes.
This removes them for all studies, but that probably makes sense anyway
given their year related names.

Before:
<img width="598" alt="Screen Shot 2021-05-05 at 3 48 39 PM" src="https://user-images.githubusercontent.com/1334004/117200555-95e06c00-adb9-11eb-8b7e-c07e830ba38e.png">

After:
<img width="609" alt="Screen Shot 2021-05-05 at 3 48 05 PM" src="https://user-images.githubusercontent.com/1334004/117200556-95e06c00-adb9-11eb-89a3-5b65fd2d4697.png">

Note - not entirely sure if we should also exclude `GENIE Sequence year` and `Age at sequencing`