### PR TITLE
Include a tip when yarn start throws dependency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ yarn run start
 Example pages:
  - http://localhost:3000/
  - http://localhost:3000/patient?studyId=lgg_ucsf_2014&caseId=P04
+> **Tip:** If you see dependency errors, especially the error that the script cannot identify the packages managed by lerna(monorepo), you could do a `yarn buildModules` first before starting the project.
 
 To run unit/integration tests
 ```


### PR DESCRIPTION
If the project hasn't been built before, the webpack may have issues identifying the packages managed by lerna(monorepo). You want to do a `yarn build` first before starting the project.

