### PR TITLE
On mutations tab don't wait for gene panel data

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -3273,13 +3273,18 @@ export class ResultsViewPageStore {
     readonly mutationsByGene = remoteData<{
         [hugoGeneSymbol: string]: Mutation[];
     }>({
-        await: () => [
-            this.selectedMolecularProfiles,
-            this.defaultOQLQuery,
-            this.mutationsReportByGene,
-            this.filteredSampleKeyToSample,
-            this.structuralVariantsReportByGene,
-        ],
+        await: () => {
+            const promises: MobxPromise<any>[] = [
+                this.selectedMolecularProfiles,
+                this.defaultOQLQuery,
+                this.mutationsReportByGene,
+                this.structuralVariantsReportByGene,
+            ];
+            if (this.hideUnprofiledSamples) {
+                promises.push(this.filteredSampleKeyToSample);
+            }
+            return promises;
+        },
         invoke: () => {
             const mutationsByGene = _.mapValues(
                 this.mutationsReportByGene.result!,

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -54,7 +54,10 @@ export default class ResultsViewMutationMapper extends MutationMapper<
             this.props.store.germlineConsentedSamples &&
             this.props.store.germlineConsentedSamples.result &&
             this.props.store.mutationData.isComplete &&
-            this.props.store.mutationData.result.length > 0
+            this.props.store.mutationData.result.length > 0 &&
+            this.props.store.samples.isComplete &&
+            this.props.store.samples.result &&
+            this.props.store.samples.result.length > 0
         ) {
             return (
                 <MutationRateSummary


### PR DESCRIPTION
This avoids waiting with loading the mutations tab until the gene panel
data call has completed. Since caching results vary widely on mskimpact
portal it's hard to measure exact performance gain. The gene panel data
call in producion can take between 20 seconds up to a minute. From rough
testing: on an EGFR query in entire mskimpact >55K samples the
performance gain can be around 30 seconds. However when getting a cache
hit the speed up is negligible. Note that initial results in
https://github.com/cBioPortal/cbioportal-frontend/pull/3730 showed a 45 seconds improvement. There the call was completely removed (as well as
several other tabs) so guessing that some competition between calls or
managing other computation related to the tabs is causing the 15 second diff.

Fix https://github.com/cBioPortal/cbioportal/issues/8596

EDIT:

Current public production portal currently does not have caching so with a big query you can see a nice speedup of ~15 seconds (this is ~45K samples, for larger cohorts it would be more):

https://bit.ly/3waOCVy
```
# with new changes
TimeElementVisible for selector ".tableSearchInput" 45427.74999991525
# before
TimeElementVisible for selector ".tableSearchInput" 62309.9650000222
```