### PR TITLE
Add link to filtered study view + Fix URL generation

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -3521,6 +3521,7 @@ export class ResultsViewPageStore
             () => this.discreteCNACache,
             this.studyToMolecularProfileDiscreteCna.result!,
             this.studyIdToStudy,
+            this.queriedStudies,
             this.molecularProfileIdToMolecularProfile,
             this.clinicalDataForSamples,
             this.studiesForSamplesWithoutCancerTypeClinicalData,

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
@@ -68,6 +68,7 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
             [studyId: string]: MolecularProfile;
         },
         public studyIdToStudy: MobxPromise<{ [studyId: string]: CancerStudy }>,
+        public queriedStudies: MobxPromise<CancerStudy[]>,
         public molecularProfileIdToMolecularProfile: MobxPromise<{
             [molecularProfileId: string]: MolecularProfile;
         }>,

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -71,10 +71,10 @@ export default class QuerySummary extends React.Component<
                     submitToStudyViewPage(
                         this.props.store.queriedStudies.result,
                         this.props.store.filteredSamples.result!,
-                        this.props.store.queriedVirtualStudies.result.length >
-                            0,
                         this.props.store.filteredSamples.result!.length <
                             this.props.store.samples.result!.length,
+                        this.props.store.queriedVirtualStudies.result.length >
+                            0,
                         this.props.store.sampleLists.result
                     );
                 }}

--- a/src/pages/resultsView/querySummary/QuerySummaryUtils.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummaryUtils.tsx
@@ -6,16 +6,20 @@ import { buildCBioPortalPageUrl } from '../../../shared/api/urls';
 
 export function getPatientSampleSummary(samples: any[], patients: any[]) {
     if (samples.length !== patients.length) {
+        const patientUnits = patients.length === 1 ? 'patient' : 'patients';
+        const sampleUnits = samples.length === 1 ? 'sample' : 'samples';
         return (
             <span>
-                <strong>{patients.length}</strong> patients /{' '}
-                <strong>{samples.length}</strong> samples
+                <strong>{patients.length}</strong> {patientUnits} /{' '}
+                <strong>{samples.length}</strong> {sampleUnits}
             </span>
         );
     } else {
+        const units =
+            samples.length === 1 ? 'patient/sample' : 'patients/samples';
         return (
             <span>
-                <strong>{samples.length}</strong> patients/samples
+                <strong>{samples.length}</strong> {units}
             </span>
         );
     }
@@ -84,8 +88,8 @@ export function getAlterationSummary(
 export function submitToStudyViewPage(
     queriedStudies: Pick<CancerStudy, 'studyId'>[],
     samples: Pick<Sample, 'sampleId' | 'studyId'>[],
-    hasVirtualStudies: boolean,
     samplesAreFiltered: boolean,
+    hasVirtualStudies?: boolean,
     sampleLists?: Pick<SampleList, 'category'>[]
 ) {
     const hasAllCaseLists = _.some(

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -59,9 +59,11 @@ export function buildCBioPortalPageUrl(
         typeof pathnameOrParams === 'string'
             ? { pathname: pathnameOrParams, query, hash }
             : pathnameOrParams;
+
+    // AppConfig.frontendUrl format is '//url/', hence the specified slice to get just 'url'
     return URL.format({
         protocol: window.location.protocol,
-        host: AppConfig.baseUrl,
+        host: AppConfig.baseUrl || AppConfig.frontendUrl?.slice(2, -1),
         ...params,
     });
 }

--- a/src/shared/components/mutationMapper/MutationMapperDataStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperDataStore.ts
@@ -196,6 +196,19 @@ export default class MutationMapperDataStore
         return countDuplicateMutations(this.tableDataGroupedByPatients);
     }
 
+    @computed
+    get tableDataSamples() {
+        return _.uniqBy(_.flatten(this.tableData), m => m.sampleId).map(m => ({
+            sampleId: m.sampleId,
+            studyId: m.studyId,
+        }));
+    }
+
+    @computed
+    get tableDataPatients() {
+        return _.uniq(_.flatten(this.tableData).map(m => m.patientId));
+    }
+
     constructor(
         data: Mutation[][],
         customFilterApplier?: FilterApplier,


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8802

### Changes:
- Modify the filter reset panel in the results view "Mutations" tab to include a link to a filtered study view page (according to the mutation table filters)
- Fix issue with local development where clicking hyperlinks (e.g. "Sample ID" link to patient view from results view mutation table cell) requires the user to manually modify the generated link. The problem was that `AppConfig.baseUrl` is undefined outside of the production portal.

![filterResetPanel_0](https://user-images.githubusercontent.com/18505975/127787199-0c6ef0e8-f225-4ea2-911d-8af6ac2bd0f8.png)
![filterResetPanel_1](https://user-images.githubusercontent.com/18505975/127917757-d6f74e2b-bf7a-46c0-8858-465ae6a4ba4f.png)