### PR TITLE
Fix group comparison download

### DIFF
--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
@@ -612,7 +612,7 @@ export function getAlterationEnrichmentColumns(
             ),
             sortBy: (d: AlterationEnrichmentRow) => Number(d.logRatio),
             download: (d: AlterationEnrichmentRow) =>
-                formatLogOddsRatio(d.logRatio!),
+                d.logRatio ? formatLogOddsRatio(d.logRatio) : '-',
         });
 
         enrichedGroupColum.tooltip = (


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8485

`logRatio` can be undefined, return `-` when it's undefined.
- logRatio Undefined case
![image](https://user-images.githubusercontent.com/15748980/120820341-722c5500-c522-11eb-850a-6dc0d6680881.png)

**Testing:**
1. Go to https://genie.cbioportal.org/comparison/alterations?sessionId=60664081e4b0242bd5d46323
2. Set `localStorage.netlify ="deploy-preview-3783--cbioportalfrontend"` in browser console.
3. Click download button
![image](https://user-images.githubusercontent.com/15748980/121069212-3b14a880-c79b-11eb-865e-7f1ae83852ce.png)
