### PR TITLE
Do not make empty call to generic assay meta endpoint on patient view page

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -613,13 +613,15 @@ export class PatientViewPageStore {
                 )
                 .value();
 
-            return client.fetchGenericAssayMetaDataUsingPOST({
-                genericAssayMetaFilter: {
-                    genericAssayStableIds: mutationalSignatureContributionStableIds
-                        ? mutationalSignatureContributionStableIds
-                        : [],
-                } as GenericAssayMetaFilter,
-            });
+            if (mutationalSignatureContributionStableIds.length > 0) {
+                return client.fetchGenericAssayMetaDataUsingPOST({
+                    genericAssayMetaFilter: {
+                        genericAssayStableIds: mutationalSignatureContributionStableIds,
+                    } as GenericAssayMetaFilter,
+                });
+            } else {
+                return Promise.resolve([]);
+            }
         },
     });
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9025

Describe changes proposed in this pull request:
- This issue caused by making empty call to generic assay meta endpoint
- But recently change in backend will force requests pass validation, so solution is to add checking before make request