### PR TITLE
Fix portals not working when deployed on a subpath/

### DIFF
--- a/src/appBootstrapper.jsx
+++ b/src/appBootstrapper.jsx
@@ -117,12 +117,12 @@ window.postLoadForMskCIS = function() {
 
 // this is the only supported way to disable tracking for the $3Dmol.js
 window.$3Dmol = { notrack: true };
-//
+
 // make sure lodash doesn't overwrite (or set) global underscore
 _.noConflict();
 
 const routingStore = new ExtendedRoutingStore();
-//
+
 const history = createBrowserHistory({
     basename: getLoadConfig().basePath || '',
 });

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -1,6 +1,7 @@
 export interface IAppConfig {
     apiRoot?: string;
     baseUrl?: string;
+    basePath?: string;
     configurationServiceUrl?: string;
     frontendUrl?: string;
     serverConfig: IServerConfig;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -253,6 +253,8 @@ export function initializeLoadConfiguration() {
         getBrowserWindow().frontendConfig.frontendUrl ||
         `//${win.location.host}/`;
 
+    const basePath = getBrowserWindow().frontendConfig.basePath;
+
     const configServiceUrl =
         getBrowserWindow().frontendConfig.configurationServiceUrl ||
         `${APIROOT}config_service.jsp`;
@@ -260,6 +262,7 @@ export function initializeLoadConfiguration() {
     const loadConfig: Partial<IAppConfig> = {
         configurationServiceUrl: configServiceUrl,
         apiRoot: APIROOT,
+        basePath: basePath,
         frontendUrl: frontendUrl,
         baseUrl: BASEURL,
     };


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/8899. Bugfix: restore basePath configuration. Basepath is necessary for successful function of portals inside sub directories of host