### PR TITLE
Fixed the rendering of html inside of the unauthorized message

### DIFF
--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -153,8 +153,7 @@ export default class StudyTagsTooltip extends React.Component<
 > {
     renderTooltip() {
         return (
-            <DefaultTooltip
-                //key={this.props.key}
+            <DefaultTooltip 
                 mouseEnterDelay={this.props.mouseEnterDelay}
                 placement={this.props.placement}
                 overlay={

--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -131,9 +131,9 @@ class StudyInfoOverlay extends React.Component<
                     ) : (
                         <div
                             style={{ maxWidth: 300 }}
-                            dangerouslySetInnerHTML={{
-                                __html: `${message}`,
-                            }}
+                            dangerouslySetInnerHTML={this.addHTMLDescription(
+                                message.toString()
+                            )}
                         />
                     );
                 }
@@ -154,7 +154,7 @@ export default class StudyTagsTooltip extends React.Component<
     renderTooltip() {
         return (
             <DefaultTooltip
-                key={this.props.key}
+                //key={this.props.key}
                 mouseEnterDelay={this.props.mouseEnterDelay}
                 placement={this.props.placement}
                 overlay={


### PR DESCRIPTION
Minor fix for listing unauthorized studies feature.

1. Adding a link to the global message (like skin.home_page.unauthorized_studies_global_message=`<a href="mailto:{$.Owner.email};subject='Access Request'">Request Access</a>`) would not be rendered by windows browser due to additional `` added in the code.

2. In the browser console there is an error about DefaultTooltip not having a key property. I commented this out
![Screenshot from 2021-12-17 15-44-33](https://user-images.githubusercontent.com/53996876/146562947-1f914f3c-bf73-4313-a40d-87ddf99835b6.png)
.