### PR TITLE
Fix gene edit pencil feature for combined study queries

### DIFF
--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -173,16 +173,25 @@ export default class QuerySummary extends React.Component<
                     </h3>
                     <span>
                         Querying {this.studyPageFilteredCasesLink} in{' '}
-                        {this.props.store.queriedStudies.result.length} studies
-                        &nbsp;-&nbsp;
-                        {getGeneSummary(this.props.store.hugoGeneSymbols)}
-                        &nbsp;
+                        {this.props.store.queriedStudies.result.length}{' '}
+                        studies&nbsp;
                         <DefaultTooltip
                             placement="bottom"
                             overlay={this.studyList}
                             destroyTooltipOnHide={true}
                         >
                             <i className="fa fa-info-circle" />
+                        </DefaultTooltip>
+                        &nbsp;
+                        {getGeneSummary(this.props.store.hugoGeneSymbols)}
+                        &nbsp;
+                        <DefaultTooltip overlay={'Edit genes or OQL'}>
+                            <a
+                                data-test="oqlQuickEditButton"
+                                onClick={this.props.onToggleOQLEditUIVisibility}
+                            >
+                                <i className={'fa fa-pencil'}></i>
+                            </a>
                         </DefaultTooltip>
                     </span>
                 </div>


### PR DESCRIPTION
The quick gene edit was not available for combined study requests.  
![image](https://user-images.githubusercontent.com/186521/157966652-94db59e2-9ad0-4a66-964d-ee9ceff0e292.png)
