### PR TITLE
Add circleci job test e2e against backend master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,15 @@ jobs:
       JUNIT_REPORT_PATH: ./remote/junit/
       SCREENSHOT_DIRECTORY: ./remote/screenshots
     <<: *run_e2e_and_save_artifacts
+  
+  end_to_end_tests_against_master:
+    <<: *defaults
+    environment:
+      SPEC_FILE_PATTERN: ./remote/specs/**/*.spec.js
+      JUNIT_REPORT_PATH: ./remote/junit/
+      SCREENSHOT_DIRECTORY: ./remote/screenshots
+      CBIOPORTAL_URL: https://master.cbioportal.org
+    <<: *run_e2e_and_save_artifacts
 
   end_to_end_tests_localdb:
     working_directory: /tmp/repo
@@ -343,6 +352,9 @@ workflows:
       - end_to_end_tests:
           requires:
             - install
+      - end_to_end_tests_against_master:
+          requires:
+            - install
       - end_to_end_tests_localdb:
           requires:
             - install
@@ -375,7 +387,9 @@ workflows:
       - end_to_end_tests:
           requires:
             - install
+      - end_to_end_tests_against_master:
+          requires:
+            - install
       - end_to_end_tests_localdb:
           requires:
             - install
-

--- a/env/master.sh
+++ b/env/master.sh
@@ -1,2 +1,2 @@
-export CBIOPORTAL_URL="https://www.cbioportal.org"
-export GENOME_NEXUS_URL="https://www.genomenexus.org"
+export CBIOPORTAL_URL="${CBIOPORTAL_URL:-https://www.cbioportal.org}"
+export GENOME_NEXUS_URL="${GENOME_NEXUS_URL:-https://www.genomenexus.org}"


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/8708. We have had several issues where the backend master branch was not working with the frontend's master branch. We would only notice this issue after deploying the master branch to master.cbioportal.org and then opening a frontend PR where we update env/master.sh. Since this takes quite some time many times we would skip this step when deploying a new release.

To automate this we have set up a cronjob that deploys the latest backend master branch frequently to master.cbioportal.org. On the frontend we then only need this one extra cirlceci job so we are testing against both www.cbioportal.org and master.cbioportal.org