### PR TITLE
Correct failing CNA e2e-localdb test

### DIFF
--- a/end-to-end-test/local/specs/core/comparison-alterations-tab.spec.js
+++ b/end-to-end-test/local/specs/core/comparison-alterations-tab.spec.js
@@ -54,7 +54,7 @@ describe('comparison alterations tab', function() {
         clickAlterationTypeCheckBox('Mutations');
         submitEnrichmentRequest();
         $('[data-test=LazyMobXTable]').waitForDisplayed();
-        assert.strictEqual(selectUnalteredCount('ACAP3'), '9 (1.17%)');
+        assert.strictEqual(selectUnalteredCount('ACAP3'), '9 (1.16%)');
         clickAlterationTypeCheckBox('Deletion');
         submitEnrichmentRequest();
         $('[data-test=LazyMobXTable]').waitForDisplayed();


### PR DESCRIPTION
Fixes test:
```
Expected values to be strictly equal:
+ actual - expected

+ '9 (1.16%)'
- '9 (1.17%)'
         ^
```