### PR TITLE
Use alteration type enum to detect mutation profile

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -388,7 +388,8 @@ export class PatientViewPageStore {
         invoke: async () =>
             findMutationMolecularProfile(
                 this.molecularProfilesInStudy,
-                this.studyId
+                this.studyId,
+                AlterationTypeConstants.MUTATION_EXTENDED
             ),
     });
 

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1079,16 +1079,14 @@ export function isMutationProfile(profile: MolecularProfile): boolean {
 export function findMutationMolecularProfile(
     molecularProfilesInStudy: MobxPromise<MolecularProfile[]>,
     studyId: string,
-    suffix: string = MOLECULAR_PROFILE_MUTATIONS_SUFFIX
+    type: string
 ) {
     if (!molecularProfilesInStudy.result) {
         return undefined;
     }
 
-    const profile = molecularProfilesInStudy.result.find(
-        (p: MolecularProfile) => {
-            return p.molecularProfileId === `${studyId}${suffix}`;
-        }
+    const profile = molecularProfilesInStudy.result!.find(
+        (profile: MolecularProfile) => profile.molecularAlterationType === type
     );
 
     return profile;
@@ -1096,13 +1094,12 @@ export function findMutationMolecularProfile(
 
 export function findUncalledMutationMolecularProfileId(
     molecularProfilesInStudy: MobxPromise<MolecularProfile[]>,
-    studyId: string,
-    suffix: string = MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX
+    studyId: string
 ) {
     const profile = findMutationMolecularProfile(
         molecularProfilesInStudy,
         studyId,
-        suffix
+        AlterationTypeConstants.MUTATION_UNCALLED
     );
     if (profile) {
         return profile.molecularProfileId;


### PR DESCRIPTION
Fixes: https://github.com/cbioportal/cbioportal/issues/9132

We were detecting mutation profile based on text "mutation" in id.  Study had a Fusion profile with mutation in it.  