### PR TITLE
fix hover detection bug

### DIFF
--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -823,6 +823,7 @@ export default class LazyMobXTable<T> extends React.Component<
     private filterInput: HTMLInputElement;
     private filterInputReaction: IReactionDisposer;
     private pageToHighlightReaction: IReactionDisposer;
+    private isChildTable: boolean;
 
     public static defaultProps = {
         showFilter: true,
@@ -1010,11 +1011,15 @@ export default class LazyMobXTable<T> extends React.Component<
                     }
                 }
             };
+        } else {
+            this.isChildTable = true;
         }
     }
 
     componentWillUnmount() {
-        window.onmousemove = null;
+        if (!this.isChildTable) {
+            document.onmousemove = null;
+        }
         this.filterInputReaction();
         this.pageToHighlightReaction();
         if (this.props.storeColumnVisibility) {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8803

It turns out that I had initially misdiagnosed the issue (#3880), but I've now understood the problem and have properly addressed it. The issue was not related to any difference between `window.onmousemove` and `document.onmousemove`. In fact, I had simply not noticed that I was manually resetting `window.onmousemove` to `null` when the table unmounted. The real issue required me to distinguish between a new table being created due to, for example, a tooltip window (in which case I call it a "child table") and a new table being created due to switching between genes.