### PR TITLE
Don't show Unknown values in Clinical Comparison

### DIFF
--- a/src/pages/groupComparison/ClinicalData.tsx
+++ b/src/pages/groupComparison/ClinicalData.tsx
@@ -319,6 +319,11 @@ export default class ClinicalData extends React.Component<
                     },
                 });
 
+                // filter out NA like values
+                clinicalData = clinicalData.filter(
+                    d => d.value.toLowerCase() !== 'unknown'
+                );
+
                 let normalizedCategory: { [id: string]: string } = {};
                 for (const d of clinicalData) {
                     const lowerCaseValue = d.value.toLowerCase();


### PR DESCRIPTION
This is a bit of a hack. Added some notes here: https://github.com/cBioPortal/cbioportal/issues/9031.

Should be merged together with [this backend PR 9010](https://github.com/cBioPortal/cbioportal/pull/9010) to make sure the statistical test is using the same values as what the user is seeing in the chart