### PR TITLE
Annotation tracks download

### DIFF
--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlotControls.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlotControls.tsx
@@ -208,7 +208,7 @@ export default class LollipopMutationPlotControls extends React.Component<
         return (
             <DownloadControls
                 getSvg={this.props.getSVG}
-                filename={`${this.props.hugoGeneSymbol}_lollipop.svg`}
+                filename={`${this.props.hugoGeneSymbol}_lollipop`}
                 dontFade={true}
                 type="button"
             />

--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/lollipopMutationPlot.scss
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/lollipopMutationPlot.scss
@@ -10,3 +10,8 @@
         }
     }
 }
+
+.hide-svg {
+    position: absolute;
+    top: 0;
+}

--- a/packages/react-mutation-mapper/src/component/track/PtmTrack.tsx
+++ b/packages/react-mutation-mapper/src/component/track/PtmTrack.tsx
@@ -254,6 +254,7 @@ export default class PtmTrack extends React.Component<PtmTrackProps, {}> {
                       proteinLength={this.props.proteinLength}
                       trackItems={item.specs}
                       idClassPrefix={`ptm-${index}-`}
+                      isSubTrack={true}
                   />
               ))
             : null;

--- a/packages/react-mutation-mapper/src/component/track/Track.tsx
+++ b/packages/react-mutation-mapper/src/component/track/Track.tsx
@@ -36,6 +36,7 @@ export type TrackProps = {
     xOffset?: number;
     defaultFilters?: DataFilter[];
     idClassPrefix?: string;
+    isSubTrack?: boolean;
 };
 
 @observer
@@ -308,7 +309,13 @@ export default class Track extends React.Component<TrackProps, {}> {
                     display: 'flex',
                 }}
             >
-                <span className={classnames(styles.trackTitle, 'small')}>
+                <span
+                    className={classnames(
+                        styles.trackTitle,
+                        'small',
+                        `${this.props.isSubTrack ? 'subtrack-' : ''}trackTitle`
+                    )}
+                >
                     {this.props.trackTitle}
                 </span>
                 <span>


### PR DESCRIPTION
Fix cBioPortal/cbioportal#6044

Describe changes proposed in this pull request:
* Removed .svg in filename. (ex. 'BRCA1_lollipop.svg.png' -> 'BRCA1_lollipop.png')
* Created SVG that contains the lollipop plot and selected tracks.
* Individual sub tracks will always show [[Issue from standup](https://github.com/cBioPortal/cbioportal/issues/6044#issuecomment-915476830)]

Screenshot examples:
All tracks with PTM track expanded
![BRCA_page](https://user-images.githubusercontent.com/59149377/132912309-9c484bf9-4797-4946-b576-0ba502ad1d99.png)|![BRCA1_lollipop](https://user-images.githubusercontent.com/59149377/132912107-ee34c3f2-3c38-4347-9667-9b77adc2b16f.png) 
All tracks with PTM track collapsed
![Screenshot 2021-09-10 161821](https://user-images.githubusercontent.com/59149377/132912814-3f6acc2c-63ae-4867-b3a0-802e89228510.png) ![BRCA1_lollipop (1)](https://user-images.githubusercontent.com/59149377/132912833-be851139-99a9-453e-ab93-ade56721f457.png)






