### PR TITLE
Allow custom tabs on patient page as well

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -1654,8 +1654,12 @@ export default class PatientViewPage extends React.Component<
                                         .map((tab: any, i: number) => {
                                             return (
                                                 <MSKTab
-                                                    key={100 + i}
-                                                    id={'customTab' + 1}
+                                                    key={getPatientViewResourceTabId(
+                                                        'customTab' + i
+                                                    )}
+                                                    id={getPatientViewResourceTabId(
+                                                        'customTab' + i
+                                                    )}
                                                     unmountOnHide={
                                                         tab.unmountOnHide ===
                                                         true


### PR DESCRIPTION
Custom tabs are not working for the patient page and getting a Page not found error when clicking on one.

This happens because customTabParamValidator expects only patient/openResource_ while the MSKTab for the patient custom tabs is using customTab id only so link will be patient/customTab

So I have modified the MSKTab key and id to be accepted in the validator and tested it.