### PR TITLE
Added unit tests for Group By function of Genomic Evolution VAF Chart

### DIFF
--- a/src/pages/patientView/timeline2/VAFChartUtils.spec.ts
+++ b/src/pages/patientView/timeline2/VAFChartUtils.spec.ts
@@ -1,7 +1,10 @@
 import { assert } from 'chai';
 import { Mutation, Sample } from 'cbioportal-ts-api-client';
 import { MutationStatus } from '../mutation/PatientViewMutationsTabUtils';
-import { generateMutationIdByGeneAndProteinChangeAndEvent } from '../../../shared/lib/StoreUtils';
+import {
+    generateMutationIdByGeneAndProteinChangeAndEvent,
+    generateMutationIdByGeneAndProteinChangeSampleIdAndEvent,
+} from '../../../shared/lib/StoreUtils';
 import { CoverageInformation } from '../../../shared/lib/GenePanelUtils';
 import {
     ceil10,
@@ -13,8 +16,10 @@ import {
     round10,
     minimalDistinctTickStrings,
     yValueScaleFunction,
+    splitMutationsBySampleGroup,
 } from './VAFChartUtils';
 import { GROUP_BY_NONE } from '../timeline2/VAFChartControls';
+
 import _ from 'lodash';
 import { assertDeepEqualInAnyOrder } from 'shared/lib/SpecUtils';
 
@@ -32,6 +37,7 @@ describe('VAFChartUtils', () => {
             expected.forEach(d => {
                 d.y = d.y.toFixed(5) as any;
             });
+
             assert.deepEqual(actual, expected, message);
         }
 
@@ -53,13 +59,18 @@ describe('VAFChartUtils', () => {
                 expected.lineData.length,
                 `${messagePrefix || ''}lineData length`
             );
+
             const mutationKeyToLineData = _.keyBy(actual.lineData, d =>
-                generateMutationIdByGeneAndProteinChangeAndEvent(d[0].mutation)
+                generateMutationIdByGeneAndProteinChangeSampleIdAndEvent(
+                    d[0].mutation
+                )
             );
+
             for (const line of expected.lineData) {
-                const mutationKey = generateMutationIdByGeneAndProteinChangeAndEvent(
+                const mutationKey = generateMutationIdByGeneAndProteinChangeSampleIdAndEvent(
                     line[0].mutation
                 );
+
                 roughlyDeepEqualPoints(
                     mutationKeyToLineData[mutationKey],
                     line,
@@ -160,7 +171,12 @@ describe('VAFChartUtils', () => {
             return ret;
         }
 
-        const sampleIdIndex = { sample1: 0, sample2: 1, sample3: 2 };
+        const sampleIdIndex = {
+            sample1: 0,
+            sample2: 1,
+            sample3: 2,
+            sample4: 3,
+        };
 
         it('handles case of empty data', () => {
             checkResult(
@@ -868,6 +884,791 @@ describe('VAFChartUtils', () => {
                 }
             );
         });
+        it('returns correct result when grouped by sample type and every sample has vaf data for every mutation', () => {
+            checkResult(
+                computeRenderData(
+                    [makeSample(1), makeSample(2), makeSample(3)],
+                    [
+                        [makeMutation(1, 'gene1', 'proteinchange1', 20)],
+                        [
+                            makeMutation(2, 'gene1', 'proteinchange1', 10),
+                            makeMutation(3, 'gene1', 'proteinchange1', 15),
+                        ],
+                        [
+                            makeMutation(
+                                1,
+                                'gene2',
+                                'proteinchange2',
+                                30,
+                                'uncalled'
+                            ),
+                        ],
+                        [
+                            makeMutation(2, 'gene2', 'proteinchange2', 50),
+                            makeMutation(3, 'gene2', 'proteinchange2', 25),
+                        ],
+
+                        [makeMutation(1, 'gene3', 'proteinchange3', 40)],
+                        [
+                            makeMutation(2, 'gene3', 'proteinchange3', 60),
+                            makeMutation(3, 'gene3', 'proteinchange3', 80),
+                        ],
+                    ],
+                    sampleIdIndex,
+                    'mutations',
+                    makeCoverageInfo([1, 2, 3], []),
+                    'SampleType',
+                    {
+                        sample1: 'Primary',
+                        sample2: 'Recurrence',
+                        sample3: 'Recurrence',
+                    }
+                ),
+                {
+                    grayPoints: [],
+                    lineData: [
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene1',
+                                    'proteinchange1',
+                                    10
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 10 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene1',
+                                    'proteinchange1',
+                                    15
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 15 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene2',
+                                    'proteinchange2',
+                                    50
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 50 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene2',
+                                    'proteinchange2',
+                                    25
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 25 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene3',
+                                    'proteinchange3',
+                                    60
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 60 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene3',
+                                    'proteinchange3',
+                                    80
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 80 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene1',
+                                    'proteinchange1',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene2',
+                                    'proteinchange2',
+                                    30,
+                                    'uncalled'
+                                ),
+                                mutationStatus:
+                                    MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED,
+                                x: 0,
+                                y: 30 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene3',
+                                    'proteinchange3',
+                                    40
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 40 / 100,
+                            },
+                        ],
+                    ],
+                }
+            );
+        });
+        it('returns correct result when grouped by sample collection source and every sample has data for every mutation, but not all have VAF', () => {
+            checkResult(
+                computeRenderData(
+                    [makeSample(1), makeSample(2), makeSample(3)],
+                    [
+                        [
+                            makeMutation(1, 'gene1', 'proteinchange1', 20),
+                            makeMutation(3, 'gene1', 'proteinchange1', 15),
+                        ],
+                        [makeMutation(2, 'gene1', 'proteinchange1')],
+                        [
+                            makeMutation(1, 'gene2', 'proteinchange2', 30),
+                            makeMutation(3, 'gene2', 'proteinchange2'),
+                        ],
+                        [makeMutation(2, 'gene2', 'proteinchange2', 50)],
+                        [
+                            makeMutation(1, 'gene3', 'proteinchange3', 40),
+                            makeMutation(3, 'gene3', 'proteinchange3', 80),
+                        ],
+                        [makeMutation(2, 'gene3', 'proteinchange3')],
+                    ],
+                    sampleIdIndex,
+                    'mutations',
+                    makeCoverageInfo([1, 2, 3], []),
+                    'SampleCollectionSource',
+                    {
+                        sample1: 'Outside',
+                        sample2: 'Inside',
+                        sample3: 'Outside',
+                    }
+                ),
+                {
+                    grayPoints: [],
+                    lineData: [
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene1',
+                                    'proteinchange1',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene1',
+                                    'proteinchange1',
+                                    15
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 15 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene2',
+                                    'proteinchange2',
+                                    30
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 30 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene2',
+                                    'proteinchange2',
+                                    50
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 50 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene3',
+                                    'proteinchange3',
+                                    40
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 40 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene3',
+                                    'proteinchange3',
+                                    80
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 80 / 100,
+                            },
+                        ],
+                    ],
+                }
+            );
+        });
+        it('returns correct result when grouped by sample collection source and not every sample has data for every mutation', () => {
+            checkResult(
+                computeRenderData(
+                    [makeSample(1), makeSample(2), makeSample(3)],
+                    [
+                        [
+                            makeMutation(1, 'gene1', 'proteinchange1', 20),
+                            makeMutation(3, 'gene1', 'proteinchange1', 60),
+                        ],
+                        [makeMutation(2, 'gene1', 'proteinchange1')],
+                        [makeMutation(2, 'gene2', 'proteinchange2', 50)],
+                        [makeMutation(3, 'gene2', 'proteinchange2')],
+                        [makeMutation(1, 'gene3', 'proteinchange3', 40)],
+                        [makeMutation(2, 'gene3', 'proteinchange3')],
+                    ],
+                    sampleIdIndex,
+                    'mutations',
+                    makeCoverageInfo([1, 2, 3], []),
+                    'SampleCollectionSource',
+                    {
+                        sample1: 'Outside',
+                        sample2: 'Inside',
+                        sample3: 'Outside',
+                    }
+                ),
+                {
+                    grayPoints: [],
+                    lineData: [
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene1',
+                                    'proteinchange1',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene1',
+                                    'proteinchange1',
+                                    60
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 60 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene2',
+                                    'proteinchange2',
+                                    50
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 50 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene3',
+                                    'proteinchange3',
+                                    40
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 40 / 100,
+                            },
+                        ],
+                    ],
+                }
+            );
+        });
+        it('returns correct result when grouped by sample collection source and one sample has no data for any mutation', () => {
+            checkResult(
+                computeRenderData(
+                    [makeSample(1), makeSample(2), makeSample(3)],
+                    [
+                        [
+                            makeMutation(1, 'gene1', 'proteinchange1', 20),
+                            makeMutation(3, 'gene1', 'proteinchange1'),
+                        ],
+                        [makeMutation(3, 'gene2', 'proteinchange2', 50)],
+                        [
+                            makeMutation(1, 'gene3', 'proteinchange3', 40),
+                            makeMutation(3, 'gene3', 'proteinchange3', 65),
+                        ],
+                    ],
+                    sampleIdIndex,
+                    'mutations',
+                    makeCoverageInfo([1, 2, 3], []),
+                    'SampleCollectionSource',
+                    {
+                        sample1: 'Outside',
+                        sample2: 'Inside',
+                        sample3: 'Outside',
+                    }
+                ),
+                {
+                    grayPoints: [],
+                    lineData: [
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene1',
+                                    'proteinchange1',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene2',
+                                    'proteinchange2',
+                                    50
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 50 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene3',
+                                    'proteinchange3',
+                                    40
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 40 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene3',
+                                    'proteinchange3',
+                                    65
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 65 / 100,
+                            },
+                        ],
+                    ],
+                }
+            );
+        });
+        it('returns correct result when grouped by sample collection source and some samples are not profiled', () => {
+            checkResult(
+                computeRenderData(
+                    [makeSample(1), makeSample(2), makeSample(3)],
+                    [
+                        [makeMutation(1, 'gene1', 'proteinchange1', 20)],
+                        [
+                            makeMutation(1, 'gene2', 'proteinchange2', 20),
+                            makeMutation(3, 'gene2', 'proteinchange2', 30),
+                        ],
+                        [makeMutation(1, 'gene3', 'proteinchange3', 40)],
+                        [makeMutation(2, 'gene3', 'proteinchange3')],
+                    ],
+                    sampleIdIndex,
+                    'mutations',
+                    makeCoverageInfo(
+                        [1, 3],
+                        [],
+                        [
+                            {
+                                i: 2,
+                                notProfiledByGene: {
+                                    gene1: {
+                                        molecularProfileId: 'mutations',
+                                        patientId: 'patient',
+                                        profiled: false,
+                                        sampleId: `sample2`,
+                                        studyId: 'study',
+                                        uniquePatientKey: `uniquePatientKey`,
+                                        uniqueSampleKey: `uniqueKey2`,
+                                    },
+                                    gene2: {
+                                        molecularProfileId: 'mutations',
+                                        patientId: 'patient',
+                                        profiled: false,
+                                        sampleId: `sample2`,
+                                        studyId: 'study',
+                                        uniquePatientKey: `uniquePatientKey`,
+                                        uniqueSampleKey: `uniqueKey2`,
+                                    },
+                                },
+                            },
+                        ]
+                    ),
+                    'SampleCollectionSource',
+                    {
+                        sample1: 'Outside',
+                        sample2: 'Inside',
+                        sample3: 'Outside',
+                    }
+                ),
+                {
+                    grayPoints: [],
+                    lineData: [
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene1',
+                                    'proteinchange1',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene2',
+                                    'proteinchange2',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene2',
+                                    'proteinchange2',
+                                    30
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 30 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene3',
+                                    'proteinchange3',
+                                    40
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 40 / 100,
+                            },
+                        ],
+                    ],
+                }
+            );
+        });
+        it('returns correct result when grouped by sample type and a sample is not profiled at all', () => {
+            checkResult(
+                computeRenderData(
+                    [makeSample(1), makeSample(2), makeSample(3)],
+                    [
+                        [makeMutation(1, 'gene1', 'proteinchange1', 20)],
+                        [makeMutation(2, 'gene1', 'proteinchange1')],
+                        [makeMutation(2, 'gene2', 'proteinchange2', 50)],
+                        [makeMutation(1, 'gene3', 'proteinchange3', 40)],
+                        [makeMutation(2, 'gene3', 'proteinchange3')],
+                    ],
+                    sampleIdIndex,
+                    'mutations',
+                    makeCoverageInfo([1, 2], [3]),
+                    'SampleType',
+                    {
+                        sample1: 'Primary',
+                        sample2: 'Recurrence',
+                        sample3: 'Recurrence',
+                    }
+                ),
+                {
+                    grayPoints: [],
+                    lineData: [
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene1',
+                                    'proteinchange1',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene2',
+                                    'proteinchange2',
+                                    50
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 50 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene3',
+                                    'proteinchange3',
+                                    40
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 40 / 100,
+                            },
+                        ],
+                    ],
+                }
+            );
+        });
+        it('returns correct result when grouped by tumor purity and one sample is not part of any group', () => {
+            checkResult(
+                computeRenderData(
+                    [
+                        makeSample(1),
+                        makeSample(2),
+                        makeSample(3),
+                        makeSample(4),
+                    ],
+                    [
+                        [makeMutation(1, 'gene1', 'proteinchange1', 20)],
+                        [makeMutation(2, 'gene1', 'proteinchange1', 10)],
+                        [
+                            makeMutation(3, 'gene1', 'proteinchange1', 15),
+                            makeMutation(4, 'gene1', 'proteinchange1', 25),
+                        ],
+                        [makeMutation(1, 'gene2', 'proteinchange2', 30)],
+                        [makeMutation(2, 'gene2', 'proteinchange2', 50)],
+                        [
+                            makeMutation(3, 'gene2', 'proteinchange2', 25),
+                            makeMutation(4, 'gene2', 'proteinchange2', 35),
+                        ],
+                    ],
+                    sampleIdIndex,
+                    'mutations',
+                    makeCoverageInfo([1, 2, 3, 4], []),
+                    'TumorPurity',
+                    { sample2: '40', sample3: '30', sample4: '30' }
+                ),
+                {
+                    grayPoints: [],
+                    lineData: [
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene1',
+                                    'proteinchange1',
+                                    20
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 20 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene1',
+                                    'proteinchange1',
+                                    10
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 10 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene1',
+                                    'proteinchange1',
+                                    15
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 15 / 100,
+                            },
+                            {
+                                sampleId: 'sample4',
+                                mutation: makeMutation(
+                                    4,
+                                    'gene1',
+                                    'proteinchange1',
+                                    25
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 3,
+                                y: 25 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample1',
+                                mutation: makeMutation(
+                                    1,
+                                    'gene2',
+                                    'proteinchange2',
+                                    30
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 0,
+                                y: 30 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample2',
+                                mutation: makeMutation(
+                                    2,
+                                    'gene2',
+                                    'proteinchange2',
+                                    50
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 1,
+                                y: 50 / 100,
+                            },
+                        ],
+                        [
+                            {
+                                sampleId: 'sample3',
+                                mutation: makeMutation(
+                                    3,
+                                    'gene2',
+                                    'proteinchange2',
+                                    25
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 2,
+                                y: 25 / 100,
+                            },
+                            {
+                                sampleId: 'sample4',
+                                mutation: makeMutation(
+                                    4,
+                                    'gene2',
+                                    'proteinchange2',
+                                    35
+                                ),
+                                mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                                x: 3,
+                                y: 35 / 100,
+                            },
+                        ],
+                    ],
+                }
+            );
+        });
     });
 
     describe('getYAxisTickmarks', () => {
@@ -990,6 +1791,150 @@ describe('VAFChartUtils', () => {
             const yPadding = 10;
             const f = yValueScaleFunction(1, 9, 120, true);
             assert.approximately(f(2), 120 - yPadding - 31.5, 0.1);
+        });
+    });
+
+    describe('splitMutationsBySampleGroup', () => {
+        function checkResult(
+            actual: Mutation[][],
+            expected: Mutation[][],
+            messagePrefix?: string
+        ) {
+            assert.equal(
+                actual.length,
+                expected.length,
+                `${messagePrefix || ''}mutations length`
+            );
+            actual.forEach((mutationGroup, groupIndex) => {
+                mutationGroup.forEach((mutation, mutationIndex) => {
+                    const actualMutationKey = generateMutationIdByGeneAndProteinChangeSampleIdAndEvent(
+                        mutation
+                    );
+                    const expectedMutationKey = generateMutationIdByGeneAndProteinChangeSampleIdAndEvent(
+                        expected[groupIndex][mutationIndex]
+                    );
+                    assert.equal(
+                        actualMutationKey,
+                        expectedMutationKey,
+                        `${messagePrefix ||
+                            ''}mutation with key ${actualMutationKey}`
+                    );
+                });
+            });
+        }
+
+        function makeMutation(
+            sampleI: number,
+            hugoGeneSymbol: string,
+            proteinChange: string,
+            vafPercent?: number,
+            mutationStatus: string = ''
+        ) {
+            return {
+                gene: {
+                    hugoGeneSymbol,
+                },
+                mutationStatus,
+                uniqueSampleKey: `uniqueKey${sampleI}`,
+                uniquePatientKey: `uniquePatientKey`,
+                sampleId: `sample${sampleI}`,
+                patientId: 'patient',
+                studyId: 'study',
+                proteinChange,
+                chr: '1',
+                startPosition: 0,
+                endPosition: 0,
+                referenceAllele: '',
+                variantAllele: '',
+                tumorAltCount: vafPercent,
+                tumorRefCount:
+                    vafPercent === undefined ? undefined : 100 - vafPercent,
+                molecularProfileId: 'mutations',
+            } as Mutation;
+        }
+
+        it('returns correct result when all samples have a group', () => {
+            checkResult(
+                splitMutationsBySampleGroup(
+                    [
+                        [
+                            makeMutation(1, 'gene1', 'proteinchange1', 20),
+                            makeMutation(2, 'gene1', 'proteinchange1', 30),
+                            makeMutation(3, 'gene1', 'proteinchange1', 40),
+                            makeMutation(4, 'gene1', 'proteinchange1', 10),
+                        ],
+                        [
+                            makeMutation(2, 'gene2', 'proteinchange2', 50),
+                            makeMutation(3, 'gene2', 'proteinchange2', 20),
+                            makeMutation(4, 'gene2', 'proteinchange2', 60),
+                        ],
+                        [
+                            makeMutation(1, 'gene3', 'proteinchange3', 40),
+                            makeMutation(2, 'gene3', 'proteinchange3', 50),
+                        ],
+                    ],
+                    {
+                        sample1: 'group1',
+                        sample2: 'group2',
+                        sample3: 'group3',
+                        sample4: 'group2',
+                    }
+                ),
+                [
+                    [makeMutation(1, 'gene1', 'proteinchange1', 20)],
+                    [
+                        makeMutation(2, 'gene1', 'proteinchange1', 30),
+                        makeMutation(4, 'gene1', 'proteinchange1', 10),
+                    ],
+                    [makeMutation(3, 'gene1', 'proteinchange1', 40)],
+                    [
+                        makeMutation(2, 'gene2', 'proteinchange2', 50),
+                        makeMutation(4, 'gene2', 'proteinchange2', 60),
+                    ],
+                    [makeMutation(3, 'gene2', 'proteinchange2', 20)],
+                    [makeMutation(1, 'gene3', 'proteinchange3', 40)],
+                    [makeMutation(2, 'gene3', 'proteinchange3', 50)],
+                ]
+            );
+        });
+        it('returns correct result when one sample has no group', () => {
+            checkResult(
+                splitMutationsBySampleGroup(
+                    [
+                        [
+                            makeMutation(1, 'gene1', 'proteinchange1', 20),
+                            makeMutation(2, 'gene1', 'proteinchange1', 30),
+                            makeMutation(3, 'gene1', 'proteinchange1', 40),
+                            makeMutation(4, 'gene1', 'proteinchange1', 10),
+                        ],
+                        [
+                            makeMutation(2, 'gene2', 'proteinchange2', 50),
+                            makeMutation(3, 'gene2', 'proteinchange2', 20),
+                            makeMutation(4, 'gene2', 'proteinchange2', 60),
+                        ],
+                        [
+                            makeMutation(1, 'gene3', 'proteinchange3', 40),
+                            makeMutation(2, 'gene3', 'proteinchange3', 50),
+                        ],
+                    ],
+                    { sample2: 'group2', sample3: 'group3', sample4: 'group2' }
+                ),
+                [
+                    [makeMutation(1, 'gene1', 'proteinchange1', 20)],
+                    [
+                        makeMutation(2, 'gene1', 'proteinchange1', 30),
+                        makeMutation(4, 'gene1', 'proteinchange1', 10),
+                    ],
+                    [makeMutation(3, 'gene1', 'proteinchange1', 40)],
+                    [
+                        makeMutation(2, 'gene2', 'proteinchange2', 50),
+                        makeMutation(4, 'gene2', 'proteinchange2', 60),
+                    ],
+                    [makeMutation(3, 'gene2', 'proteinchange2', 20)],
+                    [makeMutation(1, 'gene3', 'proteinchange3', 40)],
+                    [makeMutation(2, 'gene3', 'proteinchange3', 50)],
+                ]
+            );
         });
     });
 });

--- a/src/pages/patientView/timeline2/VAFChartUtils.ts
+++ b/src/pages/patientView/timeline2/VAFChartUtils.ts
@@ -24,7 +24,7 @@ function isPointBasedOnRealVAF(d: { mutationStatus: MutationStatus }) {
     );
 }
 
-function splitMutationsBySampleGroup(
+export function splitMutationsBySampleGroup(
     mutations: Mutation[][],
     sampleGroup: { [s: string]: string }
 ) {

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1298,6 +1298,17 @@ export function generateMutationIdByGeneAndProteinChangeAndEvent(
     ].join('_');
 }
 
+export function generateMutationIdByGeneAndProteinChangeSampleIdAndEvent(
+    m: Mutation
+): string {
+    return [
+        m.gene.hugoGeneSymbol,
+        m.proteinChange,
+        m.sampleId,
+        ...mutationEventFields(m),
+    ].join('_');
+}
+
 /** scan a collection of Mutations to see if any contain values for ASCN fields/properties
  *
  * all mutations (whether passed as a simple array or as an array of array)


### PR DESCRIPTION
Added unit tests for both splitMutationsBySampleGroup and computeRenderData methods when Group By is used:

**computeRenderData**:
- returns correct result when grouped by sample type and every sample has vaf data for every mutation
- returns correct result when grouped by sample collection source and every sample has data for every mutation, but not all have VAF
- returns correct result when grouped by sample collection source and not every sample has data for every mutation
- returns correct result when grouped by sample collection source and one sample has no data for any mutation
- returns correct result when grouped by sample collection source and some samples are not profiled
- returns correct result when grouped by sample type and a sample is not profiled at all
- returns correct result when grouped by tumor purity and one sample is not part of any group

**splitMutationsBySampleGroup**:
- returns correct result when all samples have a group
- returns correct result when one sample has no group
