### PR TITLE
Fix uniprot PTM crash when centain fields are missing in uniprot data

### DIFF
--- a/packages/cbioportal-utils/src/model/Uniprot.ts
+++ b/packages/cbioportal-utils/src/model/Uniprot.ts
@@ -23,17 +23,17 @@ export interface UniprotFeatureEvidence {
 export interface UniprotFeature {
     type: string; // "MOD_RES"
     category: string; // "PTM"
-    description: string; // "Phosphoserine; by HIPK4"
+    description?: string; // "Phosphoserine; by HIPK4"
     begin: string; // "9"
     end: string; // "9"
-    molecule: string;
-    evidences: UniprotFeatureEvidence[];
+    molecule?: string;
+    evidences?: UniprotFeatureEvidence[];
 }
 
 export interface UniprotTopology {
     type: string; // TOPO_DOM
     startPosition: number; // 25
     endPosition: number; // 645
-    description: string; // Extracellular
-    evidence: UniprotFeatureEvidence[]; // ECO:0000255
+    description?: string; // Extracellular
+    evidence?: UniprotFeatureEvidence[]; // ECO:0000255
 }

--- a/packages/cbioportal-utils/src/ptm/PtmUtils.spec.ts
+++ b/packages/cbioportal-utils/src/ptm/PtmUtils.spec.ts
@@ -5,6 +5,8 @@ import {
     compareByPtmTypePriority,
     convertDbPtmToPtm,
     convertUniprotFeatureToPtm,
+    getPtmTypeFromUniprotFeature,
+    getPubmedIdsFromUniprotFeature,
     groupPtmDataByPosition,
     groupPtmDataByTypeAndPosition,
     ptmColor,
@@ -197,6 +199,15 @@ describe('PtmUtils', () => {
         },
     ];
 
+    const partialUniprotPtm = [
+        {
+            type: 'MOD_RES',
+            category: 'PTM',
+            begin: '2',
+            end: '2',
+        },
+    ];
+
     describe('convertToPtmData', () => {
         it('identically converts residues for both dbPTM and uniprotPTM data', () => {
             assert.deepEqual(
@@ -338,6 +349,22 @@ describe('PtmUtils', () => {
                 ptmColor([ptmData[8]]),
                 '#BA21E0',
                 'Sumoylation (default): #BA21E0'
+            );
+        });
+    });
+    describe('partial Uniprot data', () => {
+        it('uses default ptm type when description is empty', () => {
+            assert.equal(
+                getPtmTypeFromUniprotFeature(partialUniprotPtm[0]),
+                'Other',
+                'Type should be "Other" if no "description" in data'
+            );
+        });
+        it('returns no pubmed ids when evidence is empty', () => {
+            assert.equal(
+                getPubmedIdsFromUniprotFeature(partialUniprotPtm[0]).length,
+                0,
+                'No pubmed ids could be found if no "evidence" in data'
             );
         });
     });

--- a/packages/cbioportal-utils/src/uniprot/UniprotUtils.ts
+++ b/packages/cbioportal-utils/src/uniprot/UniprotUtils.ts
@@ -6,23 +6,33 @@ export const UniprotCategory = {
     TOPOLOGY: 'TOPOLOGY',
 };
 
+function getTopologyTypeName(type: string, description: string | undefined) {
+    // need to conver TOPO_DOM to detailed type name(e.g. TOPO_DOM_EXTRACELLULAR), keep the same name for TRANSMEM and INTRAMEM
+    if (type === 'TOPO_DOM') {
+        return description
+            ? _.toUpper(`${type}_${description.replace(/\s+/g, '_')}`)
+            : undefined;
+    } else {
+        return type;
+    }
+}
+
 export function convertUniprotFeatureToUniprotTopology(
     uniprotFeature: UniprotFeature
-): UniprotTopology {
-    return {
-        type:
-            uniprotFeature.type === 'TOPO_DOM'
-                ? _.toUpper(
-                      `${
-                          uniprotFeature.type
-                      }_${uniprotFeature.description.replace(/\s+/g, '_')}`
-                  )
-                : uniprotFeature.type,
-        startPosition: Number(uniprotFeature.begin),
-        endPosition: Number(uniprotFeature.end),
-        description: uniprotFeature.description,
-        evidence: uniprotFeature.evidences,
-    };
+): UniprotTopology | undefined {
+    const typeName = getTopologyTypeName(
+        uniprotFeature.type,
+        uniprotFeature.description
+    );
+    return typeName
+        ? {
+              type: typeName,
+              startPosition: Number(uniprotFeature.begin),
+              endPosition: Number(uniprotFeature.end),
+              description: uniprotFeature.description,
+              evidence: uniprotFeature.evidences,
+          }
+        : undefined;
 }
 
 export const UniprotTopologyTypeToTitle: { [type: string]: string } = {

--- a/packages/react-mutation-mapper/src/store/DefaultMutationMapperStore.ts
+++ b/packages/react-mutation-mapper/src/store/DefaultMutationMapperStore.ts
@@ -802,11 +802,12 @@ class DefaultMutationMapperStore<T extends Mutation>
                         [UniprotCategory.TOPOLOGY]
                     );
                     uniprotFeatures.forEach(uniprotFeature => {
-                        data.push(
-                            convertUniprotFeatureToUniprotTopology(
-                                uniprotFeature
-                            )
+                        let uniprotTopology = convertUniprotFeatureToUniprotTopology(
+                            uniprotFeature
                         );
+                        if (uniprotTopology) {
+                            data.push(uniprotTopology);
+                        }
                     });
                     return data;
                 } else {


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/9033

From Uniprot api doc, there are some option value in the model:
https://www.ebi.ac.uk/proteins/api/doc/#!/features/getByAccession
![image](https://user-images.githubusercontent.com/16869603/140559508-356d5d68-d3ab-4cea-b838-cd0a44c1bd0a.png)
But based on my testing, `evidences` could be missing too, for example: https://www.ebi.ac.uk/proteins/api/features/P06276?categories=PTM
![image](https://user-images.githubusercontent.com/16869603/140559891-d49d929a-4000-4ec0-966e-148d2db471e2.png)

So we change `description`, `molecule` and `evidences` in UniprotFeature to optional, as well as `description` and `evidence` in UniprotTopology to optional.