### PR TITLE
Revert "test against master"

### DIFF
--- a/env/master.sh
+++ b/env/master.sh
@@ -1,2 +1,2 @@
-export CBIOPORTAL_URL="${CBIOPORTAL_URL:-https://master.cbioportal.org}"
+export CBIOPORTAL_URL="${CBIOPORTAL_URL:-https://www.cbioportal.org}"
 export GENOME_NEXUS_URL="${GENOME_NEXUS_URL:-https://www.genomenexus.org}"


### PR DESCRIPTION
This reverts commit 0c9990f38eeab9a61186b532e7373721364ef259.

This will let frontend code always run circle ci tests against `www.cbioportal.org`.