### PR TITLE
Genomic evolution fixes - VAF Chart, Group By issues

### DIFF
--- a/src/pages/patientView/timeline2/VAFChartWrapper.tsx
+++ b/src/pages/patientView/timeline2/VAFChartWrapper.tsx
@@ -223,12 +223,14 @@ export default class VAFChartWrapper extends React.Component<
         let sampleIdToClinicalValue: { [sampleId: string]: string } = {};
         if (this.props.wrapperStore.groupingByIsSelected) {
             this.props.sampleManager.samples.forEach((sample, i) => {
-                sampleIdToClinicalValue[
-                    sample.id
-                ] = SampleManager!.getClinicalAttributeInSample(
+                const clinicalData = SampleManager!.getClinicalAttributeInSample(
                     sample,
                     this.props.wrapperStore.groupByOption!
-                )!.value;
+                );
+                sampleIdToClinicalValue[sample.id] =
+                    clinicalData != undefined
+                        ? clinicalData.value
+                        : 'undefined-group';
             });
         }
         return sampleIdToClinicalValue;
@@ -297,11 +299,13 @@ export default class VAFChartWrapper extends React.Component<
 
     @computed get groupColor() {
         return (sampleId: string) => {
+            const color = this.clinicalValueToColor[
+                this.sampleIdToClinicalValue[sampleId]
+            ];
             return this.props.wrapperStore.groupingByIsSelected &&
-                this.numGroupByGroups > 1
-                ? this.clinicalValueToColor[
-                      this.sampleIdToClinicalValue[sampleId]
-                  ]
+                this.numGroupByGroups > 1 &&
+                color != undefined
+                ? color
                 : 'rgb(0,0,0)';
         };
     }
@@ -365,11 +369,13 @@ export default class VAFChartWrapper extends React.Component<
     }
 
     groupColorByGroupIndex(groupIndex: number) {
+        const groupColor = this.clinicalValueToColor[
+            this.clinicalValuesForGrouping[groupIndex]
+        ];
         return this.props.wrapperStore.groupingByIsSelected &&
-            this.numGroupByGroups > 1
-            ? this.clinicalValueToColor[
-                  this.clinicalValuesForGrouping[groupIndex]
-              ]
+            this.numGroupByGroups > 1 &&
+            groupColor != undefined
+            ? groupColor
             : 'rgb(0,0,0)';
     }
 


### PR DESCRIPTION
If samples are grouped by a clinical value, when adding data points for samples without mutations there must be a check that they are in the same group as the other samples.

For example on https://www.cbioportal.org/patient/genomicEvolution?studyId=msk_impact_2017&caseId=P-0000377

Before this fix, the highlighted mutation below contains only samples 2 and 4, but sample 3 was also added even if it is in a different group
![Screenshot from 2021-06-16 11-33-20](https://user-images.githubusercontent.com/53996876/122196629-ae9f6f80-ce97-11eb-90f1-70d8ff50e9d8.png)

After this fix, sample 3 is no longer added because it is part of a different group
![Screenshot from 2021-06-16 11-37-48](https://user-images.githubusercontent.com/53996876/122196663-b6f7aa80-ce97-11eb-8461-d7b042ccedb1.png)

