### PR TITLE
Updated group color icon tooltip to suggested message

### DIFF
--- a/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
@@ -239,7 +239,7 @@ export default class GroupCheckbox extends React.Component<
                                     >
                                         <DefaultTooltip
                                             overlay={
-                                                'Select color for group used in group comparison'
+                                                'Optional: Select color for group to be used in group comparison. If no color is selected, a random color will be applied.'
                                             }
                                             disabled={
                                                 this.props.store


### PR DESCRIPTION
Updated tooltip message to "Optional: Select color for group to be used in
group comparison. If no color is selected, a random color will be applied."