### PR TITLE
Resolve dependency issue

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10930,9 +10930,9 @@ ev-emitter@^1.0.0:
   resolved "https://registry.yarnpkg.com/ev-emitter/-/ev-emitter-1.1.1.tgz#8f18b0ce5c76a5d18017f71c0a795c65b9138f2a"
   integrity sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q==
 
-"eve@git://github.com/adobe-webplatform/eve.git#eef80ed":
+"eve@https://github.com/adobe-webplatform/eve.git#eef80ed":
   version "0.4.1"
-  resolved "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+  resolved "https://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -25331,7 +25331,7 @@ webpack-raphael@^2.1.4:
   resolved "https://registry.yarnpkg.com/webpack-raphael/-/webpack-raphael-2.1.4.tgz#bab98536d628c76cd241cba3d0a6cc764b33043e"
   integrity sha1-urmFNtYox2zSQcuj0KbMdkszBD4=
   dependencies:
-    eve "git://github.com/adobe-webplatform/eve.git#eef80ed"
+    eve "https://github.com/adobe-webplatform/eve.git#eef80ed"
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
Fix issue related to GitHub authorization protocol change: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

Updating outdated package in `yarn.lock` to meet new protocol requirements.

Outdated package:
```
eve@git://github.com/adobe-webplatform/eve.git#eef80ed
```

Updated package:
```
eve@https://github.com/adobe-webplatform/eve.git#eef80ed
```