### PR TITLE
Fix jitpack build failure

### DIFF
--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.tsx
@@ -8,7 +8,6 @@ import CosmicMutationTable from 'shared/components/cosmic/CosmicMutationTable';
 import styles from './cosmic.module.scss';
 import { ICosmicData } from 'shared/model/Cosmic';
 import generalStyles from './styles.module.scss';
-import { string } from 'yargs';
 import memoize from 'memoize-weak-decorator';
 
 export function placeArrow(tooltipEl: any) {


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/8781 by removing accidental yargs import

This did indeed fix the build on jitpack: https://jitpack.io/com/github/inodb/cbioportal-frontend/faac94871ab259a15f5a42002c05935698646a94/build.log