### PR TITLE
Remove root node fetch in placeArrowBottomLeft

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/defaultTooltip/DefaultTooltip.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/defaultTooltip/DefaultTooltip.tsx
@@ -84,7 +84,5 @@ export function setArrowLeft(tooltipEl: any, left: string) {
 // we need this to account for issue with rc-tooltip when dealing with large tooltip overlay content
 export function placeArrowBottomLeft(tooltipEl: any) {
     const arrowEl = tooltipEl.querySelector('.rc-tooltip-arrow');
-    // @ts-ignore: no-implicit-this
-    const targetEl = this.getRootDomNode(); // eslint-disable-line no-invalid-this
     arrowEl.style.left = '10px';
 }


### PR DESCRIPTION
Cannot locate the `this` reference which causes page goes blank. The targetEl is not used anywhere.

Not sure which recent change causes this issue. Maybe a better solution exists with more knowledge from @onursumer @alisman 

![Jan-11-2022 13-41-37](https://user-images.githubusercontent.com/5400599/149010871-1f54e10a-a9fc-4bed-9441-bb1368c86c6a.gif)

