### PR TITLE
Remove app_name configuration checks

### DIFF
--- a/src/appShell/App/PortalFooter.tsx
+++ b/src/appShell/App/PortalFooter.tsx
@@ -156,8 +156,8 @@ export default class PortalFooter extends React.Component<
                                     </If>
                                     <If
                                         condition={
-                                            AppConfig.serverConfig.app_name ===
-                                            'public-portal'
+                                            AppConfig.serverConfig
+                                                .skin_right_nav_show_twitter
                                         }
                                     >
                                         <li>
@@ -174,8 +174,7 @@ export default class PortalFooter extends React.Component<
                         </If>
                         <If
                             condition={
-                                AppConfig.serverConfig.app_name ===
-                                'public-portal'
+                                AppConfig.serverConfig.skin_footer_show_dev
                             }
                         >
                             <div className="footer-elem">

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -77,6 +77,7 @@ export interface IServerConfig {
     skin_examples_right_column_html: string | null;
     skin_documentation_faq: string | null;
     skin_footer: string | null;
+    skin_footer_show_dev: boolean;
     skin_login_contact_html: string | null;
     skin_login_saml_registration_html: string | null;
     skin_citation_rule_text: string | null;
@@ -88,6 +89,7 @@ export interface IServerConfig {
     skin_right_nav_show_examples: boolean;
     skin_right_nav_show_testimonials: boolean;
     skin_right_nav_show_whats_new: boolean;
+    skin_right_nav_show_twitter: boolean;
     skin_right_nav_whats_new_blurb: string | null;
     skin_show_about_tab: boolean;
     skin_show_data_tab: boolean;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -63,6 +63,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     skin_documentation_markdown: true,
     skin_email_contact: 'cbioportal at googlegroups dot com',
     skin_documentation_faq: 'FAQ.md',
+    skin_footer_show_dev: false,
     skin_login_saml_registration_html: 'Sign in with MSK',
     skin_documentation_news: 'News.md',
     skin_documentation_oql: 'Onco-Query-Language.md',
@@ -71,6 +72,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     skin_right_nav_show_examples: true,
     skin_right_nav_show_testimonials: true,
     skin_right_nav_show_whats_new: true,
+    skin_right_nav_show_twitter: false,
     skin_citation_rule_text:
         'Please cite: <a href="http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract" target="_blank">Cerami et al., 2012</a> &amp; <a href="http://www.ncbi.nlm.nih.gov/pubmed/23550210" target="_blank">Gao et al., 2013</a>',
     skin_show_about_tab: true,


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8419:
Adds explicit booleans for configuration checks instead of indirectly checking `app_name` property.
(Need to merge corresponding backend PR#8656 before this.)