### PR TITLE
Fix undefined $ reference

### DIFF
--- a/packages/react-mutation-mapper/src/util/LabelUtils.tsx
+++ b/packages/react-mutation-mapper/src/util/LabelUtils.tsx
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 export function truncateDisplayText(
     label: string,
     textElt: SVGTextElement | null,


### PR DESCRIPTION
Related to genome-nexus/genome-nexus#551

This missing import is causing `ReferenceError: $ is not defined` for external projects using `react-mutation-mapper` package.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!