### PR TITLE
Remove BACKEND var from custom.sh

### DIFF
--- a/env/custom.sh
+++ b/env/custom.sh
@@ -1,3 +1,2 @@
 export CBIOPORTAL_URL="http://localhost:8080"
 export GENOME_NEXUS_URL="https://www.genomenexus.org"
-export BACKEND=pvannierop:optimize_driver_filtering


### PR DESCRIPTION
The BACKEND var in custom.sh was accidentally added to the trunk. This PR will correct that.