### PR TITLE
Timeline: allow user to mouse into the tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "oncoprintjs": "5.0.4",
     "pako": "2.0.2",
     "parameter-validator": "^1.0.2",
+    "path-browserify": "^1.0.1",
     "pathway-mapper": "^2.2.2-beta.0",
     "pdfobject": "^2.0.201604172",
     "pegjs": "^0.10.0",

--- a/packages/cbioportal-clinical-timeline/src/TimelineTracks.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTracks.tsx
@@ -70,10 +70,17 @@ export const TimelineTracks: React.FunctionComponent<ITimelineTracks> = observer
                 </g>
                 {store.tooltipModels.map(([uid, model, index]) => {
                     const position = model.position || store.mousePosition;
-                    const placementLeft = position.x > width / 2;
+                    let placementLeft = position.x > width / 2;
+                    placementLeft = false;
                     return (
                         <Portal container={document.body}>
                             <Popover
+                                onMouseEnter={() => {
+                                    store.togglePinTooltip(uid);
+                                }}
+                                onMouseLeave={() => {
+                                    store.removeTooltip(uid);
+                                }}
                                 arrowOffsetTop={17}
                                 placement={placementLeft ? 'left' : 'right'}
                                 style={{
@@ -83,7 +90,8 @@ export const TimelineTracks: React.FunctionComponent<ITimelineTracks> = observer
                                 }}
                                 className={'tl-timeline-tooltip cbioTooltip'}
                                 positionLeft={
-                                    position.x + (placementLeft ? -10 : 10)
+                                    //position.x
+                                    position.x + (placementLeft ? -3 : 3)
                                 }
                                 positionTop={position.y - 17}
                             >

--- a/src/pages/patientView/timeline2/timeline_helpers.tsx
+++ b/src/pages/patientView/timeline2/timeline_helpers.tsx
@@ -23,6 +23,7 @@ import SampleManager from 'pages/patientView/SampleManager';
 import { ISampleMetaDeta } from 'pages/patientView/timeline2/TimelineWrapper';
 import { ClinicalEvent } from 'cbioportal-ts-api-client';
 import { getColor } from 'cbioportal-frontend-commons';
+import ReactMarkdown from 'react-markdown';
 
 const OTHER = 'Other';
 
@@ -399,7 +400,20 @@ export function buildBaseConfig(
                                                                     ' '
                                                                 )}
                                                         </th>
-                                                        <td>{d.value}</td>
+                                                        <td>
+                                                            {' '}
+                                                            <ReactMarkdown
+                                                                allowedElements={[
+                                                                    'p',
+                                                                    'a',
+                                                                ]}
+                                                                linkTarget={
+                                                                    '_blank'
+                                                                }
+                                                            >
+                                                                {d.value}
+                                                            </ReactMarkdown>
+                                                        </td>
                                                     </tr>
                                                 );
                                             }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,3 +14,5 @@ jest.mock('shared/components/copyDownloadControls/CopyDownloadQueryLinks.tsx');
 // explicitly set mock for legacy packages
 jest.setMock('webpack-raphael', {});
 jest.setMock('jquery-migrate', {});
+
+jest.setMock('react-markdown', {});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,6 +131,8 @@ var config = {
                 __dirname + '/node_modules/jquery/dist/jquery.js'
             ),
         },
+
+        fallback: { path: require.resolve('path-browserify') },
     },
 
     resolveLoader: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18345,6 +18345,11 @@ path-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
   integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"


### PR DESCRIPTION
This PR allows data managers to add links to timeline event tooltips by adding attributes to event data.   They can do so by using markdown in the text value of the attribute.

This event

```{ key:"SLIDES", value: '[Slide Viewer](http://www.example.com)' }```

produces the following output:

![image](https://user-images.githubusercontent.com/186521/145105239-7baa9aa7-6606-439e-99ad-9b5549a989c7.png)
