### PR TITLE
Fix exon track error when no exon in transcript

### DIFF
--- a/packages/react-mutation-mapper/src/component/track/ExonTrack.tsx
+++ b/packages/react-mutation-mapper/src/component/track/ExonTrack.tsx
@@ -41,41 +41,41 @@ export default class ExonTrack extends React.Component<ExonTrackProps, {}> {
         const exons = this.transcript!.exons;
         const utrs = this.transcript!.utrs || [];
 
-        const exonInfo = extractExonInformation(
-            exons,
-            utrs,
-            this.props.proteinLength
-        );
+        const exonInfo = exons
+            ? extractExonInformation(exons, utrs, this.props.proteinLength)
+            : undefined;
 
         const altColors = ['#007FFF', '#35BAF6'];
 
-        return exonInfo.map((exon: ExonDatum, index: number) => {
-            const startCodon = exon.start;
-            const endCodon = exon.start + exon.length;
-            const exonLength = exon.length;
-            const isSkippable = Number.isInteger(exonLength);
-            const stringStart = formatExonLocation(startCodon);
-            const stringEnd = formatExonLocation(endCodon);
-            const stringLength = formatExonLocation(exonLength);
+        return exonInfo
+            ? exonInfo.map((exon: ExonDatum, index: number) => {
+                  const startCodon = exon.start;
+                  const endCodon = exon.start + exon.length;
+                  const exonLength = exon.length;
+                  const isSkippable = Number.isInteger(exonLength);
+                  const stringStart = formatExonLocation(startCodon);
+                  const stringEnd = formatExonLocation(endCodon);
+                  const stringLength = formatExonLocation(exonLength);
 
-            return {
-                color: altColors[index % 2],
-                startCodon: startCodon,
-                endCodon: endCodon,
-                label: exon.rank.toString(),
-                labelColor: '#FFFFFF',
-                tooltip: (
-                    <span>
-                        <h5> Exon {exon.rank} </h5>
-                        Start: {stringStart}
-                        <br></br>
-                        End: {stringEnd}
-                        <br></br>
-                        Length: {stringLength}
-                    </span>
-                ),
-            };
-        });
+                  return {
+                      color: altColors[index % 2],
+                      startCodon: startCodon,
+                      endCodon: endCodon,
+                      label: exon.rank.toString(),
+                      labelColor: '#FFFFFF',
+                      tooltip: (
+                          <span>
+                              <h5> Exon {exon.rank} </h5>
+                              Start: {stringStart}
+                              <br></br>
+                              End: {stringEnd}
+                              <br></br>
+                              Length: {stringLength}
+                          </span>
+                      ),
+                  };
+              })
+            : [];
     }
 
     @computed get trackTitle() {


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/562
If no exon data in transcript, exon track crashes. 
```
TypeError: Cannot read properties of undefined (reading 'forEach')
    at B (ExonUtils.ts:11)
    at t.get (ExonTrack.tsx:45)
    at Je (derivation.ts:177)
    at e.t.computeValue_ (computedvalue.ts:237)
    at e.t.trackAndCompute (computedvalue.ts:205)
    at e.t.get (computedvalue.ts:178)
    at e.t.getObservablePropValue_ (observableobject.ts:120)
    at t.get (observableobject.ts:666)
    at t.value (ExonTrack.tsx:99)
    at Fe (action.ts:149)
```

Changes in this pr: Check if exon exists before extracting exon info