### PR TITLE
Timeline: fix y position of stack in context of linechart

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
@@ -56,12 +56,12 @@ export function groupEventsByPosition(events: TimelineEvent[]) {
     });
 }
 
-export function renderSuperscript(number: number) {
+export function renderSuperscript(number: number, y: number = 0) {
     return (
-        <g transform={'translate(3 -8)'}>
+        <g transform={'translate(3 -18)'}>
             <text
                 x={1}
-                y={0}
+                y={y}
                 dy={'1em'}
                 className="noselect"
                 style={{
@@ -177,8 +177,8 @@ export function renderPoint(
         if (events.length > 1) {
             contents = (
                 <>
-                    {renderSuperscript(events.length)}
-                    {renderStack(events.map(eventColorGetter))}
+                    {renderSuperscript(events.length, y)}
+                    {renderStack(events.map(eventColorGetter), y)}
                 </>
             );
         } else {

--- a/packages/cbioportal-clinical-timeline/src/svg/renderStack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/svg/renderStack.tsx
@@ -60,6 +60,6 @@ function renderCustomStack(width:number, y:number, fills:string[]) {
     }
 }
 
-export function renderStack(fills:string[]) {
-    return renderCustomStack(9, TIMELINE_TRACK_HEIGHT/2, fills);
+export function renderStack(fills:string[], y?:number) {
+    return renderCustomStack(9, y || TIMELINE_TRACK_HEIGHT/2, fills);
 }


### PR DESCRIPTION
When two+ events on same day, timeline wasn't positioning stack correctly in line chart track

Fixed:
![image](https://user-images.githubusercontent.com/186521/166831430-19f1b363-b035-4dd9-95c2-74ed1502479c.png)

Old:
![image](https://user-images.githubusercontent.com/186521/166831483-2e03f2eb-dc5f-43e5-8a0e-6dddaaf8a465.png)

