### PR TITLE
add link to proteomics video

### DIFF
--- a/src/pages/staticPages/tutorials/Tutorials.tsx
+++ b/src/pages/staticPages/tutorials/Tutorials.tsx
@@ -108,6 +108,18 @@ export default class Tutorials extends React.Component<{}, {}> {
                                         level of a gene
                                     </a>
                                 </li>
+                                <li>
+                                    <a
+                                        href={
+                                            'https://www.youtube.com/watch?v=62qbjQOH9qc'
+                                        }
+                                        target={'_blank'}
+                                    >
+                                        Proteomic profiles in cBioPortal - An
+                                        example based on cancer cell lines from
+                                        the Cancer Cell Line Encyclopedia (CCLE)
+                                    </a>
+                                </li>
                             </ol>
                         </li>
                         <li>


### PR DESCRIPTION
 We have worked on several datasets from the CPTAC consortium and integrated proteomics data with the CCLE Broad 2019 study. The Hyve released a video to showcase the integration of proteomics data and features into cBioPortal, with an example case on CCLE.

This PR adds a YouTube link to the Tutorials page, under the How-To section.

Should there also be an embed? The other How-To video is not embedded either.
