### PR TITLE
Change error message when study doesn't exist or user doesn't have ac…

### DIFF
--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -39,6 +39,8 @@ export class AppStore {
 
     @observable.ref authMethod: string | undefined = undefined;
 
+    @observable unknownOrUnauthorizedStudyIds: boolean = false;
+
     @computed get isLoggedIn() {
         return _.isString(this.userName) && this.userName !== 'anonymousUser';
     }

--- a/src/appShell/App/Container.tsx
+++ b/src/appShell/App/Container.tsx
@@ -137,6 +137,27 @@ export default class Container extends React.Component<IContainerProps, {}> {
                         </div>
                     </Else>
                 </If>
+                <If condition={this.appStore.unknownOrUnauthorizedStudyIds}>
+                    <Then>
+                        <div className="contentWrapper">
+                            <ErrorScreen
+                                title={
+                                    'The study/studies you are trying to access do not exist, or you do not have access.'
+                                }
+                                body={
+                                    <a href={buildCBioPortalPageUrl('/')}>
+                                        Return to homepage
+                                    </a>
+                                }
+                            />
+                        </div>
+                    </Then>
+                    <Else>
+                        <div className="contentWrapper">
+                            {makeRoutes(this.routingStore)}
+                        </div>
+                    </Else>
+                </If>
             </div>
         );
     }

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -525,15 +525,6 @@ export default class StudyViewPage extends React.Component<
                 )}
 
                 {this.store.comparisonConfirmationModal}
-                {this.store.unknownQueriedIds.isComplete &&
-                    this.store.unknownQueriedIds.result.length > 0 && (
-                        <Alert bsStyle="danger">
-                            <span>
-                                Unknown/Unauthorized studies{' '}
-                                {this.store.unknownQueriedIds.result.join(', ')}
-                            </span>
-                        </Alert>
-                    )}
                 <LoadingIndicator
                     size={'big'}
                     isLoading={

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -4337,12 +4337,19 @@ export class StudyViewPageStore
         onError: () => {},
         onResult: unknownIds => {
             if (unknownIds.length > 0) {
-                this.pageStatusMessages['unknownIds'] = {
-                    status: 'danger',
-                    message: `Unknown/Unauthorized ${
-                        unknownIds.length > 1 ? 'studies' : 'study'
-                    } ${unknownIds.join(', ')}`,
-                };
+                // if all studies are unknown, set flag for error page message
+                if (unknownIds.length == this.studyIds.length) {
+                    this.appStore.unknownOrUnauthorizedStudyIds = true;
+                }
+                // else only set status message for those that are unknown
+                else {
+                    this.pageStatusMessages['unknownIds'] = {
+                        status: 'danger',
+                        message: `Unknown/Unauthorized ${
+                            unknownIds.length > 1 ? 'studies' : 'study'
+                        } ${unknownIds.join(', ')}`,
+                    };
+                }
             }
         },
         default: [],


### PR DESCRIPTION
Changed error page when study doesn't exist or user doesn't have access according to issue https://github.com/cBioPortal/cbioportal/issues/8500

Currently there is code that marks the study as unknown or unauthorized but only the pageStatusMessages is updated and it continues with fetching data about the study until it finally fails at api/treatment/display-patient. So the error page "Oops. There was an error retrieving data" refers to failed api/treatment/display-patient.

I have changed this by setting a flag when all queried studies are unknown/unauthorized and displaying the error message "The study/studies you are trying to access do not exist, or you do not have access." When only some study ids are unknown/unauthorized then the page is displayed with the valid studies and a status message on the header about the unknown/unauthorized ones.

Also the status message was displayed twice (in StudyViewPage and StudyPageHeader) so I removed the one from StudyViewPage.

Error page before fix:

![Screenshot from 2021-08-06 11-34-16](https://user-images.githubusercontent.com/53996876/128490756-e0649110-a9f1-4d45-bedb-2ee1f7c9df46.png)

Status messages before fix with physical studies and virtual studies:

![Screenshot from 2021-08-06 11-33-17](https://user-images.githubusercontent.com/53996876/128490848-52fd8347-bf42-48a5-af2f-6c3ede3f5e4f.png)

![Screenshot from 2021-08-06 11-33-32](https://user-images.githubusercontent.com/53996876/128490864-f14768cb-2e6a-49ec-9221-226a02ae7be3.png)



Error page after fix:

![Screenshot from 2021-08-06 11-34-08](https://user-images.githubusercontent.com/53996876/128490888-d754661b-14c2-4aa6-83d7-acbc4f8a183f.png)



Status messages after fix:

![Screenshot from 2021-08-06 11-33-51](https://user-images.githubusercontent.com/53996876/128490911-2f8d2dda-19d4-40e2-92e6-3efaa5028c6a.png)
