### PR TITLE
In timeline add HTAN OHSU Image Icon

### DIFF
--- a/src/pages/patientView/timeline2/TimelineWrapper.tsx
+++ b/src/pages/patientView/timeline2/TimelineWrapper.tsx
@@ -19,6 +19,7 @@ import SampleManager from 'pages/patientView/SampleManager';
 import {
     buildBaseConfig,
     configureGenieTimeline,
+    configureHtanOhsuTimeline,
     configureTimelineToxicityColors,
     sortTracks,
 } from 'pages/patientView/timeline2/timeline_helpers';
@@ -57,9 +58,16 @@ const TimelineWrapper: React.FunctionComponent<ITimeline2Props> = observer(
 
         useEffect(() => {
             const isGenieBpcStudy = window.location.href.includes('genie_bpc');
+            // This patient has hardcoded functionality for showing an image
+            // icon (prototype). TODO: We can replace it once we have generalized
+            // functionality for adding links to a timepoint.
+            const isHtanOhsuPatient =
+                window.location.href.includes('htan_test_2021') &&
+                window.location.href.includes('HTA9_1');
             const isToxicityPortal = [
                 'triage.cbioportal.mskcc.org',
                 'cbioportal.mskcc.org',
+                'private.cbioportal.mskcc.org',
             ].includes(window.location.hostname);
 
             const baseConfig: ITimelineConfig = buildBaseConfig(
@@ -69,6 +77,33 @@ const TimelineWrapper: React.FunctionComponent<ITimeline2Props> = observer(
 
             if (isGenieBpcStudy) {
                 configureGenieTimeline(baseConfig);
+            }
+
+            if (isHtanOhsuPatient) {
+                const extraData = {
+                    uniquePatientKey: 'SFRBOV8xOmh0YW5fdGVzdF8yMDIx',
+                    studyId: 'htan_test_2021',
+                    patientId: 'HTA9_1',
+                    eventType: 'IMAGING',
+                    attributes: [
+                        {
+                            key: 'linkout',
+                            value:
+                                'https://minerva-story-htan-ohsu-demo.surge.sh/#s=1#w=1#g=6#m=-1#a=-100_-100#v=0.6178_0.57_0.6129#o=-100_-100_1_1#p=Q',
+                        },
+                        { key: 'ASSAY_TYPE', value: 'mIHC' },
+                        {
+                            key: 'FILE_FORMAT',
+                            value: 'OME-TIFF',
+                        },
+                    ],
+                    startNumberOfDaysSinceDiagnosis: 25726,
+                };
+
+                // @ts-ignore
+                data.push(extraData);
+
+                configureHtanOhsuTimeline(baseConfig);
             }
 
             if (isToxicityPortal) {

--- a/src/pages/patientView/timeline2/timeline_helpers.tsx
+++ b/src/pages/patientView/timeline2/timeline_helpers.tsx
@@ -26,6 +26,79 @@ import { getColor } from 'cbioportal-frontend-commons';
 
 const OTHER = 'Other';
 
+export function configureHtanOhsuTimeline(baseConfig: ITimelineConfig) {
+    baseConfig.trackEventRenderers = baseConfig.trackEventRenderers || [];
+    baseConfig.trackEventRenderers.push({
+        trackTypeMatch: /IMAGING/i,
+        configureTrack: (cat: TimelineTrackSpecification) => {
+            cat.renderEvents = function(e) {
+                return (
+                    <a
+                        href={
+                            'https://minerva-story-htan-ohsu-demo.surge.sh/#s=0#w=0#g=0#m=-1#a=-100_-100#v=0.5_0.5_0.5#o=-100_-100_1_1#p=Q'
+                        }
+                        target={'_blank'}
+                        onClick={e => e.stopPropagation()}
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            version="1.1"
+                            id="Layer_1"
+                            x="-8px"
+                            y="1px"
+                            width="16px"
+                            height="16px"
+                            viewBox="0 0 16 16"
+                            enable-background="new 0 0 16 16"
+                        >
+                            <g>
+                                <circle
+                                    fill="none"
+                                    stroke="#646464"
+                                    stroke-width="2"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-miterlimit="10"
+                                    cx="7.997"
+                                    cy="9.058"
+                                    r="3.023"
+                                />
+                                <path
+                                    fill="none"
+                                    stroke="#646464"
+                                    stroke-width="2"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-miterlimit="10"
+                                    d="   M14.168,4h-2.983l-0.521-1.36C10.503,2.288,10.07,2,9.702,2H6.359C5.99,2,5.558,2.288,5.396,2.64L4.877,4H1.893   C1.401,4,1,4.427,1,4.948v8.072C1,13.543,1.401,14,1.893,14h12.275C14.659,14,15,13.543,15,13.021V4.948   C15,4.427,14.659,4,14.168,4z"
+                                />
+                            </g>
+                        </svg>
+                    </a>
+                );
+            };
+            cat.renderTooltip = function(e) {
+                return (
+                    <div>
+                        <strong>Click camera to open image viewer</strong>
+                        <hr style={{ margin: '5px 0' }} />
+                        <table>
+                            <tr>
+                                <td>Assay Type</td>
+                                <td>mIHC</td>
+                            </tr>
+                            <tr>
+                                <td>File Format</td>
+                                <td>OME-TIFF</td>
+                            </tr>
+                        </table>
+                    </div>
+                );
+            };
+        },
+    });
+}
+
 export function configureTimelineToxicityColors(baseConfig: ITimelineConfig) {
     baseConfig.trackStructures = baseConfig.trackStructures || [];
     baseConfig.trackStructures!.push([


### PR DESCRIPTION
Add check for HTAN OHSU case to add a link to the Minerva viewer in the timeline. This supersedes https://github.com/cBioPortal/cbioportal-frontend/pull/3984

Filed a separate issue about generalizing URLs in the timeline: https://github.com/cBioPortal/cbioportal/issues/9091