### PR TITLE
Improve specificity of URLWrapper hash props

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -713,6 +713,9 @@ export default class ResultsViewPage extends React.Component<
                                 </div>
                                 {tabsReady && (
                                     <MSKTabs
+                                        // When important parts of the query change (included in the hash), we
+                                        //  want to remount the tabs so that we rerun any initialization code
+                                        //  that depends on the query.
                                         key={this.urlWrapper.hash}
                                         activeTabId={
                                             this.resultsViewPageStore.tabId

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -20,7 +20,6 @@ import IComparisonURLWrapper from 'pages/groupComparison/IComparisonURLWrapper';
 import _ from 'lodash';
 import { MapValues } from 'shared/lib/TypeScriptUtils';
 import { GroupComparisonTab } from 'pages/groupComparison/GroupComparisonTabs';
-import hashString from 'shared/lib/hashString';
 
 export type PlotsSelectionParam = {
     selectedGeneOption?: string;

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -118,112 +118,150 @@ export type ResultsViewURLQuery = {
     plots_coloring_selection: PlotsColoringParam;
 };
 
-const propertiesMap: PropertiesMap<ResultsViewURLQuery> = {
-    // NON session props here
-    // oncoprint props
-    clinicallist: { isSessionProp: false, isHashedProp: false },
-    show_samples: { isSessionProp: false, isHashedProp: false },
-    heatmap_track_groups: { isSessionProp: false, isHashedProp: false },
-    oncoprint_sortby: { isSessionProp: false, isHashedProp: false },
-    oncoprint_cluster_profile: { isSessionProp: false, isHashedProp: false },
-    oncoprint_sort_by_mutation_type: {
-        isSessionProp: false,
-        isHashedProp: false,
-    },
-    oncoprint_sort_by_drivers: { isSessionProp: false, isHashedProp: false },
-    generic_assay_groups: { isSessionProp: false, isHashedProp: false },
-    exclude_germline_mutations: { isSessionProp: false, isHashedProp: false },
-    hide_unprofiled_samples: { isSessionProp: false, isHashedProp: false },
-    patient_enrichments: { isSessionProp: false, isHashedProp: false },
+const shouldForceRemount: { [prop in keyof ResultsViewURLQuery]: boolean } = {
+    clinicallist: false,
+    show_samples: false,
+    heatmap_track_groups: false,
+    oncoprint_sortby: false,
+    oncoprint_cluster_profile: false,
+    oncoprint_sort_by_mutation_type: false,
+    oncoprint_sort_by_drivers: false,
+    generic_assay_groups: false,
+    exclude_germline_mutations: false,
+    hide_unprofiled_samples: false,
+    patient_enrichments: false,
 
-    comparison_subtab: { isSessionProp: false, isHashedProp: false },
-    comparison_overlapStrategy: { isSessionProp: false, isHashedProp: false },
-    comparison_selectedGroups: { isSessionProp: false, isHashedProp: false },
-    comparison_groupOrder: { isSessionProp: false, isHashedProp: false },
-    comparison_selectedEnrichmentEventTypes: {
-        isSessionProp: true,
-        isHashedProp: false,
-    },
+    comparison_subtab: false,
+    comparison_overlapStrategy: false,
+    comparison_selectedGroups: false,
+    comparison_groupOrder: false,
+    comparison_selectedEnrichmentEventTypes: false,
 
     // plots
-    plots_horz_selection: {
-        isSessionProp: false,
-        isHashedProp: false,
-        nestedObjectProps: PlotsSelectionParamProps,
-    },
-    plots_vert_selection: {
-        isSessionProp: false,
-        isHashedProp: false,
-        nestedObjectProps: PlotsSelectionParamProps,
-    },
-    plots_coloring_selection: {
-        isSessionProp: false,
-        isHashedProp: false,
-        nestedObjectProps: PlotsColoringParamProps,
-    },
+    plots_horz_selection: false,
+    plots_vert_selection: false,
+    plots_coloring_selection: false,
 
     // mutations
-    mutations_gene: {
-        isSessionProp: false,
-        isHashedProp: false,
-    },
-    mutations_transcript_id: {
-        isSessionProp: false,
-        isHashedProp: false,
-    },
+    mutations_gene: false,
+    mutations_transcript_id: false,
 
     // session props here
-    gene_list: {
-        isSessionProp: true,
-        isHashedProp: true,
-        doubleURIEncode: true,
-    },
-    cancer_study_list: {
-        isSessionProp: true,
-        isHashedProp: true,
-        aliases: ['cancer_study_id'],
-    },
-    case_ids: { isSessionProp: true, isHashedProp: true },
-    sample_list_ids: { isSessionProp: true, isHashedProp: true },
-    case_set_id: { isSessionProp: true, isHashedProp: true },
-    profileFilter: {
-        isSessionProp: true,
-        isHashedProp: true,
-        aliases: ['data_priority'],
-    },
-    RPPA_SCORE_THRESHOLD: { isSessionProp: true, isHashedProp: true },
-    Z_SCORE_THRESHOLD: { isSessionProp: true, isHashedProp: true },
-    geneset_list: { isSessionProp: true, isHashedProp: true },
-    genetic_profile_ids_PROFILE_MUTATION_EXTENDED: {
-        isSessionProp: true,
-        isHashedProp: true,
-    },
-    genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION: {
-        isSessionProp: true,
-        isHashedProp: true,
-    },
-    genetic_profile_ids_PROFILE_MRNA_EXPRESSION: {
-        isSessionProp: true,
-        isHashedProp: true,
-    },
-    genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: {
-        isSessionProp: true,
-        isHashedProp: true,
-    },
-    genetic_profile_ids_PROFILE_GENESET_SCORE: {
-        isSessionProp: true,
-        isHashedProp: true,
-    },
-    genetic_profile_ids_GENERIC_ASSAY: {
-        isSessionProp: true,
-        isHashedProp: true,
-    },
-    genetic_profile_ids: { isSessionProp: true, isHashedProp: true },
-    comparison_createdGroupsSessionId: {
-        isSessionProp: true,
-        isHashedProp: false,
-    },
+    gene_list: true,
+    cancer_study_list: true,
+    case_ids: true,
+    sample_list_ids: true,
+    case_set_id: true,
+    profileFilter: true,
+    RPPA_SCORE_THRESHOLD: true,
+    Z_SCORE_THRESHOLD: true,
+    geneset_list: true,
+    genetic_profile_ids_PROFILE_MUTATION_EXTENDED: true,
+    genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION: true,
+    genetic_profile_ids_PROFILE_MRNA_EXPRESSION: true,
+    genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: true,
+    genetic_profile_ids_PROFILE_GENESET_SCORE: true,
+    genetic_profile_ids_GENERIC_ASSAY: true,
+    genetic_profile_ids: true,
+    comparison_createdGroupsSessionId: false,
 };
+
+const propertiesMap = _.mapValues(
+    {
+        // NON session props here
+        // oncoprint props
+        clinicallist: { isSessionProp: false },
+        show_samples: { isSessionProp: false },
+        heatmap_track_groups: { isSessionProp: false },
+        oncoprint_sortby: { isSessionProp: false },
+        oncoprint_cluster_profile: { isSessionProp: false },
+        oncoprint_sort_by_mutation_type: {
+            isSessionProp: false,
+        },
+        oncoprint_sort_by_drivers: { isSessionProp: false },
+        generic_assay_groups: { isSessionProp: false },
+        exclude_germline_mutations: { isSessionProp: false },
+        hide_unprofiled_samples: { isSessionProp: false },
+        patient_enrichments: { isSessionProp: false },
+
+        comparison_subtab: { isSessionProp: false },
+        comparison_overlapStrategy: { isSessionProp: false },
+        comparison_selectedGroups: { isSessionProp: false },
+        comparison_groupOrder: { isSessionProp: false },
+        comparison_selectedEnrichmentEventTypes: {
+            isSessionProp: true,
+        },
+
+        // plots
+        plots_horz_selection: {
+            isSessionProp: false,
+            nestedObjectProps: PlotsSelectionParamProps,
+        },
+        plots_vert_selection: {
+            isSessionProp: false,
+            nestedObjectProps: PlotsSelectionParamProps,
+        },
+        plots_coloring_selection: {
+            isSessionProp: false,
+            nestedObjectProps: PlotsColoringParamProps,
+        },
+
+        // mutations
+        mutations_gene: {
+            isSessionProp: false,
+        },
+        mutations_transcript_id: {
+            isSessionProp: false,
+        },
+
+        // session props here
+        gene_list: {
+            isSessionProp: true,
+            doubleURIEncode: true,
+        },
+        cancer_study_list: {
+            isSessionProp: true,
+            aliases: ['cancer_study_id'],
+        },
+        case_ids: { isSessionProp: true },
+        sample_list_ids: { isSessionProp: true },
+        case_set_id: { isSessionProp: true },
+        profileFilter: {
+            isSessionProp: true,
+            aliases: ['data_priority'],
+        },
+        RPPA_SCORE_THRESHOLD: { isSessionProp: true },
+        Z_SCORE_THRESHOLD: { isSessionProp: true },
+        geneset_list: { isSessionProp: true },
+        genetic_profile_ids_PROFILE_MUTATION_EXTENDED: {
+            isSessionProp: true,
+        },
+        genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION: {
+            isSessionProp: true,
+        },
+        genetic_profile_ids_PROFILE_MRNA_EXPRESSION: {
+            isSessionProp: true,
+        },
+        genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: {
+            isSessionProp: true,
+        },
+        genetic_profile_ids_PROFILE_GENESET_SCORE: {
+            isSessionProp: true,
+        },
+        genetic_profile_ids_GENERIC_ASSAY: {
+            isSessionProp: true,
+        },
+        genetic_profile_ids: { isSessionProp: true },
+        comparison_createdGroupsSessionId: {
+            isSessionProp: true,
+        },
+    } as PropertiesMap<ResultsViewURLQuery>,
+    (propertySpec, propertyName) => {
+        propertySpec.isHashedProp =
+            shouldForceRemount[propertyName as keyof ResultsViewURLQuery];
+        return propertySpec;
+    }
+) as PropertiesMap<ResultsViewURLQuery>;
 
 function backwardsCompatibilityMapping(oldParams: any) {
     const newParams: MapValues<

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -1,4 +1,4 @@
-import URLWrapper from '../../shared/lib/URLWrapper';
+import URLWrapper, { PropertiesMap } from '../../shared/lib/URLWrapper';
 import ExtendedRouterStore from '../../shared/lib/ExtendedRouterStore';
 import { computed, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
@@ -20,6 +20,7 @@ import IComparisonURLWrapper from 'pages/groupComparison/IComparisonURLWrapper';
 import _ from 'lodash';
 import { MapValues } from 'shared/lib/TypeScriptUtils';
 import { GroupComparisonTab } from 'pages/groupComparison/GroupComparisonTabs';
+import hashString from 'shared/lib/hashString';
 
 export type PlotsSelectionParam = {
     selectedGeneOption?: string;
@@ -117,85 +118,111 @@ export type ResultsViewURLQuery = {
     plots_coloring_selection: PlotsColoringParam;
 };
 
-const propertiesMap = {
+const propertiesMap: PropertiesMap<ResultsViewURLQuery> = {
     // NON session props here
     // oncoprint props
-    clinicallist: { isSessionProp: false },
-    show_samples: { isSessionProp: false },
-    heatmap_track_groups: { isSessionProp: false },
-    oncoprint_sortby: { isSessionProp: false },
-    oncoprint_cluster_profile: { isSessionProp: false },
-    oncoprint_sort_by_mutation_type: { isSessionProp: false },
-    oncoprint_sort_by_drivers: { isSessionProp: false },
-    generic_assay_groups: { isSessionProp: false },
-    exclude_germline_mutations: { isSessionProp: false },
-    hide_unprofiled_samples: { isSessionProp: false },
-    patient_enrichments: { isSessionProp: false },
+    clinicallist: { isSessionProp: false, isHashedProp: false },
+    show_samples: { isSessionProp: false, isHashedProp: false },
+    heatmap_track_groups: { isSessionProp: false, isHashedProp: false },
+    oncoprint_sortby: { isSessionProp: false, isHashedProp: false },
+    oncoprint_cluster_profile: { isSessionProp: false, isHashedProp: false },
+    oncoprint_sort_by_mutation_type: {
+        isSessionProp: false,
+        isHashedProp: false,
+    },
+    oncoprint_sort_by_drivers: { isSessionProp: false, isHashedProp: false },
+    generic_assay_groups: { isSessionProp: false, isHashedProp: false },
+    exclude_germline_mutations: { isSessionProp: false, isHashedProp: false },
+    hide_unprofiled_samples: { isSessionProp: false, isHashedProp: false },
+    patient_enrichments: { isSessionProp: false, isHashedProp: false },
 
-    comparison_subtab: { isSessionProp: false },
-    comparison_overlapStrategy: { isSessionProp: false },
-    comparison_selectedGroups: { isSessionProp: false },
-    comparison_groupOrder: { isSessionProp: false },
+    comparison_subtab: { isSessionProp: false, isHashedProp: false },
+    comparison_overlapStrategy: { isSessionProp: false, isHashedProp: false },
+    comparison_selectedGroups: { isSessionProp: false, isHashedProp: false },
+    comparison_groupOrder: { isSessionProp: false, isHashedProp: false },
     comparison_selectedEnrichmentEventTypes: {
         isSessionProp: true,
+        isHashedProp: false,
     },
 
     // plots
     plots_horz_selection: {
         isSessionProp: false,
+        isHashedProp: false,
         nestedObjectProps: PlotsSelectionParamProps,
     },
     plots_vert_selection: {
         isSessionProp: false,
+        isHashedProp: false,
         nestedObjectProps: PlotsSelectionParamProps,
     },
     plots_coloring_selection: {
         isSessionProp: false,
+        isHashedProp: false,
         nestedObjectProps: PlotsColoringParamProps,
     },
 
     // mutations
     mutations_gene: {
         isSessionProp: false,
+        isHashedProp: false,
     },
     mutations_transcript_id: {
         isSessionProp: false,
+        isHashedProp: false,
     },
 
     // session props here
-    gene_list: { isSessionProp: true, doubleURIEncode: true },
+    gene_list: {
+        isSessionProp: true,
+        isHashedProp: true,
+        doubleURIEncode: true,
+    },
     cancer_study_list: {
         isSessionProp: true,
+        isHashedProp: true,
         aliases: ['cancer_study_id'],
     },
-    case_ids: { isSessionProp: true },
-    sample_list_ids: { isSessionProp: true },
-    case_set_id: { isSessionProp: true },
+    case_ids: { isSessionProp: true, isHashedProp: true },
+    sample_list_ids: { isSessionProp: true, isHashedProp: true },
+    case_set_id: { isSessionProp: true, isHashedProp: true },
     profileFilter: {
         isSessionProp: true,
+        isHashedProp: true,
         aliases: ['data_priority'],
     },
-    RPPA_SCORE_THRESHOLD: { isSessionProp: true },
-    Z_SCORE_THRESHOLD: { isSessionProp: true },
-    geneset_list: { isSessionProp: true },
+    RPPA_SCORE_THRESHOLD: { isSessionProp: true, isHashedProp: true },
+    Z_SCORE_THRESHOLD: { isSessionProp: true, isHashedProp: true },
+    geneset_list: { isSessionProp: true, isHashedProp: true },
     genetic_profile_ids_PROFILE_MUTATION_EXTENDED: {
         isSessionProp: true,
+        isHashedProp: true,
     },
     genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION: {
         isSessionProp: true,
+        isHashedProp: true,
     },
     genetic_profile_ids_PROFILE_MRNA_EXPRESSION: {
         isSessionProp: true,
+        isHashedProp: true,
     },
     genetic_profile_ids_PROFILE_PROTEIN_EXPRESSION: {
         isSessionProp: true,
+        isHashedProp: true,
     },
     genetic_profile_ids_PROFILE_GENESET_SCORE: {
         isSessionProp: true,
+        isHashedProp: true,
     },
-    genetic_profile_ids_GENERIC_ASSAY: { isSessionProp: true },
-    genetic_profile_ids: { isSessionProp: true },
-    comparison_createdGroupsSessionId: { isSessionProp: true },
+    genetic_profile_ids_GENERIC_ASSAY: {
+        isSessionProp: true,
+        isHashedProp: true,
+    },
+    genetic_profile_ids: { isSessionProp: true, isHashedProp: true },
+    comparison_createdGroupsSessionId: {
+        isSessionProp: true,
+        isHashedProp: false,
+    },
 };
 
 function backwardsCompatibilityMapping(oldParams: any) {

--- a/src/pages/resultsView/comparison/ResultsViewComparisonStore.ts
+++ b/src/pages/resultsView/comparison/ResultsViewComparisonStore.ts
@@ -171,6 +171,7 @@ export default class ResultsViewComparisonStore extends ComparisonStore {
     protected async saveAndGoToSession(newSession: Session) {
         const { id } = await comparisonClient.addComparisonSession(newSession);
         this.urlWrapper.updateURL({ comparison_createdGroupsSessionId: id });
+        this.newSessionPending = false;
     }
     //</session>
 

--- a/src/shared/lib/URLWrapper.spec.ts
+++ b/src/shared/lib/URLWrapper.spec.ts
@@ -36,9 +36,10 @@ type TestQuery = {
 class TestURLWrapper extends URLWrapper<TestQuery> {
     constructor(routing: ExtendedRouterStore) {
         super(routing, {
-            name: { isSessionProp: true },
+            name: { isSessionProp: true, isHashedProp: true },
             data: {
                 isSessionProp: true,
+                isHashedProp: true,
                 nestedObjectProps: { d1: '', d2: '' },
                 aliases: ['aliasForData'],
             },
@@ -285,7 +286,7 @@ describe('URLWrapper', () => {
         disposer();
     });
 
-    it('hash composed only of session props', () => {
+    it('hash composed only of hash props', () => {
         routingStore.updateRoute({ case_ids: 'bar', non_property: 'foo' });
         let beforeChange = wrapper.hash;
 
@@ -293,14 +294,14 @@ describe('URLWrapper', () => {
         assert.equal(
             wrapper.hash,
             beforeChange,
-            "hash doesn't change if we mutate non session prop"
+            "hash doesn't change if we mutate non hashed prop"
         );
 
         routingStore.updateRoute({ case_ids: 'blah', non_property: 'foo' });
         assert.notEqual(
             wrapper.hash,
             beforeChange,
-            'hash changes if we mutate session prop'
+            'hash changes if we mutate hashed prop'
         );
 
         const testWrapper = new TestURLWrapper(routingStore);
@@ -316,7 +317,7 @@ describe('URLWrapper', () => {
         assert.notEqual(
             testWrapper.hash,
             beforeChange,
-            'hash changes if we mutate nested object session prop'
+            'hash changes if we mutate nested object hashed prop'
         );
     });
 

--- a/src/shared/lib/comparison/AlterationEnrichmentTypeSelector.tsx
+++ b/src/shared/lib/comparison/AlterationEnrichmentTypeSelector.tsx
@@ -10,6 +10,7 @@ import {
     cnaGroup,
     CopyNumberEnrichmentEventType,
     deletionGroup,
+    doEnrichmentEventTypeMapsMatch,
     EnrichmentEventType,
     frameshiftDeletionGroup,
     frameshiftGroup,
@@ -299,11 +300,11 @@ export default class AlterationEnrichmentTypeSelector extends React.Component<
 
     @computed get hasSelectionChanged() {
         return (
-            !_.isEqual(
+            !doEnrichmentEventTypeMapsMatch(
                 toJS(this.currentSelectedMutations),
                 toJS(this.props.store.selectedMutationEnrichmentEventTypes)
             ) ||
-            !_.isEqual(
+            !doEnrichmentEventTypeMapsMatch(
                 toJS(this.currentSelectedCopyNumber),
                 toJS(this.props.store.selectedCopyNumberEnrichmentEventTypes)
             ) ||

--- a/src/shared/lib/comparison/ComparisonStoreUtils.ts
+++ b/src/shared/lib/comparison/ComparisonStoreUtils.ts
@@ -1,6 +1,7 @@
 import ComparisonStore from 'shared/lib/comparison/ComparisonStore';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import { stringListToMap } from 'cbioportal-frontend-commons';
+import _ from 'lodash';
 
 // For everything to work, the enum names must be identical to their value
 export enum CopyNumberEnrichmentEventType {
@@ -226,5 +227,28 @@ export function getCopyNumberEventTypesAPIParameter(
     return stringListToMap(
         cnaGroup,
         (e: CopyNumberEnrichmentEventType) => selectedEvents[e] || false
+    );
+}
+
+export function doEnrichmentEventTypeMapsMatch<T>(
+    mapA: { [type in keyof T]?: boolean },
+    mapB: { [type in keyof T]?: boolean }
+) {
+    // Just make sure that the `true`s are the same
+    return (
+        _.every(mapA, (val, key: keyof T) => {
+            if (val) {
+                return mapB[key];
+            } else {
+                return true;
+            }
+        }) &&
+        _.every(mapB, (val, key: keyof T) => {
+            if (val) {
+                return mapA[key];
+            } else {
+                return true;
+            }
+        })
     );
 }


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/8801
Credit to @kalletlak for finding the problem

This PR decouples two unrelated concepts in URLWrapper, which until now had been unified:
(1) Props that should be placed in the session service, either because they are fundamental to the query or because their long length may exceed browser URL limits

(2) Props that should be used to determine the URLWrapper "hash" which is used in the ResultsViewPage to trigger a page remount.