### PR TITLE
Calculate data types for structural variants

### DIFF
--- a/src/pages/patientView/structuralVariant/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/structuralVariant/column/AnnotationColumnFormatter.tsx
@@ -7,6 +7,7 @@ import {
     IAnnotation,
     USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
     oncoKbAnnotationSortValue,
+    calculateOncoKbAvailableDataType,
 } from 'react-mutation-mapper';
 import { CancerStudy, StructuralVariant } from 'cbioportal-ts-api-client';
 import { IAnnotationColumnProps } from 'shared/components/mutationTable/column/AnnotationColumnFormatter';
@@ -96,6 +97,12 @@ export default class AnnotationColumnFormatter {
                         uniqueSampleKeyToTumorType,
                         studyIdToStudy
                     );
+                    oncoKbAvailableDataTypes = _.uniq([
+                        ...oncoKbAvailableDataTypes,
+                        ...calculateOncoKbAvailableDataType(
+                            _.values(oncoKbData.result.indicatorMap)
+                        ),
+                    ]);
                 }
                 oncoKbStatus = oncoKbData ? oncoKbData.status : 'pending';
             }


### PR DESCRIPTION
This fixes https://github.com/cBioPortal/cbioportal/issues/8592

We need to calculate data types based on the indicatormap returned from OncoKB to determine how many icons to show on the page.