### PR TITLE
Generic Assay selection performance improvement

### DIFF
--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -123,6 +123,12 @@ import {
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { getBoxWidth } from 'shared/lib/boxPlotUtils';
 import ScrollWrapper from '../cancerSummary/ScrollWrapper';
+import {
+    DEFAULT_GENERIC_ASSAY_OPTIONS_SHOWING,
+    MenuList,
+    MenuListHeader,
+    doesOptionMatchSearchText,
+} from 'pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection';
 
 enum EventKey {
     horz_logScale,
@@ -314,6 +320,8 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
         string,
         LegendDataWithId
     >({}, { deep: false });
+    @observable _horzGenericAssaySearchText: string = '';
+    @observable _vertGenericAssaySearchText: string = '';
 
     @action.bound
     private onClickLegendItem(ld: LegendDataWithId<any>) {
@@ -3338,18 +3346,54 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                 axisSelection.dataType
             ];
         }
+        let genericAssayOptionsCount: number = 0;
+        let filteredGenericAssayOptionsCount: number = 0;
         if (vertical && this.vertGenericAssayOptions.result) {
             genericAssayOptions =
                 this.makeGenericAssayGroupOptions(
                     this.vertGenericAssayOptions.result,
-                    selectedEntities
+                    selectedEntities,
+                    this._vertGenericAssaySearchText
                 ) || [];
+            // generate statistics for options
+            genericAssayOptionsCount = this.vertGenericAssayOptions.result
+                .length;
+            const selectedOptions = this.vertGenericAssayOptions.result.filter(
+                option => selectedEntities.includes(option.value)
+            );
+            const otherEntities = _.difference(
+                this.vertGenericAssayOptions.result,
+                selectedOptions
+            );
+            filteredGenericAssayOptionsCount = otherEntities.filter(option =>
+                doesOptionMatchSearchText(
+                    this._vertGenericAssaySearchText,
+                    option
+                )
+            ).length;
         } else if (!vertical && this.horzGenericAssayOptions.result) {
             genericAssayOptions =
                 this.makeGenericAssayGroupOptions(
                     this.horzGenericAssayOptions.result,
-                    selectedEntities
+                    selectedEntities,
+                    this._horzGenericAssaySearchText
                 ) || [];
+            // generate statistics for options
+            genericAssayOptionsCount = this.horzGenericAssayOptions.result
+                .length;
+            const selectedOptions = this.horzGenericAssayOptions.result.filter(
+                option => selectedEntities.includes(option.value)
+            );
+            const otherEntities = _.difference(
+                this.horzGenericAssayOptions.result,
+                selectedOptions
+            );
+            filteredGenericAssayOptionsCount = otherEntities.filter(option =>
+                doesOptionMatchSearchText(
+                    this._horzGenericAssaySearchText,
+                    option
+                )
+            ).length;
         }
 
         const axisCategoriesPromise = vertical
@@ -3662,6 +3706,26 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                                                 axisSelection
                                             )
                                         }
+                                        onInputChange={
+                                            vertical
+                                                ? this
+                                                      .onVerticalAxisGenericAssayInputChange
+                                                : this
+                                                      .onHorizontalAxisGenericAssayInputChange
+                                        }
+                                        components={{
+                                            MenuList: MenuList,
+                                            MenuListHeader: (
+                                                <MenuListHeader
+                                                    current={
+                                                        filteredGenericAssayOptionsCount
+                                                    }
+                                                    total={
+                                                        genericAssayOptionsCount
+                                                    }
+                                                />
+                                            ),
+                                        }}
                                     />
                                     {genericAssayDescription && (
                                         <div data-test="generic-assay-info-icon">
@@ -3776,15 +3840,28 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
             value: string;
             label: string;
         }[],
-        selectedEntities: string[]
+        selectedEntities: string[],
+        serchText: string
     ) {
         if (alloptions) {
             const entities = alloptions.filter(option =>
                 selectedEntities.includes(option.value)
             );
             const otherEntities = _.difference(alloptions, entities);
+            let filteredOtherOptions = otherEntities.filter(option =>
+                doesOptionMatchSearchText(serchText, option)
+            );
+            if (
+                filteredOtherOptions.length >
+                DEFAULT_GENERIC_ASSAY_OPTIONS_SHOWING
+            ) {
+                filteredOtherOptions = filteredOtherOptions.slice(
+                    0,
+                    DEFAULT_GENERIC_ASSAY_OPTIONS_SHOWING
+                );
+            }
             if (entities.length === 0) {
-                return alloptions;
+                return filteredOtherOptions;
             } else {
                 return [
                     {
@@ -3793,12 +3870,36 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                     },
                     {
                         label: 'Other entities',
-                        options: otherEntities,
+                        options: filteredOtherOptions,
                     },
                 ];
             }
         } else {
             return undefined;
+        }
+    }
+
+    @action.bound
+    private onVerticalAxisGenericAssayInputChange(
+        input: string,
+        inputInfo: any
+    ) {
+        if (inputInfo.action === 'input-change') {
+            this._vertGenericAssaySearchText = input;
+        } else if (inputInfo.action !== 'set-value') {
+            this._vertGenericAssaySearchText = '';
+        }
+    }
+
+    @action.bound
+    private onHorizontalAxisGenericAssayInputChange(
+        input: string,
+        inputInfo: any
+    ) {
+        if (inputInfo.action === 'input-change') {
+            this._horzGenericAssaySearchText = input;
+        } else if (inputInfo.action !== 'set-value') {
+            this._horzGenericAssaySearchText = '';
         }
     }
 

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -524,20 +524,21 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                             option.value ===
                             this.selectedGenericAssayProfileIdByType.get(type)
                     )?.profileIds || [];
-                const entities = _.reduce(
-                    molecularProfileIdsInType,
-                    (set, profileId) => {
+
+                const entitityMap = molecularProfileIdsInType.reduce(
+                    (acc, profileId) => {
                         this.props.store.genericAssayEntitiesGroupedByProfileId.result![
                             profileId
-                        ].forEach(set.add, set);
-                        return set;
+                        ].forEach(meta => {
+                            acc[meta.stableId] = meta;
+                        });
+                        return acc;
                     },
-                    new Set<GenericAssayMeta>()
+                    {} as { [stableId: string]: GenericAssayMeta }
                 );
 
-                const genericAssayEntityOptions = _.map(
-                    Array.from(entities),
-                    entity => makeGenericAssayOption(entity, false)
+                const genericAssayEntityOptions = _.map(entitityMap, entity =>
+                    makeGenericAssayOption(entity, false)
                 );
 
                 const shouldShowChartOptionTable =

--- a/src/pages/studyView/addChartButton/genericAssaySelection/styles.module.scss
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/styles.module.scss
@@ -1,0 +1,6 @@
+.menuHeader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0px 12px;
+}

--- a/src/pages/studyView/addChartButton/genericAssaySelection/styles.module.scss.d.ts
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/styles.module.scss.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly "menuHeader": string;
+};
+export = styles;
+


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9155
Fix two issues in https://github.com/cBioPortal/cbioportal/issues/9253

Changes in this pr:
- Show 100 options for Generic Assay Selection
- Show warning in menu header
- Fix study view option duplication issue

[study view testing link 
](https://deploy-preview-4166--cbioportalfrontend.netlify.app/study/summary?id=laml_tcga_pan_can_atlas_2018%2Cacc_tcga_pan_can_atlas_2018%2Cblca_tcga_pan_can_atlas_2018%2Clgg_tcga_pan_can_atlas_2018%2Cbrca_tcga_pan_can_atlas_2018%2Ccesc_tcga_pan_can_atlas_2018%2Cchol_tcga_pan_can_atlas_2018%2Ccoadread_tcga_pan_can_atlas_2018%2Cdlbc_tcga_pan_can_atlas_2018%2Cesca_tcga_pan_can_atlas_2018%2Cgbm_tcga_pan_can_atlas_2018%2Chnsc_tcga_pan_can_atlas_2018%2Ckich_tcga_pan_can_atlas_2018%2Ckirc_tcga_pan_can_atlas_2018%2Ckirp_tcga_pan_can_atlas_2018%2Clihc_tcga_pan_can_atlas_2018%2Cluad_tcga_pan_can_atlas_2018%2Clusc_tcga_pan_can_atlas_2018%2Cmeso_tcga_pan_can_atlas_2018%2Cov_tcga_pan_can_atlas_2018%2Cpaad_tcga_pan_can_atlas_2018%2Cpcpg_tcga_pan_can_atlas_2018%2Cprad_tcga_pan_can_atlas_2018%2Csarc_tcga_pan_can_atlas_2018%2Cskcm_tcga_pan_can_atlas_2018%2Cstad_tcga_pan_can_atlas_2018%2Ctgct_tcga_pan_can_atlas_2018%2Cthym_tcga_pan_can_atlas_2018%2Cthca_tcga_pan_can_atlas_2018%2Cucs_tcga_pan_can_atlas_2018%2Cucec_tcga_pan_can_atlas_2018%2Cuvm_tcga_pan_can_atlas_2018)
![image](https://user-images.githubusercontent.com/15748980/152581442-bc1cf88d-f92e-4757-83b8-8d4f4480af36.png)

[plots tab testing link](https://deploy-preview-4166--cbioportalfrontend.netlify.app/results/plots?cancer_study_list=laml_tcga_pan_can_atlas_2018%2Cacc_tcga_pan_can_atlas_2018%2Cblca_tcga_pan_can_atlas_2018%2Clgg_tcga_pan_can_atlas_2018%2Cbrca_tcga_pan_can_atlas_2018%2Ccesc_tcga_pan_can_atlas_2018%2Cchol_tcga_pan_can_atlas_2018%2Ccoadread_tcga_pan_can_atlas_2018%2Cdlbc_tcga_pan_can_atlas_2018%2Cesca_tcga_pan_can_atlas_2018%2Cgbm_tcga_pan_can_atlas_2018%2Chnsc_tcga_pan_can_atlas_2018%2Ckich_tcga_pan_can_atlas_2018%2Ckirc_tcga_pan_can_atlas_2018%2Ckirp_tcga_pan_can_atlas_2018%2Clihc_tcga_pan_can_atlas_2018%2Cluad_tcga_pan_can_atlas_2018%2Clusc_tcga_pan_can_atlas_2018%2Cmeso_tcga_pan_can_atlas_2018%2Cov_tcga_pan_can_atlas_2018%2Cpaad_tcga_pan_can_atlas_2018%2Cpcpg_tcga_pan_can_atlas_2018%2Cprad_tcga_pan_can_atlas_2018%2Csarc_tcga_pan_can_atlas_2018%2Cskcm_tcga_pan_can_atlas_2018%2Cstad_tcga_pan_can_atlas_2018%2Ctgct_tcga_pan_can_atlas_2018%2Cthym_tcga_pan_can_atlas_2018%2Cthca_tcga_pan_can_atlas_2018%2Cucs_tcga_pan_can_atlas_2018%2Cucec_tcga_pan_can_atlas_2018%2Cuvm_tcga_pan_can_atlas_2018&tab_index=tab_visualize&profileFilter=mutations%2Cgistic%2Cfusion&case_set_id=all&Action=Submit&gene_list=EGFR&plots_horz_selection=%7B%22dataType%22%3A%22PHOSPHOSITE_QUANTIFICATION%22%2C%22selectedGenericAssayOption%22%3A%22ACADVL_pS522%22%7D&plots_vert_selection=%7B%22selectedGeneOption%22%3A1956%2C%22selectedGenericAssayOption%22%3A%2211p_status%22%2C%22dataType%22%3A%22ARMLEVEL_CNA%22%7D&plots_coloring_selection=%7B%7D)
![image](https://user-images.githubusercontent.com/15748980/152580740-909c41d8-3db9-4ddf-9fd1-6e2f37d2a457.png)

[oncoprintt testing link](https://deploy-preview-4166--cbioportalfrontend.netlify.app/results/oncoprint?cancer_study_list=ucec_tcga_pan_can_atlas_2018&tab_index=tab_visualize&case_set_id=ucec_tcga_pan_can_atlas_2018_all&Action=Submit&gene_list=TP53&plots_horz_selection=%7B%22dataType%22%3A%22MICROBIOME_SIGNATURE%22%7D&plots_vert_selection=%7B%22selectedGeneOption%22%3A7157%7D&plots_coloring_selection=%7B%7D)
![image](https://user-images.githubusercontent.com/15748980/152581327-3f46c6fd-526a-431e-a03d-2eb35df7454e.png)

