### PR TITLE
Fix SVG file download error

### DIFF
--- a/src/pages/groupComparison/UpSet.tsx
+++ b/src/pages/groupComparison/UpSet.tsx
@@ -62,7 +62,7 @@ const MAX_LABEL_WIDTH = 200;
 const BarComponent = (props: any) => (
     <Bar
         className={`${props.caseType}_${_.sortBy(props.datum.groups)
-            .map(g => g.replace(/ /g, '_'))
+            .map(g => encodeURI(g.replace(/ /g, '_')))
             .join('_')}_bar`}
         {...props}
     />


### PR DESCRIPTION
Related to cBioPortal/cbioportal#8563 - fix svg file download error only.
Due to the "<" symbol in the className, svg file errors out. This is fixed by using encodeURI.
PDF download issue is still pending.