### PR TITLE
Get clinvar from GN annotation endpoint

### DIFF
--- a/packages/cbioportal-utils/src/annotation/MyVariantInfoAnnotationUtils.ts
+++ b/packages/cbioportal-utils/src/annotation/MyVariantInfoAnnotationUtils.ts
@@ -63,15 +63,3 @@ export function getDbsnpRsId(myVariantInfo?: MyVariantInfo): string | null {
         return null;
     }
 }
-
-export function getClinVarId(myVariantInfo?: MyVariantInfo): string | null {
-    if (
-        myVariantInfo &&
-        myVariantInfo.clinVar &&
-        myVariantInfo.clinVar.variantId
-    ) {
-        return myVariantInfo.clinVar.variantId.toString();
-    } else {
-        return null;
-    }
-}

--- a/packages/react-mutation-mapper/src/component/clinvar/ClinVarSummary.tsx
+++ b/packages/react-mutation-mapper/src/component/clinvar/ClinVarSummary.tsx
@@ -3,86 +3,16 @@ import {
     pluralize,
     TruncatedText,
 } from 'cbioportal-frontend-commons';
-import { getClinVarId } from 'cbioportal-utils';
-import { ClinVar, MyVariantInfo } from 'genome-nexus-ts-api-client';
+import {
+    Clinvar,
+    MyVariantInfo,
+    VariantAnnotation,
+} from 'genome-nexus-ts-api-client';
 import _ from 'lodash';
 import * as React from 'react';
 
 export type ClinVarSummaryProps = {
-    myVariantInfo?: MyVariantInfo;
-};
-
-export enum ClinVarOrigin {
-    GERMLINE = 'germline',
-    SOMATIC = 'somatic',
-}
-
-export type RcvData = {
-    origin: string;
-    evidences: {
-        clinicalSignificance: string;
-        count: number;
-    }[];
-};
-
-export type RcvCountMap = {
-    [origin: string]: { [clinicalSignificance: string]: number };
-};
-
-export function getRcvCountMap(clinVar: ClinVar): RcvCountMap {
-    const filteredRcv = clinVar.rcv.filter(
-        rcv =>
-            rcv.origin === ClinVarOrigin.GERMLINE ||
-            rcv.origin === ClinVarOrigin.SOMATIC
-    );
-
-    // first map by origin, then count evidence number for each origin group
-    const rcvMap = _.groupBy(filteredRcv, d => d.origin);
-
-    return _.mapValues(rcvMap, rcvs =>
-        _.countBy(rcvs, rcv => rcv.clinicalSignificance)
-    );
-}
-
-export function getRcvData(rcvCountMap: RcvCountMap): RcvData[] {
-    return _.map(rcvCountMap, (clinicalSignificanceCountMap, origin) => ({
-        origin,
-        evidences: _.map(
-            clinicalSignificanceCountMap,
-            (count, clinicalSignificance) => ({ clinicalSignificance, count })
-        ),
-    }));
-}
-
-export function formatClinicalSignificanceText(rcvData: RcvData[]) {
-    return _.uniq(
-        _.flatten(
-            rcvData.map(d => d.evidences.map(e => e.clinicalSignificance))
-        )
-    ).join(', ');
-}
-
-export const ClinVarRcvInterpretation = (props: {
-    rcvData: RcvData[];
-    className?: string;
-}) => {
-    return (
-        <div className={props.className}>
-            {props.rcvData.map(d => (
-                <div key={d.origin}>
-                    <strong>{`${_.upperFirst(d.origin)}: `}</strong>
-                    {d.evidences
-                        .map(
-                            e =>
-                                `${e.clinicalSignificance} (${
-                                    e.count
-                                } ${pluralize('evidence', e.count)})`
-                        )
-                        .join(', ')}
-                </div>
-            ))}
-        </div>
-    );
+    clinvar?: Clinvar;
 };
 
 const NoClinVarData = () => {
@@ -106,29 +36,24 @@ const NoClinVarData = () => {
 };
 
 const ClinVarSummary = (props: ClinVarSummaryProps) => {
-    const clinVar = props.myVariantInfo
-        ? props.myVariantInfo.clinVar
-        : undefined;
-
-    if (!clinVar) {
+    if (!props.clinvar) {
         return <NoClinVarData />;
     } else {
-        const clinVarId = getClinVarId(props.myVariantInfo);
+        const clinVarId = props.clinvar.clinvarId;
         const clinVarLink = `https://www.ncbi.nlm.nih.gov/clinvar/variation/${clinVarId}/`;
-        const rcvData = getRcvData(getRcvCountMap(clinVar));
-
+        const clinicalSignificance = props.clinvar.clinicalSignificance;
+        const conflictingClinicalSignificance =
+            props.clinvar.conflictingClinicalSignificance;
         return (
             <TruncatedText
                 maxLength={30}
-                text={
-                    rcvData.length > 0
-                        ? formatClinicalSignificanceText(rcvData)
-                        : 'Unknown'
-                }
+                text={clinicalSignificance}
                 addTooltip="always"
                 tooltip={
                     <div style={{ maxWidth: 300 }}>
-                        <ClinVarRcvInterpretation rcvData={rcvData} />
+                        {conflictingClinicalSignificance && (
+                            <div>{conflictingClinicalSignificance}</div>
+                        )}
                         <div>
                             (ClinVar ID:{' '}
                             <a href={clinVarLink} target="_blank">

--- a/packages/react-mutation-mapper/src/component/clinvar/ClinvarHelper.ts
+++ b/packages/react-mutation-mapper/src/component/clinvar/ClinvarHelper.ts
@@ -1,7 +1,7 @@
 import { getVariantAnnotation, Mutation, RemoteData } from 'cbioportal-utils';
 import { Clinvar, VariantAnnotation } from 'genome-nexus-ts-api-client';
 
-export function getClinVarData(
+export function getClinvarData(
     mutation: Mutation,
     indexedVariantAnnotations?: RemoteData<
         { [genomicLocation: string]: VariantAnnotation } | undefined

--- a/packages/react-mutation-mapper/src/component/clinvar/ClinvarSummary.tsx
+++ b/packages/react-mutation-mapper/src/component/clinvar/ClinvarSummary.tsx
@@ -1,21 +1,13 @@
-import {
-    DefaultTooltip,
-    pluralize,
-    TruncatedText,
-} from 'cbioportal-frontend-commons';
-import {
-    Clinvar,
-    MyVariantInfo,
-    VariantAnnotation,
-} from 'genome-nexus-ts-api-client';
+import { DefaultTooltip, TruncatedText } from 'cbioportal-frontend-commons';
+import { Clinvar } from 'genome-nexus-ts-api-client';
 import _ from 'lodash';
 import * as React from 'react';
 
-export type ClinVarSummaryProps = {
+export type ClinvarSummaryProps = {
     clinvar?: Clinvar;
 };
 
-const NoClinVarData = () => {
+const NoClinvarData = () => {
     return (
         <DefaultTooltip
             placement="topLeft"
@@ -35,12 +27,12 @@ const NoClinVarData = () => {
     );
 };
 
-const ClinVarSummary = (props: ClinVarSummaryProps) => {
+const ClinvarSummary = (props: ClinvarSummaryProps) => {
     if (!props.clinvar) {
-        return <NoClinVarData />;
+        return <NoClinvarData />;
     } else {
-        const clinVarId = props.clinvar.clinvarId;
-        const clinVarLink = `https://www.ncbi.nlm.nih.gov/clinvar/variation/${clinVarId}/`;
+        const clinvarId = props.clinvar.clinvarId;
+        const clinvarLink = `https://www.ncbi.nlm.nih.gov/clinvar/variation/${clinvarId}/`;
         const clinicalSignificance = props.clinvar.clinicalSignificance;
         const conflictingClinicalSignificance =
             props.clinvar.conflictingClinicalSignificance;
@@ -51,13 +43,14 @@ const ClinVarSummary = (props: ClinVarSummaryProps) => {
                 addTooltip="always"
                 tooltip={
                     <div style={{ maxWidth: 300 }}>
+                        <div>{clinicalSignificance}</div>
                         {conflictingClinicalSignificance && (
                             <div>{conflictingClinicalSignificance}</div>
                         )}
                         <div>
                             (ClinVar ID:{' '}
-                            <a href={clinVarLink} target="_blank">
-                                {clinVarId}
+                            <a href={clinvarLink} target="_blank">
+                                {clinvarId}
                             </a>
                             )
                         </div>
@@ -68,4 +61,4 @@ const ClinVarSummary = (props: ClinVarSummaryProps) => {
     }
 };
 
-export default ClinVarSummary;
+export default ClinvarSummary;

--- a/packages/react-mutation-mapper/src/component/column/ClinVar.tsx
+++ b/packages/react-mutation-mapper/src/component/column/ClinVar.tsx
@@ -1,18 +1,11 @@
-import {
-    Clinvar,
-    MyVariantInfo,
-    VariantAnnotation,
-} from 'genome-nexus-ts-api-client';
+import { Clinvar, VariantAnnotation } from 'genome-nexus-ts-api-client';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
 import { defaultSortMethod, Mutation, RemoteData } from 'cbioportal-utils';
 import ClinVarSummary from '../clinvar/ClinVarSummary';
-import {
-    MyVariantInfoProps,
-    renderMyVariantInfoContent,
-} from './MyVariantInfoHelper';
 import { getClinVarData } from './ClinVarHelper';
+import { errorIcon, loaderIcon } from '../StatusHelpers';
 
 type ClinVarProps = {
     mutation: Mutation;
@@ -48,15 +41,26 @@ export function clinVarSortMethod(a: Clinvar, b: Clinvar) {
     return defaultSortMethod(sortValue(a), sortValue(b));
 }
 
+@observer
 export default class ClinVar extends React.Component<ClinVarProps, {}> {
-    get clinvar() {
-        return getClinVarData(
-            this.props.mutation,
-            this.props.indexedVariantAnnotations
-        );
-    }
-
     public render() {
-        return <ClinVarSummary clinvar={this.clinvar} />;
+        if (this.props.indexedVariantAnnotations) {
+            let content;
+            const status = this.props.indexedVariantAnnotations.status;
+            if (status === 'pending') {
+                content = loaderIcon();
+            } else if (status === 'error') {
+                content = errorIcon('Error fetching Genome Nexus annotation');
+            } else {
+                const clinvarData = getClinVarData(
+                    this.props.mutation,
+                    this.props.indexedVariantAnnotations
+                );
+                content = <ClinVarSummary clinvar={clinvarData} />;
+            }
+            return content;
+        } else {
+            return <div />;
+        }
     }
 }

--- a/packages/react-mutation-mapper/src/component/column/ClinVarHelper.ts
+++ b/packages/react-mutation-mapper/src/component/column/ClinVarHelper.ts
@@ -1,0 +1,15 @@
+import { getVariantAnnotation, Mutation, RemoteData } from 'cbioportal-utils';
+import { Clinvar, VariantAnnotation } from 'genome-nexus-ts-api-client';
+
+export function getClinVarData(
+    mutation: Mutation,
+    indexedVariantAnnotations?: RemoteData<
+        { [genomicLocation: string]: VariantAnnotation } | undefined
+    >
+): Clinvar | undefined {
+    const variantAnnotation = getVariantAnnotation(
+        mutation,
+        indexedVariantAnnotations!.result
+    );
+    return variantAnnotation?.clinvar?.annotation;
+}

--- a/packages/react-mutation-mapper/src/component/column/ClinvarInterpretation.tsx
+++ b/packages/react-mutation-mapper/src/component/column/ClinvarInterpretation.tsx
@@ -3,11 +3,11 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 
 import { defaultSortMethod, Mutation, RemoteData } from 'cbioportal-utils';
-import ClinVarSummary from '../clinvar/ClinVarSummary';
-import { getClinVarData } from './ClinVarHelper';
+import ClinvarSummary from '../clinvar/ClinvarSummary';
+import { getClinvarData } from '../clinvar/ClinvarHelper';
 import { errorIcon, loaderIcon } from '../StatusHelpers';
 
-type ClinVarProps = {
+type ClinvarInterpretationProps = {
     mutation: Mutation;
     indexedVariantAnnotations?: RemoteData<
         { [genomicLocation: string]: VariantAnnotation } | undefined
@@ -37,12 +37,15 @@ export function sortValue(clinvar?: Clinvar): string | null {
     }
 }
 
-export function clinVarSortMethod(a: Clinvar, b: Clinvar) {
+export function clinvarSortMethod(a: Clinvar, b: Clinvar) {
     return defaultSortMethod(sortValue(a), sortValue(b));
 }
 
 @observer
-export default class ClinVar extends React.Component<ClinVarProps, {}> {
+export default class ClinvarInterpretation extends React.Component<
+    ClinvarInterpretationProps,
+    {}
+> {
     public render() {
         if (this.props.indexedVariantAnnotations) {
             let content;
@@ -52,11 +55,11 @@ export default class ClinVar extends React.Component<ClinVarProps, {}> {
             } else if (status === 'error') {
                 content = errorIcon('Error fetching Genome Nexus annotation');
             } else {
-                const clinvarData = getClinVarData(
+                const clinvarData = getClinvarData(
                     this.props.mutation,
                     this.props.indexedVariantAnnotations
                 );
-                content = <ClinVarSummary clinvar={clinvarData} />;
+                content = <ClinvarSummary clinvar={clinvarData} />;
             }
             return content;
         } else {

--- a/packages/react-mutation-mapper/src/component/column/HgvsHelper.ts
+++ b/packages/react-mutation-mapper/src/component/column/HgvsHelper.ts
@@ -5,6 +5,7 @@ import {
     Mutation,
     RemoteData,
 } from 'cbioportal-utils';
+import { getAnnotation } from './VariantAnnotationHelper';
 
 export function getHgvsgColumnData(mutation: Mutation): string | null {
     return generateHgvsgByMutation(mutation) || null;
@@ -42,15 +43,4 @@ export function getHgvscColumnData(
     }
 
     return data;
-}
-
-function getAnnotation(
-    mutation?: Mutation,
-    indexedVariantAnnotations?: RemoteData<
-        { [genomicLocation: string]: VariantAnnotation } | undefined
-    >
-) {
-    return indexedVariantAnnotations
-        ? getVariantAnnotation(mutation, indexedVariantAnnotations.result)
-        : undefined;
 }

--- a/packages/react-mutation-mapper/src/component/column/HgvsHelper.ts
+++ b/packages/react-mutation-mapper/src/component/column/HgvsHelper.ts
@@ -1,7 +1,6 @@
 import { VariantAnnotation } from 'genome-nexus-ts-api-client';
 import {
     generateHgvsgByMutation,
-    getVariantAnnotation,
     Mutation,
     RemoteData,
 } from 'cbioportal-utils';

--- a/packages/react-mutation-mapper/src/component/column/VariantAnnotationHelper.ts
+++ b/packages/react-mutation-mapper/src/component/column/VariantAnnotationHelper.ts
@@ -1,0 +1,13 @@
+import { getVariantAnnotation, Mutation, RemoteData } from 'cbioportal-utils';
+import { VariantAnnotation } from 'genome-nexus-ts-api-client';
+
+export function getAnnotation(
+    mutation?: Mutation,
+    indexedVariantAnnotations?: RemoteData<
+        { [genomicLocation: string]: VariantAnnotation } | undefined
+    >
+) {
+    return indexedVariantAnnotations
+        ? getVariantAnnotation(mutation, indexedVariantAnnotations.result)
+        : undefined;
+}

--- a/packages/react-mutation-mapper/src/component/dbsnp/DbsnpId.tsx
+++ b/packages/react-mutation-mapper/src/component/dbsnp/DbsnpId.tsx
@@ -4,12 +4,12 @@ import { MyVariantInfo } from 'genome-nexus-ts-api-client';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-export type ClinVarIdProps = {
+export type DbsnpIdProps = {
     myVariantInfo?: MyVariantInfo;
 };
 
 @observer
-export default class DbsnpId extends React.Component<ClinVarIdProps, {}> {
+export default class DbsnpId extends React.Component<DbsnpIdProps, {}> {
     public render() {
         const rsId = getDbsnpRsId(this.props.myVariantInfo);
 

--- a/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { Column } from 'react-table';
 
 import Annotation, { getAnnotationData } from '../column/Annotation';
-import ClinVar from '../column/ClinVar';
+import ClinvarInterpretation from '../column/ClinvarInterpretation';
 import Dbsnp from '../column/Dbsnp';
 import Gnomad from '../column/Gnomad';
 import Hgvsc from '../column/Hgvsc';
@@ -39,7 +39,7 @@ import DataTable, {
 import { MutationColumn } from './MutationColumnHelper';
 
 import './defaultMutationTable.scss';
-import { getClinVarData } from '../column/ClinVarHelper';
+import { getClinvarData } from '../clinvar/ClinvarHelper';
 
 export type DefaultMutationTableProps = {
     hotspotData?: RemoteData<IHotspotIndex | undefined>;
@@ -166,11 +166,11 @@ export default class DefaultMutationTable extends React.Component<
     }
 
     @computed
-    get clinVarAccessor() {
+    get clinvarAccessor() {
         return this.indexedVariantAnnotationDataStatus === 'pending'
             ? () => undefined
             : (mutation: Mutation) =>
-                  getClinVarData(
+                  getClinvarData(
                       mutation,
                       this.props.indexedVariantAnnotations
                   );
@@ -192,7 +192,7 @@ export default class DefaultMutationTable extends React.Component<
             case MutationColumn.GNOMAD:
                 return this.myVariantInfoAccessor;
             case MutationColumn.CLINVAR:
-                return this.clinVarAccessor;
+                return this.clinvarAccessor;
             case MutationColumn.DBSNP:
                 return this.myVariantInfoAccessor;
             case MutationColumn.SIGNAL:
@@ -249,7 +249,7 @@ export default class DefaultMutationTable extends React.Component<
                 );
             case MutationColumn.CLINVAR:
                 return (column: any) => (
-                    <ClinVar
+                    <ClinvarInterpretation
                         mutation={column.original}
                         indexedVariantAnnotations={
                             this.props.indexedVariantAnnotations

--- a/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationTable/DefaultMutationTable.tsx
@@ -39,6 +39,7 @@ import DataTable, {
 import { MutationColumn } from './MutationColumnHelper';
 
 import './defaultMutationTable.scss';
+import { getClinVarData } from '../column/ClinVarHelper';
 
 export type DefaultMutationTableProps = {
     hotspotData?: RemoteData<IHotspotIndex | undefined>;
@@ -165,6 +166,17 @@ export default class DefaultMutationTable extends React.Component<
     }
 
     @computed
+    get clinVarAccessor() {
+        return this.indexedVariantAnnotationDataStatus === 'pending'
+            ? () => undefined
+            : (mutation: Mutation) =>
+                  getClinVarData(
+                      mutation,
+                      this.props.indexedVariantAnnotations
+                  );
+    }
+
+    @computed
     get initialSortRemoteData() {
         return this.props.initialSortRemoteData || this.annotationColumnData;
     }
@@ -180,7 +192,7 @@ export default class DefaultMutationTable extends React.Component<
             case MutationColumn.GNOMAD:
                 return this.myVariantInfoAccessor;
             case MutationColumn.CLINVAR:
-                return this.myVariantInfoAccessor;
+                return this.clinVarAccessor;
             case MutationColumn.DBSNP:
                 return this.myVariantInfoAccessor;
             case MutationColumn.SIGNAL:
@@ -239,8 +251,8 @@ export default class DefaultMutationTable extends React.Component<
                 return (column: any) => (
                     <ClinVar
                         mutation={column.original}
-                        indexedMyVariantInfoAnnotations={
-                            this.props.indexedMyVariantInfoAnnotations
+                        indexedVariantAnnotations={
+                            this.props.indexedVariantAnnotations
                         }
                     />
                 );

--- a/packages/react-mutation-mapper/src/component/mutationTable/MutationColumnHelper.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationTable/MutationColumnHelper.tsx
@@ -9,7 +9,7 @@ import ProteinChange, {
 } from '../column/ProteinChange';
 import { annotationSortMethod } from '../column/Annotation';
 import { gnomadSortMethod } from '../column/Gnomad';
-import { clinVarSortMethod } from '../column/ClinVar';
+import { clinvarSortMethod } from '../column/ClinvarInterpretation';
 import MutationType from '../column/MutationType';
 import MutationStatus from '../column/MutationStatus';
 import { dbsnpSortMethod } from '../column/Dbsnp';
@@ -30,7 +30,7 @@ export enum MutationColumn {
     HGVSG = 'hgvsg',
     HGVSC = 'hgvsc',
     GNOMAD = 'gnomad',
-    CLINVAR = 'clinVar',
+    CLINVAR = 'clinvar',
     DBSNP = 'dbsnp',
     SIGNAL = 'signal',
 }
@@ -344,7 +344,7 @@ export const MUTATION_COLUMNS_DEFINITION = {
         id: MutationColumn.CLINVAR,
         name: MutationColumnName.CLINVAR,
         Header: MUTATION_COLUMN_HEADERS[MutationColumn.CLINVAR],
-        sortMethod: clinVarSortMethod,
+        sortMethod: clinvarSortMethod,
         show: false,
     },
     [MutationColumn.DBSNP]: {

--- a/packages/react-mutation-mapper/src/index.tsx
+++ b/packages/react-mutation-mapper/src/index.tsx
@@ -3,7 +3,7 @@ export {
     download as civicDownload,
     sortValue as civicSortValue,
 } from './component/civic/Civic';
-export { default as ClinVarSummary } from './component/clinvar/ClinVarSummary';
+export { default as ClinvarSummary } from './component/clinvar/ClinvarSummary';
 export {
     AnnotationProps,
     default as Annotation,
@@ -14,11 +14,11 @@ export {
     sortValue as annotationSortValue,
 } from './component/column/Annotation';
 export {
-    default as ClinVar,
-    download as clinVarDownload,
-    sortValue as clinVarSortValue,
-} from './component/column/ClinVar';
-export * from './component/column/ClinVarHelper';
+    default as ClinvarInterpretation,
+    download as clinvarDownload,
+    sortValue as clinvarSortValue,
+} from './component/column/ClinvarInterpretation';
+export * from './component/clinvar/ClinvarHelper';
 export { default as ColumnHeader } from './component/column/ColumnHeader';
 export {
     default as Dbsnp,

--- a/packages/react-mutation-mapper/src/index.tsx
+++ b/packages/react-mutation-mapper/src/index.tsx
@@ -3,14 +3,7 @@ export {
     download as civicDownload,
     sortValue as civicSortValue,
 } from './component/civic/Civic';
-export {
-    default as ClinVarSummary,
-    ClinVarRcvInterpretation,
-    getRcvCountMap,
-    getRcvData,
-    RcvCountMap,
-    RcvData,
-} from './component/clinvar/ClinVarSummary';
+export { default as ClinVarSummary } from './component/clinvar/ClinVarSummary';
 export {
     AnnotationProps,
     default as Annotation,
@@ -25,6 +18,7 @@ export {
     download as clinVarDownload,
     sortValue as clinVarSortValue,
 } from './component/column/ClinVar';
+export * from './component/column/ClinVarHelper';
 export { default as ColumnHeader } from './component/column/ColumnHeader';
 export {
     default as Dbsnp,

--- a/packages/react-variant-view/src/component/featureTable/FeatureTable.tsx
+++ b/packages/react-variant-view/src/component/featureTable/FeatureTable.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Mutation } from 'cbioportal-utils';
 import { IndicatorQueryResp } from 'oncokb-ts-api-client';
 import {
-    ClinVar,
+    Clinvar,
     MyVariantInfo,
     SignalAnnotation,
     VariantAnnotation,
@@ -25,7 +25,7 @@ interface IFeatureTableProps {
     myVariantInfo?: MyVariantInfo;
     variantAnnotation?: VariantAnnotation;
     oncokb?: IndicatorQueryResp;
-    clinVar?: ClinVar;
+    clinVar?: Clinvar;
     signalAnnotation?: SignalAnnotation;
     isCanonicalTranscriptSelected: boolean;
     mutation: Mutation;

--- a/packages/react-variant-view/src/component/featureTable/FeatureTable.tsx
+++ b/packages/react-variant-view/src/component/featureTable/FeatureTable.tsx
@@ -25,7 +25,7 @@ interface IFeatureTableProps {
     myVariantInfo?: MyVariantInfo;
     variantAnnotation?: VariantAnnotation;
     oncokb?: IndicatorQueryResp;
-    clinVar?: Clinvar;
+    clinvar?: Clinvar;
     signalAnnotation?: SignalAnnotation;
     isCanonicalTranscriptSelected: boolean;
     mutation: Mutation;
@@ -42,7 +42,7 @@ class FeatureTable extends React.Component<IFeatureTableProps> {
                             <th>Pathogenicity:</th>
                             <td>
                                 <Pathogenicity
-                                    clinVar={this.props.clinVar}
+                                    clinvar={this.props.clinvar}
                                     oncokb={this.props.oncokb}
                                     signalAnnotation={
                                         this.props.signalAnnotation

--- a/packages/react-variant-view/src/component/pathogenicity/ClinVarInterpretation.tsx
+++ b/packages/react-variant-view/src/component/pathogenicity/ClinVarInterpretation.tsx
@@ -2,17 +2,12 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import featureTableStyle from '../featureTable/FeatureTable.module.scss';
 import { computed, makeObservable } from 'mobx';
-import { ClinVar } from 'genome-nexus-ts-api-client';
+import { Clinvar } from 'genome-nexus-ts-api-client';
 import { Button } from 'react-bootstrap';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
-import {
-    ClinVarRcvInterpretation,
-    getRcvCountMap,
-    getRcvData,
-} from 'react-mutation-mapper';
 
 export interface IClinVarInterpretationProps {
-    clinVar: ClinVar | undefined;
+    clinVar: Clinvar | undefined;
 }
 
 const ClinVarTooltip = () => {
@@ -37,40 +32,36 @@ class ClinVarInterpretation extends React.Component<
         makeObservable(this);
     }
 
-    @computed get rcvCountMap() {
+    @computed get clinvarData() {
         if (this.props.clinVar) {
-            return getRcvCountMap(this.props.clinVar);
+            if (
+                this.props.clinVar.clinicalSignificance &&
+                this.props.clinVar.conflictingClinicalSignificance
+            ) {
+                return (
+                    <div className={featureTableStyle['data-with-link']}>
+                        {`${this.props.clinVar.clinicalSignificance} (${this.props.clinVar.conflictingClinicalSignificance})`}
+                    </div>
+                );
+            } else if (this.props.clinVar.clinicalSignificance) {
+                return (
+                    <div className={featureTableStyle['data-with-link']}>
+                        {this.props.clinVar.clinicalSignificance}
+                    </div>
+                );
+            }
         }
 
-        return undefined;
-    }
-
-    @computed get rcvDisplayData() {
-        if (this.rcvCountMap) {
-            return getRcvData(this.rcvCountMap);
-        }
-        return undefined;
+        return <div>N/A</div>;
     }
 
     @computed get clinVarContent() {
-        return this.rcvDisplayData ? (
+        return (
             <div className={featureTableStyle['feature-table-layout']}>
                 <div className={featureTableStyle['data-source']}>
                     <ClinVarTooltip />
                 </div>
-                <ClinVarRcvInterpretation
-                    className={featureTableStyle['data-with-link']}
-                    rcvData={this.rcvDisplayData}
-                />
-            </div>
-        ) : (
-            <div className={featureTableStyle['feature-table-layout']}>
-                <div className={featureTableStyle['data-source']}>
-                    <ClinVarTooltip />
-                </div>
-                <div className={featureTableStyle['data-with-link']}>
-                    <div>N/A</div>
-                </div>
+                {this.clinvarData}
             </div>
         );
     }

--- a/packages/react-variant-view/src/component/pathogenicity/ClinVarInterpretation.tsx
+++ b/packages/react-variant-view/src/component/pathogenicity/ClinVarInterpretation.tsx
@@ -3,25 +3,11 @@ import { observer } from 'mobx-react';
 import featureTableStyle from '../featureTable/FeatureTable.module.scss';
 import { computed, makeObservable } from 'mobx';
 import { Clinvar } from 'genome-nexus-ts-api-client';
-import { Button } from 'react-bootstrap';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 
 export interface IClinVarInterpretationProps {
     clinVar: Clinvar | undefined;
 }
-
-const ClinVarTooltip = () => {
-    return (
-        <DefaultTooltip
-            placement="top"
-            overlay={<span>ClinVar Interpretation</span>}
-        >
-            <Button bsStyle="link" className="btn-sm p-0">
-                ClinVar Interpretation
-            </Button>
-        </DefaultTooltip>
-    );
-};
 
 @observer
 class ClinVarInterpretation extends React.Component<
@@ -32,7 +18,26 @@ class ClinVarInterpretation extends React.Component<
         makeObservable(this);
     }
 
+    @computed get clinvarTooltip() {
+        const clinvarUrl = this.props.clinVar
+            ? `https://www.ncbi.nlm.nih.gov/clinvar/variation/${this.props.clinVar.clinvarId}/`
+            : `https://www.ncbi.nlm.nih.gov/clinvar/`;
+        return (
+            <DefaultTooltip
+                placement="top"
+                overlay={<span>ClinVar Interpretation</span>}
+            >
+                <a href={clinvarUrl} target="_blank" rel="noopener noreferrer">
+                    ClinVar Interpretation
+                </a>
+            </DefaultTooltip>
+        );
+    }
+
     @computed get clinvarData() {
+        const clinvarUrl = this.props.clinVar
+            ? `https://www.ncbi.nlm.nih.gov/clinvar/variation/${this.props.clinVar.clinvarId}/`
+            : `https://www.ncbi.nlm.nih.gov/clinvar/`;
         if (this.props.clinVar) {
             if (
                 this.props.clinVar.clinicalSignificance &&
@@ -40,13 +45,27 @@ class ClinVarInterpretation extends React.Component<
             ) {
                 return (
                     <div className={featureTableStyle['data-with-link']}>
-                        {`${this.props.clinVar.clinicalSignificance} (${this.props.clinVar.conflictingClinicalSignificance})`}
+                        <a
+                            href={clinvarUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={featureTableStyle['data-with-link']}
+                        >
+                            {`${this.props.clinVar.clinicalSignificance} (${this.props.clinVar.conflictingClinicalSignificance})`}
+                        </a>
                     </div>
                 );
             } else if (this.props.clinVar.clinicalSignificance) {
                 return (
                     <div className={featureTableStyle['data-with-link']}>
-                        {this.props.clinVar.clinicalSignificance}
+                        <a
+                            href={clinvarUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={featureTableStyle['data-with-link']}
+                        >
+                            {this.props.clinVar.clinicalSignificance}
+                        </a>
                     </div>
                 );
             }
@@ -55,19 +74,15 @@ class ClinVarInterpretation extends React.Component<
         return <div>N/A</div>;
     }
 
-    @computed get clinVarContent() {
+    public render() {
         return (
             <div className={featureTableStyle['feature-table-layout']}>
                 <div className={featureTableStyle['data-source']}>
-                    <ClinVarTooltip />
+                    {this.clinvarTooltip}
                 </div>
                 {this.clinvarData}
             </div>
         );
-    }
-
-    public render() {
-        return this.clinVarContent;
     }
 }
 

--- a/packages/react-variant-view/src/component/pathogenicity/ClinvarInterpretation.tsx
+++ b/packages/react-variant-view/src/component/pathogenicity/ClinvarInterpretation.tsx
@@ -5,22 +5,22 @@ import { computed, makeObservable } from 'mobx';
 import { Clinvar } from 'genome-nexus-ts-api-client';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 
-export interface IClinVarInterpretationProps {
-    clinVar: Clinvar | undefined;
+export interface IClinvarInterpretationProps {
+    clinvar: Clinvar | undefined;
 }
 
 @observer
-class ClinVarInterpretation extends React.Component<
-    IClinVarInterpretationProps
+class ClinvarInterpretation extends React.Component<
+    IClinvarInterpretationProps
 > {
-    constructor(props: IClinVarInterpretationProps) {
+    constructor(props: IClinvarInterpretationProps) {
         super(props);
         makeObservable(this);
     }
 
     @computed get clinvarTooltip() {
-        const clinvarUrl = this.props.clinVar
-            ? `https://www.ncbi.nlm.nih.gov/clinvar/variation/${this.props.clinVar.clinvarId}/`
+        const clinvarUrl = this.props.clinvar
+            ? `https://www.ncbi.nlm.nih.gov/clinvar/variation/${this.props.clinvar.clinvarId}/`
             : `https://www.ncbi.nlm.nih.gov/clinvar/`;
         return (
             <DefaultTooltip
@@ -34,14 +34,14 @@ class ClinVarInterpretation extends React.Component<
         );
     }
 
-    @computed get clinvarData() {
-        const clinvarUrl = this.props.clinVar
-            ? `https://www.ncbi.nlm.nih.gov/clinvar/variation/${this.props.clinVar.clinvarId}/`
+    @computed get clinvarInterpretationContent() {
+        const clinvarUrl = this.props.clinvar
+            ? `https://www.ncbi.nlm.nih.gov/clinvar/variation/${this.props.clinvar.clinvarId}/`
             : `https://www.ncbi.nlm.nih.gov/clinvar/`;
-        if (this.props.clinVar) {
+        if (this.props.clinvar) {
             if (
-                this.props.clinVar.clinicalSignificance &&
-                this.props.clinVar.conflictingClinicalSignificance
+                this.props.clinvar.clinicalSignificance &&
+                this.props.clinvar.conflictingClinicalSignificance
             ) {
                 return (
                     <div className={featureTableStyle['data-with-link']}>
@@ -51,11 +51,11 @@ class ClinVarInterpretation extends React.Component<
                             rel="noopener noreferrer"
                             className={featureTableStyle['data-with-link']}
                         >
-                            {`${this.props.clinVar.clinicalSignificance} (${this.props.clinVar.conflictingClinicalSignificance})`}
+                            {`${this.props.clinvar.clinicalSignificance} (${this.props.clinvar.conflictingClinicalSignificance})`}
                         </a>
                     </div>
                 );
-            } else if (this.props.clinVar.clinicalSignificance) {
+            } else if (this.props.clinvar.clinicalSignificance) {
                 return (
                     <div className={featureTableStyle['data-with-link']}>
                         <a
@@ -64,7 +64,7 @@ class ClinVarInterpretation extends React.Component<
                             rel="noopener noreferrer"
                             className={featureTableStyle['data-with-link']}
                         >
-                            {this.props.clinVar.clinicalSignificance}
+                            {this.props.clinvar.clinicalSignificance}
                         </a>
                     </div>
                 );
@@ -80,10 +80,10 @@ class ClinVarInterpretation extends React.Component<
                 <div className={featureTableStyle['data-source']}>
                     {this.clinvarTooltip}
                 </div>
-                {this.clinvarData}
+                {this.clinvarInterpretationContent}
             </div>
         );
     }
 }
 
-export default ClinVarInterpretation;
+export default ClinvarInterpretation;

--- a/packages/react-variant-view/src/component/pathogenicity/Pathogenicity.tsx
+++ b/packages/react-variant-view/src/component/pathogenicity/Pathogenicity.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react';
 import { ClinVar, SignalAnnotation } from 'genome-nexus-ts-api-client';
 import { IndicatorQueryResp } from 'oncokb-ts-api-client';
 import Oncokb from './Oncokb';
-import ClinVarInterpretation from './ClinVarInterpretation';
+// import ClinVarInterpretation from './ClinVarInterpretation';
 import Penetrance from './Penetrance';
 import MSKExpertReview from './MSKExpertReview';
 
@@ -22,7 +22,7 @@ class Pathogenicity extends React.Component<IPathogenicityProps> {
         return (
             <div>
                 <Penetrance signalAnnotation={this.props.signalAnnotation} />
-                <ClinVarInterpretation clinVar={this.props.clinVar} />
+                {/* <ClinVarInterpretation clinVar={this.props.clinVar} /> */}
                 <Oncokb
                     oncokb={this.props.oncokb}
                     isCanonicalTranscriptSelected={

--- a/packages/react-variant-view/src/component/pathogenicity/Pathogenicity.tsx
+++ b/packages/react-variant-view/src/component/pathogenicity/Pathogenicity.tsx
@@ -2,15 +2,15 @@ import _ from 'lodash';
 import * as React from 'react';
 
 import { observer } from 'mobx-react';
-import { ClinVar, SignalAnnotation } from 'genome-nexus-ts-api-client';
+import { Clinvar, SignalAnnotation } from 'genome-nexus-ts-api-client';
 import { IndicatorQueryResp } from 'oncokb-ts-api-client';
 import Oncokb from './Oncokb';
-// import ClinVarInterpretation from './ClinVarInterpretation';
 import Penetrance from './Penetrance';
 import MSKExpertReview from './MSKExpertReview';
+import ClinVarInterpretation from './ClinVarInterpretation';
 
 interface IPathogenicityProps {
-    clinVar?: ClinVar;
+    clinVar?: Clinvar;
     oncokb?: IndicatorQueryResp;
     signalAnnotation?: SignalAnnotation;
     isCanonicalTranscriptSelected: boolean;
@@ -22,7 +22,7 @@ class Pathogenicity extends React.Component<IPathogenicityProps> {
         return (
             <div>
                 <Penetrance signalAnnotation={this.props.signalAnnotation} />
-                {/* <ClinVarInterpretation clinVar={this.props.clinVar} /> */}
+                <ClinVarInterpretation clinVar={this.props.clinVar} />
                 <Oncokb
                     oncokb={this.props.oncokb}
                     isCanonicalTranscriptSelected={

--- a/packages/react-variant-view/src/component/pathogenicity/Pathogenicity.tsx
+++ b/packages/react-variant-view/src/component/pathogenicity/Pathogenicity.tsx
@@ -7,10 +7,10 @@ import { IndicatorQueryResp } from 'oncokb-ts-api-client';
 import Oncokb from './Oncokb';
 import Penetrance from './Penetrance';
 import MSKExpertReview from './MSKExpertReview';
-import ClinVarInterpretation from './ClinVarInterpretation';
+import ClinvarInterpretation from './ClinvarInterpretation';
 
 interface IPathogenicityProps {
-    clinVar?: Clinvar;
+    clinvar?: Clinvar;
     oncokb?: IndicatorQueryResp;
     signalAnnotation?: SignalAnnotation;
     isCanonicalTranscriptSelected: boolean;
@@ -22,7 +22,7 @@ class Pathogenicity extends React.Component<IPathogenicityProps> {
         return (
             <div>
                 <Penetrance signalAnnotation={this.props.signalAnnotation} />
-                <ClinVarInterpretation clinVar={this.props.clinVar} />
+                <ClinvarInterpretation clinvar={this.props.clinvar} />
                 <Oncokb
                     oncokb={this.props.oncokb}
                     isCanonicalTranscriptSelected={

--- a/packages/react-variant-view/src/component/variantView/Variant.tsx
+++ b/packages/react-variant-view/src/component/variantView/Variant.tsx
@@ -66,7 +66,7 @@ class Variant extends React.Component<IVariantProps> {
                         annotationInternal={this.variantStore.annotationSummary}
                         variantAnnotation={this.variantAnnotation}
                         oncokb={this.oncokb}
-                        clinVar={this.clinVar}
+                        clinvar={this.clinvar}
                         signalAnnotation={this.signalAnnotation}
                         isCanonicalTranscriptSelected={
                             this.isCanonicalTranscriptSelected!
@@ -104,7 +104,7 @@ class Variant extends React.Component<IVariantProps> {
     }
 
     @computed
-    private get clinVar() {
+    private get clinvar() {
         return this.variantAnnotation?.clinvar.annotation;
     }
 

--- a/packages/react-variant-view/src/component/variantView/Variant.tsx
+++ b/packages/react-variant-view/src/component/variantView/Variant.tsx
@@ -105,7 +105,7 @@ class Variant extends React.Component<IVariantProps> {
 
     @computed
     private get clinVar() {
-        return this.myVariantInfo?.clinVar;
+        return this.variantAnnotation?.clinvar.annotation;
     }
 
     @computed

--- a/packages/react-variant-view/src/util/Constants.ts
+++ b/packages/react-variant-view/src/util/Constants.ts
@@ -24,6 +24,7 @@ export const ANNOTATION_QUERY_FIELDS = [
     'my_variant_info',
     'mutation_assessor',
     'signal',
+    'clinvar',
 ];
 
 export enum Pathogenicity {

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -1030,6 +1030,7 @@ export class PatientViewPageStore {
                     [
                         GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                         GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
+                        GENOME_NEXUS_ARG_FIELD_ENUM.CLINVAR,
                         AppConfig.serverConfig.show_signal
                             ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
                             : '',

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -4956,6 +4956,7 @@ export class ResultsViewPageStore {
                           [
                               GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                               GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
+                              GENOME_NEXUS_ARG_FIELD_ENUM.CLINVAR,
                               AppConfig.serverConfig.show_signal
                                   ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
                                   : '',

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -223,6 +223,7 @@ export default class MutationMapperToolStore {
                     [
                         GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                         GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
+                        GENOME_NEXUS_ARG_FIELD_ENUM.CLINVAR,
                         AppConfig.serverConfig.show_signal
                             ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
                             : '',

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -65,7 +65,7 @@ import { getAnnotationData, IAnnotation } from 'react-mutation-mapper';
 import HgvscColumnFormatter from './column/HgvscColumnFormatter';
 import HgvsgColumnFormatter from './column/HgvsgColumnFormatter';
 import GnomadColumnFormatter from './column/GnomadColumnFormatter';
-import ClinVarColumnFormatter from './column/ClinVarColumnFormatter';
+import ClinvarColumnFormatter from './column/ClinvarColumnFormatter';
 import autobind from 'autobind-decorator';
 import DbsnpColumnFormatter from './column/DbsnpColumnFormatter';
 import SignalColumnFormatter from './column/SignalColumnFormatter';
@@ -1039,17 +1039,17 @@ export default class MutationTable<
         this._columns[MutationTableColumnType.CLINVAR] = {
             name: 'ClinVar',
             render: (d: Mutation[]) =>
-                ClinVarColumnFormatter.renderFunction(
+                ClinvarColumnFormatter.renderFunction(
                     d,
                     this.props.indexedVariantAnnotations
                 ),
             sortBy: (d: Mutation[]) =>
-                ClinVarColumnFormatter.getSortValue(
+                ClinvarColumnFormatter.getSortValue(
                     d,
                     this.props.indexedVariantAnnotations
                 ),
             download: (d: Mutation[]) =>
-                ClinVarColumnFormatter.download(
+                ClinvarColumnFormatter.download(
                     d,
                     this.props.indexedVariantAnnotations
                 ),

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -1041,18 +1041,17 @@ export default class MutationTable<
             render: (d: Mutation[]) =>
                 ClinVarColumnFormatter.renderFunction(
                     d,
-                    this.props.indexedVariantAnnotations,
-                    this.props.indexedMyVariantInfoAnnotations
+                    this.props.indexedVariantAnnotations
                 ),
             sortBy: (d: Mutation[]) =>
                 ClinVarColumnFormatter.getSortValue(
                     d,
-                    this.props.indexedMyVariantInfoAnnotations
+                    this.props.indexedVariantAnnotations
                 ),
             download: (d: Mutation[]) =>
                 ClinVarColumnFormatter.download(
                     d,
-                    this.props.indexedMyVariantInfoAnnotations
+                    this.props.indexedVariantAnnotations
                 ),
             tooltip: (
                 <span>

--- a/src/shared/components/mutationTable/column/ClinVarColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ClinVarColumnFormatter.tsx
@@ -12,6 +12,7 @@ import {
     ClinVar,
     clinVarSortValue,
     clinVarDownload,
+    getClinVarData,
 } from 'react-mutation-mapper';
 
 export default class ClinVarColumnFormatter {
@@ -19,9 +20,6 @@ export default class ClinVarColumnFormatter {
         data: Mutation[],
         indexedVariantAnnotations?: RemoteData<
             { [genomicLocation: string]: VariantAnnotation } | undefined
-        >,
-        indexedMyVariantInfoAnnotations?: RemoteData<
-            IMyVariantInfoIndex | undefined
         >
     ) {
         return (
@@ -29,9 +27,6 @@ export default class ClinVarColumnFormatter {
                 <ClinVar
                     mutation={data[0]}
                     indexedVariantAnnotations={indexedVariantAnnotations}
-                    indexedMyVariantInfoAnnotations={
-                        indexedMyVariantInfoAnnotations
-                    }
                 />
             </div>
         );
@@ -53,29 +48,23 @@ export default class ClinVarColumnFormatter {
 
     public static download(
         data: Mutation[],
-        indexedMyVariantInfoAnnotations?: RemoteData<
-            IMyVariantInfoIndex | undefined
+        indexedVariantAnnotations?: RemoteData<
+            { [genomicLocation: string]: VariantAnnotation } | undefined
         >
     ): string {
-        const myVariantInfo = ClinVarColumnFormatter.getData(
-            data,
-            indexedMyVariantInfoAnnotations
+        return clinVarDownload(
+            getClinVarData(data[0], indexedVariantAnnotations)
         );
-
-        return clinVarDownload(myVariantInfo);
     }
 
     public static getSortValue(
         data: Mutation[],
-        indexedMyVariantInfoAnnotations?: RemoteData<
-            IMyVariantInfoIndex | undefined
+        indexedVariantAnnotations?: RemoteData<
+            { [genomicLocation: string]: VariantAnnotation } | undefined
         >
     ): string | null {
-        const myVariantInfo = ClinVarColumnFormatter.getData(
-            data,
-            indexedMyVariantInfoAnnotations
+        return clinVarSortValue(
+            getClinVarData(data[0], indexedVariantAnnotations)
         );
-
-        return clinVarSortValue(myVariantInfo);
     }
 }

--- a/src/shared/components/mutationTable/column/ClinvarColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ClinvarColumnFormatter.tsx
@@ -9,13 +9,13 @@ import {
     RemoteData,
 } from 'cbioportal-utils';
 import {
-    ClinVar,
-    clinVarSortValue,
-    clinVarDownload,
-    getClinVarData,
+    ClinvarInterpretation,
+    clinvarSortValue,
+    clinvarDownload,
+    getClinvarData,
 } from 'react-mutation-mapper';
 
-export default class ClinVarColumnFormatter {
+export default class ClinvarColumnFormatter {
     public static renderFunction(
         data: Mutation[],
         indexedVariantAnnotations?: RemoteData<
@@ -24,7 +24,7 @@ export default class ClinVarColumnFormatter {
     ) {
         return (
             <div data-test="clinvar-data">
-                <ClinVar
+                <ClinvarInterpretation
                     mutation={data[0]}
                     indexedVariantAnnotations={indexedVariantAnnotations}
                 />
@@ -52,8 +52,8 @@ export default class ClinVarColumnFormatter {
             { [genomicLocation: string]: VariantAnnotation } | undefined
         >
     ): string {
-        return clinVarDownload(
-            getClinVarData(data[0], indexedVariantAnnotations)
+        return clinvarDownload(
+            getClinvarData(data[0], indexedVariantAnnotations)
         );
     }
 
@@ -63,8 +63,8 @@ export default class ClinVarColumnFormatter {
             { [genomicLocation: string]: VariantAnnotation } | undefined
         >
     ): string | null {
-        return clinVarSortValue(
-            getClinVarData(data[0], indexedVariantAnnotations)
+        return clinvarSortValue(
+            getClinvarData(data[0], indexedVariantAnnotations)
         );
     }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -65,4 +65,5 @@ export const enum GENOME_NEXUS_ARG_FIELD_ENUM {
     MUTATION_ASSESSOR = 'mutation_assessor',
     MY_VARIANT_INFO = 'my_variant_info',
     SIGNAL = 'signal',
+    CLINVAR = 'clinvar',
 }


### PR DESCRIPTION
Part of:https://github.com/cBioPortal/cbioportal/issues/8470

- Get clinvar from genome nexus annotation endpoint.
- Be consistent with clinvar website - show one clinvar interpretation(unless it's conflicting interpretation). Previously was multiple interpretations and evidences in "Germline" and "Somatic"
- Update clinvar on Signal

Previous:
![image](https://user-images.githubusercontent.com/16869603/121093216-b6d21d80-c7ba-11eb-942f-38f2cc3b5ccd.png)

Now:
![image](https://user-images.githubusercontent.com/16869603/121093410-fef14000-c7ba-11eb-970a-2013f02b3364.png)


