### PR TITLE
RFC 59 - show studies for which a user is not authorized

### DIFF
--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI.ts
@@ -98,6 +98,8 @@ export type CancerStudy = {
 
         'studyId': string
 
+        'isAuthorized': boolean
+
 };
 export type CancerStudyTags = {
     'cancerStudyId': number

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -140,4 +140,6 @@ export interface IServerConfig {
     installation_map_url: string;
     enable_request_body_gzip_compression: boolean;
     referenceGenomeVersion: string;
+    skin_show_unauthorized_studies: boolean;
+    skin_global_message_for_unauthorized_studies: string;
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -182,6 +182,11 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     enable_request_body_gzip_compression: false,
 
     referenceGenomeVersion: 'hg19',
+
+    skin_show_unauthorized_studies: false,
+
+    skin_global_message_for_unauthorized_studies:
+        'The study is unauthorized. You need to request access.',
 };
 
 export default ServerConfigDefaults;

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -4120,7 +4120,14 @@ export class StudyViewPageStore
             return _.reduce(
                 this.studyIds,
                 (acc: CancerStudy[], next) => {
-                    if (everyStudyIdToStudy[next]) {
+                    if (
+                        everyStudyIdToStudy[next] &&
+                        (!AppConfig.serverConfig
+                            .skin_show_unauthorized_studies ||
+                            (AppConfig.serverConfig
+                                .skin_show_unauthorized_studies &&
+                                everyStudyIdToStudy[next].isAuthorized == true))
+                    ) {
                         acc.push(everyStudyIdToStudy[next]);
                     }
                     return acc;

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -237,6 +237,7 @@ import {
     CopyNumberEnrichmentEventType,
     MutationEnrichmentEventType,
 } from 'shared/lib/comparison/ComparisonStoreUtils';
+import { isQueriedStudyAuthorized } from 'shared/components/lazyMobXTable/utils';
 
 type ChartUniqueKey = string;
 type ResourceId = string;
@@ -4122,11 +4123,7 @@ export class StudyViewPageStore
                 (acc: CancerStudy[], next) => {
                     if (
                         everyStudyIdToStudy[next] &&
-                        (!AppConfig.serverConfig
-                            .skin_show_unauthorized_studies ||
-                            (AppConfig.serverConfig
-                                .skin_show_unauthorized_studies &&
-                                everyStudyIdToStudy[next].isAuthorized == true))
+                        isQueriedStudyAuthorized(everyStudyIdToStudy[next])
                     ) {
                         acc.push(everyStudyIdToStudy[next]);
                     }

--- a/src/shared/components/lazyMobXTable/utils.ts
+++ b/src/shared/components/lazyMobXTable/utils.ts
@@ -1,10 +1,20 @@
 import { SHOW_ALL_PAGE_SIZE } from '../paginationControls/PaginationControls';
+import { CancerStudy } from 'cbioportal-ts-api-client';
+import AppConfig from 'appConfig';
 export function maxPage(displayDataLength: number, itemsPerPage: number) {
     if (itemsPerPage === SHOW_ALL_PAGE_SIZE) {
         return 0;
     } else {
         return Math.floor(Math.max(displayDataLength - 1, 0) / itemsPerPage);
     }
+}
+
+export function isQueriedStudyAuthorized(study: CancerStudy) {
+    return (
+        !AppConfig.serverConfig.skin_show_unauthorized_studies ||
+        (AppConfig.serverConfig.skin_show_unauthorized_studies &&
+            study.isAuthorized !== false)
+    );
 }
 
 const validSymbols = ['<', '<=', '>', '>=', '='];

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -25,6 +25,7 @@ import {
 import { StudyLink } from '../../StudyLink/StudyLink';
 import StudyTagsTooltip from '../../studyTagsTooltip/StudyTagsTooltip';
 import { formatStudyReferenceGenome } from 'shared/lib/referenceGenomeUtils';
+import AppConfig from 'appConfig';
 
 const styles = {
     ...styles_any,
@@ -218,6 +219,10 @@ export default class StudyList extends QueryStoreComponent<
                                 study.studyId
                             ),
                             [`studyItem_${study.studyId}`]: true,
+                            [styles.UnauthorizedStudy]:
+                                AppConfig.serverConfig
+                                    .skin_show_unauthorized_studies &&
+                                study.isAuthorized == false,
                         });
                         return (
                             <CancerTreeCheckbox view={this.view} node={study}>
@@ -367,27 +372,37 @@ export default class StudyList extends QueryStoreComponent<
                             );
                         }
                         if (link.icon === 'info-circle') {
-                            content = (
-                                <StudyTagsTooltip
-                                    key={i}
-                                    studyDescription={
-                                        this.store.isVirtualStudy(study.studyId)
-                                            ? study.description.replace(
-                                                  /\r?\n/g,
-                                                  '<br />'
-                                              )
-                                            : study.description
-                                    }
-                                    studyId={study.studyId}
-                                    isVirtualStudy={this.store.isVirtualStudy(
-                                        study.studyId
-                                    )}
-                                    mouseEnterDelay={0}
-                                    placement="top"
-                                >
-                                    <a>{content}</a>
-                                </StudyTagsTooltip>
-                            );
+                            if (
+                                !AppConfig.serverConfig
+                                    .skin_show_unauthorized_studies ||
+                                (AppConfig.serverConfig
+                                    .skin_show_unauthorized_studies &&
+                                    study.isAuthorized != false)
+                            ) {
+                                content = (
+                                    <StudyTagsTooltip
+                                        key={i}
+                                        studyDescription={
+                                            this.store.isVirtualStudy(
+                                                study.studyId
+                                            )
+                                                ? study.description.replace(
+                                                      /\r?\n/g,
+                                                      '<br />'
+                                                  )
+                                                : study.description
+                                        }
+                                        studyId={study.studyId}
+                                        isVirtualStudy={this.store.isVirtualStudy(
+                                            study.studyId
+                                        )}
+                                        mouseEnterDelay={0}
+                                        placement="top"
+                                    >
+                                        <a>{content}</a>
+                                    </StudyTagsTooltip>
+                                );
+                            }
                         }
 
                         return content;
@@ -413,6 +428,26 @@ export default class StudyList extends QueryStoreComponent<
                             </span>
                         </DefaultTooltip>
                     )}
+                    {AppConfig.serverConfig.skin_show_unauthorized_studies &&
+                        study.studyId &&
+                        study.isAuthorized == false && (
+                            <DefaultTooltip
+                                mouseEnterDelay={0}
+                                placement="top"
+                                overlay={
+                                    <div className={styles.tooltip}>
+                                        {
+                                            AppConfig.serverConfig
+                                                .skin_global_message_for_unauthorized_studies
+                                        }
+                                    </div>
+                                }
+                            >
+                                <span>
+                                    <i className="fa fa-lock"></i>
+                                </span>
+                            </DefaultTooltip>
+                        )}
                 </span>
             );
         }

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -25,6 +25,7 @@ import {
 import { StudyLink } from '../../StudyLink/StudyLink';
 import StudyTagsTooltip from '../../studyTagsTooltip/StudyTagsTooltip';
 import { formatStudyReferenceGenome } from 'shared/lib/referenceGenomeUtils';
+import { isQueriedStudyAuthorized } from 'shared/components/lazyMobXTable/utils';
 import AppConfig from 'appConfig';
 
 const styles = {
@@ -222,7 +223,7 @@ export default class StudyList extends QueryStoreComponent<
                             [styles.UnauthorizedStudy]:
                                 AppConfig.serverConfig
                                     .skin_show_unauthorized_studies &&
-                                study.isAuthorized == false,
+                                study.isAuthorized === false,
                         });
                         return (
                             <CancerTreeCheckbox view={this.view} node={study}>
@@ -372,13 +373,7 @@ export default class StudyList extends QueryStoreComponent<
                             );
                         }
                         if (link.icon === 'info-circle') {
-                            if (
-                                !AppConfig.serverConfig
-                                    .skin_show_unauthorized_studies ||
-                                (AppConfig.serverConfig
-                                    .skin_show_unauthorized_studies &&
-                                    study.isAuthorized != false)
-                            ) {
+                            if (isQueriedStudyAuthorized(study)) {
                                 content = (
                                     <StudyTagsTooltip
                                         key={i}
@@ -430,7 +425,7 @@ export default class StudyList extends QueryStoreComponent<
                     )}
                     {AppConfig.serverConfig.skin_show_unauthorized_studies &&
                         study.studyId &&
-                        study.isAuthorized == false && (
+                        study.isAuthorized === false && (
                             <DefaultTooltip
                                 mouseEnterDelay={0}
                                 placement="top"

--- a/src/shared/components/query/studyList/styles.module.scss
+++ b/src/shared/components/query/studyList/styles.module.scss
@@ -218,6 +218,10 @@ li.Study {
         color: rgb(198, 203, 209);
     }
 
+    .UnauthorizedStudy {
+        color: #999;
+    }
+
     @media (min-width: 1450px) {
         .StudyName {
             max-width: 500px;
@@ -254,6 +258,10 @@ li.Study {
             }
 
             span.summaryIcon {
+                cursor: pointer;
+            }
+
+            span.lockIcon {
                 cursor: pointer;
             }
 

--- a/src/shared/components/query/studyList/styles.module.scss.d.ts
+++ b/src/shared/components/query/studyList/styles.module.scss.d.ts
@@ -14,12 +14,14 @@ declare const styles: {
   readonly "StudyMeta": string;
   readonly "StudyName": string;
   readonly "StudySamples": string;
+  readonly "UnauthorizedStudy": string;
   readonly "deselectAll": string;
   readonly "fadein": string;
   readonly "icon": string;
   readonly "iconWithTooltip": string;
   readonly "indentArrow": string;
   readonly "infoCircleIcon": string;
+  readonly "lockIcon": string;
   readonly "selectAllStudies": string;
   readonly "summaryIcon": string;
   readonly "tooltip": string;


### PR DESCRIPTION
Rfc 59 (https://docs.google.com/document/d/1NkNhBG1sk0ZvCOwk3XtiuRT9a_tKkFCgXC9I3XT-Ye4/edit#heading=h.6c2l76kgw1ta)
Physical studies that are not authorized are grayed out, have a gray info icon with no tooltip and a lock icon at then end. This behavior can be enabled/disabled from portal.properties (by default false). Also the global message that appears when hover over lock icon can be configured in portal.properties as well.

![Screenshot from 2021-08-17 12-24-03](https://user-images.githubusercontent.com/53996876/129889271-08613319-a3af-4ca5-a431-f8bb51549b34.png)


Backend PR is https://github.com/cBioPortal/cbioportal/pull/8847