### PR TITLE
Refactor reference genome id evaluation

### DIFF
--- a/src/pages/patientView/genomicOverview/Tracks.tsx
+++ b/src/pages/patientView/genomicOverview/Tracks.tsx
@@ -11,7 +11,6 @@ import {
 import SampleManager from '../SampleManager';
 import { IKeyedIconData, IIconData } from './GenomicOverviewUtils';
 import { observable, action, makeObservable } from 'mobx';
-import autobind from 'autobind-decorator';
 import { observer } from 'mobx-react';
 
 interface TracksPropTypes {
@@ -85,7 +84,7 @@ export default class Tracks extends React.Component<TracksPropTypes, {}> {
         if (this.props.mutations && this.props.mutations.length > 0) {
             genomeBuild = this.props.mutations[0].ncbiBuild;
         }
-        const chmInfo = tracksHelper.getChmInfo(genomeBuild);
+        const chmInfo = tracksHelper.getRelativeCoordinates(genomeBuild);
         tracksHelper.plotChromosomes(paper, config, chmInfo, genomeBuild);
         // --- end of chromosome chart ---
 

--- a/src/shared/lib/referenceGenomeUtils.tsx
+++ b/src/shared/lib/referenceGenomeUtils.tsx
@@ -18,6 +18,17 @@ export const REFERENCE_GENOME = {
     },
 };
 
+export const GENOME_ID_TO_GENOME_BUILD = {
+    GRCh37: 'GRCh37',
+    '37': 'GRCh37',
+    hg19: 'GRCh37',
+    GRCh38: 'GRCh38',
+    '38': 'GRCh38',
+    hg38: 'GRCh38',
+    GRCm38: 'GRCm38',
+    mm10: 'GRCm38',
+};
+
 export function isMixedReferenceGenome(studies: CancerStudy[]): boolean {
     const isAllStudiesGRCh37 = _.every(studies, study => {
         return isGrch37(study.referenceGenome);


### PR DESCRIPTION
This PR moves logic for translation of reference genome identifier to the `referenceGenomeUtils` class, as well as adds a comment that explains this strategy in the `tracksHelper.ts` class. 