### PR TITLE
Fix handling of Spearman correlation (et al) with NaN value from server

### DIFF
--- a/src/pages/studyView/charts/scatterPlot/StudyViewDensityScatterPlot.tsx
+++ b/src/pages/studyView/charts/scatterPlot/StudyViewDensityScatterPlot.tsx
@@ -493,6 +493,14 @@ export default class StudyViewDensityScatterPlot
                 </text>,
             ];
             let correlationLabels;
+
+            const pearson = _.isNumber(this.props.pearsonCorr)
+                ? this.props.pearsonCorr.toFixed(4)
+                : this.props.pearsonCorr;
+            const spearman = _.isNumber(this.props.spearmanCorr)
+                ? this.props.spearmanCorr.toFixed(4)
+                : this.props.spearmanCorr;
+
             if (this.numSamples > 2) {
                 // otherwise p-values are null
 
@@ -512,7 +520,7 @@ export default class StudyViewDensityScatterPlot
                         y={rectY + rectHeight + 55}
                         dy={'-0.3em'}
                     >
-                        {this.props.pearsonCorr.toFixed(4)}
+                        {pearson}
                     </text>,
                     <text
                         fontSize={10.5}
@@ -538,7 +546,7 @@ export default class StudyViewDensityScatterPlot
                         y={rectY + rectHeight + 115}
                         dy={'-0.3em'}
                     >
-                        {this.props.spearmanCorr.toFixed(4)}
+                        {spearman}
                     </text>,
                     <text
                         fontSize={10.5}


### PR DESCRIPTION
Related to https://github.com/cBioPortal/cbioportal/issues/9148

![image](https://user-images.githubusercontent.com/186521/147950312-eef26630-94f4-484c-a99d-4849c6291a33.png)

Issue comes from this service when you submit only one bin. 

https://www.cbioportal.org/api/clinical-data-density-plot/fetch?xAxisAttributeId=FRACTION_GENOME_ALTERED&xAxisBinCount=44&xAxisEnd=1&xAxisLogScale=false&xAxisStart=0&yAxisAttributeId=MUTATION_COUNT&yAxisBinCount=38&yAxisLogScale=false&yAxisStart=0

Service returns NaN for the correlation values which javascript then barfs on.   This PR will just print NaN instead of white screen so it's improvement.  

There seems to be a problem with selection mechanism wherein if you choose less than four bars, it considers it just a single bar.  Questions are:
A) should service return NaN?
B) should selection UI allow selection of a single bar?  When you drag from within a bar, how should that affect selection?
