### PR TITLE
fix keycloak db init docker compose setup

### DIFF
--- a/end-to-end-test/local/docker_compose/start.sh
+++ b/end-to-end-test/local/docker_compose/start.sh
@@ -14,7 +14,7 @@ if [ $CUSTOM_BACKEND -eq 1 ]; then
   compose_extensions="$compose_extensions -f $TEST_HOME/docker_compose/cbioportal-custombranch.yml"
 fi
 
-if (ls "$KC_DB_DATA_DIR"/* 2> /dev/null > /dev/null); then
+if ! (ls "$KC_DB_DATA_DIR"/* 2> /dev/null > /dev/null); then
   compose_extensions="$compose_extensions -f $TEST_HOME/docker_compose/keycloak_init.yml"
 fi
 


### PR DESCRIPTION
keycloak should be initialized whenever the keycloak data dir is missing

This actually gives some error so not the right approach