### PR TITLE
Add a new prop in react mutation mapper to collapse ptm tracks by default

### DIFF
--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -89,6 +89,7 @@ export type LollipopMutationPlotProps<T extends Mutation> = {
     filterResetPanel?: JSX.Element;
     legend?: JSX.Element;
     loadingIndicator?: JSX.Element;
+    collapsePtmTrack?: boolean;
 };
 
 @observer
@@ -811,6 +812,7 @@ export default class LollipopMutationPlot<
                         pubMedCache={this.props.pubMedCache}
                         proteinLength={this.proteinLength}
                         geneXOffset={this.geneXOffset}
+                        collapsePtmTrack={this.props.collapsePtmTrack}
                     />
                 </div>
             );

--- a/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
@@ -101,6 +101,7 @@ export type MutationMapperProps = {
     filterApplier?: FilterApplier;
     onTranscriptChange?: (transcript: string) => void;
     compactStyle?: boolean;
+    collapsePtmTrack?: boolean;
 };
 
 export function initDefaultMutationMapperStore(props: MutationMapperProps) {
@@ -357,6 +358,7 @@ export default class MutationMapper<
                 lollipopTooltipCountInfo={
                     this.props.plotLollipopTooltipCountInfo
                 }
+                collapsePtmTrack={this.props.collapsePtmTrack}
             />
         );
     }

--- a/packages/react-mutation-mapper/src/component/track/PtmTrack.tsx
+++ b/packages/react-mutation-mapper/src/component/track/PtmTrack.tsx
@@ -31,6 +31,7 @@ type PtmTrackProps = TrackProps & {
     dataSource?: string;
     dataSourceUrl?: string;
     ptmTooltipColumnOverrides?: { [id: string]: Partial<Column> };
+    collapsed?: boolean;
 };
 
 export const PtmTooltip: React.FunctionComponent<{
@@ -125,7 +126,7 @@ export default class PtmTrack extends React.Component<PtmTrackProps, {}> {
     };
 
     @observable
-    private expanded = true;
+    private expanded = !this.props.collapsed;
 
     @computed get ptmSpecs(): TrackItemSpec[] {
         const ptmDataByProteinPosStart = this.props.store

--- a/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
+++ b/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
@@ -27,6 +27,7 @@ type TrackPanelProps = {
     maxHeight?: number;
     trackVisibility?: TrackVisibility;
     tracks?: TrackName[];
+    collapsePtmTrack?: boolean;
 };
 
 @observer
@@ -132,6 +133,7 @@ export default class TrackPanel extends React.Component<TrackPanelProps, {}> {
                 ptmTooltipColumnOverrides={this.getPtmTooltipColumnOverrides(
                     ptmSource
                 )}
+                collapsed={this.props.collapsePtmTrack}
             />
         ) : null;
     }


### PR DESCRIPTION
Fix https://github.com/genome-nexus/genome-nexus/issues/537