### PR TITLE
Returns an empty list for undefined profileIds in isSampleProfiledInMultiple function

### DIFF
--- a/src/shared/lib/isSampleProfiled.ts
+++ b/src/shared/lib/isSampleProfiled.ts
@@ -62,17 +62,22 @@ export function isSampleProfiledInSomeMolecularProfile(
 
 export function isSampleProfiledInMultiple(
     uniqueSampleKey: string,
-    molecularProfileIds: string[],
+    molecularProfileIds: string[] | undefined,
     coverageInformation: CoverageInformation,
     hugoGeneSymbol?: string
 ): boolean[] {
-    // returns boolean[] in same order as molecularProfileIds
-    const profiledReport = getSampleProfiledReport(
-        uniqueSampleKey,
-        coverageInformation,
-        hugoGeneSymbol
-    );
-    return molecularProfileIds.map(
-        molecularProfileId => !!profiledReport[molecularProfileId]
-    );
+    // returns empty list if molecularProfileIds is undefined
+    if (!molecularProfileIds) {
+        return [];
+    } else {
+        // returns boolean[] in same order as molecularProfileIds
+        const profiledReport = getSampleProfiledReport(
+            uniqueSampleKey,
+            coverageInformation,
+            hugoGeneSymbol
+        );
+        return molecularProfileIds.map(
+            molecularProfileId => !!profiledReport[molecularProfileId]
+        );
+    }
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9076

**ERROR LINK**: https://www.cbioportal.org/results/cancerTypesSummary?cancer_study_list=prad_mich%2Cprad_su2c_2019%2Cprad_su2c_2015%2Cprad_mcspc_mskcc_2020%2Cnepc_wcm_2016%2Cprad_broad_2013%2Cprad_broad%2Cprad_cpcg_2017%2Cprad_fhcrc%2Cprad_cdk12_mskcc_2020%2Cprad_mskcc%2Cprad_mskcc_2014%2Cprad_p1000%2Cprad_eururol_2017%2Cprad_tcga_pub%2Cprad_tcga%2Cprad_tcga_pan_can_atlas_2018%2Cprad_mskcc_cheny1_organoids_2014%2Cprostate_dkfz_2018%2Cprad_msk_2019%2Cprad_mskcc_2017%2Cprad_msk_stopsack_2021%2Cmpcproject_broad_2021%2Cprad_mpcproject_2018&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations&case_set_id=all&gene_list=TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit

**TEST LINK**: https://deploy-preview-4083--cbioportalfrontend.netlify.app/results/cancerTypesSummary?cancer_study_list=prad_mich%2Cprad_su2c_2019%2Cprad_su2c_2015%2Cprad_mcspc_mskcc_2020%2Cnepc_wcm_2016%2Cprad_broad_2013%2Cprad_broad%2Cprad_cpcg_2017%2Cprad_fhcrc%2Cprad_cdk12_mskcc_2020%2Cprad_mskcc%2Cprad_mskcc_2014%2Cprad_p1000%2Cprad_eururol_2017%2Cprad_tcga_pub%2Cprad_tcga%2Cprad_tcga_pan_can_atlas_2018%2Cprad_mskcc_cheny1_organoids_2014%2Cprostate_dkfz_2018%2Cprad_msk_2019%2Cprad_mskcc_2017%2Cprad_msk_stopsack_2021%2Cmpcproject_broad_2021%2Cprad_mpcproject_2018&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations&case_set_id=all&gene_list=TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit