### PR TITLE
Skip flakey custom tab async test

### DIFF
--- a/end-to-end-test/remote/specs/core/customTabs.spec.js
+++ b/end-to-end-test/remote/specs/core/customTabs.spec.js
@@ -45,7 +45,7 @@ function goToUrlWithCustomTabConfig(url, custom_tabs) {
 
 function runTests(pageName, url, tabLocation) {
     describe(`${pageName} Custom Tabs`, () => {
-        it('Sync and async hide/show works', function() {
+        it.skip('Sync and async hide/show works', function() {
             this.retries(0);
 
             goToUrlWithCustomTabConfig(url, customTabBase(tabLocation));


### PR DESCRIPTION
This test is mysteriously flakey though it passes reliably locally