### PR TITLE
Putative Passenger tooltip icon (rebased)

### DIFF
--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -39,7 +39,7 @@ export const TOOLTIP_DIV_CLASS = 'oncoprint__tooltip';
 const tooltipTextElementNaN = 'N/A';
 import './styles.scss';
 import { deriveDisplayTextFromGenericAssayType } from 'pages/resultsView/plots/PlotsTabUtils';
-import { PUTATIVE_DRIVER } from 'shared/lib/StoreUtils';
+import { PUTATIVE_DRIVER, PUTATIVE_PASSENGER } from 'shared/lib/StoreUtils';
 
 function sampleViewAnchorTag(study_id: string, sample_id: string) {
     return `<a class="nobreak" href="${getSampleViewUrl(
@@ -583,6 +583,18 @@ export function makeGeneticTrackTooltip(
                     if (driver_filter && driver_filter === PUTATIVE_DRIVER) {
                         ret.append(
                             `<img src="${customDriverImg}" title="${driver_filter}: ${driver_filter_annotation}" alt="driver filter" style="height:11px; width:11px;margin-left:3px"/>`
+                        );
+                    }
+                    //If we have data for the binary custom driver annotations, append an icon to the tooltip with the annotation information
+                    else if (
+                        driver_filter &&
+                        driver_filter === PUTATIVE_PASSENGER
+                    ) {
+                        ret.append(
+                            `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="height:16px; width:16px; margin-bottom:-2px; margin-right:-2px">
+                                <title>"${driver_filter}: ${driver_filter_annotation}"</title>
+                                <circle cx="10" cy="10" r="5" stroke="#bebebe" stroke-width="2" fill="none"/>
+                            </svg>`
                         );
                     }
                     //If we have data for the class custom driver annotations, append an icon to the tooltip with the annotation information


### PR DESCRIPTION
There is a flash icon for the Putative Driver in the Oncoprint tooltip, but there is no icon for the Putative Passenger. I have added a gray circle icon for it as in the gif below.
![149132057-4b3ab352-dec4-44ce-b034-a0a1e2389432](https://user-images.githubusercontent.com/53996876/150541125-52b8c252-e086-4827-86c8-a285b8059f9b.gif)


Rebased to the new master and changed the img icon to svg circle as below:

Screenshot from 2022-01-17 15-06-42

PR is same as https://github.com/cBioPortal/cbioportal-frontend/pull/4120 but rebased to new master.
