### PR TITLE
Returns a empty list when Structural Variant filter set is empty

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -5805,12 +5805,16 @@ export class ResultsViewPageStore
                 [] as StructuralVariantFilter['sampleMolecularIdentifiers']
             );
 
-            return client.fetchStructuralVariantsUsingPOST({
-                structuralVariantFilter: {
-                    entrezGeneIds: [q.entrezGeneId],
-                    sampleMolecularIdentifiers: filters,
-                } as StructuralVariantFilter,
-            });
+            if (_.isEmpty(filters)) {
+                return [];
+            } else {
+                return client.fetchStructuralVariantsUsingPOST({
+                    structuralVariantFilter: {
+                        entrezGeneIds: [q.entrezGeneId],
+                        sampleMolecularIdentifiers: filters,
+                    } as StructuralVariantFilter,
+                });
+            }
         },
     }));
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9348

We should return an empty list when Structural Variant filter set is empty, because if not doing that the backend will complain about sending empty filters to it.