### PR TITLE
SV: Fix group refreshing issue on checkbox selection

### DIFF
--- a/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManager.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/ComparisonGroupManager.tsx
@@ -355,7 +355,11 @@ export default class ComparisonGroupManager extends React.Component<
         if (reservedColor != undefined)
             this.props.store.onGroupColorChange(id, reservedColor);
         this.props.store.notifyComparisonGroupsChange();
-        this.props.store.setComparisonGroupSelected(id); // created groups start selected
+        if (!this.props.store.isLoggedIn) {
+            //save group id to page session only for non-logged in user.
+            // this is to keep track of what groups are created by the user
+            this.props.store.trackNewlyCreatedGroup(id);
+        }
         this.cancelAddGroup();
     }
 


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/8616

Problem: same object (`_selectedComparisonGroups`) is used for both creating and selecting groups. This is causing list to re-render whenever selection is made.

Solution: use different object to track created groups and selected groups