### PR TITLE
Remove backend var from custom.sh

### DIFF
--- a/env/custom.sh
+++ b/env/custom.sh
@@ -1,3 +1,3 @@
 export BRANCH_ENV="http://localhost:8080"
 export GENOME_NEXUS_URL="https://www.genomenexus.org"
-#export BACKEND=cbioportal:release-genie-performance
+


### PR DESCRIPTION
Even though this export is commented out, still causing our validation script to fail