### PR TITLE
Hide logout button in cBioPortal header via portal.properties

### DIFF
--- a/end-to-end-test/local/specs/hide-login-button.spec.js
+++ b/end-to-end-test/local/specs/hide-login-button.spec.js
@@ -1,0 +1,18 @@
+var assert = require('assert');
+var goToUrlAndSetLocalStorageWithProperty = require('../../shared/specUtils')
+    .goToUrlAndSetLocalStorageWithProperty;
+var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+const loggedInButton = '#rightHeaderContent .identity';
+
+describe('hide logged-in button feature', function() {
+    if (useExternalFrontend) {
+        it('does not show logged-in button when portal property set', function() {
+            goToUrlAndSetLocalStorageWithProperty(CBIOPORTAL_URL, true, {
+                skin_hide_logout_button: true,
+            });
+            assert(!$(loggedInButton).isExisting());
+        });
+    }
+});

--- a/end-to-end-test/shared/specUtils.js
+++ b/end-to-end-test/shared/specUtils.js
@@ -175,6 +175,24 @@ function goToUrlAndSetLocalStorage(url, authenticated = false) {
     //browser.moveToObject('body', 0, 0);
 }
 
+const goToUrlAndSetLocalStorageWithProperty = (url, authenticated, props) => {
+    goToUrlAndSetLocalStorage(url, authenticated);
+    setServerConfiguration(props);
+    goToUrlAndSetLocalStorage(url, authenticated);
+};
+
+function setServerConfiguration(props) {
+    browser.execute(
+        function(frontendConf) {
+            this.localStorage.setItem(
+                'frontendConfig',
+                JSON.stringify(frontendConf)
+            );
+        },
+        { serverConfig: props }
+    );
+}
+
 function sessionServiceIsEnabled() {
     return browser.execute(function() {
         return window.frontendConfig.serverConfig.sessionServiceEnabled;
@@ -578,6 +596,7 @@ module.exports = {
     waitForCoExpressionTab: waitForCoExpressionTab,
     waitForPatientView: waitForPatientView,
     goToUrlAndSetLocalStorage: goToUrlAndSetLocalStorage,
+    goToUrlAndSetLocalStorageWithProperty: goToUrlAndSetLocalStorageWithProperty,
     useExternalFrontend: useExternalFrontend,
     sessionServiceIsEnabled: sessionServiceIsEnabled,
     waitForNumberOfStudyCheckboxes: waitForNumberOfStudyCheckboxes,

--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -136,7 +136,12 @@ export default class PortalHeader extends React.Component<
                     </nav>
                 </div>
                 <div id="rightHeaderContent">
-                    <If condition={!AppConfig.hide_login}>
+                    <If
+                        condition={
+                            !AppConfig.hide_login &&
+                            !AppConfig.serverConfig.skin_hide_logout_button
+                        }
+                    >
                         <If condition={this.props.appStore.isLoggedIn}>
                             <Then>
                                 <div className="identity">

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -102,6 +102,7 @@ export interface IServerConfig {
     skin_show_web_api_tab: boolean;
     skin_show_tweet_button: boolean;
     skin_show_tissue_image_tab: boolean;
+    skin_hide_logout_button: boolean;
     skin_title: string;
     skin_authorization_message: string | null;
     skin_patientview_filter_genes_profiled_all_samples: boolean;


### PR DESCRIPTION
This PR will hide the logout button in the header section when the following property is set in _portal.properties_:

```
skin.hide_logout_button=true
```

![image](https://user-images.githubusercontent.com/745885/127161699-4d4984b6-1b67-41e7-a1a7-a826283037e3.png)

Note that this functionality is already implemented with the undocumented _frontendConfig.hide_logout_ configuration option.

# Tests
A e2e-localdb test has been included to test this feature.