### PR TITLE
Fix hgvsc column blank

### DIFF
--- a/packages/react-mutation-mapper/src/component/column/Hgvsc.tsx
+++ b/packages/react-mutation-mapper/src/component/column/Hgvsc.tsx
@@ -4,6 +4,7 @@ import { Mutation, RemoteData } from 'cbioportal-utils';
 
 import { defaultSortMethod } from 'cbioportal-utils';
 import { getHgvscColumnData } from './HgvsHelper';
+import { observer } from 'mobx-react';
 
 type HgvscProps = {
     mutation: Mutation;
@@ -25,6 +26,7 @@ export function hgvscSortMethod(a: string | null, b: string | null) {
     return defaultSortMethod(sortValue(a), sortValue(b));
 }
 
+@observer
 export default class Hgvsc extends React.Component<HgvscProps, {}> {
     get hgvsc() {
         return getHgvscColumnData(


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/517
HGVSc is empty at first because it doesn't have `@observer`

Test: https://www.cbioportal.org/patient?studyId=lgg_ucsf_2014&caseId=P04
