### PR TITLE
Filter survival rows per # in group

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -74,6 +74,7 @@ export interface IServerConfig {
     show_signal: boolean;
     survival_initial_x_axis_limit: number;
     survival_show_p_q_values_in_survival_type_table: boolean;
+    survival_min_group_threshold: number;
     skin_documentation_about: string | null;
     skin_documentation_software: string | null;
     skin_documentation_baseurl: string | null;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -47,6 +47,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     show_transcript_dropdown: false,
     show_signal: false,
     survival_show_p_q_values_in_survival_type_table: true,
+    survival_min_group_threshold: 3,
     skin_description:
         'The cBioPortal for Cancer Genomics provides visualization, analysis and download of large-scale cancer genomics data sets',
     show_genomenexus: true,


### PR DESCRIPTION
Previously we were filtering for total number of patients with that
survival data rather than the total in each group. This was requested by
the stats team for GENIE (see also https://github.com/cBioPortal/icebox/issues/407)

<img width="487" alt="Screen Shot 2021-10-28 at 9 54 58 AM" src="https://user-images.githubusercontent.com/1334004/139270506-853cbc99-2ab1-43aa-8859-992f8ff8d795.png">


TODO:

- [x] make slider minimum configurable as property to get around failing tests (set it to 3 by default for public, make it 5 for GENIE as agreed)