### PR TITLE
(Study view) waiting for km plots

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -5149,7 +5149,7 @@ export class StudyViewPageStore {
             this.mutationProfiles.isPending ||
             this.cnaProfiles.isPending ||
             this.structuralVariantProfiles.isPending ||
-            this.survivalClinicalAttributesPrefix.isPending ||
+            this.survivalPlots.isPending ||
             this.displayPatientTreatments.isPending ||
             this.sharedCustomData.isPending;
 


### PR DESCRIPTION
computed value `_chartMetaSet` is using `this.survivalPlots`, but `this.survivalPlots` has an empty default value. So we need to wait `this.survivalPlots` loaded then render plots.