### PR TITLE
Fix use of study tags in unauthorized study message

### DIFF
--- a/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
+++ b/src/shared/components/studyTagsTooltip/StudyTagsTooltip.tsx
@@ -32,8 +32,10 @@ import Loader from '../loadingIndicator/LoadingIndicator';
 import styles from 'pages/studyView/styles.module.scss';
 import ServerConfigDefaults from 'config/serverConfigDefaults';
 import { getServerConfig } from 'config/config';
-import { hasJsonPathPlaceholders } from 'shared/lib/JsonPathUtils';
-import { replaceJsonPathPlaceholders } from 'shared/lib/JsonPathUtils';
+import {
+    hasJsonPathPlaceholders,
+    replaceJsonPathPlaceholders,
+} from 'shared/lib/JsonPathUtils';
 
 export enum IconType {
     INFO_ICON,
@@ -58,6 +60,10 @@ export type StudyInfoOverlayTooltipProps = {
     iconType: IconType;
 };
 
+function addHTMLDescription(description: string) {
+    return { __html: description };
+}
+
 @observer
 class StudyInfoOverlay extends React.Component<
     StudyInfoOverlayTooltipProps,
@@ -77,16 +83,12 @@ class StudyInfoOverlay extends React.Component<
         makeObservable(this);
     }
 
-    addHTMLDescription(description: string) {
-        return { __html: description };
-    }
-
     render() {
         let overlay: any = '';
         if (this.props.isVirtualStudy) {
             overlay = (
                 <div
-                    dangerouslySetInnerHTML={this.addHTMLDescription(
+                    dangerouslySetInnerHTML={addHTMLDescription(
                         this.props.studyDescription
                     )}
                 />
@@ -99,7 +101,7 @@ class StudyInfoOverlay extends React.Component<
                     .length;
                 const description = (
                     <div
-                        dangerouslySetInnerHTML={this.addHTMLDescription(
+                        dangerouslySetInnerHTML={addHTMLDescription(
                             this.props.studyDescription
                         )}
                     />
@@ -122,7 +124,8 @@ class StudyInfoOverlay extends React.Component<
                     const message = replaceJsonPathPlaceholders(
                         getServerConfig()
                             .skin_home_page_unauthorized_studies_global_message,
-                        this.studyMetadata.result
+                        this.studyMetadata.result,
+                        this.props.studyId
                     );
 
                     // if the placeholders couldn't be replaced, then show default global message
@@ -131,7 +134,7 @@ class StudyInfoOverlay extends React.Component<
                     ) : (
                         <div
                             style={{ maxWidth: 300 }}
-                            dangerouslySetInnerHTML={this.addHTMLDescription(
+                            dangerouslySetInnerHTML={addHTMLDescription(
                                 message.toString()
                             )}
                         />
@@ -153,21 +156,22 @@ export default class StudyTagsTooltip extends React.Component<
 > {
     renderTooltip() {
         return (
-            <DefaultTooltip 
+            <DefaultTooltip
                 mouseEnterDelay={this.props.mouseEnterDelay}
                 placement={this.props.placement}
                 overlay={
                     this.props.iconType === IconType.LOCK_ICON &&
-                    hasJsonPathPlaceholders(
+                    !hasJsonPathPlaceholders(
                         getServerConfig()
                             .skin_home_page_unauthorized_studies_global_message
-                    ) === false ? (
-                        <div className={styles.tooltip}>
-                            {
+                    ) ? (
+                        <div
+                            className={styles.tooltip}
+                            dangerouslySetInnerHTML={addHTMLDescription(
                                 getServerConfig()
                                     .skin_home_page_unauthorized_studies_global_message
-                            }
-                        </div>
+                            )}
+                        />
                     ) : (
                         <StudyInfoOverlay
                             studyDescription={this.props.studyDescription}

--- a/src/shared/lib/JsonPathUtils.ts
+++ b/src/shared/lib/JsonPathUtils.ts
@@ -1,25 +1,31 @@
-export function hasJsonPathPlaceholders(message: String) {
-    if (message.match(/[{][$][^}]*[}]/g) === null) return false;
-    return true;
+const jp = require('jsonpath');
+
+const placeHolderRegex = /[{][$][^}]*[}]/g;
+
+export function hasJsonPathPlaceholders(message: string): boolean {
+    return message.match(placeHolderRegex) !== null;
 }
 
 export function replaceJsonPathPlaceholders(
-    message: String,
-    studyMetadata: any
+    message: string,
+    studyMetadata: any,
+    studyId: string
 ) {
-    let placeholders = message.match(/[{][$][^}]*[}]/g);
-    let placeholdersReplaced: boolean = true;
+    let placeholders = message.match(placeHolderRegex);
     if (placeholders !== null) {
-        let jp = require('jsonpath');
         placeholders.forEach(placeholder => {
-            let placeholderReplaceValue = jp.query(
-                studyMetadata,
-                placeholder.replace(/["'{}]/g, '')
-            );
-            if (placeholderReplaceValue.length === 0)
-                placeholdersReplaced = false;
-            else
+            let placeholderReplaceValue;
+            if (placeholder === '{$.studyId}') {
+                placeholderReplaceValue = studyId;
+            } else {
+                placeholderReplaceValue = jp.query(
+                    studyMetadata,
+                    placeholder.replace(/["'{}]/g, '')
+                );
+            }
+            if (placeholderReplaceValue.length > 0) {
                 message = message.replace(placeholder, placeholderReplaceValue);
+            }
         });
     }
     return message;


### PR DESCRIPTION
This PR fixes the message for unauthorized studies not rendered when there were no study tag placeholders. Alos, it allows the use of {$.studyId} placeholder in the global message of unauthorized studies.
