### PR TITLE
Collapse GSVA hierarchy selector on initialization

### DIFF
--- a/end-to-end-test/local/specs/gsva.spec.js
+++ b/end-to-end-test/local/specs/gsva.spec.js
@@ -1,6 +1,8 @@
 var assert = require('assert');
 var goToUrlAndSetLocalStorage = require('../../shared/specUtils')
     .goToUrlAndSetLocalStorage;
+var goToUrlAndSetLocalStorageWithProperty = require('../../shared/specUtils')
+    .goToUrlAndSetLocalStorageWithProperty;
 var waitForStudyQueryPage = require('../../shared/specUtils')
     .waitForStudyQueryPage;
 var waitForGeneQueryPage = require('../../shared/specUtils')
@@ -14,7 +16,6 @@ var getReactSelectOptions = require('../../shared/specUtils')
     .getReactSelectOptions;
 var selectReactSelectOption = require('../../shared/specUtils')
     .selectReactSelectOption;
-var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
 
 var { clickQueryByGeneButton, showGsva } = require('../../shared/specUtils');
 
@@ -179,6 +180,43 @@ describe('gsva feature', function() {
             modal.$('.Select-option=75%').click();
             modal.$('[id=filterButton]').click();
             waitForModalUpdate();
+        });
+
+        describe('skin.geneset_hierarchy.collapse_by_default property', () => {
+            it('collapses tree on init when property set to true', () => {
+                goToUrlAndSetLocalStorageWithProperty(CBIOPORTAL_URL, true, {
+                    skin_geneset_hierarchy_collapse_by_default: true,
+                });
+                showGsva();
+                waitForStudyQueryPage();
+                checkTestStudy();
+                checkGSVAprofile();
+                openGsvaHierarchyDialog();
+                var gsvaEntriesNotShown = $$('*=GO_').length === 0;
+                assert(gsvaEntriesNotShown);
+            });
+            it('expands tree on init when property set to false', () => {
+                goToUrlAndSetLocalStorageWithProperty(CBIOPORTAL_URL, true, {
+                    skin_geneset_hierarchy_collapse_by_default: false,
+                });
+                showGsva();
+                waitForStudyQueryPage();
+                checkTestStudy();
+                checkGSVAprofile();
+                openGsvaHierarchyDialog();
+                var gsvaEntriesShown = $$('*=GO_').length > 0;
+                assert(gsvaEntriesShown);
+            });
+            it('expands tree on init when property not defined', () => {
+                goToUrlAndSetLocalStorage(CBIOPORTAL_URL, true);
+                showGsva();
+                waitForStudyQueryPage();
+                checkTestStudy();
+                checkGSVAprofile();
+                openGsvaHierarchyDialog();
+                var gsvaEntriesShown = $$('*=GO_').length > 0;
+                assert(gsvaEntriesShown);
+            });
         });
     });
 

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -144,6 +144,7 @@ export interface IServerConfig {
     skin_show_gsva: boolean;
     skin_geneset_hierarchy_default_gsva_score: number;
     skin_geneset_hierarchy_default_p_value: number;
+    skin_geneset_hierarchy_collapse_by_default: boolean;
     oncoKbTokenDefined: boolean;
     oncokb_merge_icons_by_default: boolean;
     generic_assay_display_text: string; // this has a default

--- a/src/shared/components/query/GenesetsJsTree.tsx
+++ b/src/shared/components/query/GenesetsJsTree.tsx
@@ -5,13 +5,11 @@ import { getHierarchyData } from 'shared/lib/StoreUtils';
 import 'jstree'; // tslint:disable-line
 import 'shared/components/query/styles/jstree/style.css'; // tslint:disable-line
 import _ from 'lodash';
-import { remoteData } from 'cbioportal-frontend-commons';
-import CBioPortalAPIInternal, {
-    GenesetHierarchyInfo,
-} from 'cbioportal-ts-api-client';
+import { GenesetHierarchyInfo } from 'cbioportal-ts-api-client';
 import { observer } from 'mobx-react';
 import { observable, ObservableMap, makeObservable } from 'mobx';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
+import { getServerConfig } from 'config/config';
 
 export interface GenesetsJsTreeProps {
     initialSelection: string[];
@@ -92,7 +90,8 @@ export default class GenesetsJsTree extends React.Component<
                 },
                 geneset: false,
                 state: {
-                    opened: true,
+                    opened: !getServerConfig()
+                        .skin_geneset_hierarchy_collapse_by_default,
                     selected: false,
                 },
             });


### PR DESCRIPTION
This PR will make the initialization state of the GSVA hierarchy selector tree widget dependent on the _skin.geneset_hierarchy.collapse_by_default_ property.

When this property is _true_ the tree will be collapsed on init: 
![image](https://user-images.githubusercontent.com/745885/151160105-a265a699-85b3-4e04-970e-eab4d4b951df.png)

When this property is _false_ or undefined the tree will be expanded on init: 
![image](https://user-images.githubusercontent.com/745885/151160073-b3c9e907-a977-4e3d-8b47-a6ed36a7025b.png)

# Tests
E2e-localdb tests are included.
