### PR TITLE
rewrite e2e xml result to eliminate duplicates reports due to retries

### DIFF
--- a/end-to-end-test/remote/specs/config.spec.js
+++ b/end-to-end-test/remote/specs/config.spec.js
@@ -28,7 +28,7 @@ describe.skip('homepage', function() {
         });
     });
 
-    it('test login observes authenticationMethod config property', function() {
+    it('login ui observes authenticationMethod', function() {
         goToUrlAndSetLocalStorage(CBIOPORTAL_URL);
 
         $('#rightHeaderContent').waitForExist();
@@ -51,7 +51,7 @@ describe.skip('homepage', function() {
         assert.equal($('button=Login').isExisting(), false);
     });
 
-    it('test login observes authenticationMethod config property', function() {
+    it('dataset nav observes authenticationMethod', function() {
         goToUrlAndSetLocalStorage(CBIOPORTAL_URL);
 
         $('#rightHeaderContent').waitForExist();

--- a/end-to-end-test/shared/edit-junit.js
+++ b/end-to-end-test/shared/edit-junit.js
@@ -3,18 +3,6 @@ var fs = require('fs'),
 var _ = require('lodash');
 
 function transformJUNITFiles(dir) {
-    // fs.readdir(dir, function(err, files) {
-    //     if (err) {
-    //         console.log(err);
-    //         return;
-    //     }
-    //     files
-    //         .filter(s => /results.*.xml$/.test(s))
-    //         .forEach(f => {
-    //             tranformFile(`${dir}${f}`);
-    //         });
-    // });
-
     const files = fs.readdirSync(dir).filter(s => /results-.*\.xml$/i.test(s));
 
     console.log(`transforming ${files.length} in results in directory: `, dir);
@@ -31,9 +19,6 @@ function tranformFile(filePath) {
 
     xml2js.parseString(data, function(err, result) {
         if (err) console.log(err);
-
-        // for debugging, save original file
-        //writeToXMLFile(`${filePath}.BK`, data);
 
         getTestCase(result, testcases => {
             const groups = _.groupBy(testcases, t => t.$.name);
@@ -66,46 +51,8 @@ function tranformFile(filePath) {
             }
         });
 
-        console.log(result.testsuites.testsuite[2]); // need to transform tessuides here
-
         writeToXMLFile(filePath, result);
     });
-
-    // fs.readFile(filePath, 'utf-8', function(err, data) {
-    //     if (err) console.log(err);
-    //
-    //     console.log('reading xml', filePath);
-    //
-    //     xml2js.parseString(data, function(err, result) {
-    //         if (err) console.log(err);
-    //
-    //         // for debugging, save original file
-    //         //writeToXMLFile(`${filePath}.BK`, data);
-    //
-    //         getTestCase(result, testcase => {
-    //             const groups = _.groupBy(testcase, t => t.$.name);
-    //
-    //             _.forEach(groups, group => {
-    //                 // if there is more than one test with matching name (retries)
-    //                 // remove all but the last test
-    //                 // which will either be an error or passing
-    //                 if (group.length > 1) {
-    //                     const removed = _.pull(testcase, ...group.slice(0, -1));
-    //                     try {
-    //                         console.log(
-    //                             'Eliminating duplicate test report',
-    //                             removed[0].$.name
-    //                         );
-    //                     } catch (ex) {
-    //                         // silent
-    //                     }
-    //                 }
-    //             });
-    //         });
-    //
-    //         writeToXMLFile(filePath, result);
-    //     });
-    // });
 }
 
 function writeToXMLFile(path, json) {

--- a/end-to-end-test/shared/edit-junit.js
+++ b/end-to-end-test/shared/edit-junit.js
@@ -1,0 +1,135 @@
+var fs = require('fs'),
+    xml2js = require('xml2js');
+var _ = require('lodash');
+
+function transformJUNITFiles(dir) {
+    // fs.readdir(dir, function(err, files) {
+    //     if (err) {
+    //         console.log(err);
+    //         return;
+    //     }
+    //     files
+    //         .filter(s => /results.*.xml$/.test(s))
+    //         .forEach(f => {
+    //             tranformFile(`${dir}${f}`);
+    //         });
+    // });
+
+    const files = fs.readdirSync(dir).filter(s => /results-.*\.xml$/i.test(s));
+
+    console.log(`transforming ${files.length} in results in directory: `, dir);
+
+    files.forEach(f => {
+        tranformFile(`${dir}${f}`);
+    });
+}
+
+function tranformFile(filePath) {
+    console.log('transforming result xml', filePath);
+
+    const data = fs.readFileSync(filePath);
+
+    xml2js.parseString(data, function(err, result) {
+        if (err) console.log(err);
+
+        // for debugging, save original file
+        //writeToXMLFile(`${filePath}.BK`, data);
+
+        getTestCase(result, testcases => {
+            const groups = _.groupBy(testcases, t => t.$.name);
+
+            _.forEach(groups, group => {
+                // if there is more than one test with matching name (retries)
+                // remove all but the last test
+                // which will either be an error or passing
+                if (group.length > 1) {
+                    const removed = _.pull(testcases, ...group.slice(0, -1));
+                    try {
+                        console.log(
+                            'Eliminating duplicate test report',
+                            removed[0].$.name
+                        );
+                    } catch (ex) {
+                        // silent
+                    }
+                }
+            });
+        });
+
+        result.testsuites.testsuite.forEach(testsuite => {
+            if (testsuite.testcase) {
+                testsuite.$.errors = testsuite.testcase
+                    .filter(t => 'error' in t)
+                    .length.toString();
+
+                testsuite.$.tests = testsuite.testcase.length;
+            }
+        });
+
+        console.log(result.testsuites.testsuite[2]); // need to transform tessuides here
+
+        writeToXMLFile(filePath, result);
+    });
+
+    // fs.readFile(filePath, 'utf-8', function(err, data) {
+    //     if (err) console.log(err);
+    //
+    //     console.log('reading xml', filePath);
+    //
+    //     xml2js.parseString(data, function(err, result) {
+    //         if (err) console.log(err);
+    //
+    //         // for debugging, save original file
+    //         //writeToXMLFile(`${filePath}.BK`, data);
+    //
+    //         getTestCase(result, testcase => {
+    //             const groups = _.groupBy(testcase, t => t.$.name);
+    //
+    //             _.forEach(groups, group => {
+    //                 // if there is more than one test with matching name (retries)
+    //                 // remove all but the last test
+    //                 // which will either be an error or passing
+    //                 if (group.length > 1) {
+    //                     const removed = _.pull(testcase, ...group.slice(0, -1));
+    //                     try {
+    //                         console.log(
+    //                             'Eliminating duplicate test report',
+    //                             removed[0].$.name
+    //                         );
+    //                     } catch (ex) {
+    //                         // silent
+    //                     }
+    //                 }
+    //             });
+    //         });
+    //
+    //         writeToXMLFile(filePath, result);
+    //     });
+    // });
+}
+
+function writeToXMLFile(path, json) {
+    // create a new builder object and then convert
+    // our json back to xml.
+    var builder = new xml2js.Builder();
+    var xml = builder.buildObject(json);
+
+    console.log('writing xml', path);
+
+    fs.writeFileSync(path, xml);
+}
+
+function getTestCase(n, callback) {
+    if (_.isObject(n)) {
+        if (n.testcase) {
+            callback(n.testcase);
+        }
+        _.forEach(n, nn => {
+            getTestCase(nn, callback);
+        });
+    }
+}
+
+module.exports = {
+    transformJUNITFiles,
+};

--- a/end-to-end-test/shared/go.js
+++ b/end-to-end-test/shared/go.js
@@ -1,0 +1,3 @@
+const { transformJUNITFiles } = require('./edit-junit');
+
+transformJUNITFiles('./results/');

--- a/package.json
+++ b/package.json
@@ -327,7 +327,8 @@
     "webpack": "^5.55.1",
     "webpack-cli": "^4.8.0",
     "webpack-raphael": "github:DmitryBaranovskiy/raphael#v2.3.0",
-    "word-wrap": "^1.2.3"
+    "word-wrap": "^1.2.3",
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@testing-library/react": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22237,7 +22237,7 @@ save-svg-as-png@^1.4.6:
   resolved "https://registry.yarnpkg.com/save-svg-as-png/-/save-svg-as-png-1.4.11.tgz#b6a8d8c1d616716f0f1eb5fe303ca20badb75eea"
   integrity sha512-NyMPYqdkyP6xX8pYh9rUJq/RmoZL6dlLrDeu9wmiziE9B3Kc1/c7TNCVZRMZa3snUz8M8K28eOSqzoOMKI79wA==
 
-sax@^1.1.4, sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
+sax@>=0.6.0, sax@^1.1.4, sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -25952,6 +25952,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Duplicate test reports due to retries were complicating result interpretation in CircleCI.  This eliminates duplicates, using only the final entry, which will either be a failure or pass.