### PR TITLE
(GC) Disable other dataType except continuous data for Generic Assay tab

### DIFF
--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.spec.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.spec.tsx
@@ -12,10 +12,12 @@ import {
     getAlterationEnrichmentColumns,
     getEnrichmentBarPlotData,
     getGeneListOptions,
+    pickGenericAssayEnrichmentProfiles,
 } from './EnrichmentsUtil';
 import expect from 'expect';
 import expectJSX from 'expect-jsx';
 import * as _ from 'lodash';
+import { MolecularProfile } from 'cbioportal-ts-api-client';
 
 expect.extend(expectJSX);
 
@@ -890,6 +892,58 @@ describe('EnrichmentsUtil', () => {
                     { label: 'Sync with table (up to 100 genes)', genes: [] },
                 ]
             );
+        });
+    });
+
+    describe('#pickGenericAssayEnrichmentProfiles()', () => {
+        it('returns picked Generic Assay profiles', () => {
+            const profiles = [
+                {
+                    molecularProfileId: 'profile_1',
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'DISCRETE',
+                },
+                {
+                    molecularProfileId: 'profile_2',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    datatype: 'MAF',
+                },
+                {
+                    molecularProfileId: 'profile_3',
+                    molecularAlterationType: 'MRNA_EXPRESSION',
+                    datatype: 'CONTINUOUS',
+                },
+                {
+                    molecularProfileId: 'profile_4',
+                    molecularAlterationType: 'STRUCTURAL_VARIANT',
+                    datatype: 'FUSION',
+                },
+                {
+                    molecularProfileId: 'profile_5',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    datatype: 'LIMIT-VALUE',
+                },
+                {
+                    molecularProfileId: 'profile_6',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    datatype: 'CATEGORICAL',
+                },
+                {
+                    molecularProfileId: 'profile_7',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    datatype: 'BINARY',
+                },
+            ] as MolecularProfile[];
+            const expectedResult = [
+                {
+                    molecularProfileId: 'profile_5',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    datatype: 'LIMIT-VALUE',
+                } as MolecularProfile,
+            ];
+            const result = pickGenericAssayEnrichmentProfiles(profiles);
+            assert.equal(result.length, 1);
+            assert.deepEqual(result, expectedResult);
         });
     });
 });

--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
@@ -11,7 +11,10 @@ import {
 } from 'shared/model/EnrichmentRow';
 import { formatLogOddsRatio, roundLogRatio } from 'shared/lib/FormatUtils';
 import * as _ from 'lodash';
-import { AlterationTypeConstants } from '../ResultsViewPageStore';
+import {
+    AlterationTypeConstants,
+    DataTypeConstants,
+} from '../ResultsViewPageStore';
 import { filterAndSortProfiles } from '../coExpression/CoExpressionTabUtils';
 import { IMiniFrequencyScatterChartData } from './MiniFrequencyScatterChart';
 import {
@@ -535,9 +538,12 @@ export function pickMethylationEnrichmentProfiles(
 export function pickGenericAssayEnrichmentProfiles(
     profiles: MolecularProfile[]
 ) {
+    // TODO: Pick profiles from all Generic Assay dataTypes after we implement related features
     return profiles.filter(p => {
         return (
-            p.molecularAlterationType === AlterationTypeConstants.GENERIC_ASSAY
+            p.molecularAlterationType ===
+                AlterationTypeConstants.GENERIC_ASSAY &&
+            p.datatype === DataTypeConstants.LIMITVALUE
         );
     });
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8557
Disable other dataType except continuous data for Generic Assay tab on Comparison page.