### PR TITLE
Customizable default thresholds for P-value and score - frontend

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -131,6 +131,8 @@ export interface IServerConfig {
     query_product_limit: number;
     dat_method: string;
     skin_show_gsva: boolean;
+    skin_geneset_hierarchy_default_gsva_score: number;
+    skin_geneset_hierarchy_default_p_value: number;
     oncoKbTokenDefined: boolean;
     generic_assay_display_text: string; // this has a default
     saml_logout_local: boolean;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -171,6 +171,10 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
 
     skin_show_gsva: false,
 
+    skin_geneset_hierarchy_default_gsva_score: 0.5,
+
+    skin_geneset_hierarchy_default_p_value: 0.05,
+
     generic_assay_display_text:
         'TREATMENT_RESPONSE:Treatment Response,MUTATIONAL_SIGNATURE:Mutational Signature',
 

--- a/src/shared/components/query/GenesetsHierarchySelector.tsx
+++ b/src/shared/components/query/GenesetsHierarchySelector.tsx
@@ -5,6 +5,7 @@ import GenesetsJsTree from './GenesetsJsTree';
 import GenesetsHierarchyFilterForm, {
     validPercentile,
 } from './GenesetsHierarchyFilterForm';
+import AppConfig from 'appConfig';
 
 export interface GenesetsHierarchySelectorProps {
     initialSelection: string[];
@@ -19,8 +20,10 @@ export default class GenesetsHierarchySelector extends React.Component<
     {}
 > {
     @observable percentile: validPercentile = 75;
-    @observable pvalueThreshold = 0.05;
-    @observable scoreThreshold = 0.5;
+    @observable pvalueThreshold =
+        AppConfig.serverConfig.skin_geneset_hierarchy_default_p_value;
+    @observable scoreThreshold =
+        AppConfig.serverConfig.skin_geneset_hierarchy_default_gsva_score;
     @observable searchValue = '';
 
     constructor(props: GenesetsHierarchySelectorProps) {


### PR DESCRIPTION
After loading gene set data, and opening the gene set hierarchy panel for selection, default filters for P-value (<0.05) and GSVA score (>0.5) are applied to filter the list of sets shown:

![b1caa613-d5fe-4d40-b93c-357c896e6286](https://user-images.githubusercontent.com/53996876/127841067-71fb843a-b5cd-4360-9001-1aa72618f603.png)

Added new properties in the portal.properties file in order to have customizable default thresholds for P-value and score.

Backend PR is https://github.com/cBioPortal/cbioportal/pull/8804