### PR TITLE
Fix e2e-localdb test for gsva tracks in oncoprint

### DIFF
--- a/end-to-end-test/local/specs/gsva.screenshot.spec.js
+++ b/end-to-end-test/local/specs/gsva.screenshot.spec.js
@@ -76,6 +76,7 @@ describe('gsva feature', () => {
             ).waitForDisplayed();
             $(trackOptionsElts.dropdown_selector + ' li:nth-child(7)').click();
 
+            waitForOncoprint(20000);
             var res = checkOncoprintElement('.oncoprintContainer');
             assertScreenShotMatch(res);
         });


### PR DESCRIPTION
This PR will let the test wait for the transition animation of oncoprint to end before taking the screenshot. This fixes the failing screenshot tests.