### PR TITLE
Generic Assay dropdown: don't show NA when name or description missing (use id instead)

### DIFF
--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
@@ -88,6 +88,61 @@ describe('GenericAssayCommonUtils', () => {
             );
         });
 
+        it('Shows entity_stable_id and description when name is missing in properties', () => {
+            const genericAssayEntity: GenericAssayMeta = {
+                stableId: 'id_1',
+                entityType: 'GENERIC_ASSAY',
+                genericEntityMetaProperties: {
+                    DESCRIPTION: 'desc_1',
+                },
+            };
+
+            const expect = {
+                value: 'id_1',
+                label: 'id_1: desc_1',
+            };
+            assert.deepEqual(
+                makeGenericAssayOption(genericAssayEntity),
+                expect
+            );
+        });
+
+        it('Shows entity_stable_id and name when description is missing in properties', () => {
+            const genericAssayEntity: GenericAssayMeta = {
+                stableId: 'id_1',
+                entityType: 'GENERIC_ASSAY',
+                genericEntityMetaProperties: {
+                    NAME: 'name_1',
+                },
+            };
+
+            const expect = {
+                value: 'id_1',
+                label: 'name_1 (id_1)',
+            };
+            assert.deepEqual(
+                makeGenericAssayOption(genericAssayEntity),
+                expect
+            );
+        });
+
+        it('Shows entity_stable_id when name and description is missing in properties', () => {
+            const genericAssayEntity: GenericAssayMeta = {
+                stableId: 'id_1',
+                entityType: 'GENERIC_ASSAY',
+                genericEntityMetaProperties: {},
+            };
+
+            const expect = {
+                value: 'id_1',
+                label: 'id_1',
+            };
+            assert.deepEqual(
+                makeGenericAssayOption(genericAssayEntity),
+                expect
+            );
+        });
+
         it('add plotAxisLabel for plot tab options', () => {
             const genericAssayEntity: GenericAssayMeta = {
                 stableId: 'id_1',

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
@@ -195,11 +195,13 @@ export function makeGenericAssayOption(
     // indentical to the entity_stable_id.
     const name = getGenericAssayMetaPropertyOrDefault(
         meta,
-        COMMON_GENERIC_ASSAY_PROPERTY.NAME
+        COMMON_GENERIC_ASSAY_PROPERTY.NAME,
+        meta.stableId
     );
     const description = getGenericAssayMetaPropertyOrDefault(
         meta,
-        COMMON_GENERIC_ASSAY_PROPERTY.DESCRIPTION
+        COMMON_GENERIC_ASSAY_PROPERTY.DESCRIPTION,
+        meta.stableId
     );
     const uniqueName = name !== meta.stableId;
     const uniqueDesc = description !== meta.stableId && description !== name;


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9041

Describe changes proposed in this pull request:
- Fix Generic Assay options show NA when name or description missing
- Add related unit tests