### PR TITLE
Fixed issue where custom tabs configuration was no longer loaded

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -309,7 +309,7 @@ export function initializeServerConfiguration(rawConfiguration: any) {
         {},
         ServerConfigDefaults,
         rawConfiguration,
-        frontendOverride.serverConfig,
+        frontendOverride,
         localStorageOverride.serverConfig
     );
 


### PR DESCRIPTION
Custom Tabs are no longer displayed after version 8.7.4 and getServerConfig().custom_tabs is undefined.

The issue is that in ./src/config/config.ts the frontendOverride.serverConfig is added to the mergedConfiguration, but it's actually the frontendOverride that contains the custom_tabs (without serverConfig).