### PR TITLE
Use variant class as well when generating the OncoKB query id

### DIFF
--- a/packages/cbioportal-utils/src/oncokb/OncoKbUtils.ts
+++ b/packages/cbioportal-utils/src/oncokb/OncoKbUtils.ts
@@ -79,9 +79,10 @@ export function generateQueryVariant(
 export function generateQueryStructuralVariantId(
     site1EntrezGeneId: number,
     site2EntrezGeneId: number | undefined,
-    tumorType: string | null
+    tumorType: string | null,
+    structuralVariantType: keyof typeof StructuralVariantType
 ): string {
-    let id = `${site1EntrezGeneId}_${site2EntrezGeneId}`;
+    let id = `${site1EntrezGeneId}_${site2EntrezGeneId}_${structuralVariantType}`;
     if (tumorType) {
         id = `${id}_${tumorType}`;
     }
@@ -267,7 +268,8 @@ export function generateAnnotateStructuralVariantQueryFromGenes(
         id: generateQueryStructuralVariantId(
             site1EntrezGeneId,
             site2EntrezGeneId,
-            tumorType
+            tumorType,
+            structuralVariantType
         ),
         geneA: {
             entrezGeneId: site1EntrezGeneId,

--- a/src/pages/patientView/structuralVariant/column/AnnotationColumnFormatter.tsx
+++ b/src/pages/patientView/structuralVariant/column/AnnotationColumnFormatter.tsx
@@ -165,7 +165,8 @@ export default class AnnotationColumnFormatter {
             structuralVariantData[0].site2EntrezGeneId,
             uniqueSampleKeyToTumorType![
                 structuralVariantData[0].uniqueSampleKey
-            ]
+            ],
+            structuralVariantData[0].variantClass.toUpperCase() as any
         );
 
         if (oncoKbData.indicatorMap[id]) {

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -5365,7 +5365,8 @@ export class ResultsViewPageStore
                             cancerTypeForOncoKb(
                                 structuralVariant.uniqueSampleKey,
                                 {}
-                            )
+                            ),
+                            structuralVariant.variantClass.toUpperCase() as any
                         );
                         return structuralVariantOncoKbDataForOncoprint.indicatorMap![
                             id


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9309

This is a workaround. We may still end up with duplicate ids for other cases when the site 2 gene id is missing.

<img width="1237" alt="Archer_fusions_annotated" src="https://user-images.githubusercontent.com/3604198/156605520-1f2d0788-9402-4f40-bf65-a64bf345ba33.png">
