### PR TITLE
Fix mutation table column hover detection bug

### DIFF
--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -955,8 +955,8 @@ export default class LazyMobXTable<T> extends React.Component<
     }
 
     componentDidMount() {
-        if (window.onmousemove === null) {
-            window.onmousemove = (mouse: any) => {
+        if (document.onmousemove === null) {
+            document.onmousemove = (mouse: any) => {
                 const headerInfo: {
                     left: number;
                     filterIcon?: any;


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8787

This bug was introduced in the latest column-filters PR (#3831), specifically in the section related to determining which column filter icon to show. I had initially identified and solved this during review for that PR, but then discovered that it's not fixed on the latest master branch. Apparently `window.onmousemove` is resetting to `null` after closing the tooltip, which wasn't happening before. I've just switched to using `document.onmousemove` instead and that apparently solves the problem, since it doesn't reset to `null` after closing the tooltip window.