### PR TITLE
Query page sample count should show sum of each study's allSampleCount property

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -122,7 +122,10 @@ export enum Focus {
 // mobx observable
 export class QueryStore {
     constructor(urlWithInitialParams?: string) {
+        getBrowserWindow().activeQueryStore = this;
+
         makeObservable(this);
+
         this.initialize(urlWithInitialParams);
     }
 
@@ -1017,6 +1020,10 @@ export class QueryStore {
             all: 0,
         },
     });
+
+    @computed get sampleCountForSelectedStudies() {
+        return _.sumBy(this.selectableSelectedStudies, s => s.allSampleCount);
+    }
 
     readonly sampleLists = remoteData({
         invoke: async () => {

--- a/src/shared/components/query/StudySelectorStats.tsx
+++ b/src/shared/components/query/StudySelectorStats.tsx
@@ -31,10 +31,7 @@ export const StudySelectorStats: React.FunctionComponent<{
                                 {numSelectedStudies === 1 ? 'study' : 'studies'}{' '}
                                 selected (
                                 <b>
-                                    {
-                                        props.store.profiledSamplesCount.result
-                                            .all
-                                    }
+                                    {props.store.sampleCountForSelectedStudies}
                                 </b>{' '}
                                 samples)
                             </a>


### PR DESCRIPTION
UI was previously calculating sum base don count of a sample list with category = all.  This turns out to overcomplicate things.  