### PR TITLE
Fix broken e2e test for HLA-A mutations

### DIFF
--- a/end-to-end-test/remote/specs/core/data/hla_a_test_mutation_mapper_tool.txt
+++ b/end-to-end-test/remote/specs/core/data/hla_a_test_mutation_mapper_tool.txt
@@ -1,10 +1,10 @@
-Hugo_Symbol Chromosome Start_Position End_Position Reference_Allele Variant_Allele Mutation_Type Protien_Change
+Hugo_Symbol Chromosome Start_Position End_Position Reference_Allele Variant_Allele Mutation_Type Protein_Change_Intentionally_Misspelled_To_Force_Annotation_On_The_Fly
 HLA-A 6 29911072 29911072 G A Missense_Mutation G124D
 HLA-A 6 29912018 29912018 G A Missense_Mutation D247N
-HLA-A 6 29910348 29910348 CCGAA C frameshift_variant&feature_truncation R7fs
-HLA-A 6 29910348 29910348 CCGAA C frameshift_variant&feature_truncation R7fs
-HLA-A 6 29911899 29911899 A ACC frameshift_variant&feature_elongation D207fs
-HLA-A 6 29910609 29910609 G GT frameshift_variant&feature_elongation G50fs
+HLA-A 6 29910347 29910352 CCGAA C frameshift_variant&feature_truncation R7fs
+HLA-A 6 29910347 29910352 CCGAA C frameshift_variant&feature_truncation R7fs
+HLA-A 6 29911900 29911900 - CC frameshift_variant&feature_elongation D207fs
+HLA-A 6 29910610 29910610 - T frameshift_variant&feature_elongation G50fs
 HLA-A 6 29912064 29912064 A T Missense_Mutation D262V
 HLA-A 6 29911941 29911941 A G Missense_Mutation H221R
 HLA-A 6 29911905 29911905 C G Missense_Mutation P209R

--- a/end-to-end-test/remote/specs/core/mutationMapperTool.spec.js
+++ b/end-to-end-test/remote/specs/core/mutationMapperTool.spec.js
@@ -280,7 +280,7 @@ describe('Mutation Mapper Tool', function() {
         // based on HLA-A user question
         // https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/cbioportal/UQP41OIT5HI/1AaX24AcAwAJ
         it('should not show the canonical transcript when there are no matching annotations', () => {
-            var input = $('#standaloneMutationTextInput');
+            const input = $('#standaloneMutationTextInput');
             const hla = require('./data/hla_a_test_mutation_mapper_tool.txt');
 
             input.setValue(hla);
@@ -288,11 +288,15 @@ describe('Mutation Mapper Tool', function() {
 
             browser.waitForVisible('[class=borderedChart]', 20000);
 
-            // check total number of mutations (this gets Showing 1-14 of 14
-            // Mutations)
+            // the canonical transcript id for HLA-A is ENST00000376809, but
+            // these mutations apply to ENST00000376802
+            browser.waitForText('.//*[text()[contains(.,"ENST00000376802")]]');
+
+            // check total number of mutations (all should be successfully annotated)
             const mutationCount = browser.getText(
-                './/*[text()[contains(.,"14 Mutations")]]'
+                './/*[text()[contains(.,"16 Mutations")]]'
             );
+
             assert.ok(mutationCount.length > 0);
         });
     });

--- a/packages/cbioportal-utils/src/mutation/MutationAnnotator.spec.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationAnnotator.spec.ts
@@ -1,8 +1,11 @@
 import { assert } from 'chai';
 import * as _ from 'lodash';
 
+import { VariantAnnotation } from 'genome-nexus-ts-api-client';
+
 import { Mutation } from '../model/Mutation';
 import {
+    annotateMutation,
     annotateMutations,
     indexAnnotationsByGenomicLocation,
     resolveMissingProteinPositions,
@@ -2207,6 +2210,37 @@ describe('MutationAnnotator', () => {
                 variantAllele: 'A',
             },
         ];
+    });
+
+    describe('annotateMutation', () => {
+        it('should handle failed annotations properly', () => {
+            const mutation: Partial<Mutation> = {
+                chromosome: '6',
+                startPosition: 29910348,
+                endPosition: 29910352,
+                referenceAllele: 'CCGAA',
+                variantAllele: 'C',
+            };
+
+            const indexedVariantAnnotations = {
+                '6,29910348,29910352,CCGAA,C': {
+                    originalVariantQuery: '6,29910348,29910352,CCGAA,C',
+                    successfully_annotated: false,
+                    variant: '6:g.29910349_29910352del',
+                } as VariantAnnotation,
+            };
+
+            const annotatedMutation = annotateMutation(
+                mutation,
+                indexedVariantAnnotations
+            );
+
+            assert.equal(
+                annotatedMutation.proteinChange,
+                '',
+                'protein change value should be empty due to annotation failure'
+            );
+        });
     });
 
     describe('annotateMutations', () => {

--- a/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
+++ b/packages/cbioportal-utils/src/mutation/MutationAnnotator.ts
@@ -270,16 +270,16 @@ export function annotateMutation(
         : undefined;
     let canonicalTranscript: TranscriptConsequenceSummary | undefined;
 
-    if (variantAnnotation) {
-        canonicalTranscript = findCanonicalTranscript(
-            variantAnnotation.annotation_summary
-        );
+    const annotationSummary = variantAnnotation?.annotation_summary;
+
+    if (annotationSummary) {
+        canonicalTranscript = findCanonicalTranscript(annotationSummary);
     }
 
-    if (variantAnnotation && canonicalTranscript) {
+    if (annotationSummary && canonicalTranscript) {
         return getAnnotatedMutationFromAnnotationSummary(
             mutation,
-            variantAnnotation.annotation_summary,
+            annotationSummary,
             canonicalTranscript,
             true,
             shouldOverwriteByAnnotatedMutation


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8744

Describe changes proposed in this pull request:
- Fix broken tests due to annotation failure
- Fix Mutation Annotator so that it can handle annotation failures properly

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!