### PR TITLE
Refine configuration loading and resolution logic

### DIFF
--- a/end-to-end-test/local/specs/core/comparison-alterations-tab.spec.js
+++ b/end-to-end-test/local/specs/core/comparison-alterations-tab.spec.js
@@ -43,7 +43,6 @@ if (useExternalFrontend) {
             $('[data-test=LazyMobXTable]').waitForDisplayed();
             var rows = $$('[data-test=LazyMobXTable] tbody tr');
             assert.strictEqual(rows.length, 8, 'table has 8 rows');
-            openAlterationTypeSelectionMenu();
             clickAlterationTypeCheckBox('Mutations');
             clickAlterationTypeCheckBox('Frameshift Deletion');
             submitEnrichmentRequest();
@@ -57,7 +56,6 @@ if (useExternalFrontend) {
             submitEnrichmentRequest();
             $('[data-test=LazyMobXTable]').waitForDisplayed();
             assert.strictEqual(selectUnalteredCount('ACAP3'), '9 (1.16%)');
-            openAlterationTypeSelectionMenu();
             clickAlterationTypeCheckBox('Deletion');
             submitEnrichmentRequest();
             $('[data-test=LazyMobXTable]').waitForDisplayed();

--- a/end-to-end-test/local/specs/group-color-chooser.spec.js
+++ b/end-to-end-test/local/specs/group-color-chooser.spec.js
@@ -92,7 +92,13 @@ describe('color chooser for groups menu in study view', function() {
         $(finalizeGroupButton).click();
 
         // select same color for both groups
+
         browser.waitUntil(() => $$(colorIcon).length === 2);
+
+        // select both groups
+        $$(groupCheckboxes)[0].click();
+        $$(groupCheckboxes)[1].click();
+
         setDropdownOpen(true, gbGroupColorIcon, colorPickerBlue);
         $(colorPickerBlue).click();
         // close color picker 0 before going to next one
@@ -101,6 +107,7 @@ describe('color chooser for groups menu in study view', function() {
         $(colorPickerBlue).click();
 
         // assert that warning sign exists
+
         $(warningSign).waitForExist();
         assert($(warningSign).isExisting());
     });

--- a/end-to-end-test/remote/specs/core/home.spec.js
+++ b/end-to-end-test/remote/specs/core/home.spec.js
@@ -28,7 +28,7 @@ describe('homepage', function() {
             // The banner is hidden in e2etests.scss
             assert.equal(
                 browser.execute(function() {
-                    return window.frontendConfig.frontendUrl;
+                    return window.getLoadConfig().frontendUrl;
                 }),
                 '//localhost:3000/'
             );

--- a/end-to-end-test/shared/specUtils.js
+++ b/end-to-end-test/shared/specUtils.js
@@ -207,14 +207,12 @@ function setServerConfiguration(props) {
 
 function sessionServiceIsEnabled() {
     return browser.execute(function() {
-        return window.frontendConfig.serverConfig.sessionServiceEnabled;
+        return window.getServerConfig().sessionServiceEnabled;
     }).value;
 }
 
 function showGsva() {
-    browser.execute(function() {
-        window.frontendConfig.serverConfig.skin_show_gsva = true;
-    });
+    setServerConfiguration({ skin_show_gsva: true });
 }
 
 function waitForNumberOfStudyCheckboxes(expectedNumber, text) {

--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -4,7 +4,7 @@ import {
     getBrowserWindow,
     remoteData,
 } from 'cbioportal-frontend-commons';
-import { initializeAPIClients } from './config/config';
+import { getLoadConfig, getServerConfig } from './config/config';
 import * as _ from 'lodash';
 import internalClient from 'shared/api/cbioportalInternalClientInstance';
 import { sendSentryMessage } from './shared/lib/tracking';
@@ -29,6 +29,14 @@ export class AppStore {
                 this.siteErrors.push({ errorObj: error, dismissed: false });
             }
         });
+    }
+
+    get serverConfig() {
+        return getServerConfig();
+    }
+
+    get loadConfig() {
+        return getLoadConfig();
     }
 
     @observable private _appReady = false;

--- a/src/appShell/App/Container.tsx
+++ b/src/appShell/App/Container.tsx
@@ -7,7 +7,7 @@ import PortalHeader from './PortalHeader';
 import { getBrowserWindow, isWebdriver } from 'cbioportal-frontend-commons';
 import { observer } from 'mobx-react';
 
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import Helmet from 'react-helmet';
 import { If, Else, Then } from 'react-if';
 import UserMessager from 'shared/components/userMessager/UserMessage';
@@ -36,7 +36,7 @@ interface IContainerProps {
 
 function isLocalDBServer() {
     try {
-        return AppConfig.serverConfig.app_name === 'localdbe2e';
+        return getServerConfig().app_name === 'localdbe2e';
     } catch (ex) {
         return false;
     }
@@ -89,10 +89,10 @@ export default class Container extends React.Component<IContainerProps, {}> {
             <div>
                 <Helmet>
                     <meta charSet="utf-8" />
-                    <title>{AppConfig.serverConfig.skin_title}</title>
+                    <title>{getServerConfig().skin_title}</title>
                     <meta
                         name="description"
-                        content={AppConfig.serverConfig.skin_description}
+                        content={getServerConfig().skin_description}
                     />
                 </Helmet>
 

--- a/src/appShell/App/PortalFooter.tsx
+++ b/src/appShell/App/PortalFooter.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import AppConfig from 'appConfig';
 import { If } from 'react-if';
 // tslint:disable-next-line:no-import-side-effect
 import './footer.scss';
@@ -7,6 +6,7 @@ import _ from 'lodash';
 import { Link } from 'react-router-dom';
 import { AppStore } from '../../AppStore';
 import { observer } from 'mobx-react';
+import { getLoadConfig, getServerConfig } from 'config/config';
 
 @observer
 export default class PortalFooter extends React.Component<
@@ -25,8 +25,8 @@ export default class PortalFooter extends React.Component<
             version = '--';
         }
         if (
-            AppConfig.serverConfig.skin_footer &&
-            !_.isEmpty(AppConfig.serverConfig.skin_footer)
+            getServerConfig().skin_footer &&
+            !_.isEmpty(getServerConfig().skin_footer)
         ) {
             return (
                 <div
@@ -34,10 +34,14 @@ export default class PortalFooter extends React.Component<
                     dangerouslySetInnerHTML={{
                         __html:
                             "<a href='http://www.cbioportal.org'>cBioPortal</a> | " +
-                            `<a href='${AppConfig.apiRoot}api/info'>${version}</a> ` +
-                            AppConfig.serverConfig.skin_footer +
+                            `<a href='${
+                                getLoadConfig().apiRoot
+                            }api/info'>${version}</a> ` +
+                            getServerConfig().skin_footer +
                             '<br />' +
-                            `Questions and Feedback: <a href="mailto:${AppConfig.serverConfig.skin_email_contact}">${AppConfig.serverConfig.skin_email_contact}</a>`,
+                            `Questions and Feedback: <a href="mailto:${
+                                getServerConfig().skin_email_contact
+                            }">${getServerConfig().skin_email_contact}</a>`,
                     }}
                 ></div>
             );
@@ -55,7 +59,7 @@ export default class PortalFooter extends React.Component<
                                 alt="cBioPortal Logo"
                             />
                             {version && (
-                                <a href={`${AppConfig.apiRoot}api/info`}>
+                                <a href={`${getLoadConfig().apiRoot}api/info`}>
                                     <div
                                         style={{
                                             paddingTop: 9,
@@ -69,9 +73,9 @@ export default class PortalFooter extends React.Component<
                         </div>
                         <If
                             condition={
-                                AppConfig.serverConfig
-                                    .skin_show_tutorials_tab !== false ||
-                                AppConfig.serverConfig.skin_show_faqs_tab
+                                getServerConfig().skin_show_tutorials_tab !==
+                                    false ||
+                                getServerConfig().skin_show_faqs_tab
                             }
                         >
                             <div className="footer-elem">
@@ -79,7 +83,7 @@ export default class PortalFooter extends React.Component<
                                 <ul>
                                     <If
                                         condition={
-                                            AppConfig.serverConfig
+                                            getServerConfig()
                                                 .skin_show_tutorials_tab !==
                                             false
                                         }
@@ -92,8 +96,7 @@ export default class PortalFooter extends React.Component<
                                     </If>
                                     <If
                                         condition={
-                                            AppConfig.serverConfig
-                                                .skin_show_faqs_tab
+                                            getServerConfig().skin_show_faqs_tab
                                         }
                                     >
                                         <li>
@@ -113,8 +116,8 @@ export default class PortalFooter extends React.Component<
                         </If>
                         <If
                             condition={
-                                AppConfig.serverConfig.skin_show_news_tab ||
-                                AppConfig.serverConfig.skin_show_about_tab
+                                getServerConfig().skin_show_news_tab ||
+                                getServerConfig().skin_show_about_tab
                             }
                         >
                             <div className="footer-elem">
@@ -122,8 +125,7 @@ export default class PortalFooter extends React.Component<
                                 <ul>
                                     <If
                                         condition={
-                                            AppConfig.serverConfig
-                                                .skin_show_news_tab
+                                            getServerConfig().skin_show_news_tab
                                         }
                                     >
                                         <li>
@@ -132,7 +134,7 @@ export default class PortalFooter extends React.Component<
                                     </If>
                                     <If
                                         condition={
-                                            AppConfig.serverConfig
+                                            getServerConfig()
                                                 .skin_show_about_tab
                                         }
                                     >
@@ -142,21 +144,25 @@ export default class PortalFooter extends React.Component<
                                     </If>
                                     <If
                                         condition={
-                                            AppConfig.serverConfig
+                                            getServerConfig()
                                                 .skin_show_r_matlab_tab ||
-                                            AppConfig.serverConfig
+                                            getServerConfig()
                                                 .skin_show_web_api_tab
                                         }
                                     >
                                         <li>
-                                            <a href={`${AppConfig.apiRoot}api`}>
+                                            <a
+                                                href={`${
+                                                    getLoadConfig().apiRoot
+                                                }api`}
+                                            >
                                                 API Docs
                                             </a>
                                         </li>
                                     </If>
                                     <If
                                         condition={
-                                            AppConfig.serverConfig
+                                            getServerConfig()
                                                 .skin_right_nav_show_twitter
                                         }
                                     >
@@ -172,11 +178,7 @@ export default class PortalFooter extends React.Component<
                                 </ul>
                             </div>
                         </If>
-                        <If
-                            condition={
-                                AppConfig.serverConfig.skin_footer_show_dev
-                            }
-                        >
+                        <If condition={getServerConfig().skin_footer_show_dev}>
                             <div className="footer-elem">
                                 <h3>DEV</h3>
                                 <ul>
@@ -217,12 +219,11 @@ export default class PortalFooter extends React.Component<
                             <ul>
                                 <li>
                                     <a
-                                        href={`mailto:${AppConfig.serverConfig.skin_email_contact}`}
+                                        href={`mailto:${
+                                            getServerConfig().skin_email_contact
+                                        }`}
                                     >
-                                        {
-                                            AppConfig.serverConfig
-                                                .skin_email_contact
-                                        }
+                                        {getServerConfig().skin_email_contact}
                                     </a>
                                 </li>
                             </ul>

--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -1,19 +1,14 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Link, NavLink } from 'react-router-dom';
-import AppConfig from 'appConfig';
 import { If, Then, Else } from 'react-if';
-import { openSocialAuthWindow } from '../../shared/lib/openSocialAuthWindow';
 import { AppStore } from '../../AppStore';
 import { observer } from 'mobx-react';
-import {
-    buildCBioPortalPageUrl,
-    getInstituteLogoUrl,
-} from '../../shared/api/urls';
+import { getInstituteLogoUrl } from '../../shared/api/urls';
 import SocialAuthButton from '../../shared/components/SocialAuthButton';
 import { Dropdown } from 'react-bootstrap';
 import { DataAccessTokensDropdown } from '../../shared/components/dataAccessTokens/DataAccessTokensDropdown';
-import { observable } from 'mobx';
+import { getLoadConfig, getServerConfig } from 'config/config';
 
 @observer
 export default class PortalHeader extends React.Component<
@@ -27,7 +22,7 @@ export default class PortalHeader extends React.Component<
                 text: 'Data Sets',
                 address: '/datasets',
                 internal: true,
-                hide: () => AppConfig.serverConfig.skin_show_data_tab === false,
+                hide: () => getServerConfig().skin_show_data_tab === false,
             },
 
             {
@@ -35,8 +30,7 @@ export default class PortalHeader extends React.Component<
                 text: 'Web API',
                 address: '/webAPI',
                 internal: true,
-                hide: () =>
-                    AppConfig.serverConfig.skin_show_web_api_tab === false,
+                hide: () => getServerConfig().skin_show_web_api_tab === false,
             },
 
             {
@@ -44,8 +38,7 @@ export default class PortalHeader extends React.Component<
                 text: 'R/MATLAB',
                 address: '/rmatlab',
                 internal: true,
-                hide: () =>
-                    AppConfig.serverConfig.skin_show_r_matlab_tab === false,
+                hide: () => getServerConfig().skin_show_r_matlab_tab === false,
             },
 
             {
@@ -53,8 +46,7 @@ export default class PortalHeader extends React.Component<
                 text: 'Tutorials/Webinars',
                 address: '/tutorials',
                 internal: true,
-                hide: () =>
-                    AppConfig.serverConfig.skin_show_tutorials_tab === false,
+                hide: () => getServerConfig().skin_show_tutorials_tab === false,
             },
 
             {
@@ -62,7 +54,7 @@ export default class PortalHeader extends React.Component<
                 text: 'FAQ',
                 address: '/faq',
                 internal: true,
-                hide: () => AppConfig.serverConfig.skin_show_faqs_tab === false,
+                hide: () => getServerConfig().skin_show_faqs_tab === false,
             },
 
             {
@@ -70,7 +62,7 @@ export default class PortalHeader extends React.Component<
                 text: 'News',
                 address: '/news',
                 internal: true,
-                hide: () => AppConfig.serverConfig.skin_show_news_tab === false,
+                hide: () => getServerConfig().skin_show_news_tab === false,
             },
 
             {
@@ -78,8 +70,7 @@ export default class PortalHeader extends React.Component<
                 text: 'Visualize Your Data',
                 address: '/visualize',
                 internal: true,
-                hide: () =>
-                    AppConfig.serverConfig.skin_show_tools_tab === false,
+                hide: () => getServerConfig().skin_show_tools_tab === false,
             },
 
             {
@@ -87,8 +78,7 @@ export default class PortalHeader extends React.Component<
                 text: 'About',
                 address: '/about',
                 internal: true,
-                hide: () =>
-                    AppConfig.serverConfig.skin_show_about_tab === false,
+                hide: () => getServerConfig().skin_show_about_tab === false,
             },
 
             {
@@ -96,7 +86,7 @@ export default class PortalHeader extends React.Component<
                 text: 'cBioPortal Installations',
                 address: '/installations',
                 internal: false,
-                hide: () => !AppConfig.serverConfig.installation_map_url,
+                hide: () => !getServerConfig().installation_map_url,
             },
         ];
     }
@@ -138,8 +128,8 @@ export default class PortalHeader extends React.Component<
                 <div id="rightHeaderContent">
                     <If
                         condition={
-                            !AppConfig.hide_login &&
-                            !AppConfig.serverConfig.skin_hide_logout_button
+                            !getLoadConfig().hide_login &&
+                            !getServerConfig().skin_hide_logout_button
                         }
                     >
                         <If condition={this.props.appStore.isLoggedIn}>
@@ -179,7 +169,7 @@ export default class PortalHeader extends React.Component<
                             </Else>
                         </If>
                     </If>
-                    <If condition={!_.isEmpty(getInstituteLogoUrl())}>
+                    <If condition={getInstituteLogoUrl()}>
                         <img
                             id="institute-logo"
                             src={getInstituteLogoUrl()}

--- a/src/appShell/App/usageAgreements/GenieAgreement.tsx
+++ b/src/appShell/App/usageAgreements/GenieAgreement.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import UsageAgreement from 'shared/components/UsageAgreement';
-import AppConfig from 'appConfig';
 import expiredStorage from 'expired-storage';
+import { getServerConfig } from 'config/config';
 
 export const GENIE_PERSISTENCE_KEY = 'genie-private-usage-agreement';
 
@@ -9,7 +9,7 @@ export function shouldShowGenieWarning() {
     // we want to show a warning message on private cbioportal instances
     // to prevent users from adding links in manuscripts
     const showGenieWarning = ['cbioportal-genie-private'].includes(
-        AppConfig.serverConfig.app_name!
+        getServerConfig().app_name!
     );
 
     return (

--- a/src/appShell/App/usageAgreements/StudyAgreement.tsx
+++ b/src/appShell/App/usageAgreements/StudyAgreement.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import UsageAgreement from 'shared/components/UsageAgreement';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import expiredStorage from 'expired-storage';
 
@@ -13,7 +13,7 @@ export function shouldShowStudyViewWarning() {
     // we don't want to show this in MSK CIS setting (iframe)
     const showStudyViewWarning =
         ['triage-portal', 'mskcc-portal'].includes(
-            AppConfig.serverConfig.app_name!
+            getServerConfig().app_name!
         ) && !getBrowserWindow().isMSKCIS;
 
     return (

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -7,6 +7,14 @@ export interface IAppConfig {
     hide_login?: boolean;
 }
 
+export interface ILoadConfig {
+    apiRoot?: string;
+    baseUrl?: string;
+    configurationServiceUrl?: string;
+    frontendUrl?: string;
+    hide_login?: boolean;
+}
+
 export type CategorizedConfigItems = {
     [category: string]: string[];
 };

--- a/src/pages/groupComparison/AlterationEnrichments.tsx
+++ b/src/pages/groupComparison/AlterationEnrichments.tsx
@@ -9,7 +9,7 @@ import ComparisonStore from '../../shared/lib/comparison/ComparisonStore';
 import { ResultsViewPageStore } from '../resultsView/ResultsViewPageStore';
 import { makeObservable } from 'mobx';
 import { GENOMIC_ALTERATIONS_TAB_NAME } from 'pages/groupComparison/GroupComparisonTabs';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export interface IAlterationEnrichmentsProps {
     store: ComparisonStore;
@@ -35,7 +35,7 @@ export default class AlterationEnrichments extends React.Component<
         true
     );
 
-    private useInlineTypeSelectorMenu = !AppConfig.serverConfig
+    private useInlineTypeSelectorMenu = !getServerConfig()
         .skin_show_settings_menu;
 
     readonly enrichmentsUI = MakeMobxView({

--- a/src/pages/groupComparison/ClinicalDataEnrichmentsTable.tsx
+++ b/src/pages/groupComparison/ClinicalDataEnrichmentsTable.tsx
@@ -10,7 +10,7 @@ import { toConditionalPrecisionWithMinimum } from '../../shared/lib/FormatUtils'
 import { makeObservable, observable } from 'mobx';
 import { toggleColumnVisibility } from 'cbioportal-frontend-commons';
 import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls/ColumnVisibilityControls';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export interface IClinicalDataEnrichmentsTableProps {
     dataStore: ClinicalDataEnrichmentStore;
@@ -166,7 +166,7 @@ export default class ClinicalDataEnrichmentsTable extends React.Component<
         return _.mapValues(
             _.keyBy(COLUMNS, c => c.name),
             c =>
-                AppConfig.serverConfig
+                getServerConfig()
                     .survival_show_p_q_values_in_survival_type_table
                     ? c.visible!
                     : !(c.name in P_Q_VALUES_AND_STATISTICAL_TEST_NAME_DICT)

--- a/src/pages/groupComparison/GroupComparisonPage.tsx
+++ b/src/pages/groupComparison/GroupComparisonPage.tsx
@@ -42,7 +42,7 @@ import { deriveDisplayTextFromGenericAssayType } from 'pages/resultsView/plots/P
 import AlterationEnrichments from './AlterationEnrichments';
 import AlterationEnrichmentTypeSelector from '../../shared/lib/comparison/AlterationEnrichmentTypeSelector';
 import { AlterationFilterMenuSection } from 'pages/groupComparison/GroupComparisonUtils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export interface IGroupComparisonPageProps {
     routing: any;
@@ -175,8 +175,7 @@ export default class GroupComparisonPage extends React.Component<
                                     : ''
                             }
                         >
-                            {(AppConfig.serverConfig
-                                .skin_show_settings_menu && (
+                            {(getServerConfig().skin_show_settings_menu && (
                                 <AlterationFilterMenuSection
                                     store={this.store}
                                     updateSelectedEnrichmentEventTypes={

--- a/src/pages/groupComparison/GroupComparisonURLWrapper.ts
+++ b/src/pages/groupComparison/GroupComparisonURLWrapper.ts
@@ -13,7 +13,7 @@ import {
     MutationEnrichmentEventType,
     mutationGroup,
 } from 'shared/lib/comparison/ComparisonStoreUtils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { MapValues } from 'shared/lib/TypeScriptUtils';
 
 export type GroupComparisonURLQuery = {
@@ -40,8 +40,8 @@ export default class GroupComparisonURLWrapper
                 selectedEnrichmentEventTypes: { isSessionProp: true },
             },
             true,
-            AppConfig.serverConfig.session_url_length_threshold
-                ? parseInt(AppConfig.serverConfig.session_url_length_threshold)
+            getServerConfig().session_url_length_threshold
+                ? parseInt(getServerConfig().session_url_length_threshold)
                 : undefined
         );
         makeObservable(this);

--- a/src/pages/groupComparison/GroupComparisonUtils.tsx
+++ b/src/pages/groupComparison/GroupComparisonUtils.tsx
@@ -40,7 +40,7 @@ import {
 import styles from 'pages/groupComparison/styles.module.scss';
 import SettingsMenu from 'shared/components/driverAnnotations/SettingsMenu';
 import { observer } from 'mobx-react';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import AlterationEnrichmentTypeSelector from 'shared/lib/comparison/AlterationEnrichmentTypeSelector';
 import { EnrichmentEventType } from 'shared/lib/comparison/ComparisonStoreUtils';
 
@@ -468,7 +468,7 @@ export function MakeEnrichmentsTabUI(
                 const content: any = [];
                 const doShowInlineTypeSelectionMenu =
                     enrichmentType == 'alterations' &&
-                    !AppConfig.serverConfig.skin_show_settings_menu;
+                    !getServerConfig().skin_show_settings_menu;
                 content.push(
                     // The alteration type selector is shown to left of the
                     // graph panels ('in-line'). This div element pushes the
@@ -993,7 +993,7 @@ export const AlterationFilterMenuSection: React.FunctionComponent<{
                             />
                         }
                         customDriverSourceName={
-                            AppConfig.serverConfig
+                            getServerConfig()
                                 .oncoprint_custom_driver_annotation_binary_menu_label ||
                             'undefined'
                         }

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer, inject } from 'mobx-react';
 import { observable, makeObservable } from 'mobx';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import 'react-select1/dist/react-select.css';
 import { QueryStore } from '../../shared/components/query/QueryStore';
 import QueryAndDownloadTabs from '../../shared/components/query/QueryAndDownloadTabs';
@@ -56,15 +56,13 @@ export default class HomePage extends React.Component<
                 <div
                     className={'headBlock'}
                     dangerouslySetInnerHTML={{
-                        __html: AppConfig.serverConfig.skin_blurb!,
+                        __html: getServerConfig().skin_blurb!,
                     }}
                 ></div>
 
                 <QueryAndDownloadTabs
                     getQueryStore={this.getQueryStore}
-                    showQuickSearchTab={
-                        AppConfig.serverConfig.quick_search_enabled
-                    }
+                    showQuickSearchTab={getServerConfig().quick_search_enabled}
                     showDownloadTab={true}
                 />
             </PageLayout>

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -34,7 +34,6 @@ import { validateParametersPatientView } from '../../shared/lib/validateParamete
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import ValidationAlert from 'shared/components/ValidationAlert';
 import PatientViewMutationsDataStore from './mutation/PatientViewMutationsDataStore';
-import AppConfig from 'appConfig';
 
 import './patient.scss';
 import IFrameLoader from '../../shared/components/iframeLoader/IFrameLoader';
@@ -44,7 +43,7 @@ import {
 } from '../../shared/api/urls';
 import { PageLayout } from '../../shared/components/PageLayout/PageLayout';
 import Helmet from 'react-helmet';
-import { ServerConfigHelpers } from '../../config/config';
+import { getServerConfig, ServerConfigHelpers } from '../../config/config';
 import autobind from 'autobind-decorator';
 import { showCustomTab } from '../../shared/lib/customTabs';
 import { StudyLink } from '../../shared/components/StudyLink/StudyLink';
@@ -227,11 +226,11 @@ export default class PatientViewPage extends React.Component<
     }
 
     public get showNewTimeline() {
-        return !AppConfig.serverConfig.patient_view_use_legacy_timeline;
+        return !getServerConfig().patient_view_use_legacy_timeline;
     }
 
     public get showOldTimeline() {
-        return AppConfig.serverConfig.patient_view_use_legacy_timeline;
+        return getServerConfig().patient_view_use_legacy_timeline;
     }
 
     @action.bound
@@ -1151,23 +1150,23 @@ export default class PatientViewPage extends React.Component<
                                                     }
                                                     userEmailAddress={ServerConfigHelpers.getUserEmailAddress()}
                                                     enableOncoKb={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .show_oncokb
                                                     }
                                                     enableFunctionalImpact={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .show_genomenexus
                                                     }
                                                     enableHotspot={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .show_hotspot
                                                     }
                                                     enableMyCancerGenome={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .mycancergenome_show
                                                     }
                                                     enableCivic={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .show_civic
                                                     }
                                                     columnVisibility={
@@ -1317,15 +1316,15 @@ export default class PatientViewPage extends React.Component<
                                                             .usingPublicOncoKbInstance
                                                     }
                                                     enableOncoKb={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .show_oncokb
                                                     }
                                                     enableCivic={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .show_civic
                                                     }
                                                     userEmailAddress={
-                                                        AppConfig.serverConfig
+                                                        getServerConfig()
                                                             .user_email_address
                                                     }
                                                     pubMedCache={
@@ -1641,9 +1640,9 @@ export default class PatientViewPage extends React.Component<
 
                                 {this.resourceTabs.component}
 
-                                {AppConfig.serverConfig.custom_tabs &&
-                                    AppConfig.serverConfig.custom_tabs
-                                        .filter(
+                                {getServerConfig().custom_tabs &&
+                                    getServerConfig()
+                                        .custom_tabs.filter(
                                             (tab: any) =>
                                                 tab.location === 'PATIENT_PAGE'
                                         )

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -64,7 +64,6 @@ import VariantCountCache from 'shared/cache/VariantCountCache';
 import CopyNumberCountCache from './CopyNumberCountCache';
 import CancerTypeCache from 'shared/cache/CancerTypeCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
-import AppConfig from 'appConfig';
 import {
     concatMutationData,
     evaluateDiscreteCNAPutativeDriverInfo,
@@ -202,6 +201,7 @@ import {
     MutationalSignatureStableIdKeyWord,
     validateMutationalSignatureRawData,
 } from 'shared/lib/GenericAssayUtils/MutationalSignaturesUtils';
+import { getServerConfig } from 'config/config';
 
 type PageMode = 'patient' | 'sample';
 type ResourceId = string;
@@ -347,15 +347,15 @@ export class PatientViewPageStore {
 
     @observable
     public mutationTableGeneFilterOption: GeneFilterOption = getGeneFilterDefault(
-        getBrowserWindow().frontendConfig
+        { serverConfig: getServerConfig() }
     );
     @observable
     public copyNumberTableGeneFilterOption: GeneFilterOption = getGeneFilterDefault(
-        getBrowserWindow().frontendConfig
+        { serverConfig: getServerConfig() }
     );
     @observable
     public structuralVariantTableGeneFilterOption: GeneFilterOption = getGeneFilterDefault(
-        getBrowserWindow().frontendConfig
+        { serverConfig: getServerConfig() }
     );
 
     @computed get sampleId() {
@@ -1031,11 +1031,11 @@ export class PatientViewPageStore {
                         GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                         GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
                         GENOME_NEXUS_ARG_FIELD_ENUM.CLINVAR,
-                        AppConfig.serverConfig.show_signal
+                        getServerConfig().show_signal
                             ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
                             : '',
                     ].filter(f => f),
-                    AppConfig.serverConfig.isoformOverrideSource,
+                    getServerConfig().isoformOverrideSource,
                     this.genomeNexusClient
                 ),
             onError: (err: Error) => {
@@ -1056,7 +1056,7 @@ export class PatientViewPageStore {
                     this.uncalledMutationData
                 ),
                 [GENOME_NEXUS_ARG_FIELD_ENUM.MY_VARIANT_INFO],
-                AppConfig.serverConfig.isoformOverrideSource,
+                getServerConfig().isoformOverrideSource,
                 this.genomeNexusClient
             );
             return getMyVariantInfoAnnotationsFromIndexedVariantAnnotations(
@@ -1409,7 +1409,7 @@ export class PatientViewPageStore {
     readonly darwinUrl = remoteData({
         await: () => [this.derivedPatientId],
         invoke: async () => {
-            if (AppConfig.serverConfig.enable_darwin === true) {
+            if (getServerConfig().enable_darwin === true) {
                 let resp = await request.get(
                     getDarwinUrl(this.sampleIds, this.patientId)
                 );
@@ -1645,7 +1645,7 @@ export class PatientViewPageStore {
     readonly oncoKbCancerGenes = remoteData(
         {
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchOncoKbCancerGenes();
                 } else {
                     return Promise.resolve([]);
@@ -1658,7 +1658,7 @@ export class PatientViewPageStore {
     readonly oncoKbInfo = remoteData(
         {
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchOncoKbInfo();
                 } else {
                     return Promise.resolve(ONCOKB_DEFAULT_INFO);
@@ -1678,7 +1678,7 @@ export class PatientViewPageStore {
         {
             await: () => [this.oncoKbCancerGenes],
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return Promise.resolve(
                         _.reduce(
                             this.oncoKbCancerGenes.result,
@@ -1713,7 +1713,7 @@ export class PatientViewPageStore {
                 this.studies,
             ],
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchOncoKbData(
                         this.uniqueSampleKeyToTumorType,
                         this.oncoKbAnnotatedGenes.result || {},
@@ -1743,7 +1743,7 @@ export class PatientViewPageStore {
                 this.clinicalDataForSamples,
             ],
             invoke: async () =>
-                AppConfig.serverConfig.show_civic
+                getServerConfig().show_civic
                     ? fetchCivicGenes(
                           this.mutationData,
                           this.uncalledMutationData
@@ -1764,10 +1764,7 @@ export class PatientViewPageStore {
                 this.uncalledMutationData,
             ],
             invoke: async () => {
-                if (
-                    AppConfig.serverConfig.show_civic &&
-                    this.civicGenes.result
-                ) {
+                if (getServerConfig().show_civic && this.civicGenes.result) {
                     return fetchCivicVariants(
                         this.civicGenes.result as ICivicGeneIndex,
                         this.mutationData,
@@ -1793,7 +1790,7 @@ export class PatientViewPageStore {
                 this.studies,
             ],
             invoke: async () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchCnaOncoKbData(
                         this.uniqueSampleKeyToTumorType,
                         this.oncoKbAnnotatedGenes.result || {},
@@ -1819,7 +1816,7 @@ export class PatientViewPageStore {
                 this.studies,
             ],
             invoke: async () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchStructuralVariantOncoKbData(
                         this.uniqueSampleKeyToTumorType,
                         this.oncoKbAnnotatedGenes.result || {},
@@ -1840,7 +1837,7 @@ export class PatientViewPageStore {
         {
             await: () => [this.discreteCNAData, this.clinicalDataForSamples],
             invoke: async () =>
-                AppConfig.serverConfig.show_civic
+                getServerConfig().show_civic
                     ? fetchCnaCivicGenes(this.discreteCNAData)
                     : {},
             onError: (err: Error) => {

--- a/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { MakeMobxView } from '../../../shared/components/MobxView';
 import LoadingIndicator from '../../../shared/components/loadingIndicator/LoadingIndicator';
-import { ServerConfigHelpers } from '../../../config/config';
-import AppConfig from 'appConfig';
+import { getServerConfig, ServerConfigHelpers } from '../../../config/config';
 import { MSKTab, MSKTabs } from '../../../shared/components/MSKTabs/MSKTabs';
 import { PatientViewPageStore } from '../clinicalInformation/PatientViewPageStore';
 import SampleManager from '../SampleManager';
@@ -316,15 +315,11 @@ export default class PatientViewMutationsTab extends React.Component<
                         this.props.patientViewPageStore.civicVariants
                     }
                     userEmailAddress={ServerConfigHelpers.getUserEmailAddress()}
-                    enableOncoKb={AppConfig.serverConfig.show_oncokb}
-                    enableFunctionalImpact={
-                        AppConfig.serverConfig.show_genomenexus
-                    }
-                    enableHotspot={AppConfig.serverConfig.show_hotspot}
-                    enableMyCancerGenome={
-                        AppConfig.serverConfig.mycancergenome_show
-                    }
-                    enableCivic={AppConfig.serverConfig.show_civic}
+                    enableOncoKb={getServerConfig().show_oncokb}
+                    enableFunctionalImpact={getServerConfig().show_genomenexus}
+                    enableHotspot={getServerConfig().show_hotspot}
+                    enableMyCancerGenome={getServerConfig().mycancergenome_show}
+                    enableCivic={getServerConfig().show_civic}
                     columnVisibility={this.props.mutationTableColumnVisibility}
                     columnVisibilityProps={{
                         onColumnToggled: this.props

--- a/src/pages/patientView/structuralVariant/PatientViewStructuralVariantTable.tsx
+++ b/src/pages/patientView/structuralVariant/PatientViewStructuralVariantTable.tsx
@@ -15,7 +15,7 @@ import { MakeMobxView } from 'shared/components/MobxView';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import ErrorMessage from 'shared/components/ErrorMessage';
 import AnnotationColumnFormatter from './column/AnnotationColumnFormatter';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { ServerConfigHelpers } from 'config/config';
 import ChromosomeColumnFormatter from 'shared/components/mutationTable/column/ChromosomeColumnFormatter';
 import { remoteData } from 'cbioportal-frontend-commons';
@@ -240,7 +240,7 @@ export default class PatientViewStructuralVariantTable extends React.Component<
                                 .oncoKbCancerGenes,
                             usingPublicOncoKbInstance: this.props.store
                                 .usingPublicOncoKbInstance,
-                            enableOncoKb: AppConfig.serverConfig
+                            enableOncoKb: getServerConfig()
                                 .show_oncokb as boolean,
                             pubMedCache: this.props.store.pubMedCache,
                             enableCivic: false,

--- a/src/pages/patientView/trialMatch/TrialMatchTable.tsx
+++ b/src/pages/patientView/trialMatch/TrialMatchTable.tsx
@@ -20,7 +20,7 @@ import {
 } from 'cbioportal-frontend-commons';
 import { getAgeRangeDisplay } from './TrialMatchTableUtils';
 import TrialMatchFeedback from './TrialMatchFeedback';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { Button } from 'react-bootstrap';
 
 export type ITrialMatchProps = {
@@ -636,9 +636,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                         show={this.showGeneralFeedback}
                         onHide={() => (this.showGeneralFeedback = false)}
                         title="OncoKB Matched Trials General Feedback"
-                        userEmailAddress={
-                            AppConfig.serverConfig.user_email_address
-                        }
+                        userEmailAddress={getServerConfig().user_email_address}
                     />
                 )}
                 {this.selectedTrialFeedbackFormData && (
@@ -648,9 +646,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                         onHide={() => this.openCloseFeedbackForm()}
                         isTrialFeedback={true}
                         title="OncoKB Matched Trial Feedback"
-                        userEmailAddress={
-                            AppConfig.serverConfig.user_email_address
-                        }
+                        userEmailAddress={getServerConfig().user_email_address}
                     />
                 )}
                 <TrialMatchTableComponent

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -16,13 +16,12 @@ import CancerSummaryContainer from 'pages/resultsView/cancerSummary/CancerSummar
 import Mutations from './mutation/Mutations';
 import MutualExclusivityTab from './mutualExclusivity/MutualExclusivityTab';
 import DownloadTab from './download/DownloadTab';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import CNSegments from './cnSegments/CNSegments';
 import './styles.scss';
 import ResultsViewPathwayMapper from './pathwayMapper/ResultsViewPathwayMapper';
 import ResultsViewOncoprint from 'shared/components/oncoprint/ResultsViewOncoprint';
 import QuerySummary from './querySummary/QuerySummary';
-import ExpressionWrapper from './expression/ExpressionWrapper';
 import PlotsTab from './plots/PlotsTab';
 import { MSKTab, MSKTabs } from '../../shared/components/MSKTabs/MSKTabs';
 import { PageLayout } from '../../shared/components/PageLayout/PageLayout';
@@ -384,7 +383,7 @@ export default class ResultsViewPage extends React.Component<
                 id: ResultsViewTab.PATHWAY_MAPPER,
                 hide: () =>
                     browser.name === 'Internet Explorer' ||
-                    !AppConfig.serverConfig.show_pathway_mapper ||
+                    !getServerConfig().show_pathway_mapper ||
                     !this.resultsViewPageStore.studies.isComplete,
                 getTab: () => {
                     const showPM =
@@ -445,9 +444,11 @@ export default class ResultsViewPage extends React.Component<
             .map(tab => tab.getTab());
 
         // now add custom tabs
-        if (AppConfig.serverConfig.custom_tabs) {
-            const customResultsTabs = AppConfig.serverConfig.custom_tabs
-                .filter((tab: any) => tab.location === 'RESULTS_PAGE')
+        if (getServerConfig().custom_tabs) {
+            const customResultsTabs = getServerConfig()
+                .custom_tabs.filter(
+                    (tab: any) => tab.location === 'RESULTS_PAGE'
+                )
                 .map((tab: any, i: number) => {
                     return (
                         <MSKTab
@@ -472,7 +473,7 @@ export default class ResultsViewPage extends React.Component<
 
     @autobind
     public evaluateTabInclusion(tab: ITabConfiguration) {
-        const excludedTabs = AppConfig.serverConfig.disabled_tabs || '';
+        const excludedTabs = getServerConfig().disabled_tabs || '';
         const isExcludedInList = parseConfigDisabledTabs(excludedTabs).includes(
             tab.id
         );
@@ -632,11 +633,9 @@ export default class ResultsViewPage extends React.Component<
                                         .length
                                 }
                                 queryProductLimit={
-                                    AppConfig.serverConfig.query_product_limit
+                                    getServerConfig().query_product_limit
                                 }
-                                email={
-                                    AppConfig.serverConfig.skin_email_contact
-                                }
+                                email={getServerConfig().skin_email_contact}
                             />
                         </div>
                     )}

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -102,7 +102,7 @@ import {
 } from 'shared/lib/GenePanelUtils';
 import { fetchHotspotsData } from 'shared/lib/CancerHotspotsUtils';
 import ResultsViewMutationMapperStore from './mutation/ResultsViewMutationMapperStore';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import * as _ from 'lodash';
 import { toSampleUuid } from '../../shared/lib/UuidUtils';
 import MutationDataCache from '../../shared/cache/MutationDataCache';
@@ -256,7 +256,6 @@ import {
     createCategoricalFilter,
 } from 'shared/lib/MutationUtils';
 import ComplexKeyCounter from 'shared/lib/complexKeyDataStructures/ComplexKeyCounter';
-import { chunkCalls } from 'cbioportal-utils';
 import SampleSet from 'shared/lib/sampleDataStructures/SampleSet';
 import {
     MutationTableColumnType,
@@ -3536,7 +3535,7 @@ export class ResultsViewPageStore
 
     public createMutationMapperStoreForSelectedGene(gene: Gene) {
         const store = new ResultsViewMutationMapperStore(
-            AppConfig.serverConfig,
+            getServerConfig(),
             {
                 filterMutationsBySelectedTranscript: true,
                 filterAppliersOverride: this.customDataFilterAppliers,
@@ -3604,7 +3603,7 @@ export class ResultsViewPageStore
     readonly oncoKbCancerGenes = remoteData(
         {
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchOncoKbCancerGenes();
                 } else {
                     return Promise.resolve([]);
@@ -3618,7 +3617,7 @@ export class ResultsViewPageStore
         {
             await: () => [this.oncoKbCancerGenes],
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return Promise.resolve(
                         _.reduce(
                             this.oncoKbCancerGenes.result,
@@ -3750,7 +3749,7 @@ export class ResultsViewPageStore
             invoke: async () => {
                 const germlineConsentedSamples: SampleIdentifier[] = await fetchGermlineConsentedSamples(
                     this.studyIds,
-                    AppConfig.serverConfig.studiesWithGermlineConsentedSamples
+                    getServerConfig().studiesWithGermlineConsentedSamples
                 );
 
                 // do not simply return all germline consented samples,
@@ -4011,9 +4010,9 @@ export class ResultsViewPageStore
 
     @computed get ensemblLink() {
         return this.referenceGenomeBuild ===
-            AppConfig.serverConfig.genomenexus_url_grch38
-            ? AppConfig.serverConfig.ensembl_transcript_grch38_url
-            : AppConfig.serverConfig.ensembl_transcript_url;
+            getServerConfig().genomenexus_url_grch38
+            ? getServerConfig().ensembl_transcript_grch38_url
+            : getServerConfig().ensembl_transcript_url;
     }
 
     @computed get genomeNexusClient() {
@@ -4386,14 +4385,13 @@ export class ResultsViewPageStore
     @computed get isQueryInvalid() {
         return (
             this.hugoGeneSymbols.length * this.samples.result.length >
-            AppConfig.serverConfig.query_product_limit
+            getServerConfig().query_product_limit
         );
     }
 
     @computed get geneLimit(): number {
         return Math.floor(
-            AppConfig.serverConfig.query_product_limit /
-                this.samples.result.length
+            getServerConfig().query_product_limit / this.samples.result.length
         );
     }
 
@@ -5068,7 +5066,7 @@ export class ResultsViewPageStore
         {
             await: () => [this.mutations],
             invoke: async () =>
-                AppConfig.serverConfig.show_transcript_dropdown &&
+                getServerConfig().show_transcript_dropdown &&
                 this.mutations.result
                     ? await fetchVariantAnnotationsIndexedByGenomicLocation(
                           this.mutations.result,
@@ -5076,11 +5074,11 @@ export class ResultsViewPageStore
                               GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                               GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
                               GENOME_NEXUS_ARG_FIELD_ENUM.CLINVAR,
-                              AppConfig.serverConfig.show_signal
+                              getServerConfig().show_signal
                                   ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
                                   : '',
                           ].filter(f => f),
-                          AppConfig.serverConfig.isoformOverrideSource,
+                          getServerConfig().isoformOverrideSource,
                           this.genomeNexusClient
                       )
                     : undefined,
@@ -5156,7 +5154,7 @@ export class ResultsViewPageStore
         {
             await: () => [this.structuralVariants, this.oncoKbAnnotatedGenes],
             invoke: async () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     let result;
                     try {
                         result = await fetchStructuralVariantOncoKbData(

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -8,7 +8,7 @@ import {
     ResultsViewComparisonSubTab,
     ResultsViewTab,
 } from 'pages/resultsView/ResultsViewPageHelpers';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import {
     cnaGroup,
     CopyNumberEnrichmentEventType,
@@ -294,8 +294,8 @@ export default class ResultsViewURLWrapper
             routing,
             propertiesMap,
             true,
-            AppConfig.serverConfig.session_url_length_threshold
-                ? parseInt(AppConfig.serverConfig.session_url_length_threshold)
+            getServerConfig().session_url_length_threshold
+                ? parseInt(getServerConfig().session_url_length_threshold)
                 : undefined,
             backwardsCompatibilityMapping
         );

--- a/src/pages/resultsView/comparison/ComparisonTab.tsx
+++ b/src/pages/resultsView/comparison/ComparisonTab.tsx
@@ -34,7 +34,7 @@ import AlterationEnrichmentTypeSelector from 'shared/lib/comparison/AlterationEn
 import GenericAssayEnrichments from 'pages/groupComparison/GenericAssayEnrichments';
 import { deriveDisplayTextFromGenericAssayType } from '../plots/PlotsTabUtils';
 import styles from 'pages/resultsView/comparison/styles.module.scss';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { AlterationFilterMenuSection } from 'pages/groupComparison/GroupComparisonUtils';
 
 export interface IComparisonTabProps {
@@ -184,8 +184,7 @@ export default class ComparisonTab extends React.Component<
                         >
                             {(this.store.activeGroups.isComplete &&
                                 this.store.activeGroups.result!.length > 1 &&
-                                AppConfig.serverConfig
-                                    .skin_show_settings_menu && (
+                                getServerConfig().skin_show_settings_menu && (
                                     <AlterationFilterMenuSection
                                         store={this.store}
                                         updateSelectedEnrichmentEventTypes={

--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
@@ -38,7 +38,7 @@ import {
     CopyNumberEnrichmentEventType,
     MutationEnrichmentEventType,
 } from 'shared/lib/comparison/ComparisonStoreUtils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export interface IAlterationEnrichmentContainerProps {
     data: AlterationEnrichmentWithQ[];
@@ -498,7 +498,7 @@ export default class AlterationEnrichmentContainer extends React.Component<
             );
         }
 
-        const useInlineTypeSelectorMenu = !AppConfig.serverConfig
+        const useInlineTypeSelectorMenu = !getServerConfig()
             .skin_show_settings_menu;
 
         return (

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -9,7 +9,7 @@ import ResultsViewMutationMapper from './ResultsViewMutationMapper';
 import { convertToMutationMapperProps } from 'shared/components/mutationMapper/MutationMapperConfig';
 import MutationMapperUserSelectionStore from 'shared/components/mutationMapper/MutationMapperUserSelectionStore';
 import { computed, action, makeObservable } from 'mobx';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import OqlStatusBanner from '../../../shared/components/banners/OqlStatusBanner';
 import autobind from 'autobind-decorator';
 import { AppStore } from '../../../AppStore';
@@ -198,17 +198,17 @@ export default class Mutations extends React.Component<
                     </div>
                     <ResultsViewMutationMapper
                         {...convertToMutationMapperProps({
-                            ...AppConfig.serverConfig,
+                            ...getServerConfig(),
                             // override ensemblLink
                             ensembl_transcript_url: this.props.store
                                 .ensemblLink,
                             // only disable oncokb and hotspots track if
                             // non-canonical transcript is selected
                             show_oncokb: mutationMapperStore.isCanonicalTranscript
-                                ? AppConfig.serverConfig.show_oncokb
+                                ? getServerConfig().show_oncokb
                                 : false,
                             show_hotspot: mutationMapperStore.isCanonicalTranscript
-                                ? AppConfig.serverConfig.show_hotspot
+                                ? getServerConfig().show_hotspot
                                 : false,
                         })}
                         oncoKbPublicApiUrl={getOncoKbApiUrl()}
@@ -249,12 +249,12 @@ export default class Mutations extends React.Component<
                         }
                         mutationAlignerUrlTemplate={getMutationAlignerUrlTemplate()}
                         showTranscriptDropDown={
-                            AppConfig.serverConfig.show_transcript_dropdown
+                            getServerConfig().show_transcript_dropdown
                         }
                         onTranscriptChange={this.onTranscriptChange}
                         onClickSettingMenu={this.onClickSettingMenu}
                         compactStyle={true}
-                        ptmSources={AppConfig.serverConfig.ptmSources}
+                        ptmSources={getServerConfig().ptmSources}
                     />
                 </div>
             );

--- a/src/pages/resultsView/plots/PlotsTabUtils.spec.ts
+++ b/src/pages/resultsView/plots/PlotsTabUtils.spec.ts
@@ -37,7 +37,7 @@ import {
     IAxisData,
     axisHasNegativeNumbers,
 } from 'pages/resultsView/plots/PlotsTabUtils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import ServerConfigDefaults from 'config/serverConfigDefaults';
 import * as _ from 'lodash';
 import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
@@ -902,7 +902,7 @@ describe('PlotsTabUtils', () => {
 
     describe('deriveDisplayTextFromGenericAssayType', () => {
         before(() => {
-            AppConfig.serverConfig.generic_assay_display_text = ServerConfigDefaults.generic_assay_display_text!;
+            getServerConfig().generic_assay_display_text = ServerConfigDefaults.generic_assay_display_text!;
         });
         it('derive from the existing display text', () => {
             const displayText = 'Treatment Response';

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -62,7 +62,7 @@ import {
 } from '../../../shared/components/plots/PlotUtils';
 import { isSampleProfiledInMultiple } from '../../../shared/lib/isSampleProfiled';
 import Pluralize from 'pluralize';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { SpecialChartsUniqueKeyEnum } from 'pages/studyView/StudyViewUtils';
 import { ObservableMap } from 'mobx';
 import { toFixedWithoutTrailingZeros } from '../../../shared/lib/FormatUtils';
@@ -129,7 +129,7 @@ export function deriveDisplayTextFromGenericAssayType(
     plural?: boolean
 ) {
     let derivedDisplayText = '';
-    const typewWithTextList = AppConfig.serverConfig.generic_assay_display_text.split(
+    const typewWithTextList = getServerConfig().generic_assay_display_text.split(
         ','
     );
     const typeToTextDict = _.reduce(

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -13,7 +13,7 @@ import autobind from 'autobind-decorator';
 import ExtendedRouterStore from '../../../shared/lib/ExtendedRouterStore';
 import { ShareUI } from './ShareUI';
 import { ServerConfigHelpers } from '../../../config/config';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { StudyLink } from '../../../shared/components/StudyLink/StudyLink';
 import {
     getAlterationSummary,
@@ -328,7 +328,7 @@ export default class QuerySummary extends React.Component<
                             <ShareUI
                                 sessionEnabled={ServerConfigHelpers.sessionServiceIsEnabled()}
                                 bitlyAccessToken={
-                                    AppConfig.serverConfig.bitly_access_token
+                                    getServerConfig().bitly_access_token
                                 }
                                 urlWrapper={this.props.store.urlWrapper}
                             />

--- a/src/pages/resultsView/querySummary/ShareUI.tsx
+++ b/src/pages/resultsView/querySummary/ShareUI.tsx
@@ -7,7 +7,7 @@ import { BookmarkModal } from '../bookmark/BookmarkModal';
 import { action, makeObservable, observable } from 'mobx';
 import ResultsViewURLWrapper from 'pages/resultsView/ResultsViewURLWrapper';
 import request from 'superagent';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { getBitlyShortenedUrl } from '../../../shared/lib/bitly';
 
 interface IShareUI {

--- a/src/pages/resultsView/survival/SurvivalChart.tsx
+++ b/src/pages/resultsView/survival/SurvivalChart.tsx
@@ -46,7 +46,7 @@ import {
     pluralize,
 } from 'cbioportal-frontend-commons';
 import { logRankTest } from 'pages/resultsView/survival/logRankTest';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export enum LegendLocation {
     TOOLTIP = 'tooltip',
@@ -133,9 +133,9 @@ export default class SurvivalChart
     };
 
     private getInitialSliderValue() {
-        if (AppConfig.serverConfig.survival_initial_x_axis_limit) {
+        if (getServerConfig().survival_initial_x_axis_limit) {
             return Math.min(
-                AppConfig.serverConfig.survival_initial_x_axis_limit,
+                getServerConfig().survival_initial_x_axis_limit,
                 this.maximumDataMonthValue
             );
         } else {

--- a/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
+++ b/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
@@ -21,7 +21,7 @@ import {
 } from 'cbioportal-frontend-commons';
 import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls/ColumnVisibilityControls';
 import { observable, computed, makeObservable, action } from 'mobx';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import Slider from 'react-rangeslider';
 import styles from 'pages/resultsView/survival/styles.module.scss';
 
@@ -312,10 +312,7 @@ export default class SurvivalPrefixTable extends React.Component<
             ...this.props.groupNames.map(makeGroupColumn),
             ...this.props.groupNames.map(makeGroupMedianSurvivalColumn),
         ];
-        if (
-            AppConfig.serverConfig
-                .survival_show_p_q_values_in_survival_type_table
-        ) {
+        if (getServerConfig().survival_show_p_q_values_in_survival_type_table) {
             cols.push(...P_Q_COLUMNS);
         }
         return cols;

--- a/src/pages/staticPages/aboutus/AboutUs.tsx
+++ b/src/pages/staticPages/aboutus/AboutUs.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
 import './styles.scss';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import StaticContent from '../../../shared/components/staticContent/StaticContent';
 import Helmet from 'react-helmet';
 
@@ -13,7 +13,7 @@ export default class AboutUs extends React.Component<{}, {}> {
                     <title>{'cBioPortal for Cancer Genomics::About Us'}</title>
                 </Helmet>
                 <StaticContent
-                    sourceUrl={AppConfig.serverConfig.skin_documentation_about!}
+                    sourceUrl={getServerConfig().skin_documentation_about!}
                     title={'About Us'}
                 />
             </PageLayout>

--- a/src/pages/staticPages/datasetView/DatasetPage.tsx
+++ b/src/pages/staticPages/datasetView/DatasetPage.tsx
@@ -4,7 +4,7 @@ import DatasetList from './DatasetList';
 import { inject, observer } from 'mobx-react';
 import client from 'shared/api/cbioportalClientInstance';
 import { remoteData } from 'cbioportal-frontend-commons';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import styles from './styles.module.scss';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
@@ -21,7 +21,7 @@ export class DatasetPageStore {
     });
 
     readonly downloadList = remoteData(() => {
-        if (AppConfig.serverConfig.app_name === 'public-portal') {
+        if (getServerConfig().app_name === 'public-portal') {
             return request(getStudyDownloadListUrl()).then(resp => resp.body);
         } else {
             return Promise.resolve([]);
@@ -40,12 +40,12 @@ export default class DatasetPage extends React.Component<{}, {}> {
 
     public render() {
         const header: JSX.Element | null = !_.isEmpty(
-            AppConfig.serverConfig.skin_data_sets_header
+            getServerConfig().skin_data_sets_header
         ) ? (
             <p
                 style={{ marginBottom: '20px' }}
                 dangerouslySetInnerHTML={{
-                    __html: AppConfig.serverConfig.skin_data_sets_header!,
+                    __html: getServerConfig().skin_data_sets_header!,
                 }}
             ></p>
         ) : null;

--- a/src/pages/staticPages/faq/FAQ.tsx
+++ b/src/pages/staticPages/faq/FAQ.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import StaticContent from '../../../shared/components/staticContent/StaticContent';
 import Helmet from 'react-helmet';
 import './styles.scss';
@@ -51,7 +51,7 @@ export default class FAQ extends React.Component<{}, {}> {
 
                 <a id="pageTop" />
                 <StaticContent
-                    sourceUrl={AppConfig.serverConfig.skin_documentation_faq!}
+                    sourceUrl={getServerConfig().skin_documentation_faq!}
                     title={'FAQs'}
                     renderers={renderers}
                 />

--- a/src/pages/staticPages/installations/InstallationMap.tsx
+++ b/src/pages/staticPages/installations/InstallationMap.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
 import './styles.scss';
 import Helmet from 'react-helmet';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export default class InstallationMap extends React.Component<{}, {}> {
     public render() {
-        const installations_url = AppConfig.serverConfig.installation_map_url;
+        const installations_url = getServerConfig().installation_map_url;
         return (
             <PageLayout
                 className={'whiteBackground staticPage installationMap'}

--- a/src/pages/staticPages/news/News.tsx
+++ b/src/pages/staticPages/news/News.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import StaticContent from '../../../shared/components/staticContent/StaticContent';
 import './styles.scss';
 import Helmet from 'react-helmet';
@@ -13,7 +13,7 @@ export default class News extends React.Component<{}, {}> {
                     <title>{'cBioPortal for Cancer Genomics::News'}</title>
                 </Helmet>
                 <StaticContent
-                    sourceUrl={AppConfig.serverConfig.skin_documentation_news!}
+                    sourceUrl={getServerConfig().skin_documentation_news!}
                     title={'News'}
                 />
                 <a

--- a/src/pages/staticPages/oql/OQL.tsx
+++ b/src/pages/staticPages/oql/OQL.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import StaticContent from '../../../shared/components/staticContent/StaticContent';
 import './styles.scss';
 import Helmet from 'react-helmet';
@@ -13,7 +13,7 @@ export default class OQL extends React.Component<{}, {}> {
                     <title>{'cBioPortal for Cancer Genomics::OQL Guide'}</title>
                 </Helmet>
                 <StaticContent
-                    sourceUrl={AppConfig.serverConfig.skin_documentation_oql!}
+                    sourceUrl={getServerConfig().skin_documentation_oql!}
                 />
             </PageLayout>
         );

--- a/src/pages/staticPages/software/Software.tsx
+++ b/src/pages/staticPages/software/Software.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
 import './styles.scss';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import StaticContent from '../../../shared/components/staticContent/StaticContent';
 import Helmet from 'react-helmet';
 
@@ -13,9 +13,7 @@ export default class Software extends React.Component<{}, {}> {
                     <title>{'cBioPortal for Cancer Genomics::Software'}</title>
                 </Helmet>
                 <StaticContent
-                    sourceUrl={
-                        AppConfig.serverConfig.skin_documentation_software!
-                    }
+                    sourceUrl={getServerConfig().skin_documentation_software!}
                     title={'Software'}
                 />
             </PageLayout>

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperTool.tsx
@@ -22,13 +22,13 @@ import { parseInput } from 'shared/lib/MutationInputParser';
 import StandaloneMutationMapper from './StandaloneMutationMapper';
 import MutationMapperToolStore from './MutationMapperToolStore';
 
-import AppConfig from 'appConfig';
 import {
     getMutationAlignerUrlTemplate,
     getOncoKbApiUrl,
 } from 'shared/api/urls';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { REFERENCE_GENOME } from 'shared/lib/referenceGenomeUtils';
+import { getServerConfig } from 'config/config';
 
 interface IMutationMapperToolProps {
     routing: any;
@@ -68,12 +68,12 @@ export default class MutationMapperTool extends React.Component<
         this.userSelectionStore = new MutationMapperUserSelectionStore();
         // set genomenexus url to grch38 instance if "show_mutation_mapper_tool_grch38" is true and choose "GRCh38", otherwise use default url
         if (
-            AppConfig.serverConfig.show_mutation_mapper_tool_grch38 &&
+            getServerConfig().show_mutation_mapper_tool_grch38 &&
             getBrowserWindow().localStorage.getItem('referenceGenomeId') ===
                 REFERENCE_GENOME.grch38.NCBI
         ) {
             this.store.setGenomeNexusUrl(
-                AppConfig.serverConfig.genomenexus_url_grch38!
+                getServerConfig().genomenexus_url_grch38!
             );
             this.referenceGenomeSelection = REFERENCE_GENOME.grch38.NCBI;
         }
@@ -481,7 +481,7 @@ export default class MutationMapperTool extends React.Component<
 
     @computed get referenceGenomeSelector() {
         // show reference genome selector if "show_mutation_mapper_tool_grch38" is true
-        if (AppConfig.serverConfig.show_mutation_mapper_tool_grch38) {
+        if (getServerConfig().show_mutation_mapper_tool_grch38) {
             return (
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                     <strong style={{ paddingRight: '5px' }}>
@@ -544,7 +544,7 @@ export default class MutationMapperTool extends React.Component<
                     <MSKTab key={gene} id={gene} linkText={gene}>
                         <StandaloneMutationMapper
                             {...convertToMutationMapperProps({
-                                ...AppConfig.serverConfig,
+                                ...getServerConfig(),
                                 //override ensemblLink
                                 ensembl_transcript_url: this.ensemblLink,
                             })}
@@ -698,10 +698,10 @@ export default class MutationMapperTool extends React.Component<
                 <a href={CIVIC_URL}>CIViC</a>,&nbsp;
                 <a href={CANCER_HOTSPOTS_URL}>Cancer Hotspots</a>,&nbsp;
                 <a href={MY_CANCER_GENOME_URL}>My Cancer Genome</a> and&nbsp;
-                <a href={AppConfig.serverConfig.g2s_url!}>3D structures</a>.
-                Although most of the time the canonical transcript for a gene
-                will be the same between GRCh37 and GRCh38 be sure to look at
-                the results from these annotation sources carefully.
+                <a href={getServerConfig().g2s_url!}>3D structures</a>. Although
+                most of the time the canonical transcript for a gene will be the
+                same between GRCh37 and GRCh38 be sure to look at the results
+                from these annotation sources carefully.
             </div>
         );
     }
@@ -712,8 +712,8 @@ export default class MutationMapperTool extends React.Component<
 
     @computed get ensemblLink() {
         return this.isGrch38
-            ? AppConfig.serverConfig.ensembl_transcript_grch38_url
-            : AppConfig.serverConfig.ensembl_transcript_url;
+            ? getServerConfig().ensembl_transcript_grch38_url
+            : getServerConfig().ensembl_transcript_url;
     }
 
     @computed get shouldShowGrch38Warning() {

--- a/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
+++ b/src/pages/staticPages/tools/mutationMapper/MutationMapperToolStore.ts
@@ -10,8 +10,6 @@ import {
     resolveDefaultsForMissingValues,
 } from 'cbioportal-utils';
 
-import AppConfig from 'appConfig';
-
 import { remoteData } from 'cbioportal-frontend-commons';
 import {
     EnsemblTranscript,
@@ -51,6 +49,7 @@ import defaultGenomeNexusInternalClient from 'shared/api/genomeNexusInternalClie
 import autobind from 'autobind-decorator';
 import { getGenomeNexusHgvsgUrl } from 'shared/api/urls';
 import { GENOME_NEXUS_ARG_FIELD_ENUM } from 'shared/constants';
+import { getServerConfig } from 'config/config';
 
 export default class MutationMapperToolStore {
     @observable mutationData: Partial<MutationInput>[] | undefined;
@@ -94,7 +93,7 @@ export default class MutationMapperToolStore {
     }
 
     @computed get isoformOverrideSource(): string {
-        return AppConfig.serverConfig.isoformOverrideSource;
+        return getServerConfig().isoformOverrideSource;
     }
 
     @computed get genomeNexusClient() {
@@ -120,7 +119,7 @@ export default class MutationMapperToolStore {
     readonly oncoKbCancerGenes = remoteData(
         {
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchOncoKbCancerGenes();
                 } else {
                     return Promise.resolve([]);
@@ -134,7 +133,7 @@ export default class MutationMapperToolStore {
         {
             await: () => [this.oncoKbCancerGenes],
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return Promise.resolve(
                         _.reduce(
                             this.oncoKbCancerGenes.result,
@@ -224,11 +223,11 @@ export default class MutationMapperToolStore {
                         GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                         GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
                         GENOME_NEXUS_ARG_FIELD_ENUM.CLINVAR,
-                        AppConfig.serverConfig.show_signal
+                        getServerConfig().show_signal
                             ? GENOME_NEXUS_ARG_FIELD_ENUM.SIGNAL
                             : '',
                     ].filter(f => f),
-                    AppConfig.serverConfig.isoformOverrideSource,
+                    getServerConfig().isoformOverrideSource,
                     this.genomeNexusClient
                 ),
             onError: (err: Error) => {
@@ -246,7 +245,7 @@ export default class MutationMapperToolStore {
                 const indexedVariantAnnotations = await fetchVariantAnnotationsIndexedByGenomicLocation(
                     this.rawMutations,
                     ['my_variant_info'],
-                    AppConfig.serverConfig.isoformOverrideSource,
+                    getServerConfig().isoformOverrideSource,
                     this.genomeNexusClient
                 );
 
@@ -310,7 +309,7 @@ export default class MutationMapperToolStore {
                                 map[
                                     gene.hugoGeneSymbol
                                 ] = new MutationMapperStore(
-                                    AppConfig.serverConfig,
+                                    getServerConfig(),
                                     {
                                         filterMutationsBySelectedTranscript: !this
                                             .hasInputWithProteinChanges,

--- a/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
+++ b/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
@@ -7,7 +7,7 @@ import OncoprintControls, {
     IOncoprintControlsState,
 } from 'shared/components/oncoprint/controls/OncoprintControls';
 import { percentAltered } from '../../../../shared/components/oncoprint/OncoprintUtils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import OncoprintJS from 'oncoprintjs';
 import fileDownload from 'react-file-download';
 import { FadeInteraction, svgToPdfDownload } from 'cbioportal-frontend-commons';
@@ -94,7 +94,7 @@ export default class Oncoprinter extends React.Component<
                 return self.props.store.driverAnnotationSettings.oncoKb;
             },
             get annotateDriversOncoKbDisabled() {
-                return !AppConfig.serverConfig.show_oncokb;
+                return !getServerConfig().show_oncokb;
             },
             get annotateDriversOncoKbError() {
                 return self.props.store.didOncoKbFail;
@@ -129,7 +129,7 @@ export default class Oncoprinter extends React.Component<
                 return self.props.store.driverAnnotationSettings.hotspots;
             },
             get annotateDriversHotspotsDisabled() {
-                return !AppConfig.serverConfig.show_hotspot;
+                return !getServerConfig().show_hotspot;
             },
             get annotateCustomDriverBinary() {
                 return self.props.store.driverAnnotationSettings.customBinary;

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.ts
@@ -1,5 +1,5 @@
 import { observable } from 'mobx';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { default as OncoprinterStore } from './OncoprinterStore';
 import _ from 'lodash';
 import {
@@ -176,7 +176,7 @@ export function initDriverAnnotationSettings(store: OncoprinterStore) {
         },
         get oncoKb() {
             return !!(
-                AppConfig.serverConfig.show_oncokb &&
+                getServerConfig().show_oncokb &&
                 this._oncoKb &&
                 !store.didOncoKbFail
             );

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
@@ -1,6 +1,6 @@
 import { DriverAnnotationSettings } from '../../../../shared/alterationFiltering/AnnotationFilteringSettings';
 import { action, computed, makeObservable, observable } from 'mobx';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import {
     annotateGeneticTrackData,
     fetchOncoKbDataForCna,
@@ -313,7 +313,7 @@ export default class OncoprinterStore {
     readonly oncoKbCancerGenes = remoteData(
         {
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchOncoKbCancerGenes();
                 } else {
                     return Promise.resolve([]);
@@ -327,7 +327,7 @@ export default class OncoprinterStore {
         {
             await: () => [this.oncoKbCancerGenes],
             invoke: () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return Promise.resolve(
                         _.reduce(
                             this.oncoKbCancerGenes.result,
@@ -358,7 +358,7 @@ export default class OncoprinterStore {
                 this.oncoKbAnnotatedGenes,
             ],
             invoke: async () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     return fetchOncoKbDataForMutations(
                         this.oncoKbAnnotatedGenes.result!,
                         this.nonAnnotatedGeneticData.result!
@@ -381,7 +381,7 @@ export default class OncoprinterStore {
                 this.oncoKbAnnotatedGenes,
             ],
             invoke: async () => {
-                if (AppConfig.serverConfig.show_oncokb) {
+                if (getServerConfig().show_oncokb) {
                     let result;
                     try {
                         result = await fetchOncoKbDataForCna(

--- a/src/pages/staticPages/tutorials/Tutorials.tsx
+++ b/src/pages/staticPages/tutorials/Tutorials.tsx
@@ -4,7 +4,7 @@ import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
 import './styles.scss';
 import Helmet from 'react-helmet';
 import { getNCBIlink } from 'cbioportal-frontend-commons';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 const ReturnToTop: React.FunctionComponent<{}> = function() {
     return (
@@ -35,7 +35,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 {/*    </a>{' '}*/}
                 {/*    or{' '}*/}
                 {/*    <a*/}
-                {/*        href={`${AppConfig.serverConfig*/}
+                {/*        href={`${getServerConfig()*/}
                 {/*            .skin_documentation_baseurl!.replace(*/}
                 {/*                'raw.githubusercontent.com',*/}
                 {/*                'www.github.com'*/}
@@ -189,7 +189,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                     <span style={{ color: '#eee' }}> | </span>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Webinar 1 Introduction to cBioPortal.pdf`}
                         >
                             Download PDF
@@ -237,7 +237,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                     <span style={{ color: '#eee' }}> | </span>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Webinar 2 Mutation Details and Patient View.pdf`}
                         >
                             Download PDF
@@ -285,7 +285,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                     <span style={{ color: '#eee' }}> | </span>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Webinar 3 Expression Data Analysis.pdf`}
                         >
                             Download PDF
@@ -333,7 +333,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                     <span style={{ color: '#eee' }}> | </span>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Webinar 4 Group Comparison.pdf`}
                         >
                             Download PDF
@@ -382,7 +382,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                     <span style={{ color: '#eee' }}> | </span>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Webinar 5 API and R Client.pdf`}
                         >
                             Download PDF
@@ -421,7 +421,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <div>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 1 Single Study Exploration.pdf`}
                         >
                             Download PDF
@@ -449,7 +449,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <div>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 2 Single Study Query.pdf`}
                         >
                             Download PDF
@@ -477,7 +477,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <div>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 3 Patient View.pdf`}
                         >
                             Download PDF
@@ -505,7 +505,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <div>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 4 Virtual Studies.pdf`}
                         >
                             Download PDF
@@ -533,7 +533,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <div>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 5 Onco Query Language.pdf`}
                         >
                             Download PDF
@@ -561,7 +561,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <div>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 6 Group Comparison.pdf`}
                         >
                             Download PDF
@@ -589,7 +589,7 @@ export default class Tutorials extends React.Component<{}, {}> {
                 <div>
                     <h4 style={{ display: 'inline' }}>
                         <a
-                            href={`${AppConfig.serverConfig
+                            href={`${getServerConfig()
                                 .skin_documentation_baseurl!}tutorials/cBioPortal Tutorial 7 Pathways.pdf`}
                         >
                             Download PDF

--- a/src/pages/staticPages/webAPI/WebAPIPage.tsx
+++ b/src/pages/staticPages/webAPI/WebAPIPage.tsx
@@ -4,7 +4,7 @@ import { observable, makeObservable } from 'mobx';
 import { PageLayout } from '../../../shared/components/PageLayout/PageLayout';
 import './styles.scss';
 import Helmet from 'react-helmet';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { buildCBioPortalAPIUrl } from 'shared/api/urls';
 
@@ -40,10 +40,10 @@ export default class WebAPIPage extends React.Component<{}, {}> {
 
     renderDataAccessTokensDiv() {
         if (
-            AppConfig.serverConfig.authenticationMethod === 'social_auth' ||
-            (AppConfig.serverConfig.dat_method !== 'uuid' &&
-                AppConfig.serverConfig.dat_method !== 'jwt' &&
-                AppConfig.serverConfig.dat_method !== 'oauth2')
+            getServerConfig().authenticationMethod === 'social_auth' ||
+            (getServerConfig().dat_method !== 'uuid' &&
+                getServerConfig().dat_method !== 'jwt' &&
+                getServerConfig().dat_method !== 'oauth2')
         ) {
             return <div></div>;
         } else {

--- a/src/pages/studyView/StudyViewConfig.ts
+++ b/src/pages/studyView/StudyViewConfig.ts
@@ -1,4 +1,4 @@
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { StudyView } from '../../config/IAppConfig';
 import { Layout } from 'react-grid-layout';
 import * as _ from 'lodash';
@@ -235,5 +235,5 @@ const studyViewFrontEnd = {
 
 export const STUDY_VIEW_CONFIG: StudyViewConfig = _.assign(
     studyViewFrontEnd,
-    (AppConfig.serverConfig || {}).study_view
+    (getServerConfig() || {}).study_view
 );

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -40,9 +40,7 @@ import {
 } from '../../shared/lib/tracking';
 import ComparisonGroupManager from '../groupComparison/comparisonGroupManager/ComparisonGroupManager';
 import classNames from 'classnames';
-import AppConfig from 'appConfig';
-import SocialAuthButton from '../../shared/components/SocialAuthButton';
-import { ServerConfigHelpers } from '../../config/config';
+import { getServerConfig, ServerConfigHelpers } from '../../config/config';
 import {
     AlterationMenuHeader,
     getButtonNameWithDownPointer,
@@ -337,7 +335,7 @@ export default class StudyViewPage extends React.Component<
     async getBookmarkUrl(): Promise<ShareUrls> {
         const bitlyUrl = await getBitlyShortenedUrl(
             this.studyViewFullUrlWithFilter,
-            AppConfig.serverConfig.bitly_access_token
+            getServerConfig().bitly_access_token
         );
 
         return {
@@ -781,7 +779,7 @@ export default class StudyViewPage extends React.Component<
                                                 </DefaultTooltip>
                                             </>
                                         )}
-                                        {AppConfig.serverConfig
+                                        {getServerConfig()
                                             .skin_show_settings_menu && (
                                             <DefaultTooltip
                                                 trigger={['click']}
@@ -798,10 +796,8 @@ export default class StudyViewPage extends React.Component<
                                                             />
                                                         }
                                                         customDriverSourceName={
-                                                            getBrowserWindow()
-                                                                .frontendConfig
-                                                                .serverConfig
-                                                                .oncoprint_custom_driver_annotation_binary_menu_label
+                                                            getServerConfig()
+                                                                .oncoprint_custom_driver_annotation_binary_menu_label!
                                                         }
                                                         showDriverAnnotationSection={
                                                             this.store

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import AppConfig from 'appConfig';
 import internalClient from 'shared/api/cbioportalInternalClientInstance';
 import defaultClient from 'shared/api/cbioportalClientInstance';
 import oncoKBClient from 'shared/api/oncokbClientInstance';
@@ -238,6 +237,7 @@ import {
     MutationEnrichmentEventType,
 } from 'shared/lib/comparison/ComparisonStoreUtils';
 import { isQueriedStudyAuthorized } from 'shared/components/lazyMobXTable/utils';
+import { getServerConfig } from 'config/config';
 
 type ChartUniqueKey = string;
 type ResourceId = string;
@@ -864,7 +864,7 @@ export class StudyViewPageStore
             if (
                 this.studyIds.length > 0 &&
                 (this.isLoggedIn ||
-                    AppConfig.serverConfig.authenticationMethod ===
+                    getServerConfig().authenticationMethod ===
                         'noauthsessionservice') &&
                 !this.pendingDecision.result
             ) {
@@ -4603,7 +4603,7 @@ export class StudyViewPageStore
             await: () => [this.queriedPhysicalStudyIds],
             onError: () => {},
             invoke: async () => {
-                if (AppConfig.serverConfig.show_mdacc_heatmap) {
+                if (getServerConfig().show_mdacc_heatmap) {
                     let isSinglePhysicalStudy =
                         this.queriedPhysicalStudyIds.result.length === 1;
                     if (isSinglePhysicalStudy) {
@@ -4762,7 +4762,7 @@ export class StudyViewPageStore
     });
 
     @computed get oncokbCancerGeneFilterEnabled(): boolean {
-        if (!AppConfig.serverConfig.show_oncokb) {
+        if (!getServerConfig().show_oncokb) {
             return false;
         }
         return !this.oncokbCancerGenes.isError && !this.oncokbGenes.isError;
@@ -8479,9 +8479,9 @@ export class StudyViewPageStore
         return !!(
             this.customDriverAnnotationReport.isComplete &&
             this.customDriverAnnotationReport.result!.hasBinary &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_binary_menu_label &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_tiers_menu_label
         );
     }
@@ -8490,9 +8490,9 @@ export class StudyViewPageStore
         return !!(
             this.customDriverAnnotationReport.isComplete &&
             this.customDriverAnnotationReport.result!.tiers.length > 0 &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_binary_menu_label &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_tiers_menu_label
         );
     }

--- a/src/pages/studyView/studyPageHeader/rightPanel/RightPanel.tsx
+++ b/src/pages/studyView/studyPageHeader/rightPanel/RightPanel.tsx
@@ -14,7 +14,7 @@ import classnames from 'classnames';
 import { serializeEvent } from '../../../../shared/lib/tracking';
 import { getOqlMessages } from '../../../../shared/lib/StoreUtils';
 import { CUSTOM_CASE_LIST_ID } from '../../../../shared/components/query/QueryStore';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { remoteData } from 'cbioportal-frontend-commons';
 
 export interface IRightPanelProps {
@@ -68,7 +68,7 @@ export default class RightPanel extends React.Component<IRightPanelProps, {}> {
             return (
                 this.props.store.geneQueries.length *
                     this.props.store.selectedSamples.result.length >
-                AppConfig.serverConfig.query_product_limit
+                getServerConfig().query_product_limit
             );
         } else {
             return false;
@@ -78,7 +78,7 @@ export default class RightPanel extends React.Component<IRightPanelProps, {}> {
     @computed get geneLimit(): number {
         if (this.props.store.selectedSamples.isComplete) {
             return Math.floor(
-                AppConfig.serverConfig.query_product_limit /
+                getServerConfig().query_product_limit /
                     this.props.store.selectedSamples.result.length
             );
         } else {

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -32,7 +32,7 @@ import { DataType } from 'cbioportal-frontend-commons';
 import { GenericAssayDataBin } from 'cbioportal-ts-api-client/dist/generated/CBioPortalAPIInternal';
 import DelayedRender from 'shared/components/DelayedRender';
 import { getRemoteDataGroupStatus } from 'cbioportal-utils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export interface IStudySummaryTabProps {
     store: StudyViewPageStore;
@@ -278,8 +278,7 @@ export class StudySummaryTab extends React.Component<
                 props.downloadTypes = ['Data'];
                 props.filterByCancerGenes = this.store.filterMutatedGenesTableByCancerGenes;
                 props.onChangeCancerGeneFilter = this.store.updateMutatedGenesTableByCancerGenesFilter;
-                props.alterationFilterEnabled =
-                    AppConfig.serverConfig.skin_show_settings_menu;
+                props.alterationFilterEnabled = getServerConfig().skin_show_settings_menu;
                 props.filterAlterations = this.store.isGlobalMutationFilterActive;
                 break;
             }
@@ -303,8 +302,7 @@ export class StudySummaryTab extends React.Component<
                 props.downloadTypes = ['Data'];
                 props.filterByCancerGenes = this.store.filterSVGenesTableByCancerGenes;
                 props.onChangeCancerGeneFilter = this.store.updateSVGenesTableByCancerGenesFilter;
-                props.alterationFilterEnabled =
-                    AppConfig.serverConfig.skin_show_settings_menu;
+                props.alterationFilterEnabled = getServerConfig().skin_show_settings_menu;
                 props.filterAlterations = this.store.isGlobalMutationFilterActive;
                 break;
             }
@@ -327,8 +325,7 @@ export class StudySummaryTab extends React.Component<
                 props.downloadTypes = ['Data'];
                 props.filterByCancerGenes = this.store.filterCNAGenesTableByCancerGenes;
                 props.onChangeCancerGeneFilter = this.store.updateCNAGenesTableByCancerGenesFilter;
-                props.alterationFilterEnabled =
-                    AppConfig.serverConfig.skin_show_settings_menu;
+                props.alterationFilterEnabled = getServerConfig().skin_show_settings_menu;
                 props.filterAlterations = this.store.isGlobalAlterationFilterActive;
                 break;
             }

--- a/src/shared/alterationFiltering/AnnotationFilteringSettings.ts
+++ b/src/shared/alterationFiltering/AnnotationFilteringSettings.ts
@@ -1,5 +1,5 @@
 import { action, observable, ObservableMap } from 'mobx';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { MobxPromiseUnionType } from 'mobxpromise';
 import _ from 'lodash';
 
@@ -81,7 +81,7 @@ export interface IDriverAnnotationReport {
 
 export function buildDriverAnnotationSettings(
     didOncoKbFailInOncoprint: () => boolean,
-    config = AppConfig.serverConfig
+    config = getServerConfig()
 ): DriverAnnotationSettings {
     return observable({
         cbioportalCount: false,
@@ -257,7 +257,7 @@ export function buildDriverAnnotationControlsState(
     customDriverAnnotationReport: IDriverAnnotationReport | undefined,
     didOncoKbFailInOncoprint?: boolean,
     didHotspotFailInOncoprint?: boolean,
-    config = AppConfig.serverConfig
+    config = getServerConfig()
 ): IDriverAnnotationControlsState {
     return observable({
         get distinguishDrivers() {
@@ -304,8 +304,8 @@ export function buildDriverAnnotationControlsState(
         },
         get customDriverAnnotationBinaryMenuLabel() {
             if (customDriverAnnotationReport) {
-                const label =
-                    config.oncoprint_custom_driver_annotation_binary_menu_label;
+                const label = getServerConfig()
+                    .oncoprint_custom_driver_annotation_binary_menu_label;
                 if (
                     label &&
                     customDriverAnnotationReport &&
@@ -317,8 +317,8 @@ export function buildDriverAnnotationControlsState(
         },
         get customDriverAnnotationTiersMenuLabel() {
             if (customDriverAnnotationReport) {
-                const label =
-                    config.oncoprint_custom_driver_annotation_tiers_menu_label;
+                const label = getServerConfig()
+                    .oncoprint_custom_driver_annotation_tiers_menu_label;
                 if (
                     label &&
                     customDriverAnnotationReport &&

--- a/src/shared/api/index.jsx
+++ b/src/shared/api/index.jsx
@@ -1,8 +1,8 @@
 import Swagger from 'swagger-client';
-import AppConfig from 'appConfig';
+import { getLoadConfig } from 'config/config';
 
 const clientPromise = new Swagger({
-    url: `http://${AppConfig.apiRoot}/v2/api-docs`,
+    url: `http://${getLoadConfig().apiRoot}/v2/api-docs`,
     usePromise: true,
 });
 export default clientPromise;

--- a/src/shared/api/urls.spec.ts
+++ b/src/shared/api/urls.spec.ts
@@ -6,20 +6,20 @@ import Adapter from 'enzyme-adapter-react-16';
 import sinon from 'sinon';
 
 Enzyme.configure({ adapter: new Adapter() });
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { IServerConfig } from 'config/IAppConfig';
+import { getLoadConfig } from 'config/config';
 
 describe('url library', () => {
     before(() => {
         //global.window = { location: { protocol: 'https://' } };
-        AppConfig.serverConfig.genomenexus_url = 'http://www.test.com/hello/';
-        AppConfig.apiRoot = 'http://www.cbioportal.org';
+        getServerConfig().genomenexus_url = 'http://www.test.com/hello/';
+        getLoadConfig().apiRoot = 'http://www.cbioportal.org';
     });
 
     after(() => {
-        delete (AppConfig.serverConfig as Partial<IServerConfig>)
-            .genomenexus_url;
-        delete AppConfig.apiRoot;
+        delete (getServerConfig() as Partial<IServerConfig>).genomenexus_url;
+        delete getLoadConfig().apiRoot;
     });
 
     it('transforms genome nexus url configuration url to proxied url: removes protocol and trailing slash', () => {
@@ -33,7 +33,7 @@ describe('url library', () => {
     });
 
     it('transforms genome nexus url configuration url to proxied url: removes protocol and trailing slash', () => {
-        AppConfig.serverConfig.genomenexus_url = null;
+        getServerConfig().genomenexus_url = null;
         // note that this is WRONG (http: should be followed by double shlash)
         // note that this is WRONG (http: should be followed by double shlash)
         // but this is due to testing env and url builder library

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -1,5 +1,4 @@
 import { default as URL, QueryParams } from 'url';
-import AppConfig from 'appConfig';
 import { BuildUrlParams, getBrowserWindow } from 'cbioportal-frontend-commons';
 import { DEFAULT_MUTATION_ALIGNER_URL_TEMPLATE } from 'react-mutation-mapper';
 import * as _ from 'lodash';
@@ -7,6 +6,7 @@ import { GroupComparisonLoadingParams } from '../../pages/groupComparison/GroupC
 import { GroupComparisonURLQuery } from '../../pages/groupComparison/GroupComparisonURLWrapper';
 import { PagePath } from 'shared/enums/PagePaths';
 import { EncodedURLParam } from '../lib/bitly';
+import { getLoadConfig, getServerConfig } from 'config/config';
 
 export function trimTrailingSlash(str: string) {
     return str.replace(/\/$/g, '');
@@ -28,7 +28,7 @@ export function buildCBioPortalAPIUrl(
             ? { pathname: pathnameOrParams, query, hash }
             : pathnameOrParams;
 
-    const apiRootUrl = URL.parse(trimTrailingSlash(AppConfig.apiRoot!));
+    const apiRootUrl = URL.parse(trimTrailingSlash(getLoadConfig().apiRoot!));
 
     // prepend the root path (e.g. "beta"
     params.pathname =
@@ -63,7 +63,9 @@ export function buildCBioPortalPageUrl(
     // AppConfig.frontendUrl format is '//url/', hence the specified slice to get just 'url'
     return URL.format({
         protocol: window.location.protocol,
-        host: AppConfig.baseUrl || AppConfig.frontendUrl?.slice(2, -1),
+        host:
+            getLoadConfig().baseUrl ||
+            getLoadConfig().frontendUrl?.slice(2, -1),
         ...params,
     });
 }
@@ -79,16 +81,16 @@ export function getCurrentURLWithoutHash() {
 
 // this gives us the root of the instance (.e.g. //www.bioportal.org/beta)
 export function buildCBioLink(path: string) {
-    return '//' + AppConfig.baseUrl + '/' + path;
+    return '//' + getLoadConfig().baseUrl + '/' + path;
 }
 
 export function getCbioPortalApiUrl() {
-    const root = trimTrailingSlash(AppConfig.apiRoot!);
+    const root = trimTrailingSlash(getLoadConfig().apiRoot!);
     return `${root}/api`;
 }
 
 export function getFrontendAssetUrl(path: string) {
-    const root = trimTrailingSlash(AppConfig.frontendUrl!);
+    const root = trimTrailingSlash(getLoadConfig().frontendUrl!);
     return `${root}/${path}`;
 }
 
@@ -161,17 +163,17 @@ export function getComparisonLoadingUrl(
 }
 
 export function getPubMedUrl(pmid: string) {
-    return _.template(AppConfig.serverConfig.pubmed_url!)({ pmid });
+    return _.template(getServerConfig().pubmed_url!)({ pmid });
 }
 
 export function getMyGeneUrl(entrezGeneId: number) {
-    return _.template(AppConfig.serverConfig.mygene_info_url!)({
+    return _.template(getServerConfig().mygene_info_url!)({
         entrezGeneId,
     });
 }
 
 export function getUniprotIdUrl(swissProtAccession: string) {
-    return _.template(AppConfig.serverConfig.uniprot_id_url!)({
+    return _.template(getServerConfig().uniprot_id_url!)({
         swissProtAccession: swissProtAccession,
     });
 }
@@ -210,12 +212,12 @@ export function getOncoKbApiUrl() {
 }
 
 export function getInstituteLogoUrl() {
-    if (AppConfig.serverConfig.skin_right_logo) {
-        if (/^http/.test(AppConfig.serverConfig.skin_right_logo)) {
-            return AppConfig.serverConfig.skin_right_logo;
+    if (getServerConfig().skin_right_logo) {
+        if (/^http/.test(getServerConfig().skin_right_logo || '')) {
+            return getServerConfig().skin_right_logo!;
         } else {
             return buildCBioPortalPageUrl(
-                `images/${AppConfig.serverConfig.skin_right_logo}`
+                `images/${getServerConfig().skin_right_logo}`
             );
         }
     } else {
@@ -224,7 +226,7 @@ export function getInstituteLogoUrl() {
 }
 
 export function getGenomeNexusApiUrl() {
-    let url = AppConfig.serverConfig.genomenexus_url;
+    let url = getServerConfig().genomenexus_url;
     return getProxyUrlIfNecessary(url);
 }
 
@@ -232,16 +234,13 @@ export function getGenomeNexusHgvsgUrl(
     hgvsg: string,
     referenceGenomeUrl: string | undefined
 ) {
-    return referenceGenomeUrl === AppConfig.serverConfig.genomenexus_url_grch38
-        ? `${AppConfig.serverConfig.genomenexus_url_grch38}/variant/${hgvsg}`
-        : `${AppConfig.serverConfig.genomenexus_website_url}/variant/${hgvsg}`;
+    return referenceGenomeUrl === getServerConfig().genomenexus_url_grch38
+        ? `${getServerConfig().genomenexus_url_grch38}/variant/${hgvsg}`
+        : `${getServerConfig().genomenexus_website_url}/variant/${hgvsg}`;
 }
 
 export function getSessionUrl() {
-    if (
-        AppConfig.serverConfig &&
-        AppConfig.serverConfig.hasOwnProperty('apiRoot')
-    ) {
+    if (getServerConfig() && getServerConfig().hasOwnProperty('apiRoot')) {
         // TODO: remove this after switch to AWS. This is a hack to use proxy
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
@@ -252,10 +251,7 @@ export function getSessionUrl() {
 }
 
 export function fetchComparisonGroupsServiceUrl() {
-    if (
-        AppConfig.serverConfig &&
-        AppConfig.serverConfig.hasOwnProperty('apiRoot')
-    ) {
+    if (getServerConfig() && getServerConfig().hasOwnProperty('apiRoot')) {
         // TODO: remove this after switch to AWS. This is a hack to use proxy
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
@@ -266,10 +262,7 @@ export function fetchComparisonGroupsServiceUrl() {
 }
 
 export function getComparisonGroupServiceUrl() {
-    if (
-        AppConfig.serverConfig &&
-        AppConfig.serverConfig.hasOwnProperty('apiRoot')
-    ) {
+    if (getServerConfig() && getServerConfig().hasOwnProperty('apiRoot')) {
         // TODO: remove this after switch to AWS. This is a hack to use proxy
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
@@ -280,10 +273,7 @@ export function getComparisonGroupServiceUrl() {
 }
 
 export function getComparisonSessionServiceUrl() {
-    if (
-        AppConfig.serverConfig &&
-        AppConfig.serverConfig.hasOwnProperty('apiRoot')
-    ) {
+    if (getServerConfig() && getServerConfig().hasOwnProperty('apiRoot')) {
         // TODO: remove this after switch to AWS. This is a hack to use proxy
         // session-service from non apiRoot. We'll have to come up with a better
         // solution for auth portals
@@ -301,23 +291,23 @@ export function getEncodedRedirectUrl(targetUrl: string) {
 
 export function getConfigurationServiceApiUrl() {
     return (
-        AppConfig.configurationServiceUrl ||
+        getLoadConfig().configurationServiceUrl ||
         buildCBioPortalAPIUrl('config_service.jsp')
     );
 }
 
 export function getG2SApiUrl() {
-    return AppConfig.serverConfig.g2s_url;
+    return getServerConfig().g2s_url;
 }
 
 export function getDigitalSlideArchiveMetaUrl(patientId: string) {
-    return AppConfig.serverConfig.digital_slide_archive_meta_url + patientId;
+    return getServerConfig().digital_slide_archive_meta_url + patientId;
 }
 export function getDigitalSlideArchiveIFrameUrl(patientId: string) {
     //format:
     //https://cancer.digitalslidearchive.org/#!/CDSA/caseName/TCGA-02-0006
     return (
-        AppConfig.serverConfig.digital_slide_archive_iframe_url +
+        getServerConfig().digital_slide_archive_iframe_url +
         `#!/CDSA/${patientId}`
     );
 }
@@ -334,23 +324,23 @@ export function getStudyDownloadListUrl() {
 }
 
 export function getMDAndersonHeatmapPatientUrl(patientId: string) {
-    return AppConfig.serverConfig.mdacc_heatmap_patient_url + patientId;
+    return getServerConfig().mdacc_heatmap_patient_url + patientId;
 }
 
 export function getMDAndersonHeatMapMetaUrl(patientId: string) {
-    return AppConfig.serverConfig.mdacc_heatmap_meta_url + patientId;
+    return getServerConfig().mdacc_heatmap_meta_url + patientId;
 }
 
 export function getMDAndersonHeatmapStudyMetaUrl(studyId: string) {
-    return AppConfig.serverConfig.mdacc_heatmap_study_meta_url + studyId;
+    return getServerConfig().mdacc_heatmap_study_meta_url + studyId;
 }
 
 export function getMDAndersonHeatmapStudyUrl(studyId: string) {
-    return AppConfig.serverConfig.mdacc_heatmap_study_url + studyId;
+    return getServerConfig().mdacc_heatmap_study_url + studyId;
 }
 
 export function getBasePath() {
-    return AppConfig.baseUrl!.replace(/[^\/]*/, '');
+    return getLoadConfig().baseUrl!.replace(/[^\/]*/, '');
 }
 
 export function getDocsUrl(sourceUrl: string, docsBaseUrl?: string): string {
@@ -368,7 +358,7 @@ export function getWholeSlideViewerUrl(
 ): string {
     try {
         const tokenInfo = JSON.parse(
-            AppConfig.serverConfig.mskWholeSlideViewerToken
+            getServerConfig().mskWholeSlideViewerToken
         );
         const token = `&token=${tokenInfo.token}`;
         const time = `&t=${tokenInfo.time}`;

--- a/src/shared/cache/GenomeNexusCache.ts
+++ b/src/shared/cache/GenomeNexusCache.ts
@@ -4,7 +4,7 @@ import { VariantAnnotation } from 'genome-nexus-ts-api-client';
 import { extractGenomicLocation } from 'cbioportal-utils';
 import { Mutation } from 'cbioportal-ts-api-client';
 import LazyMobXCache, { CacheData } from 'shared/lib/LazyMobXCache';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { GENOME_NEXUS_ARG_FIELD_ENUM } from 'shared/constants';
 
 export type GenomeNexusCacheDataType = CacheData<VariantAnnotation>;
@@ -16,7 +16,7 @@ export function defaultGNFetch(
         return fetchVariantAnnotationsByMutation(
             queries,
             [GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY],
-            AppConfig.serverConfig.isoformOverrideSource
+            getServerConfig().isoformOverrideSource
         );
     } else {
         return Promise.resolve([]);

--- a/src/shared/cache/GenomeNexusMutationAssessorCache.ts
+++ b/src/shared/cache/GenomeNexusMutationAssessorCache.ts
@@ -2,7 +2,7 @@ import { fetchVariantAnnotationsByMutation } from 'shared/lib/StoreUtils';
 import { genomicLocationString } from 'shared/lib/MutationUtils';
 import { Mutation } from 'cbioportal-ts-api-client';
 import LazyMobXCache, { CacheData } from 'shared/lib/LazyMobXCache';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { VariantAnnotation } from 'genome-nexus-ts-api-client';
 import { extractGenomicLocation } from 'cbioportal-utils';
 import { GENOME_NEXUS_ARG_FIELD_ENUM } from 'shared/constants';
@@ -19,7 +19,7 @@ export function defaultGNFetch(
                 GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
                 GENOME_NEXUS_ARG_FIELD_ENUM.MUTATION_ASSESSOR,
             ],
-            AppConfig.serverConfig.isoformOverrideSource
+            getServerConfig().isoformOverrideSource
         );
     } else {
         return Promise.resolve([]);

--- a/src/shared/components/ErrorMessage.tsx
+++ b/src/shared/components/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import ErrorIcon from './ErrorIcon';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export interface IErrorMessageProps {
     message?: string;
@@ -30,10 +30,8 @@ export default class ErrorMessage extends React.Component<
                 {this.props.message!} Please let us know about this error and
                 how you got here at{' '}
                 <b style={{ whiteSpace: 'nowrap' }}>
-                    <a
-                        href={`mailto:${AppConfig.serverConfig.skin_email_contact}`}
-                    >
-                        {AppConfig.serverConfig.skin_email_contact}
+                    <a href={`mailto:${getServerConfig().skin_email_contact}`}>
+                        {getServerConfig().skin_email_contact}
                     </a>
                 </b>
             </span>

--- a/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
+++ b/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { Link } from 'react-router-dom';
 import { AppStore } from '../../../AppStore';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
@@ -57,7 +57,7 @@ export class DataAccessTokensDropdown extends React.Component<
                         href={buildCBioPortalPageUrl(
                             this.props.appStore.logoutUrl,
                             {
-                                local: AppConfig.serverConfig.saml_logout_local.toString(),
+                                local: getServerConfig().saml_logout_local.toString(),
                             }
                         )}
                     >
@@ -75,9 +75,9 @@ export class DataAccessTokensDropdown extends React.Component<
                 ),
                 hide:
                     this.props.appStore.isSocialAuthenticated ||
-                    (AppConfig.serverConfig.dat_method !== 'uuid' &&
-                        AppConfig.serverConfig.dat_method !== 'jwt' &&
-                        AppConfig.serverConfig.dat_method !== 'oauth2'),
+                    (getServerConfig().dat_method !== 'uuid' &&
+                        getServerConfig().dat_method !== 'jwt' &&
+                        getServerConfig().dat_method !== 'oauth2'),
             },
         ];
         const shownListItems = listItems.filter(l => {

--- a/src/shared/components/errorScreen/ErrorScreen.tsx
+++ b/src/shared/components/errorScreen/ErrorScreen.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { observer } from 'mobx-react';
 import './errorScreen.scss';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { buildCBioPortalPageUrl } from 'shared/api/urls';
 import { computed, makeObservable } from 'mobx';
 import autobind from 'autobind-decorator';
@@ -80,13 +80,13 @@ export default class ErrorScreen extends React.Component<
 
                 {this.props.body && <div>{this.props.body}</div>}
 
-                {this.errorLog && AppConfig.serverConfig.skin_email_contact && (
+                {this.errorLog && getServerConfig().skin_email_contact && (
                     <div style={{ marginTop: 20 }}>
                         <p style={{ marginBottom: 20 }}>
                             Please contact us at{' '}
                             <a
                                 href={`mailto:${
-                                    AppConfig.serverConfig.skin_email_contact
+                                    getServerConfig().skin_email_contact
                                 }?subject=${encodeURIComponent(
                                     subject
                                 )}&body=${encodeURIComponent(
@@ -95,7 +95,7 @@ export default class ErrorScreen extends React.Component<
                                     this.props.errorLog || ''
                                 )}`}
                             >
-                                {AppConfig.serverConfig.skin_email_contact}
+                                {getServerConfig().skin_email_contact}
                             </a>
                             .
                         </p>

--- a/src/shared/components/lazyMobXTable/utils.ts
+++ b/src/shared/components/lazyMobXTable/utils.ts
@@ -1,6 +1,6 @@
 import { SHOW_ALL_PAGE_SIZE } from '../paginationControls/PaginationControls';
 import { CancerStudy } from 'cbioportal-ts-api-client';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 export function maxPage(displayDataLength: number, itemsPerPage: number) {
     if (itemsPerPage === SHOW_ALL_PAGE_SIZE) {
         return 0;
@@ -11,8 +11,8 @@ export function maxPage(displayDataLength: number, itemsPerPage: number) {
 
 export function isQueriedStudyAuthorized(study: CancerStudy) {
     return (
-        !AppConfig.serverConfig.skin_show_unauthorized_studies ||
-        (AppConfig.serverConfig.skin_show_unauthorized_studies &&
+        !getServerConfig().skin_show_unauthorized_studies ||
+        (getServerConfig().skin_show_unauthorized_studies &&
             study.isAuthorized !== false)
     );
 }

--- a/src/shared/components/mutationMapper/MutationMapperUtils.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUtils.ts
@@ -1,7 +1,7 @@
 import { Mutation } from 'cbioportal-ts-api-client';
 import { GenomeNexusAPI, VariantAnnotation } from 'genome-nexus-ts-api-client';
 import { fetchVariantAnnotationsByMutation } from 'react-mutation-mapper';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export function normalizeMutation<T extends Pick<Mutation, 'chr'>>(
     mutation: T
@@ -24,7 +24,7 @@ export function createVariantAnnotationsByMutationFetcher(
             return fetchVariantAnnotationsByMutation(
                 queries,
                 fields,
-                AppConfig.serverConfig.isoformOverrideSource,
+                getServerConfig().isoformOverrideSource,
                 client
             );
         } else {

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -139,7 +139,7 @@ export interface IMutationTableProps {
     deactivateColumnFilter?: (columnId: string) => void;
 }
 import MobxPromise from 'mobxpromise';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import Timeout = NodeJS.Timeout;
 
 export enum MutationTableColumnType {
@@ -1199,7 +1199,7 @@ export default class MutationTable<
                 </span>
             ),
             visible: false,
-            shouldExclude: () => !AppConfig.serverConfig.show_signal,
+            shouldExclude: () => !getServerConfig().show_signal,
         };
     }
 

--- a/src/shared/components/mutationTable/column/annotation/AnnotationHeader.tsx
+++ b/src/shared/components/mutationTable/column/annotation/AnnotationHeader.tsx
@@ -9,7 +9,7 @@ import {
     OncoKbHelper,
 } from 'react-mutation-mapper';
 import classnames from 'classnames';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 // oncokb
 enum OncokbTabs {
@@ -328,7 +328,7 @@ const AnnotationHeader: React.FunctionComponent<{
         <span>
             {props.name}
             <br />
-            {AppConfig.serverConfig.show_oncokb && (
+            {getServerConfig().show_oncokb && (
                 <DefaultTooltip
                     placement="top"
                     overlay={
@@ -354,7 +354,7 @@ const AnnotationHeader: React.FunctionComponent<{
                     />
                 </DefaultTooltip>
             )}
-            {AppConfig.serverConfig.show_civic && (
+            {getServerConfig().show_civic && (
                 <DefaultTooltip
                     placement="top"
                     overlay={
@@ -377,7 +377,7 @@ const AnnotationHeader: React.FunctionComponent<{
                     />
                 </DefaultTooltip>
             )}
-            {AppConfig.serverConfig.mycancergenome_show && (
+            {getServerConfig().mycancergenome_show && (
                 <DefaultTooltip
                     placement="top"
                     overlay={
@@ -402,7 +402,7 @@ const AnnotationHeader: React.FunctionComponent<{
                     />
                 </DefaultTooltip>
             )}
-            {AppConfig.serverConfig.show_hotspot && (
+            {getServerConfig().show_hotspot && (
                 <DefaultTooltip
                     placement="top"
                     overlay={

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -48,7 +48,7 @@ import {
 } from './OncoprintUtils';
 import _ from 'lodash';
 import onMobxPromise from 'shared/lib/onMobxPromise';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import OncoprintJS, { TrackGroupIndex, TrackId } from 'oncoprintjs';
 import fileDownload from 'react-file-download';
@@ -443,7 +443,7 @@ export default class ResultsViewOncoprint extends React.Component<
                 return self.props.store.driverAnnotationSettings.oncoKb;
             },
             get annotateDriversOncoKbDisabled() {
-                return !AppConfig.serverConfig.show_oncokb;
+                return !getServerConfig().show_oncokb;
             },
             get annotateDriversOncoKbError() {
                 return self.props.store.didOncoKbFailInOncoprint;
@@ -452,7 +452,7 @@ export default class ResultsViewOncoprint extends React.Component<
                 return self.props.store.driverAnnotationSettings.hotspots;
             },
             get annotateDriversHotspotsDisabled() {
-                return !AppConfig.serverConfig.show_hotspot;
+                return !getServerConfig().show_hotspot;
             },
             get annotateDriversHotspotsError() {
                 return self.props.store.didHotspotFailInOncoprint;
@@ -502,7 +502,7 @@ export default class ResultsViewOncoprint extends React.Component<
                 return self.heatmapIsDynamicallyQueried;
             },
             get ngchmButtonActive() {
-                return AppConfig.serverConfig.show_mdacc_heatmap &&
+                return getServerConfig().show_mdacc_heatmap &&
                     self.props.store.remoteNgchmUrl.result &&
                     self.props.store.remoteNgchmUrl.result != ''
                     ? true
@@ -512,9 +512,8 @@ export default class ResultsViewOncoprint extends React.Component<
                 return self.heatmapGeneInputValue;
             },
             get customDriverAnnotationBinaryMenuLabel() {
-                const label =
-                    AppConfig.serverConfig
-                        .oncoprint_custom_driver_annotation_binary_menu_label;
+                const label = getServerConfig()
+                    .oncoprint_custom_driver_annotation_binary_menu_label;
                 const customDriverReport =
                     self.props.store.customDriverAnnotationReport.result;
                 if (
@@ -528,9 +527,8 @@ export default class ResultsViewOncoprint extends React.Component<
                 }
             },
             get customDriverAnnotationTiersMenuLabel() {
-                const label =
-                    AppConfig.serverConfig
-                        .oncoprint_custom_driver_annotation_tiers_menu_label;
+                const label = getServerConfig()
+                    .oncoprint_custom_driver_annotation_tiers_menu_label;
                 const customDriverReport =
                     self.props.store.customDriverAnnotationReport.result;
                 if (

--- a/src/shared/components/oncoprint/TooltipUtils.spec.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.spec.ts
@@ -16,7 +16,7 @@ import {
 import $ from 'jquery';
 import { MolecularProfile, Mutation } from 'cbioportal-ts-api-client';
 import { getPatientViewUrl, getSampleViewUrl } from '../../api/urls';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import ServerConfigDefaults from 'config/serverConfigDefaults';
 import { PUTATIVE_DRIVER, PUTATIVE_PASSENGER } from 'shared/lib/StoreUtils';
 
@@ -2679,7 +2679,7 @@ describe('Oncoprint TooltipUtils', () => {
         );
 
         before(() => {
-            AppConfig.serverConfig.generic_assay_display_text = ServerConfigDefaults.generic_assay_display_text!;
+            getServerConfig().generic_assay_display_text = ServerConfigDefaults.generic_assay_display_text!;
         });
 
         it('should show data rounded to 2 decimal digits', () => {

--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -21,7 +21,7 @@ import { QueryStore } from './QueryStore';
 import SectionHeader from '../sectionHeader/SectionHeader';
 import { Modal } from 'react-bootstrap';
 import Autosuggest from 'react-bootstrap-autosuggest';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { ServerConfigHelpers } from '../../../config/config';
 import autobind from 'autobind-decorator';
 import { PAN_CAN_SIGNATURE } from './StudyListLogic';
@@ -198,7 +198,7 @@ export default class CancerStudySelector extends React.Component<
         } = this.logic.mainView.getSelectionReport();
 
         const quickSetButtons = this.logic.mainView.quickSelectButtons(
-            AppConfig.serverConfig.skin_quick_select_buttons
+            getServerConfig().skin_quick_select_buttons
         );
 
         return (
@@ -226,8 +226,8 @@ export default class CancerStudySelector extends React.Component<
                     <Observer>
                         {() => {
                             let searchTextOptions = ServerConfigHelpers.skin_example_study_queries(
-                                AppConfig.serverConfig!
-                                    .skin_example_study_queries || ''
+                                getServerConfig()!.skin_example_study_queries ||
+                                    ''
                             );
                             if (
                                 this.store.searchText &&

--- a/src/shared/components/query/GeneSetSelector.tsx
+++ b/src/shared/components/query/GeneSetSelector.tsx
@@ -12,12 +12,11 @@ import { QueryStoreComponent, Focus, GeneReplacement } from './QueryStore';
 import MutSigGeneSelector from './MutSigGeneSelector';
 import GisticGeneSelector from './GisticGeneSelector';
 import SectionHeader from '../sectionHeader/SectionHeader';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { ServerConfigHelpers } from '../../../config/config';
 import OQLTextArea, { GeneBoxType } from '../GeneSelectionBox/OQLTextArea';
 import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
 import { Gene } from 'cbioportal-ts-api-client';
-import { bind } from 'bind-decorator';
 import GenesetsValidator from './GenesetsValidator';
 import FontAwesome from 'react-fontawesome';
 import GeneSymbolValidationError from './GeneSymbolValidationError';
@@ -38,9 +37,9 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
     @computed get geneListOptions() {
         let geneList: { id: string; genes: string[] }[] = gene_lists;
 
-        if (AppConfig.serverConfig.query_sets_of_genes) {
+        if (getServerConfig().query_sets_of_genes) {
             const parsed = ServerConfigHelpers.parseQuerySetsOfGenes(
-                AppConfig.serverConfig.query_sets_of_genes
+                getServerConfig().query_sets_of_genes!
             );
             if (parsed) {
                 geneList = parsed;
@@ -90,9 +89,9 @@ export default class GeneSetSelector extends QueryStoreComponent<{}, {}> {
                         <GeneSymbolValidationError
                             sampleCount={this.store.approxSampleCount}
                             queryProductLimit={
-                                AppConfig.serverConfig.query_product_limit
+                                getServerConfig().query_product_limit
                             }
-                            email={AppConfig.serverConfig.skin_email_contact}
+                            email={getServerConfig().skin_email_contact}
                         />
                     </div>
                 </div>

--- a/src/shared/components/query/GenesetsHierarchySelector.tsx
+++ b/src/shared/components/query/GenesetsHierarchySelector.tsx
@@ -5,7 +5,7 @@ import GenesetsJsTree from './GenesetsJsTree';
 import GenesetsHierarchyFilterForm, {
     validPercentile,
 } from './GenesetsHierarchyFilterForm';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export interface GenesetsHierarchySelectorProps {
     initialSelection: string[];
@@ -20,10 +20,10 @@ export default class GenesetsHierarchySelector extends React.Component<
     {}
 > {
     @observable percentile: validPercentile = 75;
-    @observable pvalueThreshold =
-        AppConfig.serverConfig.skin_geneset_hierarchy_default_p_value;
-    @observable scoreThreshold =
-        AppConfig.serverConfig.skin_geneset_hierarchy_default_gsva_score;
+    @observable pvalueThreshold = getServerConfig()
+        .skin_geneset_hierarchy_default_p_value;
+    @observable scoreThreshold = getServerConfig()
+        .skin_geneset_hierarchy_default_gsva_score;
     @observable searchValue = '';
 
     constructor(props: GenesetsHierarchySelectorProps) {

--- a/src/shared/components/query/GenesetsSelector.tsx
+++ b/src/shared/components/query/GenesetsSelector.tsx
@@ -10,7 +10,7 @@ import { QueryStoreComponent, Focus } from './QueryStore';
 import GenesetsHierarchySelector from './GenesetsHierarchySelector';
 import GenesetsVolcanoSelector from './GenesetsVolcanoSelector';
 import SectionHeader from '../sectionHeader/SectionHeader';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { ServerConfigHelpers } from '../../../config/config';
 
 export interface GenesetsSelectorProps {}
@@ -34,9 +34,9 @@ export default class GenesetsSelector extends QueryStoreComponent<
     @computed get geneListOptions() {
         let geneList: { id: string; genes: string[] }[] = gene_lists;
 
-        if (AppConfig.serverConfig.query_sets_of_genes) {
+        if (getServerConfig().query_sets_of_genes) {
             const parsed = ServerConfigHelpers.parseQuerySetsOfGenes(
-                AppConfig.serverConfig.query_sets_of_genes
+                getServerConfig().query_sets_of_genes!
             );
             if (parsed) {
                 geneList = parsed;

--- a/src/shared/components/query/MolecularProfileSelector.tsx
+++ b/src/shared/components/query/MolecularProfileSelector.tsx
@@ -8,7 +8,7 @@ import { FlexRow } from '../flexbox/FlexBox';
 import { QueryStoreComponent } from './QueryStore';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import SectionHeader from '../sectionHeader/SectionHeader';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
 
 @observer
@@ -17,7 +17,7 @@ export default class MolecularProfileSelector extends QueryStoreComponent<
     {}
 > {
     private get showGSVA() {
-        return AppConfig.serverConfig.skin_show_gsva;
+        return getServerConfig().skin_show_gsva;
     }
 
     render() {

--- a/src/shared/components/query/QueryAndDownloadTabs.tsx
+++ b/src/shared/components/query/QueryAndDownloadTabs.tsx
@@ -10,7 +10,7 @@ import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import autobind from 'autobind-decorator';
 import { trackEvent } from 'shared/lib/tracking';
 import { If } from 'react-if';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { ModifyQueryParams } from 'pages/resultsView/ResultsViewPageStore';
 
 const DOWNLOAD = 'download';
@@ -93,12 +93,11 @@ export default class QueryAndDownloadTabs extends React.Component<
     render() {
         return (
             <div className={styles.QueryAndDownloadTabs}>
-                <If condition={AppConfig.serverConfig.skin_citation_rule_text}>
+                <If condition={getServerConfig().skin_citation_rule_text}>
                     <div
                         className="citationRule"
                         dangerouslySetInnerHTML={{
-                            __html: AppConfig.serverConfig
-                                .skin_citation_rule_text!,
+                            __html: getServerConfig().skin_citation_rule_text!,
                         }}
                     ></div>
                 </If>

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -32,7 +32,6 @@ import internalClient from '../../api/cbioportalInternalClientInstance';
 import { SingleGeneQuery, SyntaxError } from '../../lib/oql/oql-parser';
 import { parseOQLQuery } from '../../lib/oql/oqlfilter';
 import memoize from 'memoize-weak-decorator';
-import AppConfig from 'appConfig';
 import { ComponentGetsStoreContext } from '../../lib/ContextUtils';
 import URL from 'url';
 import { buildCBioPortalPageUrl, redirectToStudyView } from '../../api/urls';
@@ -58,7 +57,7 @@ import {
 } from 'shared/components/query/GenesetsSelectorStore';
 import SampleListsInStudyCache from 'shared/cache/SampleListsInStudyCache';
 import formSubmit from '../../lib/formSubmit';
-import { ServerConfigHelpers } from '../../../config/config';
+import { getServerConfig, ServerConfigHelpers } from '../../../config/config';
 import { AlterationTypeConstants } from '../../../pages/resultsView/ResultsViewPageStore';
 import {
     ResultsViewURLQuery,
@@ -515,7 +514,7 @@ export class QueryStore {
     @observable showGenesetsHierarchyPopup = false;
     @observable showGenesetsVolcanoPopup = false;
     @observable priorityStudies = ServerConfigHelpers.parseConfigFormat(
-        AppConfig.serverConfig.priority_studies
+        getServerConfig().priority_studies
     );
     @observable showSelectedStudiesOnly: boolean = false;
     @observable.shallow selectedCancerTypeIds: string[] = [];
@@ -527,7 +526,7 @@ export class QueryStore {
     } = { label: '75%', value: '75' };
 
     @observable private _maxTreeDepth: number = parseInt(
-        AppConfig.serverConfig.skin_query_max_tree_depth!,
+        getServerConfig().skin_query_max_tree_depth!,
         10
     );
     @computed get maxTreeDepth() {
@@ -1860,13 +1859,13 @@ export class QueryStore {
     @computed get isQueryLimitReached(): boolean {
         return (
             this.oql.query.length * this.approxSampleCount >
-            AppConfig.serverConfig.query_product_limit
+            getServerConfig().query_product_limit
         );
     }
 
     @computed get geneLimit(): number {
         return Math.floor(
-            AppConfig.serverConfig.query_product_limit / this.approxSampleCount
+            getServerConfig().query_product_limit / this.approxSampleCount
         );
     }
 

--- a/src/shared/components/query/quickSearch/QuickSearch.tsx
+++ b/src/shared/components/query/quickSearch/QuickSearch.tsx
@@ -11,7 +11,7 @@ import * as moduleStyles from './styles.module.scss';
 import { action, computed, makeObservable, observable } from 'mobx';
 import { getBrowserWindow, remoteData } from 'cbioportal-frontend-commons';
 import Pluralize from 'pluralize';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { ServerConfigHelpers } from 'config/config';
 import sessionServiceClient from 'shared/api/sessionServiceInstance';
 import { trackEvent } from 'shared/lib/tracking';
@@ -131,8 +131,8 @@ export default class QuickSearch extends React.Component<QuickSearchProps, {}> {
 
     // tslint:disable-next-line:member-ordering
     readonly geneStudyQueryVirtualStudy = remoteData(async () => {
-        const virtualStudyId =
-            AppConfig.serverConfig.default_cross_cancer_study_session_id;
+        const virtualStudyId = getServerConfig()
+            .default_cross_cancer_study_session_id;
 
         if (ServerConfigHelpers.sessionServiceIsEnabled() && virtualStudyId) {
             try {
@@ -161,11 +161,9 @@ export default class QuickSearch extends React.Component<QuickSearchProps, {}> {
             } else {
                 return Promise.resolve({
                     type: GeneStudyQueryType.STUDY_LIST,
-                    query:
-                        AppConfig.serverConfig.default_cross_cancer_study_list,
-                    name:
-                        AppConfig.serverConfig
-                            .default_cross_cancer_study_list_name,
+                    query: getServerConfig().default_cross_cancer_study_list,
+                    name: getServerConfig()
+                        .default_cross_cancer_study_list_name,
                 });
             }
         },

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -26,7 +26,7 @@ import { StudyLink } from '../../StudyLink/StudyLink';
 import StudyTagsTooltip from '../../studyTagsTooltip/StudyTagsTooltip';
 import { formatStudyReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { isQueriedStudyAuthorized } from 'shared/components/lazyMobXTable/utils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 const styles = {
     ...styles_any,
@@ -221,7 +221,7 @@ export default class StudyList extends QueryStoreComponent<
                             ),
                             [`studyItem_${study.studyId}`]: true,
                             [styles.UnauthorizedStudy]:
-                                AppConfig.serverConfig
+                                getServerConfig()
                                     .skin_show_unauthorized_studies &&
                                 study.isAuthorized === false,
                         });
@@ -423,7 +423,7 @@ export default class StudyList extends QueryStoreComponent<
                             </span>
                         </DefaultTooltip>
                     )}
-                    {AppConfig.serverConfig.skin_show_unauthorized_studies &&
+                    {getServerConfig().skin_show_unauthorized_studies &&
                         study.studyId &&
                         study.isAuthorized === false && (
                             <DefaultTooltip
@@ -432,7 +432,7 @@ export default class StudyList extends QueryStoreComponent<
                                 overlay={
                                     <div className={styles.tooltip}>
                                         {
-                                            AppConfig.serverConfig
+                                            getServerConfig()
                                                 .skin_global_message_for_unauthorized_studies
                                         }
                                     </div>

--- a/src/shared/components/rightbar/RightBar.tsx
+++ b/src/shared/components/rightbar/RightBar.tsx
@@ -3,11 +3,11 @@ import * as _ from 'lodash';
 import { observer } from 'mobx-react';
 import { TypeOfCancer as CancerType } from 'cbioportal-ts-api-client';
 import Testimonials from '../testimonials/Testimonials';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { QueryStore } from 'shared/components/query/QueryStore';
 import { Link } from 'react-router-dom';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
-import { buildCBioPortalPageUrl, redirectToStudyView } from '../../api/urls';
+import { buildCBioPortalPageUrl } from '../../api/urls';
 import { ResultsViewTab } from '../../../pages/resultsView/ResultsViewPageHelpers';
 
 interface IRightBarProps {
@@ -71,18 +71,14 @@ export default class RightBar extends React.Component<
     }
 
     private getWhatsNew() {
-        if (AppConfig.serverConfig.skin_right_nav_show_whats_new) {
-            if (
-                !_.isEmpty(
-                    AppConfig.serverConfig.skin_right_nav_whats_new_blurb
-                )
-            ) {
+        if (getServerConfig().skin_right_nav_show_whats_new) {
+            if (!_.isEmpty(getServerConfig().skin_right_nav_whats_new_blurb)) {
                 return (
                     <div className="rightBarSection">
                         <h3>What's New</h3>
                         <div
                             dangerouslySetInnerHTML={{
-                                __html: AppConfig.serverConfig
+                                __html: getServerConfig()
                                     .skin_right_nav_whats_new_blurb!,
                             }}
                         ></div>
@@ -157,7 +153,7 @@ export default class RightBar extends React.Component<
     }
 
     private getInstallationMap() {
-        const installations_url = AppConfig.serverConfig.installation_map_url;
+        const installations_url = getServerConfig().installation_map_url;
         return !installations_url ? null : (
             <div className="rightBarSection">
                 <h3 style={{ paddingBottom: 8 }}>
@@ -201,19 +197,15 @@ export default class RightBar extends React.Component<
     }
 
     public getExampleSection() {
-        if (AppConfig.serverConfig.skin_right_nav_show_examples) {
-            if (
-                !_.isEmpty(
-                    AppConfig.serverConfig.skin_examples_right_column_html
-                )
-            ) {
+        if (getServerConfig().skin_right_nav_show_examples) {
+            if (!_.isEmpty(getServerConfig().skin_examples_right_column_html)) {
                 return (
                     <div
                         className="rightBarSection exampleQueries"
                         dangerouslySetInnerHTML={{
                             __html:
                                 '<h3>Example Queries</h3>' +
-                                AppConfig.serverConfig
+                                getServerConfig()
                                     .skin_examples_right_column_html,
                         }}
                     ></div>
@@ -287,7 +279,7 @@ export default class RightBar extends React.Component<
     }
 
     public getTestimonialsSection() {
-        return AppConfig.serverConfig.skin_right_nav_show_testimonials ? (
+        return getServerConfig().skin_right_nav_show_testimonials ? (
             <div className="rightBarSection" style={{ minHeight: '300px' }}>
                 <h3>Testimonials</h3>
                 <Testimonials />

--- a/src/shared/components/staticContent/StaticContent.tsx
+++ b/src/shared/components/staticContent/StaticContent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import $ from 'jquery';
 import { observer } from 'mobx-react';
 import ReactMarkdown from 'react-markdown';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { remoteData } from 'cbioportal-frontend-commons';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
 import { getDocsUrl } from '../../api/urls';
@@ -10,13 +10,13 @@ import './gfm.css';
 
 function isMarkDown(url: string) {
     return (
-        !AppConfig.serverConfig.skin_documentation_markdown === false &&
+        !getServerConfig().skin_documentation_markdown === false &&
         /\.md$/.test(url)
     );
 }
 
 function setImageRoot(path: string) {
-    return `${AppConfig.serverConfig.skin_documentation_baseurl}/${path}`;
+    return `${getServerConfig().skin_documentation_baseurl}/${path}`;
 }
 
 @observer
@@ -27,7 +27,7 @@ export default class StaticContent extends React.Component<
     private get url() {
         return getDocsUrl(
             this.props.sourceUrl!,
-            AppConfig.serverConfig.skin_documentation_baseurl!
+            getServerConfig().skin_documentation_baseurl!
         );
     }
 

--- a/src/shared/lib/ExtendedRouterStore.spec.ts
+++ b/src/shared/lib/ExtendedRouterStore.spec.ts
@@ -10,7 +10,7 @@ import { createBrowserHistory, MemoryHistory } from 'history';
 import { SinonStub } from 'sinon';
 import { sleep } from './TimeUtils';
 import { computed } from 'mobx';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { setServerConfig } from '../../config/config';
 
 describe('ExtendedRouterStore', () => {

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -78,7 +78,7 @@ import {
     CustomDriverNumericGeneMolecularData,
 } from '../../pages/resultsView/ResultsViewPageStore';
 import { normalizeMutations } from '../components/mutationMapper/MutationMapperUtils';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { getFrontendAssetUrl } from 'shared/api/urls';
 import {
     AnnotateCopyNumberAlterationQuery,
@@ -236,7 +236,9 @@ export async function fetchAllReferenceGenomeGenes(
     const doCaching = window.location.hostname.includes('.cbioportal.org');
 
     // allows us to clear cache when data changes
-    const referenceGenomeKey = `referenceGenome-${AppConfig.serverConfig.referenceGenomeVersion}`;
+    const referenceGenomeKey = `referenceGenome-${
+        getServerConfig().referenceGenomeVersion
+    }`;
 
     const hg19cached = doCaching
         ? await localForage.getItem(referenceGenomeKey)
@@ -1456,10 +1458,10 @@ export function getGenomeNexusUrl(studies: CancerStudy[]) {
                     )
             )
         ) {
-            return AppConfig.serverConfig.genomenexus_url_grch38!;
+            return getServerConfig().genomenexus_url_grch38!;
         }
     }
-    return AppConfig.serverConfig.genomenexus_url!;
+    return getServerConfig().genomenexus_url!;
 }
 
 export function getSurvivalClinicalAttributesPrefix(
@@ -1639,7 +1641,7 @@ export async function fetchOncoKbDataForOncoprint(
     >,
     mutations: MobxPromise<Mutation[]>
 ) {
-    if (AppConfig.serverConfig.show_oncokb) {
+    if (getServerConfig().show_oncokb) {
         let result;
         try {
             result = await fetchOncoKbData(
@@ -1661,7 +1663,7 @@ export async function fetchCnaOncoKbDataForOncoprint(
     oncoKbAnnotatedGenes: MobxPromise<{ [entrezGeneId: number]: boolean }>,
     cnaMolecularData: MobxPromise<NumericGeneMolecularData[]>
 ) {
-    if (AppConfig.serverConfig.show_oncokb) {
+    if (getServerConfig().show_oncokb) {
         let result;
         try {
             result = await fetchCnaOncoKbDataWithNumericGeneMolecularData(

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -99,7 +99,7 @@ import {
     IDriverAnnotationReport,
     initializeCustomDriverAnnotationSettings,
 } from 'shared/alterationFiltering/AnnotationFilteringSettings';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import IComparisonURLWrapper from 'pages/groupComparison/IComparisonURLWrapper';
 
 export enum OverlapStrategy {
@@ -2110,9 +2110,9 @@ export default abstract class ComparisonStore
         return !!(
             this.customDriverAnnotationReport.isComplete &&
             this.customDriverAnnotationReport.result!.hasBinary &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_binary_menu_label &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_tiers_menu_label
         );
     }
@@ -2121,9 +2121,9 @@ export default abstract class ComparisonStore
         return !!(
             this.customDriverAnnotationReport.isComplete &&
             this.customDriverAnnotationReport.result!.tiers.length > 0 &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_binary_menu_label &&
-            AppConfig.serverConfig
+            getServerConfig()
                 .oncoprint_custom_driver_annotation_tiers_menu_label
         );
     }

--- a/src/shared/lib/genomeNexusAnnotationSourcesUtils.ts
+++ b/src/shared/lib/genomeNexusAnnotationSourcesUtils.ts
@@ -1,7 +1,7 @@
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 
 export function shouldShowMutationAssessor() {
     return RegExp('mutation_assessor', 'gi').test(
-        AppConfig.serverConfig.show_genomenexus_annotation_sources
+        getServerConfig().show_genomenexus_annotation_sources
     );
 }

--- a/src/shared/lib/redirectHelpers.ts
+++ b/src/shared/lib/redirectHelpers.ts
@@ -2,7 +2,7 @@ import ExtendedRouterStore from './ExtendedRouterStore';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { QueryParams } from 'url';
 import { PatientViewUrlParams } from '../../pages/patientView/PatientViewPage';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import ResultsViewURLWrapper from 'pages/resultsView/ResultsViewURLWrapper';
 import { EncodedURLParam } from './bitly';
 import { ServerConfigHelpers } from 'config/config';
@@ -114,10 +114,10 @@ export function handleCaseDO() {
 async function getCuratedNonRedundantStudyList() {
     // Parse curated non-redundant set from AppConfig
     let quickSelectButtons: CategorizedConfigItems = {};
-    if (AppConfig.serverConfig.skin_quick_select_buttons) {
+    if (getServerConfig().skin_quick_select_buttons) {
         try {
             quickSelectButtons = ServerConfigHelpers.parseConfigFormat(
-                AppConfig.serverConfig.skin_quick_select_buttons
+                getServerConfig().skin_quick_select_buttons
             );
         } catch (ex) {
             return {};
@@ -162,8 +162,8 @@ export async function handleLinkOut() {
             currentQuery.cancer_study_id ||
             // use same set of studies as quick search gene query if no
             // specific study is supplied
-            AppConfig.serverConfig.default_cross_cancer_study_session_id ||
-            AppConfig.serverConfig.default_cross_cancer_study_list,
+            getServerConfig().default_cross_cancer_study_session_id ||
+            getServerConfig().default_cross_cancer_study_list,
     };
 
     (getBrowserWindow().routingStore as ExtendedRouterStore).updateRoute(

--- a/src/shared/lib/tracking.ts
+++ b/src/shared/lib/tracking.ts
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import AppConfig from 'appConfig';
+import { getServerConfig } from 'config/config';
 import { getBrowserWindow, isWebdriver } from 'cbioportal-frontend-commons';
 import * as _ from 'lodash';
 import { log } from './consoleLog';
@@ -20,10 +20,8 @@ export type GAEvent = {
 };
 
 export function initializeTracking() {
-    if (!_.isEmpty(AppConfig.serverConfig.google_analytics_profile_id)) {
-        embedGoogleAnalytics(
-            AppConfig.serverConfig.google_analytics_profile_id!
-        );
+    if (!_.isEmpty(getServerConfig().google_analytics_profile_id)) {
+        embedGoogleAnalytics(getServerConfig().google_analytics_profile_id!);
     }
 
     $('body').on('click', '[data-event]', el => {


### PR DESCRIPTION
The way we were importing configuration did not allow for it to be manipulated in e2e test context.  This ensures that there is a single source of truth for configuration and that every time code references it, it retrieves the central configuration 