### PR TITLE
study view - Always show available generic assay add chart tabs regardless of filtering

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -5019,7 +5019,6 @@ export class StudyViewPageStore
                                     ),
                                 };
                             })
-                            .filter(record => record.count > 0)
                             .value();
                     })
                     .value()

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -518,11 +518,12 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 // And one tab can only has one selected profile at a time
                 // selectedGenericAssayProfileIdByType been initialzed at the begining
                 // so we know we can always find a selected profile for each Generic Assay type
-                const molecularProfileIdsInType = options.find(
-                    option =>
-                        option.value ===
-                        this.selectedGenericAssayProfileIdByType.get(type)
-                )!.profileIds;
+                const molecularProfileIdsInType =
+                    options.find(
+                        option =>
+                            option.value ===
+                            this.selectedGenericAssayProfileIdByType.get(type)
+                    )?.profileIds || [];
                 const entities = _.reduce(
                     molecularProfileIdsInType,
                     (set, profileId) => {


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/8969

The study view would crash when, in a study view with multiple studies, some with generic assay data, all the samples with generic assay data were filtered out. This was related to code in the UI for adding generic assay charts, which would hide/show depending on whether the currently filtered samples had generic assay data. This PR does away with the problem by no longer hiding the generic assay add chart UI regardless of the filtered sample state.