### PR TITLE
Only show entities that associated with selected profile

### DIFF
--- a/end-to-end-test/local/specs/core/studyview.screenshot.spec.js
+++ b/end-to-end-test/local/specs/core/studyview.screenshot.spec.js
@@ -38,6 +38,7 @@ describe('study view generic assay categorical/binary features', function() {
         $('div[data-test="GenericAssaySelection"] input').setValue(
             'mutational_signature_category_10'
         );
+        $('div=Select all filtered options (1)').waitForExist();
         $('div=Select all filtered options (1)').click();
         // close the dropdown
         var indicators = $$('div[class$="indicatorContainer"]');

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -4481,7 +4481,7 @@ export class ResultsViewPageStore
     );
 
     readonly genericAssayEntitiesGroupByMolecularProfileId = remoteData<{
-        [genericAssayType: string]: GenericAssayMeta[];
+        [profileId: string]: GenericAssayMeta[];
     }>({
         await: () => [this.molecularProfilesInStudies],
         invoke: async () => {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -222,7 +222,10 @@ import {
     GenericAssayDataCountItem,
     GenericAssayDataCountFilter,
 } from 'cbioportal-ts-api-client/dist/generated/CBioPortalAPIInternal';
-import { fetchGenericAssayMetaByMolecularProfileIdsGroupedByGenericAssayType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import {
+    fetchGenericAssayMetaByMolecularProfileIdsGroupByMolecularProfileId,
+    fetchGenericAssayMetaByMolecularProfileIdsGroupedByGenericAssayType,
+} from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import {
     buildDriverAnnotationSettings,
     DriverAnnotationSettings,
@@ -4836,6 +4839,17 @@ export class StudyViewPageStore
         },
     });
 
+    readonly genericAssayEntitiesGroupedByProfileId = remoteData<{
+        [profileId: string]: GenericAssayMeta[];
+    }>({
+        await: () => [this.genericAssayProfiles],
+        invoke: async () => {
+            return await fetchGenericAssayMetaByMolecularProfileIdsGroupByMolecularProfileId(
+                this.genericAssayProfiles.result
+            );
+        },
+    });
+
     readonly genericAssayStableIdToMeta = remoteData<{
         [genericAssayStableId: string]: GenericAssayMeta;
     }>({
@@ -4897,6 +4911,9 @@ export class StudyViewPageStore
                                     description: profiles[0].description,
                                     dataType: profiles[0].datatype,
                                     patientLevel: profiles[0].patientLevel,
+                                    profileIds: profiles.map(
+                                        profile => profile.molecularProfileId
+                                    ),
                                 };
                             })
                             .filter(record => record.count > 0)

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
@@ -92,8 +92,6 @@ export default class GenericAssaySelection extends React.Component<
             if (this.props.onTrackSubmit) {
                 const option = this.selectedProfileOption as ISelectOption;
                 // select profile if onSelectGenericAssayProfile exists
-                this.props.onSelectGenericAssayProfile &&
-                    this.props.onSelectGenericAssayProfile(option.value);
                 const info = this._selectedGenericAssayEntityIds.map(
                     entityId => {
                         return {
@@ -118,6 +116,8 @@ export default class GenericAssaySelection extends React.Component<
     private handleProfileSelect(option: any) {
         if (option && option.value) {
             this._selectedProfileOption = option;
+            this.props.onSelectGenericAssayProfile &&
+                this.props.onSelectGenericAssayProfile(option.value);
         }
     }
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8520

If there are more than one profiles falls into one `Generic Assay Type`, in this case, one tab has more than one profiles.
When you switch between profiles, entities should be changed based on your selection. Previously, we just show all entities in all profiles.

![image](https://user-images.githubusercontent.com/15748980/133837799-f89b5fdb-8db1-4069-afb7-f67c0077f402.png)

![image](https://user-images.githubusercontent.com/15748980/133837768-5cd8d824-d8b7-4f48-a149-b1bc6cd87c2d.png)
