### PR TITLE
Fix detection of rna_seq molecular profile

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -1310,7 +1310,11 @@ export class PatientViewPageStore {
         {
             await: () => [this.molecularProfilesInStudy],
             invoke: async () =>
-                findMrnaRankMolecularProfileId(this.molecularProfilesInStudy),
+                findMrnaRankMolecularProfileId(
+                    this.molecularProfilesInStudy.result!.map(
+                        p => p.molecularProfileId
+                    )
+                ),
         },
         null
     );

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -7,6 +7,7 @@ import {
     fetchStudiesForSamplesWithoutCancerTypeClinicalData,
     filterAndAnnotateMolecularData,
     filterAndAnnotateMutations,
+    findMrnaRankMolecularProfileId,
     findSamplesWithoutCancerTypeClinicalData,
     generateMutationIdByEvent,
     generateMutationIdByGeneAndProteinChangeAndEvent,
@@ -1468,6 +1469,49 @@ describe('StoreUtils', () => {
                 getOncoKbOncogenic({ oncogenic: undefined } as any),
                 ''
             );
+        });
+    });
+
+    describe('findMrnaRankMolecularProfileId', () => {
+        it('requires `rna_seq` in profile name', () => {
+            const list = [
+                'ucec_tcga_pub_rppa',
+                'ucec_tcga_pub_rppa_Zscores',
+                'ucec_tcga_pub_gistic',
+                'ucec_tcga_pub_linear_CNA',
+                'ucec_tcga_pub_mutations',
+                'ucec_tcga_pub_methylation_hm27',
+                'ucec_tcga_pub_mrna',
+                'ucec_tcga_pub_mrna_median_Zscores',
+                ',ucec_tcga_pub_mrna_median_all_sample_Zscores',
+                'ucec_tcga_pub_rna_seq_v2_mrna',
+                'ucec_tcga_pub_rna_seq_v2_mrna_median_Zscores',
+                'ucec_tcga_pub_rna_seq_v2_mrna_median_all_sample_Zscores',
+            ];
+
+            assert.equal(
+                findMrnaRankMolecularProfileId(list),
+                'ucec_tcga_pub_rna_seq_v2_mrna_median_Zscores'
+            );
+        });
+
+        it('does not match rppa profiles', () => {
+            const list = [
+                'brca_tcga_pub_rppa',
+                'brca_tcga_pub_rppa_Zscores',
+                'brca_tcga_pub_gistic',
+                'brca_tcga_pub_mrna',
+                'brca_tcga_pub_mrna_median_Zscores',
+                'brca_tcga_pub_linear_CNA',
+                'brca_tcga_pub_methylation_hm27',
+                'brca_tcga_pub_mutations',
+                'brca_tcga_pub_mirna',
+                'brca_tcga_pub_mirna_median_Zscores',
+                'brca_tcga_pub_mrna_merged_median_Zscores',
+                'brca_tcga_pub_mrna_median_all_sample_Zscores',
+            ];
+
+            assert.equal(findMrnaRankMolecularProfileId(list), null);
         });
     });
 });

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1109,33 +1109,16 @@ export function findUncalledMutationMolecularProfileId(
 }
 
 export function findMrnaRankMolecularProfileId(
-    molecularProfilesInStudy: MobxPromise<MolecularProfile[]>
+    molecularProfilesInStudy: string[]
 ) {
-    if (!molecularProfilesInStudy.result) {
-        return null;
-    }
-
-    const regex1 = /^.+rna_seq.*_zscores$/; // We prefer profiles that look like this
-    const regex2 = /^.*_zscores$/; // If none of the above are available, we'll look for ones like this
-    const preferredProfile:
-        | MolecularProfile
-        | undefined = molecularProfilesInStudy.result.find(
-        (gp: MolecularProfile) =>
-            regex1.test(gp.molecularProfileId.toLowerCase())
+    const regex1 = /^.+rna_seq.*_zscores$/i; // We prefer profiles that look like this
+    const preferredProfileId:
+        | string
+        | undefined = molecularProfilesInStudy.find(profileId =>
+        regex1.test(profileId)
     );
 
-    if (preferredProfile) {
-        return preferredProfile.molecularProfileId;
-    } else {
-        const fallbackProfile:
-            | MolecularProfile
-            | undefined = molecularProfilesInStudy.result.find(
-            (gp: MolecularProfile) =>
-                regex2.test(gp.molecularProfileId.toLowerCase())
-        );
-
-        return fallbackProfile ? fallbackProfile.molecularProfileId : null;
-    }
+    return preferredProfileId || null;
 }
 
 export function generateUniqueSampleKeyToTumorTypeMap(


### PR DESCRIPTION
We are submitting an rppa profile to an incompatible service.   We should not fallback to an rppa profile for the default mrna expression column of the patient view

Fixes https://github.com/cbioportal/cbioportal/issues/9140