### PR TITLE
Show namespace columns in MAF file in Mutation Table component

### DIFF
--- a/end-to-end-test/local/specs/namespace-columns-in-mutation-tables.spec.js
+++ b/end-to-end-test/local/specs/namespace-columns-in-mutation-tables.spec.js
@@ -1,0 +1,113 @@
+const assert = require('assert');
+const {
+    goToUrlAndSetLocalStorageWithProperty,
+} = require('../../shared/specUtils');
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+const resultsViewUrl = `${CBIOPORTAL_URL}/results/mutations?cancer_study_list=study_es_0&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cfusion%2Cgistic&case_set_id=study_es_0_all&gene_list=BRCA1&geneset_list=%20&tab_index=tab_visualize&Action=Submit`;
+const patientViewUrl = `${CBIOPORTAL_URL}/patient?sampleId=TEST_SAMPLE_SOMATIC_HOMOZYGOUS&studyId=study_es_0`;
+
+describe('namespace columns in mutation tables', function() {
+    describe('results view', () => {
+        it('hides namespace columns when no property set', () => {
+            goToUrlAndSetLocalStorageWithProperty(resultsViewUrl, true, {});
+            waitForMutationTable();
+            assert(namespaceColumnsAreNotDisplayed());
+        });
+        it('shows columns when column menu is used', () => {
+            // Click on column button.
+            $('button*=Columns').click();
+            // Filter menu options.
+            $('[data-test=fixed-header-table-search-input]').setValue(
+                'zygosity'
+            );
+            $('[data-test=add-by-type]')
+                .$('div*=Zygosity')
+                .waitForDisplayed();
+            // Click namespace column checkboxes.
+            $('[data-test=add-by-type]')
+                .$$('div*=Zygosity')
+                .forEach(checkbox => checkbox.click());
+            $('button*=Columns').click();
+            assert(namespaceColumnsAreDisplayed());
+        });
+        it('shows namespace columns when property set', () => {
+            goToUrlAndSetLocalStorageWithProperty(resultsViewUrl, true, {
+                skin_mutation_table_namespace_column_show_by_default: true,
+            });
+            waitForMutationTable();
+            assert(namespaceColumnsAreDisplayed());
+        });
+        it('has filter icons', () => {
+            $("//span[text() = 'Zygosity Code']").moveTo();
+            assert(
+                filterIconOfHeader(
+                    "//span[text() = 'Zygosity Code']"
+                ).isDisplayed()
+            );
+        });
+        it('filters rows when using filter icon', () => {
+            assert($('=TEST_SAMPLE_SOMATIC_HOMOZYGOUS').isDisplayed());
+            filterIconOfHeader("//span[text() = 'Zygosity Code']").click();
+            // Hide row with Zygosity code = 2.
+            $("//span[text()='2']").click();
+            assert(!$('=TEST_SAMPLE_SOMATIC_HOMOZYGOUS').isDisplayed());
+        });
+    });
+    describe('patient view', () => {
+        it('hides namespace columns when no property set', () => {
+            goToUrlAndSetLocalStorageWithProperty(patientViewUrl, true, {});
+            waitForPatientViewMutationTable();
+            assert(namespaceColumnsAreNotDisplayed());
+        });
+        it('shows columns when column menu is used', () => {
+            // Click on column button.
+            $('[data-test=patientview-mutation-table]')
+                .$('button*=Columns')
+                .click();
+            // Click namespace column checkboxes.
+            $('[data-id="Zygosity Code"]').click();
+            $('[data-id="Zygosity Name"]').click();
+            $('[data-test=patientview-mutation-table]')
+                .$('button*=Columns')
+                .click();
+            assert(namespaceColumnsAreDisplayed());
+        });
+        it('shows namespace columns when property set', () => {
+            goToUrlAndSetLocalStorageWithProperty(patientViewUrl, true, {
+                skin_mutation_table_namespace_column_show_by_default: true,
+            });
+            waitForPatientViewMutationTable();
+            assert(namespaceColumnsAreDisplayed());
+        });
+    });
+});
+
+waitForMutationTable = () => {
+    $('[data-test=LazyMobXTable]').waitForDisplayed();
+};
+
+waitForPatientViewMutationTable = () => {
+    $('[data-test=patientview-mutation-table]').waitForDisplayed();
+};
+
+namespaceColumnsAreDisplayed = () => {
+    return (
+        $("//span[text() = 'Zygosity Code']").isDisplayed() &&
+        $("//span[text() = 'Zygosity Name']").isDisplayed()
+    );
+};
+
+namespaceColumnsAreNotDisplayed = () => {
+    return !(
+        $("//span[text() = 'Zygosity Code']").isDisplayed() &&
+        $("//span[text() = 'Zygosity Name']").isDisplayed()
+    );
+};
+
+filterIconOfHeader = selector => {
+    return $(selector)
+        .parentElement()
+        .parentElement()
+        .$('.fa-filter');
+};

--- a/env/custom.sh
+++ b/env/custom.sh
@@ -1,2 +1,3 @@
-#export CBIOPORTAL_URL="http://www.cbioportal.org"
+export CBIOPORTAL_URL="http://localhost:8080"
 export GENOME_NEXUS_URL="https://www.genomenexus.org"
+export BACKEND=cbioportal:master

--- a/env/namespacecolumns_in_mutationtable.sh
+++ b/env/namespacecolumns_in_mutationtable.sh
@@ -1,2 +1,3 @@
 export CBIOPORTAL_URL="https://www.cbioportal.org"
 export GENOME_NEXUS_URL="https://www.genomenexus.org"
+

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -155,4 +155,5 @@ export interface IServerConfig {
     referenceGenomeVersion: string;
     skin_home_page_show_unauthorized_studies: boolean;
     skin_home_page_unauthorized_studies_global_message: string;
+    skin_mutation_table_namespace_column_show_by_default: boolean;
 }

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -1220,6 +1220,10 @@ export default class PatientViewPage extends React.Component<
                                                             .patientViewPageStore
                                                             .existsSomeMutationWithAscnProperty
                                                     }
+                                                    namespaceColumns={
+                                                        this.dataStore
+                                                            .namespaceColumnData
+                                                    }
                                                 />
                                             </div>
                                         )}

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -3,6 +3,7 @@ import { computed, makeObservable } from 'mobx';
 import {
     default as MutationTable,
     IMutationTableProps,
+    MutationTableColumn,
     MutationTableColumnType,
 } from 'shared/components/mutationTable/MutationTable';
 import SampleManager from '../SampleManager';
@@ -21,6 +22,8 @@ import { getDefaultClonalColumnDefinition } from 'shared/components/mutationTabl
 import { getDefaultExpectedAltCopiesColumnDefinition } from 'shared/components/mutationTable/column/expectedAltCopies/ExpectedAltCopiesColumnFormatter';
 import { ASCNAttributes } from 'shared/enums/ASCNEnums';
 import AnnotationHeader from 'shared/components/mutationTable/column/annotation/AnnotationHeader';
+import _ from 'lodash';
+import { createNamespaceColumns } from 'shared/components/mutationTable/MutationTableUtils';
 
 export interface IPatientViewMutationTableProps extends IMutationTableProps {
     sampleManager: SampleManager | null;
@@ -385,6 +388,24 @@ export default class PatientViewMutationTable extends MutationTable<
                 this.getSamples().length > 1
             );
         };
+
+        // generate namespace columns
+        const namespaceColumns = createNamespaceColumns(
+            this.props.namespaceColumns
+        );
+        _.forIn(
+            namespaceColumns,
+            (column: MutationTableColumn, columnName: string) => {
+                if (
+                    this.props.columns &&
+                    !this.props.columns.includes(columnName)
+                ) {
+                    this.props.columns.push(columnName);
+                }
+
+                this._columns[columnName] = column;
+            }
+        );
     }
 
     @computed private get hasUncalledMutations(): boolean {

--- a/src/pages/patientView/mutation/PatientViewMutationsDataStore.ts
+++ b/src/pages/patientView/mutation/PatientViewMutationsDataStore.ts
@@ -3,6 +3,7 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import { action, computed, observable, makeObservable } from 'mobx';
 import _ from 'lodash';
 import PatientViewUrlWrapper from '../PatientViewUrlWrapper';
+import { NamespaceColumnConfig } from 'shared/components/mutationTable/MutationTable';
 
 function mutationMatch(d: Mutation[], id: Mutation) {
     return (
@@ -84,6 +85,21 @@ export default class PatientViewMutationsDataStore extends SimpleGetterLazyMobXT
 
     public isMutationSelected(m: Mutation) {
         return this.selectedMutationsMap.has(mutationIdKey(m));
+    }
+
+    @computed get namespaceColumnData(): NamespaceColumnConfig {
+        const namespaceData = _(this.allData)
+            .flatMap()
+            .map(mutation => mutation.namespaceColumns)
+            .value();
+        const namespaceDataMerged = _.reduce(
+            namespaceData,
+            (result, value, key) => _.assign(result, value),
+            {}
+        );
+        return _.mapValues(namespaceDataMerged, namespaceColumnData =>
+            _.keys(namespaceColumnData)
+        );
     }
 
     protected getSortedFilteredData = () => {

--- a/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
@@ -349,6 +349,7 @@ export default class PatientViewMutationsTab extends React.Component<
                         this.props.patientViewPageStore
                             .existsSomeMutationWithAscnProperty
                     }
+                    namespaceColumns={this.dataStore.namespaceColumnData}
                 />
             </div>
         ),

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -251,6 +251,7 @@ export default class ResultsViewMutationMapper extends MutationMapper<
                     this.columnToHeaderFilterIconModal
                 }
                 deactivateColumnFilter={this.deactivateColumnFilter}
+                namespaceColumns={this.props.store.namespaceColumnConfig}
             />
         );
     }

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
@@ -15,7 +15,7 @@ import {
     GenomeNexusAPI,
     GenomeNexusAPIInternal,
 } from 'genome-nexus-ts-api-client';
-import { labelMobxPromises, MobxPromise, cached } from 'mobxpromise';
+import { MobxPromise } from 'mobxpromise';
 import { fetchCosmicData } from 'shared/lib/StoreUtils';
 import MutationCountCache from 'shared/cache/MutationCountCache';
 import ClinicalAttributeCache from 'shared/cache/ClinicalAttributeCache';
@@ -27,7 +27,7 @@ import MutationMapperStore, {
     IMutationMapperStoreConfig,
 } from 'shared/components/mutationMapper/MutationMapperStore';
 import { IServerConfig } from '../../../config/IAppConfig';
-import { action, computed, makeObservable } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import {
     createNumericalFilter,
     createCategoricalFilter,
@@ -43,6 +43,10 @@ import DiscreteCNAColumnFormatter from 'shared/components/mutationTable/column/D
 import CancerTypeColumnFormatter from 'shared/components/mutationTable/column/CancerTypeColumnFormatter';
 import HgvscColumnFormatter from 'shared/components/mutationTable/column/HgvscColumnFormatter';
 import ClinicalAttributeColumnFormatter from 'shared/components/mutationTable/column/ClinicalAttributeColumnFormatter';
+import _ from 'lodash';
+import { createNamespaceColumnName } from 'shared/components/mutationMapper/MutationMapperUtils';
+import NumericNamespaceColumnFormatter from 'shared/components/mutationTable/column/NumericNamespaceColumnFormatter';
+import CategoricalNamespaceColumnFormatter from 'shared/components/mutationTable/column/CategoricalNamespaceColumnFormatter';
 
 export default class ResultsViewMutationMapperStore extends MutationMapperStore {
     constructor(
@@ -222,6 +226,31 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
             }
         });
 
+        // Add numerical namespace column definitions.
+        _.forIn(
+            this.namespaceColumnConfig,
+            (namespaceColumnNames, namespaceName) => {
+                _.forIn(namespaceColumnNames, (type, namespaceColumnName) => {
+                    if (type === 'number') {
+                        const columnName = createNamespaceColumnName(
+                            namespaceName,
+                            namespaceColumnName
+                        );
+                        columnIds.add(columnName);
+                        this.mutationMapperStoreConfig[
+                            'filterAppliersOverride'
+                        ]![columnName] = createNumericalFilter((d: Mutation) =>
+                            NumericNamespaceColumnFormatter.getData(
+                                [d],
+                                namespaceName,
+                                namespaceColumnName
+                            )
+                        );
+                    }
+                });
+            }
+        );
+
         return columnIds;
     }
 
@@ -306,6 +335,33 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
                 );
             }
         });
+
+        // Add categorical namespace column definitions.
+        _.forIn(
+            this.namespaceColumnConfig,
+            (namespaceColumnNames, namespaceName) => {
+                _.forIn(namespaceColumnNames, (type, namespaceColumnName) => {
+                    if (type !== 'number') {
+                        const columnName = createNamespaceColumnName(
+                            namespaceName,
+                            namespaceColumnName
+                        );
+                        columnIds.add(columnName);
+                        this.mutationMapperStoreConfig[
+                            'filterAppliersOverride'
+                        ]![
+                            columnName
+                        ] = createCategoricalFilter((d: Mutation) =>
+                            CategoricalNamespaceColumnFormatter.download(
+                                [d],
+                                namespaceName,
+                                namespaceColumnName
+                            )
+                        );
+                    }
+                });
+            }
+        );
 
         return columnIds;
     }

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -4,6 +4,7 @@ import {
     IMutationTableProps,
     MutationTableColumnType,
     default as MutationTable,
+    MutationTableColumn,
 } from 'shared/components/mutationTable/MutationTable';
 import CancerTypeColumnFormatter from 'shared/components/mutationTable/column/CancerTypeColumnFormatter';
 import TumorAlleleFreqColumnFormatter from 'shared/components/mutationTable/column/TumorAlleleFreqColumnFormatter';
@@ -14,6 +15,8 @@ import { ASCNAttributes } from 'shared/enums/ASCNEnums';
 import { IColumnVisibilityControlsProps } from 'shared/components/columnVisibilityControls/ColumnVisibilityControls';
 import AddColumns from './AddColumns';
 import ClinicalAttributeCache from 'shared/cache/ClinicalAttributeCache';
+import { createNamespaceColumns } from 'shared/components/mutationTable/MutationTableUtils';
+import _ from 'lodash';
 
 export interface IResultsViewMutationTableProps extends IMutationTableProps {
     // add results view specific props here if needed
@@ -172,6 +175,24 @@ export default class ResultsViewMutationTable extends MutationTable<
                 order: 300,
             };
         }
+
+        // generate namespace columns
+        const namespaceColumns = createNamespaceColumns(
+            this.props.namespaceColumns
+        );
+        _.forIn(
+            namespaceColumns,
+            (column: MutationTableColumn, columnName: string) => {
+                if (
+                    this.props.columns &&
+                    !this.props.columns.includes(columnName)
+                ) {
+                    this.props.columns.push(columnName);
+                }
+
+                this._columns[columnName] = column;
+            }
+        );
 
         // override default visibility for some columns
         this._columns[

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
@@ -63,6 +63,7 @@ export default class StandaloneMutationMapper extends MutationMapper<
                     this.props.generateGenomeNexusHgvsgUrl
                 }
                 selectedTranscriptId={this.props.store.activeTranscript.result}
+                namespaceColumns={this.props.store.namespaceColumnConfig}
             />
         );
     }

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationTable.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationTable.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { observer } from 'mobx-react';
 import {
     IMutationTableProps,
     MutationTableColumnType,
     default as MutationTable,
+    MutationTableColumn,
 } from 'shared/components/mutationTable/MutationTable';
 import TumorAlleleFreqColumnFormatter from 'shared/components/mutationTable/column/TumorAlleleFreqColumnFormatter';
 import CancerTypeColumnFormatter from 'shared/components/mutationTable/column/CancerTypeColumnFormatter';
+import _ from 'lodash';
+import { createNamespaceColumns } from 'shared/components/mutationTable/MutationTableUtils';
 
 export interface IStandaloneMutationTableProps extends IMutationTableProps {
     // add standalone specific props here if needed
@@ -55,6 +57,24 @@ export default class StandaloneMutationTable extends MutationTable<
 
     protected generateColumns() {
         super.generateColumns();
+
+        // generate namespace columns
+        const namespaceColumns = createNamespaceColumns(
+            this.props.namespaceColumns
+        );
+        _.forIn(
+            namespaceColumns,
+            (column: MutationTableColumn, columnName: string) => {
+                if (
+                    this.props.columns &&
+                    !this.props.columns.includes(columnName)
+                ) {
+                    this.props.columns.push(columnName);
+                }
+
+                this._columns[columnName] = column;
+            }
+        );
 
         // override default visibility for some columns
         this._columns[

--- a/src/shared/components/mutationMapper/MutationMapperStore.ts
+++ b/src/shared/components/mutationMapper/MutationMapperStore.ts
@@ -50,8 +50,12 @@ import {
 import PdbChainDataStore from './PdbChainDataStore';
 import MutationMapperDataStore from './MutationMapperDataStore';
 import { IMutationMapperConfig } from './MutationMapperConfig';
-import { normalizeMutations } from './MutationMapperUtils';
+import {
+    buildNamespaceColumnConfig,
+    normalizeMutations,
+} from './MutationMapperUtils';
 import { getOncoKbApiUrl } from 'shared/api/urls';
+import { NamespaceColumnConfig } from 'shared/components/mutationTable/MutationTable';
 
 export interface IMutationMapperStoreConfig {
     filterMutationsBySelectedTranscript?: boolean;
@@ -189,6 +193,10 @@ export default class MutationMapperStore extends DefaultMutationMapperStore<
         },
         []
     );
+
+    @computed get namespaceColumnConfig(): NamespaceColumnConfig {
+        return buildNamespaceColumnConfig(this.mutationData.result);
+    }
 
     public countUniqueMutations(mutations: Mutation[]): number {
         return countUniqueMutations(mutations);

--- a/src/shared/components/mutationMapper/MutationMapperUtils.spec.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUtils.spec.ts
@@ -1,0 +1,147 @@
+import { assert } from 'chai';
+import { Gene, Mutation } from 'cbioportal-ts-api-client';
+import {
+    buildNamespaceColumnConfig,
+    createNamespaceColumnName,
+} from 'shared/components/mutationMapper/MutationMapperUtils';
+
+describe('MutationMapperUtils', () => {
+    describe('buildNamespaceColumnConfig', () => {
+        it('derives namespace config from mutation data - single namespace, single column', () => {
+            const mutations = [
+                createMutation({ myNamespace: { column: 'value1' } }),
+                createMutation({ myNamespace: { column: 'value2' } }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {
+                myNamespace: { column: 'string' },
+            });
+        });
+
+        it('derives namespace config from mutation data - two namespaces, single column', () => {
+            const mutations = [
+                createMutation({ myNamespace1: { column: 'value1' } }),
+                createMutation({ myNamespace2: { column: 'value2' } }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {
+                myNamespace1: { column: 'string' },
+                myNamespace2: { column: 'string' },
+            });
+        });
+
+        it('derives namespace config from mutation data - single namespace, two columns', () => {
+            const mutations = [
+                createMutation({ myNamespace: { column1: 'value1' } }),
+                createMutation({ myNamespace: { column2: 'value2' } }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {
+                myNamespace: {
+                    column1: 'string',
+                    column2: 'string',
+                },
+            });
+        });
+
+        it('derives namespace config from mutation data - empty arguments', () => {
+            const mutations = [
+                createMutation({ myNamespace: {} }),
+                createMutation({ myNamespace: {} }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, { myNamespace: {} });
+        });
+
+        it('derives namespace config from mutation data - no namespace data', () => {
+            const mutations = [
+                createMutation({}),
+                createMutation({}),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {});
+        });
+
+        it('derives namespace config from mutation data - numeric column', () => {
+            const mutations = [
+                createMutation({ myNamespace: { column: 1 } }),
+                createMutation({ myNamespace: { column: 2 } }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {
+                myNamespace: { column: 'number' },
+            });
+        });
+
+        it('derives namespace config from mutation data - mixed column is not numeric', () => {
+            const mutations = [
+                createMutation({ myNamespace: { column: 1 } }),
+                createMutation({ myNamespace: { column: 'value' } }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {
+                myNamespace: { column: 'string' },
+            });
+        });
+
+        it('derives namespace config from mutation data - numeric column with null is numeric ', () => {
+            const mutations = [
+                createMutation({ myNamespace: { column: 1 } }),
+                createMutation({ myNamespace: { column: null } }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {
+                myNamespace: { column: 'number' },
+            });
+        });
+
+        it('derives namespace config from mutation data - numeric column with undefined is numeric', () => {
+            const mutations = [
+                createMutation({ myNamespace: { column: 1 } }),
+                createMutation({ myNamespace: { column: undefined } }),
+            ] as Mutation[];
+            const columnConfig = buildNamespaceColumnConfig(mutations);
+            assert.deepEqual(columnConfig, {
+                myNamespace: { column: 'number' },
+            });
+        });
+    });
+
+    describe('createNamespaceColumnName', () => {
+        it('Capitalizes column name', () => {
+            assert.equal(
+                createNamespaceColumnName('Namespace', 'column'),
+                'Namespace Column'
+            );
+        });
+        it('Does not affect namespace column case', () => {
+            assert.equal(
+                createNamespaceColumnName('nAmEsPaCe', 'column'),
+                'nAmEsPaCe Column'
+            );
+        });
+    });
+});
+
+const createMutation = (namespaceData: any) => {
+    return ({
+        gene: {
+            hugoGeneSymbol: 'GENE',
+        } as Gene,
+        mutationStatus: undefined,
+        uniqueSampleKey: undefined,
+        uniquePatientKey: undefined,
+        sampleId: 'sample',
+        patientId: 'patient',
+        studyId: 'study',
+        chr: '1',
+        startPosition: 0,
+        endPosition: 0,
+        referenceAllele: '',
+        variantAllele: '',
+        tumorAltCount: 1,
+        tumorRefCount: 1,
+        molecularProfileId: 'mutations',
+        namespaceColumns: namespaceData,
+    } as unknown) as Mutation;
+};

--- a/src/shared/components/mutationMapper/MutationMapperUtils.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUtils.ts
@@ -2,6 +2,8 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import { GenomeNexusAPI, VariantAnnotation } from 'genome-nexus-ts-api-client';
 import { fetchVariantAnnotationsByMutation } from 'react-mutation-mapper';
 import { getServerConfig } from 'config/config';
+import _ from 'lodash';
+import { NamespaceColumnConfig } from 'shared/components/mutationTable/MutationTable';
 
 export function normalizeMutation<T extends Pick<Mutation, 'chr'>>(
     mutation: T
@@ -31,4 +33,40 @@ export function createVariantAnnotationsByMutationFetcher(
             return Promise.resolve([]);
         }
     };
+}
+
+export function buildNamespaceColumnConfig(
+    mutations: Mutation[]
+): NamespaceColumnConfig {
+    if (!mutations) {
+        return {};
+    }
+    const namespaceConfig: NamespaceColumnConfig = {};
+    const nameSpaces = _.flatMap(mutations, m => _.keys(m.namespaceColumns));
+    nameSpaces.forEach(nameSpace => {
+        let columnCollapse: any = {};
+        _(mutations)
+            .map(m => _.get(m.namespaceColumns, nameSpace))
+            .forEach(column => _.mergeWith(columnCollapse, column, fMerge));
+        columnCollapse = _.mapValues(columnCollapse, (values: any[]) => {
+            return !values.some(_.isString) ? 'number' : 'string';
+        });
+        namespaceConfig[nameSpace] = columnCollapse;
+    });
+    return namespaceConfig;
+}
+
+export function createNamespaceColumnName(
+    namespaceName: string,
+    namespaceColumnName: string
+) {
+    return namespaceName + ' ' + _.capitalize(namespaceColumnName);
+}
+
+function fMerge(refObject: any, addedObject: any) {
+    if (_.isArray(refObject)) {
+        return refObject.concat(addedObject);
+    } else {
+        return [addedObject];
+    }
 }

--- a/src/shared/components/mutationTable/MutationTableUtils.ts
+++ b/src/shared/components/mutationTable/MutationTableUtils.ts
@@ -1,0 +1,91 @@
+import _ from 'lodash';
+import {
+    defaultFilter,
+    ExtendedMutationTableColumnType,
+    MutationTableColumn,
+    NamespaceColumnConfig,
+} from 'shared/components/mutationTable/MutationTable';
+import { Mutation } from 'cbioportal-ts-api-client';
+import { getServerConfig } from 'config/config';
+import { createNamespaceColumnName } from 'shared/components/mutationMapper/MutationMapperUtils';
+import NumericNamespaceColumnFormatter from 'shared/components/mutationTable/column/NumericNamespaceColumnFormatter';
+import CategoricalNamespaceColumnFormatter from 'shared/components/mutationTable/column/CategoricalNamespaceColumnFormatter';
+
+export function createNamespaceColumns(
+    namespaceColumnConfig: NamespaceColumnConfig | undefined
+): Record<ExtendedMutationTableColumnType, MutationTableColumn> {
+    const columns = {} as Record<
+        ExtendedMutationTableColumnType,
+        MutationTableColumn
+    >;
+    if (namespaceColumnConfig) {
+        _.forIn(namespaceColumnConfig, (namespaceColumnNames, namespaceName) =>
+            _.forIn(namespaceColumnNames, (type, namespaceColumnName) => {
+                const columnName = createNamespaceColumnName(
+                    namespaceName,
+                    namespaceColumnName
+                );
+                const fRender =
+                    type === 'number'
+                        ? (d: Mutation[]) =>
+                              NumericNamespaceColumnFormatter.renderFunction(
+                                  d,
+                                  namespaceName,
+                                  namespaceColumnName
+                              )
+                        : (d: Mutation[]) =>
+                              CategoricalNamespaceColumnFormatter.renderFunction(
+                                  d,
+                                  namespaceName,
+                                  namespaceColumnName
+                              );
+                const fSort =
+                    type === 'number'
+                        ? (d: Mutation[]) =>
+                              NumericNamespaceColumnFormatter.sortValue(
+                                  d,
+                                  namespaceName,
+                                  namespaceColumnName
+                              )
+                        : (d: Mutation[]) =>
+                              CategoricalNamespaceColumnFormatter.sortValue(
+                                  d,
+                                  namespaceName,
+                                  namespaceColumnName
+                              );
+
+                const fDownload =
+                    type === 'number'
+                        ? (d: Mutation[]) =>
+                              NumericNamespaceColumnFormatter.download(
+                                  d,
+                                  namespaceName,
+                                  namespaceColumnName
+                              )
+                        : (d: Mutation[]) =>
+                              CategoricalNamespaceColumnFormatter.download(
+                                  d,
+                                  namespaceName,
+                                  namespaceColumnName
+                              );
+                columns[columnName] = {
+                    id: columnName,
+                    name: columnName,
+                    render: fRender,
+                    sortBy: fSort,
+                    download: fDownload,
+                    filter: (
+                        d: Mutation[],
+                        filterString: string,
+                        filterStringUpper: string
+                    ) => defaultFilter(d, columnName, filterStringUpper),
+                    visible: !!getServerConfig()
+                        .skin_mutation_table_namespace_column_show_by_default,
+                    order: 400,
+                    align: type === 'number' ? 'right' : 'left',
+                };
+            })
+        );
+    }
+    return columns;
+}

--- a/src/shared/components/mutationTable/column/CategoricalNamespaceColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CategoricalNamespaceColumnFormatter.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { Mutation } from 'cbioportal-ts-api-client';
+import _ from 'lodash';
+
+/**
+ * @author Pim van Nierop
+ */
+export default class CategoricalNamespaceColumnFormatter {
+    public static getData(
+        data: Mutation[],
+        namespaceName: any,
+        namespaceColumnName: any
+    ): string | null {
+        if (data) {
+            const namespaces = data[0].namespaceColumns;
+            const namespace = _.get(namespaces, namespaceName, undefined);
+            return namespace
+                ? _.get(namespace, namespaceColumnName, null)
+                : null;
+        }
+        return null;
+    }
+
+    public static sortValue(
+        data: Mutation[],
+        namespaceName: string,
+        namespaceColumnName: string
+    ): string | null {
+        return CategoricalNamespaceColumnFormatter.getData(
+            data,
+            namespaceName,
+            namespaceColumnName
+        );
+    }
+
+    public static download(
+        data: Mutation[],
+        namespaceName: string,
+        namespaceColumnName: string
+    ): string {
+        const value = CategoricalNamespaceColumnFormatter.getData(
+            data,
+            namespaceName,
+            namespaceColumnName
+        );
+        return value ? value.toString() : '';
+    }
+
+    public static renderFunction(
+        data: Mutation[],
+        namespaceName: string,
+        namespaceColumnName: string
+    ) {
+        const download = CategoricalNamespaceColumnFormatter.getData(
+            data,
+            namespaceName,
+            namespaceColumnName
+        );
+        return <div>{download}</div>;
+    }
+}

--- a/src/shared/components/mutationTable/column/NumericNamespaceColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/NumericNamespaceColumnFormatter.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { Mutation } from 'cbioportal-ts-api-client';
+import _ from 'lodash';
+import generalStyles from 'shared/components/mutationTable/column/styles.module.scss';
+
+/**
+ * @author Pim van Nierop
+ */
+export default class NumericNamespaceColumnFormatter {
+    public static getData(
+        data: Mutation[],
+        namespaceName: any,
+        namespaceColumnName: any
+    ): number | null {
+        if (data) {
+            const namespaces = data[0].namespaceColumns;
+            const namespace = _.get(namespaces, namespaceName, undefined);
+            return namespace
+                ? _.get(namespace, namespaceColumnName, null)
+                : null;
+        }
+        return null;
+    }
+
+    public static sortValue(
+        data: Mutation[],
+        namespaceName: string,
+        namespaceColumnName: string
+    ): number | null {
+        return NumericNamespaceColumnFormatter.getData(
+            data,
+            namespaceName,
+            namespaceColumnName
+        );
+    }
+
+    public static download(
+        data: Mutation[],
+        namespaceName: string,
+        namespaceColumnName: string
+    ): string {
+        const value = NumericNamespaceColumnFormatter.getData(
+            data,
+            namespaceName,
+            namespaceColumnName
+        );
+        return value ? value.toString() : '';
+    }
+
+    public static renderFunction(
+        data: Mutation[],
+        namespaceName: string,
+        namespaceColumnName: string
+    ) {
+        const download = NumericNamespaceColumnFormatter.getData(
+            data,
+            namespaceName,
+            namespaceColumnName
+        );
+        return <div className={generalStyles['integer-data']}>{download}</div>;
+    }
+}


### PR DESCRIPTION
# Description

This PR will show custom columns in the MAF file imported with the namespace import mechanism in Mutation Table components of Results View, Patient View and Standalone Mutation Mapper.

# Comment
- Passing of e2e-localdb tests depends on acceptance of PR https://github.com/cBioPortal/cbioportal/pull/9086.

# Video
![Peek 2021-12-02 13-35](https://user-images.githubusercontent.com/745885/144423165-fe6efe07-f429-48b5-bf8f-ab93d89b7202.gif)


