### PR TITLE
Fix FAQ linking

### DIFF
--- a/src/pages/staticPages/faq/FAQ.tsx
+++ b/src/pages/staticPages/faq/FAQ.tsx
@@ -4,7 +4,6 @@ import { getServerConfig } from 'config/config';
 import StaticContent from '../../../shared/components/staticContent/StaticContent';
 import Helmet from 'react-helmet';
 import './styles.scss';
-import { computed } from 'mobx';
 
 class Heading extends React.Component<{ level: number }, {}> {
     render() {
@@ -38,7 +37,15 @@ class Heading extends React.Component<{ level: number }, {}> {
 }
 
 const renderers = {
-    heading: Heading,
+    h2: (props: any) => {
+        return <Heading level={2} {...props} />;
+    },
+    h3: (props: any) => {
+        return <Heading level={3} {...props} />;
+    },
+    h4: (props: any) => {
+        return <Heading level={4} {...props} />;
+    },
 };
 
 export default class FAQ extends React.Component<{}, {}> {


### PR DESCRIPTION
This was broken after recent upgrade to ReactMarkdown package.  Signature of the custom components changed.