### PR TITLE
Prevent auto publish from failing when yarn.lock is different

### DIFF
--- a/scripts/update_package_version.sh
+++ b/scripts/update_package_version.sh
@@ -15,6 +15,10 @@ if [[ "$GITHUB_RUN_ID" ]]; then
   git config --local user.name "Lerna Publish Bot"
   git config --global github.token $GITHUB_TOKEN
 
+  # this is a workaround to ignore a possible mismatching yarn.lock file
+  # see https://github.com/lerna/lerna/issues/1994
+  git stash
+
   # by default just bump to the next patch
   # so this will, for example, bump 1.0.0 to 1.0.1, 1.0.0-alpha.2 to 1.0.0, 0.1.1-beta.0 to 0.1.1, etc.
   lerna version patch --yes


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9303

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!