### PR TITLE
Sort event attributes for generic timeline track

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
@@ -360,14 +360,19 @@ export const EventTooltipContent: React.FunctionComponent<{
         <div>
             <table>
                 <tbody>
-                    {_.map(event.event.attributes, (att: any) => {
-                        return (
-                            <tr>
-                                <th>{att.key.replace(/_/g, ' ')}</th>
-                                <td>{att.value}</td>
-                            </tr>
-                        );
-                    })}
+                    {_.map(
+                        event.event.attributes.sort((a: any, b: any) =>
+                            a.key > b.key ? 1 : -1
+                        ),
+                        (att: any) => {
+                            return (
+                                <tr>
+                                    <th>{att.key.replace(/_/g, ' ')}</th>
+                                    <td>{att.value}</td>
+                                </tr>
+                            );
+                        }
+                    )}
                     <tr>
                         <th>{`${
                             event.event.endNumberOfDaysSinceDiagnosis


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8545

Sorts the event attributes for any generic timeline track in patient view. Maintains `DATE` rows (e.g. `DATE`, `START DATE`, `END DATE`) together at the bottom, but everything above it is sorted alphabetically.

## Old ordering (basically random)
![old](https://user-images.githubusercontent.com/18505975/130099551-3f78e2fb-e896-481b-8f21-babdfe5abccc.png)
## New (sorted alphabetically)
![new](https://user-images.githubusercontent.com/18505975/130099570-f5106267-debc-4553-a3c5-303c360cd41d.png)