### PR TITLE
add new byPatientId param to CDSA slideviewer URL to fix mapping

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -275,7 +275,7 @@ export function getDigitalSlideArchiveIFrameUrl(patientId: string) {
     //https://cancer.digitalslidearchive.org/#!/CDSA/caseName/TCGA-02-0006
     return (
         getServerConfig().digital_slide_archive_iframe_url +
-        `#!/CDSA/${patientId}`
+        `#!/CDSA/byPatientID/${patientId}`
     );
 }
 


### PR DESCRIPTION
Mapping from patientId to CDSA slide viewer was broken because they introduced a new byPatentId route to handle case where cancer type is not passed