### PR TITLE
Correct use of case list by gene set hierarchy selector component

### DIFF
--- a/src/shared/components/query/GenesetsHierarchySelector.tsx
+++ b/src/shared/components/query/GenesetsHierarchySelector.tsx
@@ -6,11 +6,12 @@ import GenesetsHierarchyFilterForm, {
     validPercentile,
 } from './GenesetsHierarchyFilterForm';
 import { getServerConfig } from 'config/config';
+import { SampleList } from 'cbioportal-ts-api-client';
 
 export interface GenesetsHierarchySelectorProps {
     initialSelection: string[];
     gsvaProfile: string;
-    sampleListId: string | undefined;
+    sampleList: SampleList | undefined;
     onSelect: (map_geneSet_selected: ObservableMap<string, boolean>) => void;
 }
 
@@ -47,6 +48,20 @@ export default class GenesetsHierarchySelector extends React.Component<
     render() {
         return (
             <div>
+                <div style={{ marginBottom: 15 }}>
+                    <text>
+                        Selected sample set:{' '}
+                        <i>
+                            {this.props.sampleList?.name} (
+                            {this.props.sampleList?.sampleCount})
+                        </i>
+                    </text>
+                    <br />
+                    <text>
+                        The outcome of score-based selection depends on the
+                        geneset scores of samples included in the analysis.
+                    </text>
+                </div>
                 <text>Search hierarchy</text>
                 <div
                     className={`form-group has-feedback input-group-sm`}
@@ -79,7 +94,7 @@ export default class GenesetsHierarchySelector extends React.Component<
                     pvalueThreshold={this.pvalueThreshold}
                     percentile={this.percentile}
                     gsvaProfile={this.props.gsvaProfile}
-                    sampleListId={this.props.sampleListId}
+                    sampleListId={this.props.sampleList?.sampleListId}
                     searchValue={this.searchValue}
                     onSelect={this.props.onSelect}
                 />

--- a/src/shared/components/query/GenesetsSelector.tsx
+++ b/src/shared/components/query/GenesetsSelector.tsx
@@ -139,9 +139,7 @@ export default class GenesetsSelector extends QueryStoreComponent<
                                         'GENESET_SCORE'
                                     )[0].molecularProfileId
                                 }
-                                sampleListId={
-                                    this.store.defaultSelectedSampleListId
-                                }
+                                sampleList={this.store.selectedSampleList}
                                 onSelect={map_geneset_selected => {
                                     this.store.applyGenesetSelection(
                                         map_geneset_selected

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -465,6 +465,13 @@ export class QueryStore {
         this._selectedSampleListId = value;
     }
 
+    @computed
+    public get selectedSampleList() {
+        return this.selectedSampleListId
+            ? this.dict_sampleListId_sampleList[this.selectedSampleListId]
+            : undefined;
+    }
+
     @observable caseIds = '';
 
     // this variable is used to set set custom case ids if the query is a shared virtual study query
@@ -1759,7 +1766,7 @@ export class QueryStore {
                 Number(this.volcanoPlotSelectedPercentile.value),
                 0,
                 1,
-                this.defaultSelectedSampleListId
+                this.selectedSampleListId
             );
             return hierarchyData;
         },


### PR DESCRIPTION
# Problem
The selected samples determine the outcome of the score-based geneset selection in the hierarchy selection component. In the present state the component receives the _defaultSelectedSampleList_ to represent the sample collection. This behavior is incorrect since the gene set selection should depend on the sample list that is currently selected on Query Page. In addition, the dependence of geneset score-based selection on sample set is not made clear to the user.

# Solution
This PR will:
- Correct GenesetHierarchySelector to use the currently selected sample list.
- Add a message to the GenesetHierarchySelector to inform the user of the dependence of geneset score-based selection on sample set (see image below)

![image](https://user-images.githubusercontent.com/745885/151378463-c853b4f7-e847-4b7c-89b1-24699426c2d3.png)