### PR TITLE
Improve handling of unknown/invalid studies in study view

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -451,8 +451,16 @@ export class StudyViewPageStore
         private urlWrapper: StudyViewURLWrapper
     ) {
         makeObservable(this);
+
         this.chartItemToColor = new Map();
         this.chartToUsedColors = new Map();
+
+        /*
+        Note for future refactoring:
+        We should not have to put a check here because ideally this would never be called unless we have valid studies.
+        This can be achieved by a better control mechanism: as for all our fetches, they should be invoked by reference in view layer.
+        Here, we fire this in constructor of store, which is an anti-pattern in our app.
+         */
         this.reactionDisposers.push(
             reaction(
                 () => this.loadingInitialDataForSummaryTab,
@@ -4418,7 +4426,7 @@ export class StudyViewPageStore
                 this.pageStatusMessages['unknownIds'] = {
                     status: 'danger',
                     message: `Unknown/Unauthorized ${
-                        unknownIds.length > 1 ? 'studies' : 'study'
+                        unknownIds.length > 1 ? 'studies:' : 'study:'
                     } ${unknownIds.join(', ')}`,
                 };
             }
@@ -5313,6 +5321,13 @@ export class StudyViewPageStore
 
     @computed
     get loadingInitialDataForSummaryTab(): boolean {
+        if (
+            !this.queriedPhysicalStudyIds.isComplete ||
+            this.queriedPhysicalStudyIds.result.length === 0
+        ) {
+            return false;
+        }
+
         let pending =
             this.defaultVisibleAttributes.isPending ||
             this.clinicalAttributes.isPending ||


### PR DESCRIPTION
Fixes cBioPortal/cbioportal#8500

When we detect invalid or unauthorized studies on study view page, we should short circuit rendering of page so that we don't cause cascade of errors and show confusing messages to user.

All studies are invalid: 
![image](https://user-images.githubusercontent.com/186521/128923623-cc8aeca7-b340-43e4-a1ab-d5709d2cc51d.png)

At least one study is valid:

![image](https://user-images.githubusercontent.com/186521/128923671-7793df42-4df1-43b3-9354-d63f7dce6371.png)

