### PR TITLE
Fix issue for unauthorized studies global message

### DIFF
--- a/src/shared/components/query/QueryContainer.tsx
+++ b/src/shared/components/query/QueryContainer.tsx
@@ -24,6 +24,7 @@ import { StudySelectorStats } from 'shared/components/query/StudySelectorStats';
 import $ from 'jquery';
 import { serializeEvent } from 'shared/lib/tracking';
 import { ModifyQueryParams } from 'pages/resultsView/ResultsViewPageStore';
+import { getServerConfig } from 'config/config';
 
 interface QueryContainerProps {
     store: QueryStore;
@@ -202,11 +203,13 @@ export default class QueryContainer extends React.Component<
                         </div>
                     )}
 
-                {this.store.unknownStudyIds.isComplete && (
-                    <UnknownStudiesWarning
-                        ids={this.store.unknownStudyIds.result}
-                    />
-                )}
+                {this.store.unknownStudyIds.isComplete &&
+                    !!getServerConfig()
+                        .skin_home_page_show_unauthorized_studies === false && (
+                        <UnknownStudiesWarning
+                            ids={this.store.unknownStudyIds.result}
+                        />
+                    )}
 
                 {this.store.forDownloadTab && (
                     <div className={'alert alert-danger'} role="alert">

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -65,6 +65,7 @@ import {
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
 import { VirtualStudy } from 'shared/api/session-service/sessionServiceModels';
+import { isQueriedStudyAuthorized } from 'pages/studyView/StudyViewUtils';
 
 // interface for communicating
 export type CancerStudyQueryUrlParams = {
@@ -832,7 +833,9 @@ export class QueryStore {
             let result: { [studyId: string]: string[] } = {};
 
             _.each(this.physicalStudiesSet.result, (study, studyId) => {
-                result[studyId] = [studyId];
+                if (isQueriedStudyAuthorized(study)) {
+                    result[studyId] = [studyId];
+                }
             });
 
             _.each(

--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -58,6 +58,10 @@ export type StudyInfoOverlayTooltipProps = {
     iconType: IconType;
 };
 
+function addHTMLDescription(description: string) {
+    return { __html: description };
+}
+
 @observer
 class StudyInfoOverlay extends React.Component<
     StudyInfoOverlayTooltipProps,
@@ -77,16 +81,12 @@ class StudyInfoOverlay extends React.Component<
         makeObservable(this);
     }
 
-    addHTMLDescription(description: string) {
-        return { __html: description };
-    }
-
     render() {
         let overlay: any = '';
         if (this.props.isVirtualStudy) {
             overlay = (
                 <div
-                    dangerouslySetInnerHTML={this.addHTMLDescription(
+                    dangerouslySetInnerHTML={addHTMLDescription(
                         this.props.studyDescription
                     )}
                 />
@@ -99,7 +99,7 @@ class StudyInfoOverlay extends React.Component<
                     .length;
                 const description = (
                     <div
-                        dangerouslySetInnerHTML={this.addHTMLDescription(
+                        dangerouslySetInnerHTML={addHTMLDescription(
                             this.props.studyDescription
                         )}
                     />
@@ -122,7 +122,8 @@ class StudyInfoOverlay extends React.Component<
                     const message = replaceJsonPathPlaceholders(
                         getServerConfig()
                             .skin_home_page_unauthorized_studies_global_message,
-                        this.studyMetadata.result
+                        this.studyMetadata.result,
+                        this.props.studyId
                     );
 
                     // if the placeholders couldn't be replaced, then show default global message
@@ -131,7 +132,7 @@ class StudyInfoOverlay extends React.Component<
                     ) : (
                         <div
                             style={{ maxWidth: 300 }}
-                            dangerouslySetInnerHTML={this.addHTMLDescription(
+                            dangerouslySetInnerHTML={addHTMLDescription(
                                 message.toString()
                             )}
                         />
@@ -153,7 +154,7 @@ export default class StudyTagsTooltip extends React.Component<
 > {
     renderTooltip() {
         return (
-            <DefaultTooltip 
+            <DefaultTooltip
                 mouseEnterDelay={this.props.mouseEnterDelay}
                 placement={this.props.placement}
                 overlay={
@@ -162,12 +163,13 @@ export default class StudyTagsTooltip extends React.Component<
                         getServerConfig()
                             .skin_home_page_unauthorized_studies_global_message
                     ) === false ? (
-                        <div className={styles.tooltip}>
-                            {
+                        <div
+                            className={styles.tooltip}
+                            dangerouslySetInnerHTML={addHTMLDescription(
                                 getServerConfig()
                                     .skin_home_page_unauthorized_studies_global_message
-                            }
-                        </div>
+                            )}
+                        />
                     ) : (
                         <StudyInfoOverlay
                             studyDescription={this.props.studyDescription}

--- a/src/shared/lib/JsonPathUtils.ts
+++ b/src/shared/lib/JsonPathUtils.ts
@@ -1,25 +1,33 @@
-export function hasJsonPathPlaceholders(message: String) {
+const jp = require('jsonpath');
+
+export function hasJsonPathPlaceholders(message: string) {
     if (message.match(/[{][$][^}]*[}]/g) === null) return false;
     return true;
 }
 
 export function replaceJsonPathPlaceholders(
-    message: String,
-    studyMetadata: any
+    message: string,
+    studyMetadata: any,
+    studyId: string
 ) {
     let placeholders = message.match(/[{][$][^}]*[}]/g);
     let placeholdersReplaced: boolean = true;
     if (placeholders !== null) {
-        let jp = require('jsonpath');
         placeholders.forEach(placeholder => {
-            let placeholderReplaceValue = jp.query(
-                studyMetadata,
-                placeholder.replace(/["'{}]/g, '')
-            );
-            if (placeholderReplaceValue.length === 0)
+            let placeholderReplaceValue = '';
+            if (placeholder === '{$.studyId}') {
+                placeholderReplaceValue = studyId;
+            } else {
+                placeholderReplaceValue = jp.query(
+                    studyMetadata,
+                    placeholder.replace(/["'{}]/g, '')
+                );
+            }
+            if (placeholderReplaceValue.length === 0) {
                 placeholdersReplaced = false;
-            else
+            } else {
                 message = message.replace(placeholder, placeholderReplaceValue);
+            }
         });
     }
     return message;


### PR DESCRIPTION
This PR fixes two problems:
- The SELECT ALL button selected unauthorized studies
- The message for unauthorized studies would not be rendered when there were no study tag placeholders.  

Plus, it allows the use of {$.studyId} placeholder in the global message of unauthorized studies.
