### PR TITLE
Add uniprot topology track

### DIFF
--- a/packages/cbioportal-utils/src/index.tsx
+++ b/packages/cbioportal-utils/src/index.tsx
@@ -41,6 +41,7 @@ export * from './promise/PromiseUtils';
 export * from './ptm/PtmUtils';
 
 export * from './signal/SignalMutationUtils';
+export * from './uniprot/UniprotUtils';
 
 export * from './table/ReactTableUtils';
 

--- a/packages/cbioportal-utils/src/model/Uniprot.ts
+++ b/packages/cbioportal-utils/src/model/Uniprot.ts
@@ -29,3 +29,11 @@ export interface UniprotFeature {
     molecule: string;
     evidences: UniprotFeatureEvidence[];
 }
+
+export interface UniprotTopology {
+    type: string; // TOPO_DOM
+    startPosition: number; // 25
+    endPosition: number; // 645
+    description: string; // Extracellular
+    evidence: UniprotFeatureEvidence[]; // ECO:0000255
+}

--- a/packages/cbioportal-utils/src/model/Uniprot.ts
+++ b/packages/cbioportal-utils/src/model/Uniprot.ts
@@ -12,7 +12,7 @@ export interface UniprotFeatureList {
 
 export interface UniprotFeatureEvidence {
     code: string; // "ECO:0000269"
-    source: {
+    source?: {
         name: string; // "PubMed",
         id: string; // "18022393"
         url: string; // "http://www.ncbi.nlm.nih.gov/pubmed/18022393",

--- a/packages/cbioportal-utils/src/ptm/PtmUtils.ts
+++ b/packages/cbioportal-utils/src/ptm/PtmUtils.ts
@@ -310,7 +310,7 @@ export function getPubmedIdsFromUniprotFeature(ptm: UniprotFeature) {
                 e.source.name &&
                 e.source.name.toLowerCase().includes('pubmed')
         )
-        .map(e => e.source.id);
+        .map(e => e.source!.id);
 }
 
 export function getPtmTypeFromUniprotFeature(ptm: UniprotFeature) {

--- a/packages/cbioportal-utils/src/uniprot/UniprotUtils.spec.ts
+++ b/packages/cbioportal-utils/src/uniprot/UniprotUtils.spec.ts
@@ -1,0 +1,114 @@
+import { convertUniprotFeatureToUniprotTopology } from './UniprotUtils';
+import { assert } from 'chai';
+
+describe('UniprotTopologyUtils', () => {
+    const uniprotFeature = [
+        // 0
+        {
+            type: 'TOPO_DOM',
+            category: 'TOPOLOGY',
+            description: 'Extracellular',
+            begin: '1',
+            end: '2',
+            molecule: '',
+            evidences: [
+                {
+                    code: 'ECO:0000255',
+                },
+            ],
+        },
+        // 1
+        {
+            type: 'TRANSMEM',
+            category: 'TOPOLOGY',
+            description: 'Helical',
+            begin: '3',
+            end: '4',
+            molecule: '',
+            evidences: [
+                {
+                    code: 'ECO:0000255',
+                },
+            ],
+        },
+        // 2
+        {
+            type: 'TOPO_DOM',
+            category: 'TOPOLOGY',
+            description: 'Lumenal Thylakoid',
+            begin: '5',
+            end: '6',
+            molecule: '',
+            evidences: [
+                {
+                    code: 'ECO:0000255',
+                },
+            ],
+        },
+        // 3
+        {
+            type: 'INTRAMEM',
+            category: 'TOPOLOGY',
+            description: 'Helical',
+            begin: '7',
+            end: '8',
+            molecule: '',
+            evidences: [
+                {
+                    code: 'ECO:0000255',
+                },
+            ],
+        },
+    ];
+    describe('convertToUniprotTopologyData', () => {
+        it('should convert uniprot feature data to uniprot topology', () => {
+            const topologyData = uniprotFeature.map(
+                convertUniprotFeatureToUniprotTopology
+            );
+            assert.deepEqual(topologyData[0], {
+                type: 'TOPO_DOM_EXTRACELLULAR',
+                startPosition: 1,
+                endPosition: 2,
+                description: 'Extracellular',
+                evidence: [
+                    {
+                        code: 'ECO:0000255',
+                    },
+                ],
+            });
+            assert.deepEqual(topologyData[1], {
+                type: 'TRANSMEM',
+                startPosition: 3,
+                endPosition: 4,
+                description: 'Helical',
+                evidence: [
+                    {
+                        code: 'ECO:0000255',
+                    },
+                ],
+            });
+            assert.deepEqual(topologyData[2], {
+                type: 'TOPO_DOM_LUMENAL_THYLAKOID',
+                startPosition: 5,
+                endPosition: 6,
+                description: 'Lumenal Thylakoid',
+                evidence: [
+                    {
+                        code: 'ECO:0000255',
+                    },
+                ],
+            });
+            assert.deepEqual(topologyData[3], {
+                type: 'INTRAMEM',
+                startPosition: 7,
+                endPosition: 8,
+                description: 'Helical',
+                evidence: [
+                    {
+                        code: 'ECO:0000255',
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/packages/cbioportal-utils/src/uniprot/UniprotUtils.ts
+++ b/packages/cbioportal-utils/src/uniprot/UniprotUtils.ts
@@ -1,0 +1,88 @@
+import _ from 'lodash';
+import { UniprotFeature, UniprotTopology } from '../model/Uniprot';
+
+export const UniprotCategory = {
+    PTM: 'PTM',
+    TOPOLOGY: 'TOPOLOGY',
+};
+
+export function convertUniprotFeatureToUniprotTopology(
+    uniprotFeature: UniprotFeature
+): UniprotTopology {
+    return {
+        type:
+            uniprotFeature.type === 'TOPO_DOM'
+                ? _.toUpper(
+                      `${
+                          uniprotFeature.type
+                      }_${uniprotFeature.description.replace(/\s+/g, '_')}`
+                  )
+                : uniprotFeature.type,
+        startPosition: Number(uniprotFeature.begin),
+        endPosition: Number(uniprotFeature.end),
+        description: uniprotFeature.description,
+        evidence: uniprotFeature.evidences,
+    };
+}
+
+export const UniprotTopologyTypeToTitle: { [type: string]: string } = {
+    TRANSMEM: 'Transmembrane',
+    INTRAMEM: 'Intramembrane',
+    TOPO_DOM_CHLOROPLAST_INTERMEMBRANE: 'Chloroplast intermembrane',
+    TOPO_DOM_CYTOPLASMIC: 'Cytoplasmic',
+    TOPO_DOM_EXTRACELLULAR: 'Extracellular',
+    TOPO_DOM_INTRAVACUOLAR: 'Intravacuolar',
+    TOPO_DOM_INTRAVIRION: 'Intravirion',
+    TOPO_DOM_LUMENAL: 'Lumenal',
+    TOPO_DOM_LUMENAL_THYLAKOID: 'Lumenal thylakoid',
+    TOPO_DOM_LUMENAL_VESICLE: 'Lumenal vesicle',
+    TOPO_DOM_MITOCHONDRIAL_INTERMEMBRANE: 'Mitochondrial intermembrane',
+    TOPO_DOM_MITOCHONDRIAL_MATRIX: 'Mitochondrial matrix',
+    TOPO_DOM_PERIPLASMIC: 'Periplasmic',
+    TOPO_DOM_PEROXISOMAL: 'Peroxisomal',
+    TOPO_DOM_PEROXISOMAL_MATRIX: 'Peroxisomal matrix',
+    TOPO_DOM_NUCLEAR: 'Nuclear',
+    TOPO_DOM_PERINUCLEAR_SPACE: 'Perinuclear space',
+    TOPO_DOM_STROMAL: 'Stromal',
+    TOPO_DOM_VACUOLAR: 'Vacuolar',
+    TOPO_DOM_VESICULAR: 'Vesicular',
+    TOPO_DOM_VIRION_SURFACE: 'Virion surface',
+    TOPO_DOM_LUMENAL_MELANOSOME: 'Lumenal melanosome',
+    TOPO_DOM_MOTHER_CELL_CYTOPLASMIC: 'Mother cell cytoplasmic',
+    TOPO_DOM_FORESPORE_INTERMEMBRANE_SPACE: 'Forespore intermembrane space',
+    TOPO_DOM_INTRAGRANULAR: 'Intragranular',
+    TOPO_DOM_IN_MEMBRANE: 'In membrane',
+    TOPO_DOM_PORE_FORMING: 'Pore forming',
+    TOPO_DOM_EXOPLASMIC_LOOP: 'Exoplasmic loop',
+};
+
+export const UniprotTopologyTrackToColor: { [type: string]: string } = {
+    INTRAMEM: '#0096c7',
+    TRANSMEM: '#8d99ae',
+    TOPO_DOM_CHLOROPLAST_INTERMEMBRANE: '#a2d729',
+    TOPO_DOM_CYTOPLASMIC: '#e76f51',
+    TOPO_DOM_EXTRACELLULAR: '#e9c46a',
+    TOPO_DOM_INTRAVACUOLAR: '#379956',
+    TOPO_DOM_INTRAVIRION: '#a68a64',
+    TOPO_DOM_LUMENAL: '#f4a261',
+    TOPO_DOM_LUMENAL_THYLAKOID: '#e4c1f9',
+    TOPO_DOM_LUMENAL_VESICLE: '#97dffc',
+    TOPO_DOM_MITOCHONDRIAL_INTERMEMBRANE: '#e9d8a6',
+    TOPO_DOM_MITOCHONDRIAL_MATRIX: 'vca6702',
+    TOPO_DOM_PERIPLASMIC: '#90be6d',
+    TOPO_DOM_PEROXISOMAL: '#b7b7a4',
+    TOPO_DOM_PEROXISOMAL_MATRIX: '#ef476f',
+    TOPO_DOM_NUCLEAR: '#0077b6',
+    TOPO_DOM_PERINUCLEAR_SPACE: '#9b2226',
+    TOPO_DOM_STROMAL: '#7a4419',
+    TOPO_DOM_VACUOLAR: '#5603ad',
+    TOPO_DOM_VESICULAR: '#264653',
+    TOPO_DOM_VIRION_SURFACE: '#fa9500',
+    TOPO_DOM_LUMENAL_MELANOSOME: '#861657',
+    TOPO_DOM_MOTHER_CELL_CYTOPLASMIC: '#ffd000',
+    TOPO_DOM_FORESPORE_INTERMEMBRANE_SPACE: '#4ecdc4',
+    TOPO_DOM_INTRAGRANULAR: 'v560bad',
+    TOPO_DOM_IN_MEMBRANE: '#c9ada7',
+    TOPO_DOM_PORE_FORMING: '#4281a4',
+    TOPO_DOM_EXOPLASMIC_LOOP: '#e5989b',
+};

--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -117,6 +117,7 @@ export type LollipopMutationPlotProps<T extends Mutation> = {
     legend?: JSX.Element;
     loadingIndicator?: JSX.Element;
     collapsePtmTrack?: boolean;
+    collapseUniprotTopologyTrack?: boolean;
 };
 
 @observer
@@ -901,6 +902,9 @@ export default class LollipopMutationPlot<
                         proteinLength={this.proteinLength}
                         geneXOffset={this.geneXOffset}
                         collapsePtmTrack={this.props.collapsePtmTrack}
+                        collapseUniprotTopologyTrack={
+                            this.props.collapseUniprotTopologyTrack
+                        }
                     />
                 </div>
             );

--- a/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationMapper/MutationMapper.tsx
@@ -102,6 +102,7 @@ export type MutationMapperProps = {
     onTranscriptChange?: (transcript: string) => void;
     compactStyle?: boolean;
     collapsePtmTrack?: boolean;
+    collapseUniprotTopologyTrack?: boolean;
 };
 
 export function initDefaultMutationMapperStore(props: MutationMapperProps) {
@@ -359,6 +360,9 @@ export default class MutationMapper<
                     this.props.plotLollipopTooltipCountInfo
                 }
                 collapsePtmTrack={this.props.collapsePtmTrack}
+                collapseUniprotTopologyTrack={
+                    this.props.collapseUniprotTopologyTrack
+                }
             />
         );
     }

--- a/packages/react-mutation-mapper/src/component/track/Track.tsx
+++ b/packages/react-mutation-mapper/src/component/track/Track.tsx
@@ -25,6 +25,7 @@ import TrackItem, { TrackItemSpec, TrackItemType } from './TrackItem';
 import styles from './trackStyles.module.scss';
 
 const DEFAULT_ID_CLASS_PREFIX = 'track-circle-';
+const DEFAULT_HEIGHT = 15; // height of rectangle element
 
 export type TrackProps = {
     dataStore: DataStore;
@@ -200,7 +201,7 @@ export default class Track extends React.Component<TrackProps, {}> {
     }
 
     get svgHeight() {
-        return 10;
+        return 10; // height of baseline element
     }
 
     get items() {
@@ -217,9 +218,9 @@ export default class Track extends React.Component<TrackProps, {}> {
                     ((spec.endCodon! - spec.startCodon) /
                         this.props.proteinLength) *
                     this.props.width;
-                dim2 = 22;
+                dim2 = spec.height || DEFAULT_HEIGHT;
                 hoverdim1 = dim1;
-                y = -this.svgHeight / 2;
+                y = (this.svgHeight - dim2) / 2; // y is the vertical start position of rectangle, half of baseline element height = half of element height + y
                 specFeats = {
                     ...spec,
                     endCodon: spec.endCodon!,

--- a/packages/react-mutation-mapper/src/component/track/TrackItem.tsx
+++ b/packages/react-mutation-mapper/src/component/track/TrackItem.tsx
@@ -27,13 +27,11 @@ export type TrackItemSpec = {
     label?: string;
     color?: string;
     tooltip?: JSX.Element;
+    height?: number;
 };
 
 @observer
-export default class TrackItem extends React.Component<
-    TrackItemProps,
-    TrackItemSpec
-> {
+export default class TrackItem extends React.Component<TrackItemProps> {
     constructor(props: any) {
         super(props);
         makeObservable(this);
@@ -85,6 +83,7 @@ export default class TrackItem extends React.Component<
                 <TrackRect
                     isHovered={this.isHovered}
                     width={this.props.dim1}
+                    height={this.props.dim2}
                     {...this.props}
                 />
             );

--- a/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
+++ b/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
@@ -17,6 +17,7 @@ import PtmTrack from './PtmTrack';
 
 import './defaultTrackTooltipTable.scss';
 import { PtmAnnotationTableColumnId } from '../ptm/PtmAnnotationTable';
+import UniprotTopologyTrack from './UniprotTopologyTrack';
 
 type TrackPanelProps = {
     store: MutationMapperStore<Mutation>;
@@ -38,6 +39,7 @@ export default class TrackPanel extends React.Component<TrackPanelProps, {}> {
             TrackName.OncoKB,
             TrackName.dbPTM,
             TrackName.Exon,
+            TrackName.UniprotTopology,
         ],
     };
 
@@ -91,6 +93,18 @@ export default class TrackPanel extends React.Component<TrackPanelProps, {}> {
                 !this.props.trackVisibility ||
                 this.props.trackVisibility[TrackName.Exon] === 'visible' ? (
                     <ExonTrack
+                        store={this.props.store}
+                        dataStore={this.props.store.dataStore}
+                        width={this.props.geneWidth}
+                        xOffset={this.props.geneXOffset}
+                        proteinLength={this.proteinLength}
+                    />
+                ) : null,
+            [TrackName.UniprotTopology]:
+                !this.props.trackVisibility ||
+                this.props.trackVisibility[TrackName.UniprotTopology] ===
+                    'visible' ? (
+                    <UniprotTopologyTrack
                         store={this.props.store}
                         dataStore={this.props.store.dataStore}
                         width={this.props.geneWidth}

--- a/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
+++ b/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
@@ -29,6 +29,7 @@ type TrackPanelProps = {
     trackVisibility?: TrackVisibility;
     tracks?: TrackName[];
     collapsePtmTrack?: boolean;
+    collapseUniprotTopologyTrack?: boolean;
 };
 
 @observer
@@ -110,6 +111,7 @@ export default class TrackPanel extends React.Component<TrackPanelProps, {}> {
                         width={this.props.geneWidth}
                         xOffset={this.props.geneXOffset}
                         proteinLength={this.proteinLength}
+                        collapsed={this.props.collapseUniprotTopologyTrack}
                     />
                 ) : null,
         };

--- a/packages/react-mutation-mapper/src/component/track/TrackSelector.tsx
+++ b/packages/react-mutation-mapper/src/component/track/TrackSelector.tsx
@@ -16,6 +16,7 @@ export enum TrackName {
     dbPTM = 'DB_PTM',
     UniprotPTM = 'UNIPROT_PTM',
     Exon = 'EXON',
+    UniprotTopology = 'UNIPROT_TOPOLOGY',
 }
 
 type TrackSelectorProps = {
@@ -45,6 +46,7 @@ export default class TrackSelector extends React.Component<
             TrackName.dbPTM,
             TrackName.PDB,
             TrackName.Exon,
+            TrackName.UniprotTopology,
         ],
     };
 
@@ -117,6 +119,16 @@ export default class TrackSelector extends React.Component<
                     </span>
                 ),
                 value: TrackName.Exon,
+            },
+            [TrackName.UniprotTopology]: {
+                label: (
+                    <span>
+                        Uniprot Topology
+                        {this.isPending(TrackName.UniprotTopology) &&
+                            this.loaderIcon()}
+                    </span>
+                ),
+                value: TrackName.UniprotTopology,
             },
         };
     }

--- a/packages/react-mutation-mapper/src/component/track/UniprotTopologyTrack.tsx
+++ b/packages/react-mutation-mapper/src/component/track/UniprotTopologyTrack.tsx
@@ -1,0 +1,324 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { observer } from 'mobx-react';
+import { action, computed, makeObservable, observable } from 'mobx';
+
+import { default as Track, TrackProps } from './Track';
+import { Collapse } from 'react-collapse';
+import { TrackItemSpec } from './TrackItem';
+import { MutationMapperStore } from '../../model/MutationMapperStore';
+import {
+    Mutation,
+    UniprotTopology,
+    UniprotTopologyTypeToTitle,
+    UniprotTopologyTrackToColor,
+} from 'cbioportal-utils';
+
+import {
+    DefaultTooltip,
+    EllipsisTextTooltip,
+} from 'cbioportal-frontend-commons';
+import { Button } from 'react-bootstrap';
+
+type UniprotTopologyTrackProps = TrackProps & {
+    store: MutationMapperStore<Mutation>;
+    subTrackMargin?: number;
+    collapsed?: boolean;
+};
+
+function topologyTooltip(
+    color: string,
+    title: string,
+    uniprotData: UniprotTopology
+) {
+    return {
+        color: color,
+        startCodon: uniprotData.startPosition,
+        endCodon: uniprotData.endPosition,
+        tooltip: (
+            <span>
+                <h5>{title}</h5>
+                Start: {uniprotData.startPosition}
+                <br></br>
+                End: {uniprotData.endPosition}
+                <br></br>
+                Length: {uniprotData.endPosition - uniprotData.startPosition}
+                <br></br>
+                Description: {uniprotData.description}
+            </span>
+        ),
+    };
+}
+
+@observer
+export default class UniprotTopologyTrack extends React.Component<
+    UniprotTopologyTrackProps,
+    {}
+> {
+    constructor(props: any) {
+        super(props);
+        makeObservable(this);
+    }
+    public static defaultProps = {
+        subTrackMargin: 25,
+    };
+
+    @observable
+    private expanded = !this.props.collapsed;
+    @observable topologyDescriptionTooltipCollapsed = false;
+
+    @computed get subTrackMargin() {
+        return (
+            this.props.subTrackMargin ||
+            UniprotTopologyTrack.defaultProps.subTrackMargin
+        );
+    }
+
+    @computed get subTrackTitleWidth() {
+        return this.props.xOffset
+            ? this.props.xOffset - this.subTrackMargin
+            : 0;
+    }
+
+    @computed get uniprotTopologySpecs(): TrackItemSpec[] {
+        const uniprotData = this.props.store.uniprotTopologyData.result;
+        if (uniprotData && !_.isEmpty(uniprotData)) {
+            return _.reduce(
+                uniprotData,
+                this.uniprotDataToTrackItemSpecsReducer,
+                []
+            );
+        } else {
+            return [];
+        }
+    }
+
+    @computed get expander(): JSX.Element | null {
+        const className = this.hasSubTracks
+            ? this.mainTrackHidden
+                ? 'fa fa-caret-down'
+                : 'fa fa-caret-right'
+            : null;
+
+        if (className) {
+            return (
+                <i className={className} style={{ width: 10, marginLeft: 2 }} />
+            );
+        }
+        return null;
+    }
+
+    @computed get mainTrackTitle() {
+        return (
+            <span style={{ cursor: 'pointer' }}>
+                <span onClick={this.handleToggleExpand}>{this.expander}</span>
+                <DefaultTooltip
+                    placement="right"
+                    overlay={this.topologyDescriptionTooltip}
+                    destroyTooltipOnHide={true}
+                >
+                    <span
+                        style={{ marginLeft: 4 }}
+                        onClick={this.handleToggleExpand}
+                    >
+                        Topology <i className="fa fa-info-circle" />
+                    </span>
+                </DefaultTooltip>
+            </span>
+        );
+    }
+
+    @computed get topologyDescriptionTooltip() {
+        const dataSourceDiv = this.props.store.uniprotId.result ? (
+            <div>
+                Data Source:{' '}
+                <a
+                    href={`https://www.uniprot.org/uniprot/${this.props.store.uniprotId.result}`}
+                    target="_blank"
+                >
+                    UniProt
+                </a>
+            </div>
+        ) : (
+            <div>
+                Data Source:{' '}
+                <a href={'https://www.uniprot.org/'} target="_blank">
+                    UniProt
+                </a>
+            </div>
+        );
+
+        const defaultDisplayList = this.uniprotTopologyTypes;
+        const expandedDisplayList = _.difference(
+            _.keys(UniprotTopologyTypeToTitle),
+            defaultDisplayList
+        );
+
+        return (
+            <div style={{ maxWidth: 400 }}>
+                <p>
+                    Information of the subcellular location of the mature
+                    protein.
+                </p>
+                <p>
+                    Domains and corresponding color codes are as follows:
+                    <ul>
+                        {_.map(defaultDisplayList, type => (
+                            <li
+                                style={{
+                                    color: UniprotTopologyTrackToColor[type],
+                                }}
+                            >
+                                <strong>
+                                    {UniprotTopologyTypeToTitle[type]}
+                                </strong>
+                            </li>
+                        ))}
+                        <Collapse
+                            isOpened={this.topologyDescriptionTooltipCollapsed}
+                        >
+                            {_.map(expandedDisplayList, type => (
+                                <li
+                                    style={{
+                                        color:
+                                            UniprotTopologyTrackToColor[type],
+                                    }}
+                                >
+                                    <strong>
+                                        {UniprotTopologyTypeToTitle[type]}
+                                    </strong>
+                                </li>
+                            ))}
+                        </Collapse>
+                    </ul>
+                    <Button
+                        onClick={this.handleToggleTopologyDescriptionTooltip}
+                        aria-controls="table-content"
+                        bsStyle="link"
+                        className="btn-sm"
+                    >
+                        <strong>
+                            {this.topologyDescriptionTooltipCollapsed
+                                ? 'Less'
+                                : 'More'}
+                        </strong>
+                    </Button>
+                </p>
+                {dataSourceDiv}
+            </div>
+        );
+    }
+
+    @action.bound
+    private handleToggleTopologyDescriptionTooltip() {
+        this.topologyDescriptionTooltipCollapsed = !this
+            .topologyDescriptionTooltipCollapsed;
+    }
+
+    @computed get uniprotTopologyTypes(): string[] {
+        const uniprotData = this.props.store.uniprotTopologyData.result;
+        const uniprotDataByType = _.uniq(_.map(uniprotData, data => data.type));
+        return uniprotDataByType || [];
+    }
+
+    @computed get uniprotTopologySubSpecs(): {
+        title: string;
+        specs: TrackItemSpec[];
+    }[] {
+        const uniprotData = this.props.store.uniprotTopologyData.result;
+        const uniprotDataByType = _.groupBy(uniprotData, data => data.type);
+        return _.keys(uniprotDataByType)
+            .map(type => ({
+                title: UniprotTopologyTypeToTitle[type],
+                specs: _.reduce(
+                    uniprotDataByType[type],
+                    this.uniprotDataToTrackItemSpecsReducer,
+                    []
+                ),
+            }))
+            .filter(s => !_.isEmpty(s.specs));
+    }
+
+    private uniprotDataToTrackItemSpecsReducer = (
+        acc: TrackItemSpec[],
+        uniprotData: UniprotTopology
+    ): TrackItemSpec[] => {
+        const trackColor = UniprotTopologyTrackToColor[uniprotData.type];
+        const trackTitle = UniprotTopologyTypeToTitle[uniprotData.type];
+
+        if (trackTitle && trackColor) {
+            acc.push(topologyTooltip(trackColor, trackTitle, uniprotData));
+        }
+        return acc;
+    };
+
+    @computed get mainTrackHidden() {
+        return this.expanded && this.hasSubTracks;
+    }
+
+    @computed get hasSubTracks() {
+        return this.uniprotTopologySubSpecs.length > 0;
+    }
+
+    @computed get subTracks() {
+        return this.hasSubTracks
+            ? this.uniprotTopologySubSpecs.map((item, index) => (
+                  <Track
+                      key={item.title}
+                      dataStore={this.props.dataStore}
+                      xOffset={this.props.xOffset}
+                      trackTitle={
+                          <span
+                              style={{
+                                  marginLeft: this.subTrackMargin,
+                                  width: this.subTrackTitleWidth,
+                                  display: 'flex',
+                              }}
+                          >
+                              <EllipsisTextTooltip
+                                  text={item.title}
+                                  style={{
+                                      overflow: 'hidden',
+                                      whiteSpace: 'nowrap',
+                                      textOverflow: 'ellipsis',
+                                  }}
+                              />
+                          </span>
+                      }
+                      width={this.props.width}
+                      proteinLength={this.props.proteinLength}
+                      trackItems={item.specs}
+                      idClassPrefix={`uniprot-topology-${index}-`}
+                      isSubTrack={true}
+                  />
+              ))
+            : null;
+    }
+
+    public render() {
+        return (
+            <span>
+                <Track
+                    dataStore={this.props.dataStore}
+                    width={this.props.width}
+                    xOffset={this.props.xOffset}
+                    proteinLength={this.props.proteinLength}
+                    trackTitle={this.mainTrackTitle}
+                    trackItems={
+                        this.mainTrackHidden ? [] : this.uniprotTopologySpecs
+                    }
+                    hideBaseline={this.mainTrackHidden}
+                    idClassPrefix={'uniprot-topology-track-'}
+                />
+                <Collapse isOpened={this.mainTrackHidden}>
+                    <span>{this.subTracks}</span>
+                </Collapse>
+            </span>
+        );
+    }
+
+    @action.bound
+    private handleToggleExpand() {
+        this.expanded = !this.expanded;
+    }
+}

--- a/packages/react-mutation-mapper/src/component/track/UniprotTopologyTrack.tsx
+++ b/packages/react-mutation-mapper/src/component/track/UniprotTopologyTrack.tsx
@@ -18,7 +18,6 @@ import {
     DefaultTooltip,
     EllipsisTextTooltip,
 } from 'cbioportal-frontend-commons';
-import { Button } from 'react-bootstrap';
 
 type UniprotTopologyTrackProps = TrackProps & {
     store: MutationMapperStore<Mutation>;
@@ -50,6 +49,56 @@ function topologyRectangleBlockSpec(
     };
 }
 
+export const UniprotTopologyTrackDescriptionTooltip: React.FunctionComponent<{
+    displayList: string[];
+    uniprotId?: string;
+}> = props => {
+    const dataSourceDiv = props.uniprotId ? (
+        <div>
+            Data Source:{' '}
+            <a
+                href={`https://www.uniprot.org/uniprot/${props.uniprotId}`}
+                target="_blank"
+            >
+                UniProt
+            </a>
+        </div>
+    ) : (
+        <div>
+            Data Source:{' '}
+            <a href={'https://www.uniprot.org/'} target="_blank">
+                UniProt
+            </a>
+        </div>
+    );
+    return (
+        <div style={{ maxWidth: 400 }}>
+            <p>
+                Information of the subcellular location of the mature protein.
+            </p>
+            {props.displayList.length > 0 && (
+                <p>
+                    Domains and corresponding color codes are as follows:
+                    <ul>
+                        {_.map(props.displayList, type => (
+                            <li
+                                style={{
+                                    color: UniprotTopologyTrackToColor[type],
+                                }}
+                            >
+                                <strong>
+                                    {UniprotTopologyTypeToTitle[type]}
+                                </strong>
+                            </li>
+                        ))}
+                    </ul>
+                </p>
+            )}
+            {dataSourceDiv}
+        </div>
+    );
+};
+
 @observer
 export default class UniprotTopologyTrack extends React.Component<
     UniprotTopologyTrackProps,
@@ -65,7 +114,6 @@ export default class UniprotTopologyTrack extends React.Component<
 
     @observable
     private expanded = !this.props.collapsed;
-    @observable topologyDescriptionTooltipCollapsed = false;
 
     @computed get subTrackMargin() {
         return (
@@ -114,7 +162,12 @@ export default class UniprotTopologyTrack extends React.Component<
                 <span onClick={this.handleToggleExpand}>{this.expander}</span>
                 <DefaultTooltip
                     placement="right"
-                    overlay={this.topologyDescriptionTooltip}
+                    overlay={
+                        <UniprotTopologyTrackDescriptionTooltip
+                            displayList={this.uniprotTopologyTypes}
+                            uniprotId={this.props.store.uniprotId.result}
+                        />
+                    }
                     destroyTooltipOnHide={true}
                 >
                     <span
@@ -126,93 +179,6 @@ export default class UniprotTopologyTrack extends React.Component<
                 </DefaultTooltip>
             </span>
         );
-    }
-
-    @computed get topologyDescriptionTooltip() {
-        const dataSourceDiv = this.props.store.uniprotId.result ? (
-            <div>
-                Data Source:{' '}
-                <a
-                    href={`https://www.uniprot.org/uniprot/${this.props.store.uniprotId.result}`}
-                    target="_blank"
-                >
-                    UniProt
-                </a>
-            </div>
-        ) : (
-            <div>
-                Data Source:{' '}
-                <a href={'https://www.uniprot.org/'} target="_blank">
-                    UniProt
-                </a>
-            </div>
-        );
-
-        const defaultDisplayList = this.uniprotTopologyTypes;
-        const expandedDisplayList = _.difference(
-            _.keys(UniprotTopologyTypeToTitle),
-            defaultDisplayList
-        );
-
-        return (
-            <div style={{ maxWidth: 400 }}>
-                <p>
-                    Information of the subcellular location of the mature
-                    protein.
-                </p>
-                <p>
-                    Domains and corresponding color codes are as follows:
-                    <ul>
-                        {_.map(defaultDisplayList, type => (
-                            <li
-                                style={{
-                                    color: UniprotTopologyTrackToColor[type],
-                                }}
-                            >
-                                <strong>
-                                    {UniprotTopologyTypeToTitle[type]}
-                                </strong>
-                            </li>
-                        ))}
-                        <Collapse
-                            isOpened={this.topologyDescriptionTooltipCollapsed}
-                        >
-                            {_.map(expandedDisplayList, type => (
-                                <li
-                                    style={{
-                                        color:
-                                            UniprotTopologyTrackToColor[type],
-                                    }}
-                                >
-                                    <strong>
-                                        {UniprotTopologyTypeToTitle[type]}
-                                    </strong>
-                                </li>
-                            ))}
-                        </Collapse>
-                    </ul>
-                    <Button
-                        onClick={this.handleToggleTopologyDescriptionTooltip}
-                        aria-controls="table-content"
-                        bsStyle="link"
-                        className="btn-sm"
-                    >
-                        <strong>
-                            {this.topologyDescriptionTooltipCollapsed
-                                ? 'Less'
-                                : 'More'}
-                        </strong>
-                    </Button>
-                </p>
-                {dataSourceDiv}
-            </div>
-        );
-    }
-
-    @action.bound
-    private handleToggleTopologyDescriptionTooltip() {
-        this.topologyDescriptionTooltipCollapsed = !this
-            .topologyDescriptionTooltipCollapsed;
     }
 
     @computed get uniprotTopologyTypes(): string[] {

--- a/packages/react-mutation-mapper/src/component/track/UniprotTopologyTrack.tsx
+++ b/packages/react-mutation-mapper/src/component/track/UniprotTopologyTrack.tsx
@@ -26,7 +26,7 @@ type UniprotTopologyTrackProps = TrackProps & {
     collapsed?: boolean;
 };
 
-function topologyTooltip(
+function topologyRectangleBlockSpec(
     color: string,
     title: string,
     uniprotData: UniprotTopology
@@ -247,7 +247,9 @@ export default class UniprotTopologyTrack extends React.Component<
         const trackTitle = UniprotTopologyTypeToTitle[uniprotData.type];
 
         if (trackTitle && trackColor) {
-            acc.push(topologyTooltip(trackColor, trackTitle, uniprotData));
+            acc.push(
+                topologyRectangleBlockSpec(trackColor, trackTitle, uniprotData)
+            );
         }
         return acc;
     };

--- a/packages/react-mutation-mapper/src/model/MutationMapperDataFetcher.ts
+++ b/packages/react-mutation-mapper/src/model/MutationMapperDataFetcher.ts
@@ -58,6 +58,7 @@ export interface MutationMapperDataFetcher {
     ): Promise<PostTranslationalModification[]>;
     fetchUniprotFeatures(
         swissProtId: string,
+        category: string[],
         client?: GenomeNexusAPI
     ): Promise<UniprotFeature[]>;
     fetchCancerHotspotData(

--- a/packages/react-mutation-mapper/src/model/MutationMapperStore.ts
+++ b/packages/react-mutation-mapper/src/model/MutationMapperStore.ts
@@ -8,6 +8,7 @@ import {
     Mutation,
     PostTranslationalModification,
     RemoteData,
+    UniprotTopology,
 } from 'cbioportal-utils';
 import {
     EnsemblTranscript,
@@ -56,6 +57,7 @@ export interface MutationMapperStore<T extends Mutation> {
           }
         | undefined
     >;
+    uniprotTopologyData: RemoteData<UniprotTopology[] | undefined>;
     indexedHotspotData: RemoteData<IHotspotIndex | undefined>;
     hotspotsByPosition: { [pos: number]: Hotspot[] };
     oncoKbCancerGenes: RemoteData<CancerGene[] | Error | undefined>;

--- a/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
+++ b/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
@@ -220,13 +220,16 @@ export class DefaultMutationMapperDataFetcher
 
     public async fetchUniprotFeatures(
         swissProtId: string,
+        category: string[],
         client: GenomeNexusAPI = this.genomeNexusClient
     ): Promise<UniprotFeature[]> {
         if (swissProtId) {
-            // TODO for now fetching only PTM features
+            // TODO for now fetching only PTM and TOPOLOGY features
             const uniprotData: Response = await request.get(
                 getUrl(
-                    `https://www.ebi.ac.uk/proteins/api/features/<%= uniprotAccession %>?categories=PTM`,
+                    `https://www.ebi.ac.uk/proteins/api/features/<%= uniprotAccession %>?categories=${category.join(
+                        ','
+                    )}`,
                     { uniprotAccession: swissProtId }
                 )
             );

--- a/packages/react-mutation-mapper/src/util/TrackUtils.ts
+++ b/packages/react-mutation-mapper/src/util/TrackUtils.ts
@@ -8,5 +8,6 @@ export function initDefaultTrackVisibility(): TrackVisibility {
         [TrackName.UniprotPTM]: 'hidden',
         [TrackName.PDB]: 'hidden',
         [TrackName.Exon]: 'hidden',
+        [TrackName.UniprotTopology]: 'hidden',
     };
 }

--- a/src/shared/components/mutationMapper/MutationMapper.tsx
+++ b/src/shared/components/mutationMapper/MutationMapper.tsx
@@ -323,6 +323,17 @@ export default class MutationMapper<
             }
         }
 
+        let uniprotTopologyDataStatus:
+            | 'pending'
+            | 'error'
+            | 'complete'
+            | 'empty' = this.props.store.uniprotTopologyData.status;
+        if (uniprotTopologyDataStatus === 'complete') {
+            if (this.props.store.uniprotTopologyData.result?.length === 0) {
+                uniprotTopologyDataStatus = 'empty';
+            }
+        }
+
         return {
             [TrackName.OncoKB]: oncoKbDataStatus,
             [TrackName.CancerHotspots]: hotspotDataStatus,
@@ -330,6 +341,7 @@ export default class MutationMapper<
             [TrackName.UniprotPTM]: uniprotPtmDataStatus,
             [TrackName.PDB]: alignmentDataStatus,
             [TrackName.Exon]: 'complete',
+            [TrackName.UniprotTopology]: uniprotTopologyDataStatus,
         };
     }
 
@@ -548,6 +560,7 @@ export default class MutationMapper<
             tracks.push(TrackName.dbPTM);
         }
         tracks.push(TrackName.Exon);
+        tracks.push(TrackName.UniprotTopology);
         tracks.push(TrackName.PDB);
 
         return tracks;


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/547

### Goal
Add extracellular info from uniprot. For example their topology track shows cytoplasmic vs extracellular in the description of the tooltip. We group them by topological domains and adding as individual tracks.

### Test
https://deploy-preview-4004--cbioportalfrontend.netlify.app/results/mutations?cancer_study_list=metastatic_solid_tumors_mich_2017&tab_index=tab_visualize&case_set_id=metastatic_solid_tumors_mich_2017_all&Action=Submit&gene_list=SCN5A%2520EGFR&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cfusion&geneset_list=%20

Click `Add annotation tracks` dropdown, select `Uniprot Topology`. 
`SCN5A` is an example with complex domains, switch to `EGFR` to see a less complex track.

### Screenshots
#### Expand
Tracks are expanded by default, click track name `Topology` to collapse or expand tracks.
![image](https://user-images.githubusercontent.com/16869603/138909774-e29d5ec1-b5fa-47ec-8b11-ddeeb62fdfb5.png)

#### Collapse
![image](https://user-images.githubusercontent.com/16869603/138909830-270baa04-60cf-493a-9670-2df8ed8823a1.png)

#### Track Tooltip
![image](https://user-images.githubusercontent.com/16869603/138910083-8d4a596f-8822-4a3e-95e6-25d591a8efb9.png)

#### Track description tooltip
![image](https://user-images.githubusercontent.com/16869603/140103811-22638995-be97-4b74-abfb-a0b19b3f28e0.png)



