### PR TITLE
Tweak padding on tabs inside of menus

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -665,3 +665,10 @@ h2.divider {
     padding-bottom: 10px;
     border-bottom: 1px solid $borderColor;
 }
+
+.dropdown-menu,
+.rc-tooltip {
+    .nav-tabs {
+        padding-top: 4px;
+    }
+}


### PR DESCRIPTION
Adds a little more padding above the tabs when msk-tabs appears inside of a dropdown