### PR TITLE
Deactivate checkbox for unauthorized studies (when skin.home_page.sho…

### DIFF
--- a/src/shared/components/query/StudyListLogic.ts
+++ b/src/shared/components/query/StudyListLogic.ts
@@ -16,7 +16,7 @@ import {
     SearchResult,
 } from '../../lib/textQueryUtils';
 import { cached } from 'mobxpromise';
-import { ServerConfigHelpers } from '../../../config/config';
+import { getServerConfig, ServerConfigHelpers } from '../../../config/config';
 import memoize from 'memoize-weak-decorator';
 
 export const PAN_CAN_SIGNATURE = 'pan_can_atlas';
@@ -285,7 +285,7 @@ export class FilteredCancerTreeView {
             let checked = !!this.store.selectableSelectedStudyIds.find(
                 id => id == study.studyId
             );
-            let disabled = this.store.isDeletedVirtualStudy(study.studyId);
+            let disabled = this.isCheckBoxDisabled(node);
             return { checked, disabled };
         }
     }
@@ -297,6 +297,9 @@ export class FilteredCancerTreeView {
         } else {
             let study = node as CancerStudy;
             if (this.store.isDeletedVirtualStudy(study.studyId)) {
+                return true;
+            }
+            if (study.readPermission === false) {
                 return true;
             }
             return false;

--- a/src/shared/components/query/StudyListLogic.ts
+++ b/src/shared/components/query/StudyListLogic.ts
@@ -16,7 +16,7 @@ import {
     SearchResult,
 } from '../../lib/textQueryUtils';
 import { cached } from 'mobxpromise';
-import { getServerConfig, ServerConfigHelpers } from '../../../config/config';
+import { ServerConfigHelpers } from '../../../config/config';
 import memoize from 'memoize-weak-decorator';
 
 export const PAN_CAN_SIGNATURE = 'pan_can_atlas';


### PR DESCRIPTION
The unauthorized studies can be displayed in the study list when  when skin.home_page.show_unauthorized_studies is set to true in portal.properties.

This PR is deactivating the checkbox of these studies.
![Screenshot from 2021-12-07 11-00-48](https://user-images.githubusercontent.com/53996876/145008641-156e1ecd-442b-47af-894e-0a0ca1d59020.png)

