### PR TITLE
Do not fetch structural variants data when there are no applicable samples

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -3177,17 +3177,24 @@ export class ResultsViewPageStore
                 [] as StructuralVariantFilter['sampleMolecularIdentifiers']
             );
 
-            const data = {
-                entrezGeneIds: _.map(
-                    this.genes.result,
-                    (gene: Gene) => gene.entrezGeneId
-                ),
-                sampleMolecularIdentifiers: filters,
-            } as StructuralVariantFilter;
+            // filters can be an empty list
+            // when all selected samples are coming from studies that don't have structural variant profile
+            // in this case, we should not fetch structural variants data
+            if (_.isEmpty(filters)) {
+                return [];
+            } else {
+                const data = {
+                    entrezGeneIds: _.map(
+                        this.genes.result,
+                        (gene: Gene) => gene.entrezGeneId
+                    ),
+                    sampleMolecularIdentifiers: filters,
+                } as StructuralVariantFilter;
 
-            return await client.fetchStructuralVariantsUsingPOST({
-                structuralVariantFilter: data,
-            });
+                return await client.fetchStructuralVariantsUsingPOST({
+                    structuralVariantFilter: data,
+                });
+            }
         },
     });
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8920

**Cause:**
- This happens when you select a study list that contains structural variant profiles, and then you use a custom sample list to select samples from studies that don’t contain structural variant profiles, then our frontend will try to fetch structural variants with an empty sample list. Then we will get an error because we sent an empty sample list.

**Solution:**
- Do not fetch structural variants data when there are no applicable samples

**Test:**
https://deploy-preview-4089--cbioportalfrontend.netlify.app/results?plots_horz_selection=%7B%7D&plots_vert_selection=%7B%7D&plots_coloring_selection=%7B%7D&tab_index=tab_visualize&Action=Submit&session_id=6149d140e6ebe01a6ee32224