### PR TITLE
Hide Download Controls

### DIFF
--- a/end-to-end-test/local/specs/hide-download-controls.spec.js
+++ b/end-to-end-test/local/specs/hide-download-controls.spec.js
@@ -1,0 +1,645 @@
+var assert = require('assert');
+var goToUrlAndSetLocalStorage = require('../../shared/specUtils')
+    .goToUrlAndSetLocalStorage;
+var waitForStudyQueryPage = require('../../shared/specUtils')
+    .waitForStudyQueryPage;
+var waitForOncoprint = require('../../shared/specUtils').waitForOncoprint;
+var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
+var waitForPatientView = require('../../shared/specUtils').waitForPatientView;
+var waitForStudyView = require('../../shared/specUtils').waitForStudyView;
+var studyViewChartHoverHamburgerIcon = require('../../shared/specUtils')
+    .studyViewChartHoverHamburgerIcon;
+var setServerConfiguration = require('../../shared/specUtils')
+    .setServerConfiguration;
+var openGroupComparison = require('../../shared/specUtils').openGroupComparison;
+var waitForNetworkQuiet = require('../../shared/specUtils').waitForNetworkQuiet;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+
+const downloadIcon = '.fa-download';
+const downloadCloudIcon = '.fa-cloud-download';
+const clipboardIcon = '.fa-clipboard';
+
+describe('hide download controls feature', function() {
+    if (useExternalFrontend) {
+        describe('study query page', () => {
+            const expectedTabNames = ['Query'];
+
+            before(() => {
+                openAndSetProperty(CBIOPORTAL_URL, {
+                    skin_hide_download_controls: true,
+                });
+                // browser.debug();
+                waitForStudyQueryPage();
+                waitForTabs(expectedTabNames.length);
+            });
+
+            it('covers all tabs with download control tests', () => {
+                const observedTabNames = $$('.tabAnchor')
+                    .filter(a => a.isVisible())
+                    .map(a => a.getText());
+                assert.deepStrictEqual(
+                    expectedTabNames,
+                    observedTabNames,
+                    'There appears to be a new tab on the page (observed names: [' +
+                        observedTabNames.join(', ') +
+                        '] expected names: [' +
+                        expectedTabNames.join(', ') +
+                        ']). Please make sure to hide download controls depending on the "skin_hide_download_controls" property and include' +
+                        ' tests for this in hide-download-controls.spec.js.'
+                );
+            });
+
+            it('global check for icon and occurrence of "Download" as a word', () => {
+                globalCheck();
+            });
+
+            it('does not show Download tab', () => {
+                assert(!$('.tabAnchor_download').isExisting());
+            });
+
+            it('does not show download icons data sets in study rows', () => {
+                goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}/datasets`, true);
+                $('[data-test=LazyMobXTable]').waitForExist();
+                assert(!$(downloadIcon).isExisting());
+            });
+        });
+
+        describe('results view page', () => {
+            const expectedTabNames = [
+                'OncoPrint',
+                'Cancer Types Summary',
+                'Mutual Exclusivity',
+                'Plots',
+                'Mutations',
+                'Co-expression',
+                'Comparison/Survival',
+                'CN Segments',
+                'Pathways',
+            ];
+            before(() => {
+                openAndSetProperty(
+                    `${CBIOPORTAL_URL}/results/oncoprint?genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&cancer_study_list=study_es_0&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=mutations%2Cfusion%2Cgistic&case_set_id=study_es_0_cnaseq&gene_list=CREB3L1%2520RPS11%2520PNMA1%2520MMP2%2520ZHX3%2520ERCC5%2520TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit&comparison_subtab=mrna`,
+                    { skin_hide_download_controls: true }
+                );
+                waitForOncoprint();
+                waitForTabs(expectedTabNames.length);
+            });
+
+            it('covers all tabs with download control tests', () => {
+                const observedTabNames = $$('.tabAnchor')
+                    .filter(a => a.isVisible())
+                    .map(a => a.getText());
+                assert.deepStrictEqual(
+                    expectedTabNames,
+                    observedTabNames,
+                    'There appears to be a new tab on the page (observed names: [' +
+                        observedTabNames.join(', ') +
+                        '] expected names: [' +
+                        expectedTabNames.join(', ') +
+                        ']). Please make sure to hide download controls depending on the "skin_hide_download_controls" property and include' +
+                        ' tests for this in hide-download-controls.spec.js.'
+                );
+            });
+
+            describe('oncoprint', () => {
+                it('does not show download/clipboard icons and does not contain the word "Download"', () => {
+                    globalCheck();
+                });
+            });
+
+            describe('cancer type summary', () => {
+                it('does not show download/clipboard icons and does not contain the word "Download"', () => {
+                    $('.tabAnchor_cancerTypesSummary').click();
+                    $('[data-test=cancerTypeSummaryChart]').waitForExist();
+                    globalCheck();
+                });
+            });
+
+            describe('mutual exclusivity', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_mutualExclusivity').click();
+                    $('[data-test=LazyMobXTable]').waitForExist();
+                    globalCheck();
+                });
+            });
+
+            describe('plots', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_plots').click();
+                    $('=mRNA vs mut type').waitForExist();
+                    $('=mRNA vs mut type').click();
+                    $('[data-test=PlotsTabPlotDiv]').waitForExist();
+                    globalCheck();
+                });
+            });
+
+            describe('mutations', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_mutations').click();
+                    $('[data-test=LollipopPlot]').waitForExist();
+                    $('.tabAnchor_TP53').click();
+                    $('[data-test=LollipopPlot]').waitForExist();
+                    globalCheck();
+                    // $('[data-test=view3DStructure]').click();
+                    // $('.borderedChart canvas').waitForExist();
+                    // globalCheck();
+                });
+            });
+
+            describe('co-expression', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_coexpression').click();
+                    $('#coexpression-plot-svg').waitForExist();
+                    globalCheck();
+                });
+            });
+
+            describe('comparison/survival', () => {
+                before(() => {
+                    $('.tabAnchor_comparison').click();
+                });
+                it('covers all tabs with download control tests', () => {
+                    $('.tabAnchor_overlap').waitForExist();
+                    const expectedTabNames = [
+                        'Overlap',
+                        'Survival',
+                        'Clinical',
+                        'Genomic Alterations',
+                        'mRNA',
+                        'DNA Methylation',
+                        'Treatment Response',
+                        'Mutational Signature',
+                    ];
+                    const observedTabNames = $$(
+                        '[data-test=ComparisonTabDiv] .tabAnchor'
+                    )
+                        .filter(a => a.isVisible())
+                        .map(a => a.getText());
+                    assert.deepStrictEqual(
+                        expectedTabNames,
+                        observedTabNames,
+                        'There appears to be a new tab on the page (observed names: [' +
+                            observedTabNames.join(', ') +
+                            '] expected names: [' +
+                            expectedTabNames.join(', ') +
+                            ']). Please make sure to hide download controls depending on the "skin_hide_download_controls" property and include' +
+                            ' tests for this in hide-download-controls.spec.js.'
+                    );
+                });
+                describe('overlap tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $('.tabAnchor_overlap').click();
+                        $(
+                            '[data-test=ComparisonPageOverlapTabContent]'
+                        ).waitForExist();
+                        globalCheck();
+                    });
+                });
+                describe('survival tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $('.tabAnchor_survival').click();
+                        $('[data-test=SurvivalChart]').waitForExist();
+                        globalCheck();
+                    });
+                });
+                describe('clinical tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $('.tabAnchor_clinical').click();
+                        $('[data-test=ClinicalTabPlotDiv]').waitForExist();
+                        globalCheck();
+                    });
+                });
+                describe('alterations tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $('.tabAnchor_alterations').click();
+                        $('[data-test=LazyMobXTable]').waitForExist();
+                        globalCheck();
+                    });
+                });
+                describe('mrna tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $('.tabAnchor_mrna').click();
+                        $(
+                            '[data-test=GroupComparisonMRNAEnrichments]'
+                        ).waitForExist();
+                        $$(
+                            '[data-test=GroupComparisonMRNAEnrichments] tbody tr b'
+                        )[0].click();
+                        $('[data-test=MiniBoxPlot]').waitForExist();
+                        globalCheck();
+                    });
+                });
+                describe('dna_methylation tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $('.tabAnchor_dna_methylation').click();
+                        $(
+                            '[data-test=GroupComparisonMethylationEnrichments]'
+                        ).waitForExist();
+                        $$(
+                            '[data-test=GroupComparisonMethylationEnrichments] tbody tr b'
+                        )[0].click();
+                        $('[data-test=MiniBoxPlot]').waitForExist();
+                        globalCheck();
+                    });
+                });
+                describe('treatment response tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $(
+                            '.tabAnchor_generic_assay_treatment_response'
+                        ).click();
+                        $(
+                            '[data-test=GroupComparisonGenericAssayEnrichments]'
+                        ).waitForExist();
+                        $$(
+                            '[data-test=GroupComparisonGenericAssayEnrichments] tbody tr b'
+                        )[0].click();
+                        $('[data-test=MiniBoxPlot]').waitForExist();
+                        globalCheck();
+                    });
+                });
+                describe('mutational signature tab', () => {
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        $(
+                            '.tabAnchor_generic_assay_mutational_signature'
+                        ).click();
+                        $(
+                            '[data-test=GroupComparisonGenericAssayEnrichments]'
+                        ).waitForExist();
+                        $$(
+                            '[data-test=GroupComparisonGenericAssayEnrichments] tbody tr b'
+                        )[1].click(); // first row is invisible treatment response 'Name of 17-AAG'
+                        $('[data-test=MiniBoxPlot]').waitForExist();
+                        globalCheck();
+                    });
+                });
+
+                describe('CN segments', () => {
+                    before(() => {
+                        $('.tabAnchor_cnSegments').click();
+                        $('.igvContainer').waitForExist();
+                    });
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        globalCheck();
+                    });
+                });
+
+                describe('pathways', () => {
+                    before(() => {
+                        $('.tabAnchor_pathways').click();
+                        $('.pathwayMapper').waitForExist();
+                    });
+                    it('global check for icon and occurrence of "Download" as a word', () => {
+                        globalCheck();
+                    });
+                });
+
+                it('does not show Download tab', () => {
+                    assert(!$('.tabAnchor_download').isExisting());
+                });
+            });
+        });
+
+        describe('patient view', () => {
+            const expectedTabNames = [
+                'Summary',
+                'Pathways',
+                'Clinical Data',
+                'Files & Links',
+                'Tissue Image',
+                'Pathology Slide',
+                'Study Sponsors',
+            ];
+            before(() => {
+                openAndSetProperty(
+                    `${CBIOPORTAL_URL}/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK`,
+                    { skin_hide_download_controls: true }
+                );
+                waitForPatientView();
+                waitForTabs(expectedTabNames.length);
+            });
+            it('covers all tabs with download control tests', () => {
+                const observedTabNames = $$('.tabAnchor')
+                    .filter(a => a.isVisible())
+                    .map(a => a.getText());
+                assert.deepStrictEqual(
+                    expectedTabNames,
+                    observedTabNames,
+                    'There appears to be a new tab on the page (observed names: [' +
+                        observedTabNames.join(', ') +
+                        '] expected names: [' +
+                        expectedTabNames.join(', ') +
+                        ']). Please make sure to hide download controls depending on the "skin_hide_download_controls" property and include' +
+                        ' tests for this in hide-download-controls.spec.js.'
+                );
+            });
+            describe('summary tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_summary').click();
+                    $('[data-test=LazyMobXTable]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('pathways tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_pathways').click();
+                    $('.pathwayMapper').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('clinical data tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_clinicalData').click();
+                    $('[data-test=LazyMobXTable]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('files and links tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_filesAndLinks').click();
+                    $('[data-test=LazyMobXTable]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('tissue image tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_tissueImage').click();
+                    $('iframe').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('pathology slide tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_openResource_PATHOLOGY_SLIDE').click();
+                    $('h2').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('study sponsors tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_openResource_STUDY_SPONSORS').click();
+                    $('h2').waitForExist();
+                    globalCheck();
+                });
+            });
+        });
+
+        describe('study view', () => {
+            const expectedTabNames = [
+                'Summary',
+                'Clinical Data',
+                'CN Segments',
+                'Files & Links',
+                'Study Sponsors',
+            ];
+            before(() => {
+                openAndSetProperty(
+                    `${CBIOPORTAL_URL}/study/summary?id=study_es_0`,
+                    { skin_hide_download_controls: true }
+                );
+                waitForStudyView();
+                waitForTabs(expectedTabNames.length);
+            });
+            describe('summary tab', () => {
+                it('covers all tabs with download control tests', () => {
+                    const observedTabNames = $$('.tabAnchor')
+                        .filter(a => a.isVisible())
+                        .map(a => a.getText());
+                    assert.deepStrictEqual(
+                        expectedTabNames,
+                        observedTabNames,
+                        'There appears to be a new tab on the page (observed names: [' +
+                            observedTabNames.join(', ') +
+                            '] expected names: [' +
+                            expectedTabNames.join(', ') +
+                            ']). Please make sure to hide download controls depending on the "skin_hide_download_controls" property and include' +
+                            ' tests for this in hide-download-controls.spec.js.'
+                    );
+                });
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    globalCheck();
+                });
+                it('does not show download option in chart menu-s', () => {
+                    studyViewChartHoverHamburgerIcon(
+                        'chart-container-SAMPLE_COUNT',
+                        1000
+                    );
+                    globalCheck();
+                    studyViewChartHoverHamburgerIcon(
+                        'chart-container-study_es_0_mutations',
+                        1000
+                    );
+                    globalCheck();
+                    studyViewChartHoverHamburgerIcon(
+                        'chart-container-MUTATION_COUNT',
+                        1000
+                    );
+                    globalCheck();
+                    studyViewChartHoverHamburgerIcon(
+                        'chart-container-GENOMIC_PROFILES_SAMPLE_COUNT',
+                        1000
+                    );
+                    globalCheck();
+                    studyViewChartHoverHamburgerIcon(
+                        'chart-container-FRACTION_GENOME_ALTERED',
+                        1000
+                    );
+                    globalCheck();
+                    studyViewChartHoverHamburgerIcon(
+                        'chart-container-OS_SURVIVAL',
+                        1000
+                    );
+                    globalCheck();
+                });
+            });
+            describe('clinical data tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_clinicalData').click();
+                    $('[data-test=LazyMobXTable]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('CN segments tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_cnSegments').click();
+                    $('.igvContainer').waitForExist(30000);
+                    globalCheck();
+                });
+            });
+            describe('files and links tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_filesAndLinks').click();
+                    $('.resourcesSection').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('study sponsors tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_openResource_STUDY_SPONSORS').click();
+                    $('h2').waitForExist();
+                    globalCheck();
+                });
+            });
+        });
+
+        describe('group comparison', () => {
+            const expectedTabNames = [
+                'Overlap',
+                'Survival',
+                'Clinical',
+                'Genomic Alterations',
+                'mRNA',
+                'DNA Methylation',
+                'Treatment Response',
+                'Mutational Signature',
+            ];
+            before(() => {
+                openAndSetProperty(browser.getUrl(), {
+                    skin_hide_download_controls: false,
+                });
+                openGroupComparison(
+                    `${CBIOPORTAL_URL}/study/summary?id=study_es_0`,
+                    'chart-container-OS_STATUS',
+                    true,
+                    30000
+                );
+                openAndSetProperty(browser.getUrl(), {
+                    skin_hide_download_controls: true,
+                });
+                waitForTabs(expectedTabNames.length);
+            });
+            it('covers all tabs with download control tests', () => {
+                const observedTabNames = $$('.tabAnchor')
+                    .filter(a => a.isVisible())
+                    .map(a => a.getText());
+                assert.deepStrictEqual(
+                    expectedTabNames,
+                    observedTabNames,
+                    'There appears to be a new tab on the page (observed names: [' +
+                        observedTabNames.join(', ') +
+                        '] expected names: [' +
+                        expectedTabNames.join(', ') +
+                        ']). Please make sure to hide download controls depending on the "skin_hide_download_controls" property and include' +
+                        ' tests for this in hide-download-controls.spec.js.'
+                );
+            });
+            describe('overlap tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('[data-test=ComparisonPageOverlapTabDiv]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('survival tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_survival').click();
+                    $(
+                        '[data-test=ComparisonPageSurvivalTabDiv]'
+                    ).waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('clinical tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_clinical').click();
+                    $('[data-test=ClinicalTabPlotDiv]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('genomic alterations tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_alterations').click();
+                    $('[data-test=GeneBarPlotDiv]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('mRNA tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_mrna').click();
+                    $(
+                        '[data-test=GroupComparisonMRNAEnrichments]'
+                    ).waitForExist();
+                    $$(
+                        '[data-test=GroupComparisonMRNAEnrichments] tbody tr b'
+                    )[0].click();
+                    $('[data-test=MiniBoxPlot]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('DNA methylation tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_dna_methylation').click();
+                    $(
+                        '[data-test=GroupComparisonMethylationEnrichments]'
+                    ).waitForExist();
+                    $$(
+                        '[data-test=GroupComparisonMethylationEnrichments] tbody tr b'
+                    )[0].click();
+                    $('[data-test=MiniBoxPlot]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('treatment response tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_generic_assay_treatment_response').click();
+                    $('[data-test=LazyMobXTable]').waitForExist();
+                    $(
+                        '[data-test=GroupComparisonGenericAssayEnrichments]'
+                    ).waitForExist();
+                    $$(
+                        '[data-test=GroupComparisonGenericAssayEnrichments] tbody tr b'
+                    )[0].click();
+                    $('[data-test=MiniBoxPlot]').waitForExist();
+                    globalCheck();
+                });
+            });
+            describe('mutational signature tab', () => {
+                it('global check for icon and occurrence of "Download" as a word', () => {
+                    $('.tabAnchor_generic_assay_mutational_signature').click();
+                    $(
+                        '[data-test=GroupComparisonGenericAssayEnrichments]'
+                    ).waitForExist();
+                    $$(
+                        '[data-test=GroupComparisonGenericAssayEnrichments] tbody tr b'
+                    )[5].click(); // first 5 rows is invisible treatment responses
+                    $('[data-test=MiniBoxPlot]').waitForExist();
+                    globalCheck();
+                });
+            });
+        });
+    }
+});
+
+const globalCheck = () => {
+    assert(
+        !$('*=Download').isExisting(),
+        'The word "Download" occurs on the page. Make sure that it is displayed conditionally based on the skin_hide_download_controls property'
+    );
+    assert(
+        !$('*=download').isExisting(),
+        'The word "download" occurs on the page. Make sure that it is displayed conditionally based on the skin_hide_download_controls property'
+    );
+    assert(
+        !$(downloadIcon).isExisting(),
+        'A download button/icon is visible on the page. Make sure that it is displayed conditionally based on the skin_hide_download_controls property'
+    );
+    assert(
+        !$(downloadCloudIcon).isExisting(),
+        'A cloud download button/icon is visible on the page. Make sure that it is displayed conditionally based on the skin_hide_download_controls property'
+    );
+    assert(
+        !$(clipboardIcon).isExisting(),
+        'A download button/icon is visible on the page. Make sure that it is displayed conditionally based on the skin_hide_download_controls property'
+    );
+};
+
+const openAndSetProperty = (url, prop) => {
+    goToUrlAndSetLocalStorage(url, true);
+    setServerConfiguration(prop);
+    goToUrlAndSetLocalStorage(url, true);
+};
+
+const waitForTabs = count => {
+    browser.waitUntil(() => {
+        return $$('.tabAnchor').length >= count;
+    }, 300000);
+};

--- a/end-to-end-test/remote/specs/config.spec.js
+++ b/end-to-end-test/remote/specs/config.spec.js
@@ -5,6 +5,8 @@ var goToUrlAndSetLocalStorage = require('../../shared/specUtils')
     .goToUrlAndSetLocalStorage;
 var executeInBrowser = require('../../shared/specUtils').executeInBrowser;
 var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
+var setServerConfiguration = require('../../shared/specUtils')
+    .setServerConfiguration;
 
 const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
 

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -118,6 +118,7 @@ export interface IServerConfig {
     skin_title: string;
     skin_authorization_message: string | null;
     skin_patientview_filter_genes_profiled_all_samples: boolean;
+    skin_hide_download_controls: boolean;
     show_mdacc_heatmap: boolean;
     quick_search_enabled: boolean;
     default_cross_cancer_study_list: string; // this has a default

--- a/src/pages/groupComparison/ClinicalData.tsx
+++ b/src/pages/groupComparison/ClinicalData.tsx
@@ -49,6 +49,7 @@ import { Sample } from 'cbioportal-ts-api-client';
 import ComparisonStore from '../../shared/lib/comparison/ComparisonStore';
 import { createSurvivalAttributeIdsDict } from 'pages/resultsView/survival/SurvivalUtil';
 import { getComparisonCategoricalNaValue } from './ClinicalDataUtils';
+import AppConfig from 'appConfig';
 
 export interface IClinicalDataProps {
     store: ComparisonStore;
@@ -848,13 +849,15 @@ export default class ClinicalData extends React.Component<
     private toolbar() {
         return (
             <div style={{ textAlign: 'center', position: 'relative' }}>
-                <DownloadControls
-                    getSvg={this.getSvg}
-                    filename={SVG_ID}
-                    dontFade={true}
-                    type="button"
-                    style={{ position: 'absolute', right: 0, top: 0 }}
-                />
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <DownloadControls
+                        getSvg={this.getSvg}
+                        filename={SVG_ID}
+                        dontFade={true}
+                        type="button"
+                        style={{ position: 'absolute', right: 0, top: 0 }}
+                    />
+                )}
             </div>
         );
     }

--- a/src/pages/groupComparison/ClinicalDataEnrichmentsTable.tsx
+++ b/src/pages/groupComparison/ClinicalDataEnrichmentsTable.tsx
@@ -11,6 +11,7 @@ import { makeObservable, observable } from 'mobx';
 import { toggleColumnVisibility } from 'cbioportal-frontend-commons';
 import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls/ColumnVisibilityControls';
 import { getServerConfig } from 'config/config';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export interface IClinicalDataEnrichmentsTableProps {
     dataStore: ClinicalDataEnrichmentStore;
@@ -203,7 +204,7 @@ export default class ClinicalDataEnrichmentsTable extends React.Component<
                 paginationProps={{ itemsPerPageOptions: [20] }}
                 initialItemsPerPage={20}
                 copyDownloadProps={{
-                    showCopy: false,
+                    showCopy: shouldShowDownloadAndCopyControls(),
                 }}
             />
         );

--- a/src/pages/groupComparison/Overlap.tsx
+++ b/src/pages/groupComparison/Overlap.tsx
@@ -20,6 +20,7 @@ import { getPatientIdentifiers } from '../studyView/StudyViewUtils';
 import OverlapExclusionIndicator from './OverlapExclusionIndicator';
 import OverlapUpset from './OverlapUpset';
 import ComparisonStore from '../../shared/lib/comparison/ComparisonStore';
+import AppConfig from 'appConfig';
 
 export interface IOverlapProps {
     store: ComparisonStore;
@@ -378,17 +379,20 @@ export default class Overlap extends React.Component<IOverlapProps, {}> {
                 data-test="ComparisonPageOverlapTabContent"
                 className="borderedChart posRelative"
             >
-                {this.plotExists && (
-                    <DownloadControls
-                        getSvg={this.getSvg}
-                        getData={this.props.store.getGroupsDownloadDataPromise}
-                        buttons={['SVG', 'PNG', 'PDF', 'Data']}
-                        filename={'overlap'}
-                        dontFade={true}
-                        style={{ position: 'absolute', right: 10, top: 10 }}
-                        type="button"
-                    />
-                )}
+                {this.plotExists &&
+                    !AppConfig.serverConfig.skin_hide_download_controls && (
+                        <DownloadControls
+                            getSvg={this.getSvg}
+                            getData={
+                                this.props.store.getGroupsDownloadDataPromise
+                            }
+                            buttons={['SVG', 'PNG', 'PDF', 'Data']}
+                            filename={'overlap'}
+                            dontFade={true}
+                            style={{ position: 'absolute', right: 10, top: 10 }}
+                            type="button"
+                        />
+                    )}
                 <div style={{ position: 'relative', display: 'inline-block' }}>
                     {this.plot.component}
                 </div>

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -63,7 +63,9 @@ export default class HomePage extends React.Component<
                 <QueryAndDownloadTabs
                     getQueryStore={this.getQueryStore}
                     showQuickSearchTab={getServerConfig().quick_search_enabled}
-                    showDownloadTab={true}
+                    showDownloadTab={
+                        !AppConfig.serverConfig.skin_hide_download_controls
+                    }
                 />
             </PageLayout>
         );

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
@@ -43,6 +43,7 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import ReactDOM from 'react-dom';
 import PatientViewUrlWrapper from '../../PatientViewUrlWrapper';
 import { getVariantAlleleFrequency } from 'shared/lib/MutationUtils';
+import AppConfig from 'appConfig';
 
 export interface IMutationOncoprintProps {
     store: PatientViewPageStore;
@@ -648,25 +649,27 @@ export default class MutationOncoprint extends React.Component<
                     </LabeledCheckbox>
                     {this.zoomControls}
                 </div>
-                <DownloadControls
-                    filename="vafHeatmap"
-                    getSvg={() =>
-                        this.oncoprint ? this.oncoprint.toSVG(true) : null
-                    }
-                    getData={() => {
-                        const data = _.flatMap(
-                            this.heatmapTracks.result!,
-                            track => track.data
-                        );
-                        return getDownloadData(data);
-                    }}
-                    buttons={['SVG', 'PNG', 'Data']}
-                    type="button"
-                    dontFade
-                    style={{
-                        marginLeft: 10,
-                    }}
-                />
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <DownloadControls
+                        filename="vafHeatmap"
+                        getSvg={() =>
+                            this.oncoprint ? this.oncoprint.toSVG(true) : null
+                        }
+                        getData={() => {
+                            const data = _.flatMap(
+                                this.heatmapTracks.result!,
+                                track => track.data
+                            );
+                            return getDownloadData(data);
+                        }}
+                        buttons={['SVG', 'PNG', 'Data']}
+                        type="button"
+                        dontFade
+                        style={{
+                            marginLeft: 10,
+                        }}
+                    />
+                )}
             </div>
         );
     }

--- a/src/pages/patientView/patientHeader/PatientHeader.tsx
+++ b/src/pages/patientView/patientHeader/PatientHeader.tsx
@@ -9,6 +9,8 @@ import {
     placeArrowBottomLeft,
 } from 'cbioportal-frontend-commons';
 import SampleManager from '../SampleManager';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export type IPatientHeaderProps = {
     patient: any;
@@ -68,7 +70,7 @@ export default class PatientHeader extends React.Component<
                     <h5>{patient.id}</h5>
                     <ClinicalInformationPatientTable
                         showFilter={false}
-                        showCopyDownload={false}
+                        showCopyDownload={shouldShowDownloadAndCopyControls()}
                         showTitleBar={false}
                         data={patient.clinicalData}
                     />

--- a/src/pages/patientView/patientHeader/SampleInline.tsx
+++ b/src/pages/patientView/patientHeader/SampleInline.tsx
@@ -7,6 +7,8 @@ import {
 import { ClinicalDataBySampleId } from 'cbioportal-ts-api-client';
 import ClinicalInformationPatientTable from '../clinicalInformation/ClinicalInformationPatientTable';
 import './styles.scss';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 interface ISampleInlineProps {
     sample: ClinicalDataBySampleId;
@@ -52,7 +54,7 @@ export default class SampleInline extends React.Component<
                 {!this.props.hideClinicalTable && (
                     <ClinicalInformationPatientTable
                         showFilter={false}
-                        showCopyDownload={false}
+                        showCopyDownload={shouldShowDownloadAndCopyControls()}
                         showTitleBar={false}
                         data={sample.clinicalData}
                         onSelectGenePanel={this.props.onSelectGenePanel}

--- a/src/pages/patientView/timeline/ClinicalEventsTables.tsx
+++ b/src/pages/patientView/timeline/ClinicalEventsTables.tsx
@@ -3,6 +3,7 @@ import { ClinicalEvent } from 'cbioportal-ts-api-client';
 import { groupTimelineData } from 'pages/patientView/timeline/timelineDataUtils.ts';
 import LazyMobXTable from 'shared/components/lazyMobXTable/LazyMobXTable';
 import _ from 'lodash';
+import AppConfig from 'appConfig';
 
 class EventsTable extends LazyMobXTable<{}> {}
 
@@ -61,7 +62,10 @@ const ClinicalEventsTables: React.FunctionComponent<{
                             showPagination={false}
                             showColumnVisibility={false}
                             showFilter={true}
-                            showCopyDownload={true}
+                            showCopyDownload={
+                                !AppConfig.serverConfig
+                                    .skin_hide_download_controls
+                            }
                         />
                     </>
                 );

--- a/src/pages/patientView/timeline/Timeline.tsx
+++ b/src/pages/patientView/timeline/Timeline.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import $ from 'jquery';
+import 'jquery-migrate';
+require('datatables.net');
+import { buildTimeline } from './legacy.js';
+import 'qtip2';
+import 'qtip2/dist/jquery.qtip.css';
+
+import './styles.scss';
+import SampleManager from '../SampleManager';
+
+import { PatientViewPageStore } from '../clinicalInformation/PatientViewPageStore';
+import { ClinicalEvent, ClinicalEventData } from 'cbioportal-ts-api-client';
+import { DownloadControls } from 'cbioportal-frontend-commons';
+import autobind from 'autobind-decorator';
+import AppConfig from 'appConfig';
+
+interface ITimelineProps {
+    sampleManager: SampleManager;
+    store: PatientViewPageStore;
+    width: number;
+}
+
+type TimelineDataPoint = {
+    eventType: string;
+    patientId: string;
+    startDate: number | null;
+    stopDate: number | null;
+    eventData: any;
+};
+
+export default class Timeline extends React.Component<ITimelineProps, {}> {
+    private currentWidth: number;
+
+    shouldComponentUpdate(nextProps: ITimelineProps) {
+        if (nextProps.width !== this.currentWidth) {
+            // only rerender to resize
+            this.drawTimeline(nextProps.width);
+        }
+        return false;
+    }
+
+    componentDidMount() {
+        this.drawTimeline(this.props.width);
+
+        /*var debouncedResize =  _.debounce(()=>this.drawTimeline(),500);
+
+        $(window).resize(debouncedResize);*/
+    }
+
+    drawTimeline(width: number) {
+        let clinicalDataMap = this.props.store.patientViewData.result.samples!.reduce(
+            (memo: any, item) => {
+                memo[item.id] = item.clinicalData.reduce(
+                    (innerMemo: any, innerItem) => {
+                        innerMemo[innerItem.clinicalAttributeId] =
+                            innerItem.value;
+                        return innerMemo;
+                    },
+                    {}
+                );
+                return memo;
+            },
+            {}
+        );
+
+        let caseIds = this.props.sampleManager.getSampleIdsInOrder();
+
+        let params = {
+            cancer_study_id: this.props.store.studyId,
+            patient_id: this.props.store.patientId,
+        };
+
+        let patientInfo = this.props.store.patientViewData.result!.patient!.clinicalData.reduce(
+            (memo: any, item) => {
+                memo[item.clinicalAttributeId] = item.value;
+                return memo;
+            },
+            {}
+        );
+
+        let caseMetaData = {
+            color: this.props.sampleManager.sampleColors,
+            label: this.props.sampleManager.sampleLabels,
+            index: this.props.sampleManager.sampleIndex,
+        };
+
+        let timelineData = this.props.store.clinicalEvents.result.map(
+            (eventData: ClinicalEvent) => {
+                return {
+                    eventType: eventData.eventType,
+                    patientId: eventData.patientId,
+                    startDate: _.isUndefined(
+                        eventData.startNumberOfDaysSinceDiagnosis
+                    )
+                        ? null
+                        : eventData.startNumberOfDaysSinceDiagnosis,
+                    stopDate: _.isUndefined(
+                        eventData.endNumberOfDaysSinceDiagnosis
+                    )
+                        ? null
+                        : eventData.endNumberOfDaysSinceDiagnosis,
+                    eventData: eventData.attributes.reduce(
+                        (memo: any, evData: ClinicalEventData) => {
+                            memo[evData.key] = evData.value;
+                            return memo;
+                        },
+                        {}
+                    ),
+                };
+            }
+        );
+
+        buildTimeline(
+            params,
+            caseIds,
+            patientInfo,
+            clinicalDataMap,
+            caseMetaData,
+            timelineData,
+            width
+        );
+        this.currentWidth = width;
+    }
+
+    private svgContainer: HTMLDivElement;
+    @autobind
+    private getSvg() {
+        return this.svgContainer.firstChild as SVGElement;
+    }
+
+    public render() {
+        return (
+            <div id="timeline-container" className="timelineContainer">
+                <div
+                    id="timeline"
+                    ref={container => {
+                        this.svgContainer = container!;
+                    }}
+                ></div>
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <DownloadControls
+                        buttons={['PDF', 'PNG', 'SVG']}
+                        dataExtension={'tsv'}
+                        getSvg={this.getSvg}
+                        filename="timeline"
+                        dontFade={true}
+                        type="button"
+                        style={{ position: 'absolute', top: 0, right: 5 }}
+                    />
+                )}
+            </div>
+        );
+    }
+}

--- a/src/pages/patientView/trialMatch/TrialMatchTable.tsx
+++ b/src/pages/patientView/trialMatch/TrialMatchTable.tsx
@@ -22,6 +22,7 @@ import { getAgeRangeDisplay } from './TrialMatchTableUtils';
 import TrialMatchFeedback from './TrialMatchFeedback';
 import { getServerConfig } from 'config/config';
 import { Button } from 'react-bootstrap';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export type ITrialMatchProps = {
     sampleManager: SampleManager | null;
@@ -652,7 +653,7 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                 <TrialMatchTableComponent
                     data={this.props.detailedTrialMatches}
                     columns={this._columns}
-                    showCopyDownload={false}
+                    showCopyDownload={shouldShowDownloadAndCopyControls()}
                 />
                 <div className={styles.powered}>
                     Powered by{' '}

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -68,6 +68,8 @@ import {
     prepareCustomTabConfigurations,
 } from 'shared/lib/customTabs/customTabHelpers';
 import { buildCBioPortalPageUrl } from 'shared/api/urls';
+import UserMessager from 'shared/components/userMessager/UserMessage';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export function initStore(
     appStore: AppStore,
@@ -412,7 +414,10 @@ export default class ResultsViewPage extends React.Component<
                     );
                 },
             },
-            {
+        ];
+
+        if (!AppConfig.serverConfig.skin_hide_download_controls) {
+            tabMap.push({
                 id: ResultsViewTab.DOWNLOAD,
                 getTab: () => {
                     return (
@@ -425,8 +430,8 @@ export default class ResultsViewPage extends React.Component<
                         </MSKTab>
                     );
                 },
-            },
-        ];
+            });
+        }
 
         let filteredTabs = tabMap
             .filter(this.evaluateTabInclusion)
@@ -539,7 +544,7 @@ export default class ResultsViewPage extends React.Component<
                     <QueryAndDownloadTabs
                         forkedMode={false}
                         showQuickSearchTab={false}
-                        showDownloadTab={false}
+                        showDownloadTab={shouldShowDownloadAndCopyControls()}
                         showAlerts={true}
                         getQueryStore={() =>
                             createQueryStore(

--- a/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
@@ -41,6 +41,7 @@ import URL from 'url';
 import { CANCER_SUMMARY_ALL_GENES } from './CancerSummaryContainer';
 import { ResultsViewURLQueryEnum } from 'pages/resultsView/ResultsViewURLWrapper';
 import ScrollWrapper from './ScrollWrapper';
+import AppConfig from 'appConfig';
 
 interface CancerSummaryChartProps {
     colors: Record<keyof IAlterationCountMap, string>;
@@ -881,15 +882,17 @@ export class CancerSummaryChart extends React.Component<
                         </svg>
                     </div>
                 </ScrollWrapper>
-                <DownloadControls
-                    getSvg={this.getSvg}
-                    getData={this.getData}
-                    filename="cancer_types_summary"
-                    dontFade={true}
-                    type="button"
-                    buttons={['SVG', 'PNG', 'PDF', 'Data']}
-                    style={{ position: 'absolute', top: 10, right: 10 }}
-                />
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <DownloadControls
+                        getSvg={this.getSvg}
+                        getData={this.getData}
+                        filename="cancer_types_summary"
+                        dontFade={true}
+                        type="button"
+                        buttons={['SVG', 'PNG', 'PDF', 'Data']}
+                        style={{ position: 'absolute', top: 10, right: 10 }}
+                    />
+                )}
             </div>
         );
     }

--- a/src/pages/resultsView/cnSegments/CNSegments.tsx
+++ b/src/pages/resultsView/cnSegments/CNSegments.tsx
@@ -23,6 +23,7 @@ import {
 } from 'shared/components/progressIndicator/ProgressIndicator';
 import { remoteData } from 'cbioportal-frontend-commons';
 import CaseFilterWarning from 'shared/components/banners/CaseFilterWarning';
+import AppConfig from 'appConfig';
 
 @observer
 export default class CNSegments extends React.Component<
@@ -174,10 +175,12 @@ export default class CNSegments extends React.Component<
                         sequential={true}
                     />
                 </LoadingIndicator>
-                <CNSegmentsDownloader
-                    promise={this.props.store.cnSegments}
-                    filename={this.filename}
-                />
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <CNSegmentsDownloader
+                        promise={this.props.store.cnSegments}
+                        filename={this.filename}
+                    />
+                )}
                 <div className={'tabMessageContainer'}>
                     <CaseFilterWarning store={this.props.store} />
                 </div>

--- a/src/pages/resultsView/coExpression/CoExpressionPlot.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionPlot.tsx
@@ -17,6 +17,7 @@ import _ from 'lodash';
 import { scatterPlotSize } from '../../../shared/components/plots/PlotUtils';
 import { IAxisLogScaleParams } from 'pages/resultsView/plots/PlotsTabUtils';
 import autobind from 'autobind-decorator';
+import AppConfig from 'appConfig';
 
 export interface ICoExpressionPlotProps {
     xAxisGeneticEntity: GeneticEntity;
@@ -340,16 +341,17 @@ export default class CoExpressionPlot extends React.Component<
                         </label>
                     </div>
                 </div>
-
-                <DownloadControls
-                    getSvg={this.getSvg}
-                    getData={this.getDownloadData}
-                    buttons={['SVG', 'PNG', 'PDF', 'Data']}
-                    filename="coexpression"
-                    dontFade={true}
-                    type="button"
-                    style={{ position: 'absolute', top: 0, right: 0 }}
-                />
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <DownloadControls
+                        getSvg={this.getSvg}
+                        getData={this.getDownloadData}
+                        buttons={['SVG', 'PNG', 'PDF', 'Data']}
+                        filename="coexpression"
+                        dontFade={true}
+                        type="button"
+                        style={{ position: 'absolute', top: 0, right: 0 }}
+                    />
+                )}
             </div>
         );
     }

--- a/src/pages/resultsView/coExpression/CoExpressionTableGenes.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionTableGenes.tsx
@@ -15,6 +15,8 @@ import { bind } from 'bind-decorator';
 import { cytobandFilter } from 'pages/resultsView/ResultsViewTableUtils';
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
 import { formatSignificanceValueWithStyle } from 'shared/lib/FormatUtils';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export interface ICoExpressionTableGenesProps {
     referenceGeneticEntity: Gene | Geneset;
@@ -179,7 +181,7 @@ export default class CoExpressionTableGenes extends React.Component<
                     paginationProps={this.paginationProps}
                     initialItemsPerPage={25}
                     copyDownloadProps={{
-                        showCopy: false,
+                        showCopy: shouldShowDownloadAndCopyControls(),
                     }}
                 />
             </div>

--- a/src/pages/resultsView/coExpression/CoExpressionTableGenesets.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionTableGenesets.tsx
@@ -14,6 +14,8 @@ import InfoIcon from '../../../shared/components/InfoIcon';
 import { bind } from 'bind-decorator';
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
 import { formatSignificanceValueWithStyle } from 'shared/lib/FormatUtils';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export interface ICoExpressionTableGenesetsProps {
     referenceGeneticEntity: Gene | Geneset;
@@ -162,7 +164,7 @@ export default class CoExpressionTableGenesets extends React.Component<
                     paginationProps={this.paginationProps}
                     initialItemsPerPage={25}
                     copyDownloadProps={{
-                        showCopy: false,
+                        showCopy: shouldShowDownloadAndCopyControls(),
                     }}
                 />
             </div>

--- a/src/pages/resultsView/download/CaseAlterationTable.tsx
+++ b/src/pages/resultsView/download/CaseAlterationTable.tsx
@@ -23,6 +23,7 @@ import { AlteredStatus } from 'pages/resultsView/mutualExclusivity/MutualExclusi
 import { Alteration } from 'shared/lib/oql/oql-parser';
 import { parsedOQLAlterationToSourceOQL } from 'shared/lib/oql/oqlfilter';
 import { insertBetween } from 'shared/lib/ArrayUtils';
+import AppConfig from 'appConfig';
 
 export interface ISubAlteration {
     type: string;
@@ -514,7 +515,9 @@ export default class CaseAlterationTable extends React.Component<
                 showPagination={true}
                 showColumnVisibility={true}
                 showFilter={true}
-                showCopyDownload={true}
+                showCopyDownload={
+                    !AppConfig.serverConfig.skin_hide_download_controls
+                }
                 enableHorizontalScroll={true}
                 copyDownloadProps={{
                     downloadFilename: 'alterations_across_samples.tsv',

--- a/src/pages/resultsView/download/GeneAlterationTable.tsx
+++ b/src/pages/resultsView/download/GeneAlterationTable.tsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import LazyMobXTable from 'shared/components/lazyMobXTable/LazyMobXTable';
 import FrequencyBar from 'shared/components/cohort/FrequencyBar';
+import AppConfig from 'appConfig';
 
 export interface IGeneAlteration {
     gene: string;
@@ -102,7 +103,9 @@ export default class GeneAlterationTable extends React.Component<
                 initialItemsPerPage={10}
                 showColumnVisibility={true}
                 showFilter={true}
-                showCopyDownload={true}
+                showCopyDownload={
+                    !AppConfig.serverConfig.skin_hide_download_controls
+                }
                 copyDownloadProps={{
                     downloadFilename: 'gene_alteration_frequency.tsv',
                 }}

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsBoxPlot.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsBoxPlot.tsx
@@ -30,6 +30,7 @@ import { getSampleViewUrl } from 'shared/api/urls';
 import classNames from 'classnames';
 import { getGeneSummary } from '../querySummary/QuerySummaryUtils';
 import { EnrichmentAnalysisComparisonGroup } from 'pages/groupComparison/GroupComparisonUtils';
+import AppConfig from 'appConfig';
 import {
     COMMON_GENERIC_ASSAY_PROPERTY,
     formatGenericAssayCompactLabelByNameAndId,
@@ -362,15 +363,17 @@ export default class ExpressionEnrichmentsBoxPlot extends React.Component<
 
             plotElt = (
                 <div className={styles.BoxPlot} data-test="MiniBoxPlot">
-                    <DownloadControls
-                        buttons={['SVG', 'PNG', 'Data']}
-                        getSvg={() => this.svgContainer}
-                        getData={this.getData}
-                        filename={downloadFileName}
-                        dontFade={true}
-                        style={{ position: 'absolute', right: 10, top: 10 }}
-                        type="button"
-                    />
+                    {!AppConfig.serverConfig.skin_hide_download_controls && (
+                        <DownloadControls
+                            buttons={['SVG', 'PNG', 'Data']}
+                            getSvg={() => this.svgContainer}
+                            getData={this.getData}
+                            filename={downloadFileName}
+                            dontFade={true}
+                            style={{ position: 'absolute', right: 10, top: 10 }}
+                            type="button"
+                        />
+                    )}
                     <EnrichmentsBoxPlotComponent
                         domainPadding={10}
                         startDataAxisAtZero={true}

--- a/src/pages/resultsView/enrichments/GeneBarPlot.tsx
+++ b/src/pages/resultsView/enrichments/GeneBarPlot.tsx
@@ -26,6 +26,7 @@ import {
     QueryStore,
 } from 'shared/components/query/QueryStore';
 import { EnrichmentsTableDataStore } from './EnrichmentsTableDataStore';
+import AppConfig from 'appConfig';
 
 export interface IGeneBarPlotProps {
     data: AlterationEnrichmentRow[];
@@ -270,12 +271,15 @@ export default class GeneBarPlot extends React.Component<
                                 </button>
                             </div>
                         </DefaultTooltip>
-                        <DownloadControls
-                            getSvg={() => this.svgContainer}
-                            filename={'GroupComparisonGeneFrequencyPlot'}
-                            dontFade={true}
-                            type="button"
-                        />
+                        {!AppConfig.serverConfig
+                            .skin_hide_download_controls && (
+                            <DownloadControls
+                                getSvg={() => this.svgContainer}
+                                filename={'GroupComparisonGeneFrequencyPlot'}
+                                dontFade={true}
+                                type="button"
+                            />
+                        )}
                     </div>
                 </div>
             </React.Fragment>

--- a/src/pages/resultsView/enrichments/MiniFrequencyScatterChart.tsx
+++ b/src/pages/resultsView/enrichments/MiniFrequencyScatterChart.tsx
@@ -22,6 +22,7 @@ import {
     getTextWidth,
     truncateWithEllipsis,
 } from 'cbioportal-frontend-commons';
+import AppConfig from 'appConfig';
 
 export interface IMiniFrequencyScatterChartData {
     x: number;
@@ -373,18 +374,20 @@ export default class MiniFrequencyScatterChart extends React.Component<
                             }
                         />
                     </VictoryChart>
-                    <DownloadControls
-                        getSvg={() => this.svgContainer}
-                        filename="enrichments-frequency-scatter"
-                        dontFade={true}
-                        type="button"
-                        style={{
-                            position: 'absolute',
-                            top: 10,
-                            right: 10,
-                            zIndex: 0,
-                        }}
-                    />
+                    {!AppConfig.serverConfig.skin_hide_download_controls && (
+                        <DownloadControls
+                            getSvg={() => this.svgContainer}
+                            filename="enrichments-frequency-scatter"
+                            dontFade={true}
+                            type="button"
+                            style={{
+                                position: 'absolute',
+                                top: 10,
+                                right: 10,
+                                zIndex: 0,
+                            }}
+                        />
+                    )}
                 </div>
                 <Observer>{this.getTooltip}</Observer>
             </div>

--- a/src/pages/resultsView/enrichments/MiniScatterChart.tsx
+++ b/src/pages/resultsView/enrichments/MiniScatterChart.tsx
@@ -21,6 +21,7 @@ import {
     getTextWidth,
     truncateWithEllipsis,
 } from 'cbioportal-frontend-commons';
+import AppConfig from 'appConfig';
 
 export interface IMiniScatterChartProps {
     data: any[];
@@ -274,18 +275,20 @@ export default class MiniScatterChart<
                             }
                         />
                     </VictoryChart>
-                    <DownloadControls
-                        getSvg={() => this.svgContainer}
-                        filename="enrichments-volcano"
-                        dontFade={true}
-                        type="button"
-                        style={{
-                            position: 'absolute',
-                            top: 10,
-                            right: 10,
-                            zIndex: 0,
-                        }}
-                    />
+                    {!AppConfig.serverConfig.skin_hide_download_controls && (
+                        <DownloadControls
+                            getSvg={() => this.svgContainer}
+                            filename="enrichments-volcano"
+                            dontFade={true}
+                            type="button"
+                            style={{
+                                position: 'absolute',
+                                top: 10,
+                                right: 10,
+                                zIndex: 0,
+                            }}
+                        />
+                    )}
                 </div>
                 <Observer>{this.getTooltip}</Observer>
             </div>

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -132,6 +132,7 @@ import {
 } from 'pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection';
 import { doesOptionMatchSearchText } from 'shared/lib/GenericAssayUtils/GenericAssaySelectionUtils';
 import { GENERIC_ASSAY_CONFIG } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
+import AppConfig from 'appConfig';
 
 enum EventKey {
     horz_logScale,
@@ -5316,7 +5317,11 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                             )}
                             <Observer>
                                 {() => {
-                                    if (this.plotExists) {
+                                    if (
+                                        this.plotExists &&
+                                        !AppConfig.serverConfig
+                                            .skin_hide_download_controls
+                                    ) {
                                         return (
                                             <DownloadControls
                                                 getSvg={this.getSvg}

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -28,6 +28,7 @@ import { createQueryStore } from 'shared/lib/createQueryStore';
 import _ from 'lodash';
 import { mixedReferenceGenomeWarning } from 'shared/lib/referenceGenomeUtils';
 import SettingsMenuButton from 'shared/components/driverAnnotations/SettingsMenuButton';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 interface QuerySummaryProps {
     routingStore: ExtendedRouterStore;
@@ -264,7 +265,7 @@ export default class QuerySummary extends React.Component<
                     onSubmit={this.onSubmit}
                     forkedMode={false}
                     showQuickSearchTab={false}
-                    showDownloadTab={false}
+                    showDownloadTab={shouldShowDownloadAndCopyControls()}
                     showAlerts={true}
                     modifyQueryParams={this.props.store.modifyQueryParams}
                     getQueryStore={() =>

--- a/src/pages/resultsView/survival/SurvivalChart.tsx
+++ b/src/pages/resultsView/survival/SurvivalChart.tsx
@@ -584,17 +584,22 @@ export default class SurvivalChart
     get chart() {
         return (
             <div className={this.props.className} data-test={'SurvivalChart'}>
-                {this.props.showDownloadButtons && (
-                    <DownloadControls
-                        dontFade={true}
-                        filename={this.props.fileName}
-                        buttons={['SVG', 'PNG', 'PDF', 'Data']}
-                        getSvg={this.getSvg}
-                        getData={this.getData}
-                        style={{ position: 'absolute', zIndex: 10, right: 10 }}
-                        type="button"
-                    />
-                )}
+                {this.props.showDownloadButtons &&
+                    !AppConfig.serverConfig.skin_hide_download_controls && (
+                        <DownloadControls
+                            dontFade={true}
+                            filename={this.props.fileName}
+                            buttons={['SVG', 'PNG', 'PDF', 'Data']}
+                            getSvg={this.getSvg}
+                            getData={this.getData}
+                            style={{
+                                position: 'absolute',
+                                zIndex: 10,
+                                right: 10,
+                            }}
+                            type="button"
+                        />
+                    )}
 
                 {this.props.showSlider && (
                     <div

--- a/src/pages/resultsView/survival/SurvivalDescriptionTable.tsx
+++ b/src/pages/resultsView/survival/SurvivalDescriptionTable.tsx
@@ -1,6 +1,8 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import LazyMobXTable from 'shared/components/lazyMobXTable/LazyMobXTable';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export interface ISurvivalDescription {
     studyName: string;
@@ -48,7 +50,7 @@ export default class SurvivalDescriptionTable extends React.Component<
                 initialItemsPerPage={10}
                 showColumnVisibility={false}
                 showFilter={false}
-                showCopyDownload={false}
+                showCopyDownload={shouldShowDownloadAndCopyControls()}
             />
         );
     }

--- a/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
+++ b/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
@@ -24,6 +24,7 @@ import { observable, computed, makeObservable, action } from 'mobx';
 import { getServerConfig } from 'config/config';
 import Slider from 'react-rangeslider';
 import styles from 'pages/resultsView/survival/styles.module.scss';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export interface ISurvivalPrefixTableProps {
     survivalPrefixes: SurvivalPrefixSummary[];
@@ -269,7 +270,8 @@ export default class SurvivalPrefixTable extends React.Component<
 > {
     private dataStore: SurvivalPrefixTableStore;
     @observable private columnVisibility: { [group: string]: boolean };
-    @observable private patientMinThreshold = getServerConfig().survival_min_group_threshold;
+    @observable private patientMinThreshold = getServerConfig()
+        .survival_min_group_threshold;
 
     constructor(props: ISurvivalPrefixTableProps) {
         super(props);
@@ -372,7 +374,7 @@ export default class SurvivalPrefixTable extends React.Component<
                 paginationProps={{ itemsPerPageOptions: [15] }}
                 initialItemsPerPage={15}
                 copyDownloadProps={{
-                    showCopy: false,
+                    showCopy: shouldShowDownloadAndCopyControls(),
                 }}
                 filterBoxWidth={120}
             />

--- a/src/pages/staticPages/datasetView/DatasetList.tsx
+++ b/src/pages/staticPages/datasetView/DatasetList.tsx
@@ -8,6 +8,8 @@ import { getStudyDownloadListUrl } from '../../../shared/api/urls';
 import { getBrowserWindow, getNCBIlink } from 'cbioportal-frontend-commons';
 import { StudyLink } from '../../../shared/components/StudyLink/StudyLink';
 import { StudyDataDownloadLink } from '../../../shared/components/StudyDataDownloadLink/StudyDataDownloadLink';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 interface IDataTableRow {
     name: string;
@@ -235,7 +237,7 @@ export default class DataSetsPageTable extends React.Component<
                         showColumnVisibility={true}
                         showFilter={true}
                         showFilterClearButton={true}
-                        showCopyDownload={false}
+                        showCopyDownload={shouldShowDownloadAndCopyControls()}
                         initialItemsPerPage={this.props.datasets.length}
                     />
                 </div>

--- a/src/pages/studyView/chartHeader/ChartHeader.tsx
+++ b/src/pages/studyView/chartHeader/ChartHeader.tsx
@@ -22,6 +22,7 @@ import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import { ISurvivalDescription } from 'pages/resultsView/survival/SurvivalDescriptionTable';
 import ComparisonVsIcon from 'shared/components/ComparisonVsIcon';
 import { getComparisonParamsForTable } from 'pages/studyView/StudyViewComparisonUtils';
+import AppConfig from 'appConfig';
 
 export interface IChartHeaderProps {
     chartMeta: ChartMeta;
@@ -552,7 +553,8 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
         if (
             this.props.chartControls &&
             this.props.downloadTypes &&
-            this.props.downloadTypes.length > 0
+            this.props.downloadTypes.length > 0 &&
+            !AppConfig.serverConfig.skin_hide_download_controls
         ) {
             const downloadSubmenuWidth = 70;
             items.push(

--- a/src/pages/studyView/studyPageHeader/ActionButtons.tsx
+++ b/src/pages/studyView/studyPageHeader/ActionButtons.tsx
@@ -13,6 +13,7 @@ import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import classNames from 'classnames';
 import { AppStore } from '../../../AppStore';
 import { serializeEvent } from '../../../shared/lib/tracking';
+import AppConfig from 'appConfig';
 
 export interface ActionButtonsProps {
     loadingComplete: boolean;
@@ -185,33 +186,34 @@ export default class ActionButtons extends React.Component<
                         </button>
                     </DefaultTooltip>
                 </DefaultTooltip>
-
-                <DefaultTooltip
-                    trigger={['hover']}
-                    placement={'top'}
-                    overlay={<span>{this.downloadButtonTooltip}</span>}
-                >
-                    <button
-                        className="btn btn-default btn-sm"
-                        disabled={!this.props.loadingComplete}
-                        onClick={this.initiateDownload}
-                        data-event={serializeEvent({
-                            category: 'studyPage',
-                            action: 'dataDownload',
-                            label: this.props.store.queriedPhysicalStudyIds
-                                .result,
-                        })}
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <DefaultTooltip
+                        trigger={['hover']}
+                        placement={'top'}
+                        overlay={<span>{this.downloadButtonTooltip}</span>}
                     >
-                        <If condition={this.downloadingData}>
-                            <Then>
-                                <i className="fa fa-spinner fa-spin"></i>
-                            </Then>
-                            <Else>
-                                <i className="fa fa-download"></i>
-                            </Else>
-                        </If>
-                    </button>
-                </DefaultTooltip>
+                        <button
+                            className="btn btn-default btn-sm"
+                            disabled={!this.props.loadingComplete}
+                            onClick={this.initiateDownload}
+                            data-event={serializeEvent({
+                                category: 'studyPage',
+                                action: 'dataDownload',
+                                label: this.props.store.queriedPhysicalStudyIds
+                                    .result,
+                            })}
+                        >
+                            <If condition={this.downloadingData}>
+                                <Then>
+                                    <i className="fa fa-spinner fa-spin"></i>
+                                </Then>
+                                <Else>
+                                    <i className="fa fa-download"></i>
+                                </Else>
+                            </If>
+                        </button>
+                    </DefaultTooltip>
+                )}
             </div>
         );
     }

--- a/src/pages/studyView/studyPageHeader/studySummary/StudySummary.tsx
+++ b/src/pages/studyView/studyPageHeader/studySummary/StudySummary.tsx
@@ -13,6 +13,7 @@ import MobxPromise from 'mobxpromise';
 import { StudyDataDownloadLink } from '../../../../shared/components/StudyDataDownloadLink/StudyDataDownloadLink';
 import { serializeEvent } from '../../../../shared/lib/tracking';
 import { mixedReferenceGenomeWarning } from 'shared/lib/referenceGenomeUtils';
+import AppConfig from 'appConfig';
 
 interface IStudySummaryProps {
     studies: CancerStudy[];
@@ -127,34 +128,38 @@ export default class StudySummary extends React.Component<
                     {this.name}
                     {this.props.isMixedReferenceGenome &&
                         mixedReferenceGenomeWarning()}
-                    {this.props.hasRawDataForDownload && (
-                        <DefaultTooltip
-                            trigger={['hover']}
-                            placement={'top'}
-                            overlay={
-                                <span>
-                                    Download all clinical and genomic data of
-                                    this study
-                                </span>
-                            }
-                        >
-                            <span
-                                data-test="studySummaryRawDataDownloadIcon"
-                                data-event={serializeEvent({
-                                    category: 'studyPage',
-                                    action: 'dataDownload',
-                                    label: this.props.studies
-                                        .map(s => s.studyId)
-                                        .join(','),
-                                })}
-                                style={{ marginLeft: '10px', fontSize: '14px' }}
+                    {this.props.hasRawDataForDownload &&
+                        !AppConfig.serverConfig.skin_hide_download_controls && (
+                            <DefaultTooltip
+                                trigger={['hover']}
+                                placement={'top'}
+                                overlay={
+                                    <span>
+                                        Download all clinical and genomic data
+                                        of this study
+                                    </span>
+                                }
                             >
-                                <StudyDataDownloadLink
-                                    studyId={this.props.studies[0].studyId}
-                                />
-                            </span>
-                        </DefaultTooltip>
-                    )}
+                                <span
+                                    data-test="studySummaryRawDataDownloadIcon"
+                                    data-event={serializeEvent({
+                                        category: 'studyPage',
+                                        action: 'dataDownload',
+                                        label: this.props.studies
+                                            .map(s => s.studyId)
+                                            .join(','),
+                                    })}
+                                    style={{
+                                        marginLeft: '10px',
+                                        fontSize: '14px',
+                                    }}
+                                >
+                                    <StudyDataDownloadLink
+                                        studyId={this.props.studies[0].studyId}
+                                    />
+                                </span>
+                            </DefaultTooltip>
+                        )}
                 </h3>
                 <div className={styles.description}>
                     <div>

--- a/src/pages/studyView/tabs/CNSegments.tsx
+++ b/src/pages/studyView/tabs/CNSegments.tsx
@@ -20,6 +20,7 @@ import WindowStore from 'shared/components/window/WindowStore';
 
 import { StudyViewPageTabKeyEnum } from 'pages/studyView/StudyViewPageTabs';
 import { StudyViewPageStore } from '../StudyViewPageStore';
+import AppConfig from 'appConfig';
 
 @observer
 export default class CNSegments extends React.Component<
@@ -160,12 +161,13 @@ export default class CNSegments extends React.Component<
                 </LoadingIndicator>
                 <div style={{ marginBottom: 15, marginLeft: 15 }}>
                     <span>{this.selectionInfo}</span>
-                    {!this.hasNoSegmentData && (
-                        <CNSegmentsDownloader
-                            promise={this.activePromise!}
-                            filename={this.filename}
-                        />
-                    )}
+                    {!this.hasNoSegmentData &&
+                        !AppConfig.serverConfig.skin_hide_download_controls && (
+                            <CNSegmentsDownloader
+                                promise={this.activePromise!}
+                                filename={this.filename}
+                            />
+                        )}
                 </div>
                 <div
                     style={

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -23,6 +23,8 @@ import ProgressIndicator, {
 } from '../../../shared/components/progressIndicator/ProgressIndicator';
 import autobind from 'autobind-decorator';
 import { WindowWidthBox } from '../../../shared/components/WindowWidthBox/WindowWidthBox';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 export interface IClinicalDataTabTable {
     store: StudyViewPageStore;
@@ -205,7 +207,10 @@ export class ClinicalDataTab extends React.Component<
                         <Else>
                             <ClinicalDataTabTableComponent
                                 initialItemsPerPage={20}
-                                showCopyDownload={true}
+                                showCopyDownload={
+                                    !AppConfig.serverConfig
+                                        .skin_hide_download_controls
+                                }
                                 showColumnVisibility={false}
                                 data={
                                     this.props.store.getDataForClinicalDataTab
@@ -213,7 +218,7 @@ export class ClinicalDataTab extends React.Component<
                                 }
                                 columns={this.columns.result}
                                 copyDownloadProps={{
-                                    showCopy: false,
+                                    showCopy: shouldShowDownloadAndCopyControls(),
                                     downloadFilename: this.props.store
                                         .clinicalDataDownloadFilename,
                                 }}

--- a/src/shared/components/ChartContainer/ChartContainer.tsx
+++ b/src/shared/components/ChartContainer/ChartContainer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DownloadControls } from 'cbioportal-frontend-commons';
+import AppConfig from 'appConfig';
 
 interface IChartContainer {
     getSVGElement?: () => SVGElement | null;
@@ -13,18 +14,20 @@ export default class ChartContainer extends React.Component<
     render() {
         return (
             <div className="borderedChart inlineBlock">
-                <DownloadControls
-                    filename={this.props.exportFileName || 'chart-download'}
-                    dontFade={true}
-                    getSvg={this.props.getSVGElement!}
-                    type="button"
-                    style={{
-                        position: 'absolute',
-                        top: 10,
-                        right: 10,
-                        zIndex: 10,
-                    }}
-                />
+                {!AppConfig.serverConfig.skin_hide_download_controls && (
+                    <DownloadControls
+                        filename={this.props.exportFileName || 'chart-download'}
+                        dontFade={true}
+                        getSvg={this.props.getSVGElement!}
+                        type="button"
+                        style={{
+                            position: 'absolute',
+                            top: 10,
+                            right: 10,
+                            zIndex: 10,
+                        }}
+                    />
+                )}
                 <div style={{ overflowX: 'auto', overflowY: 'hidden' }}>
                     {this.props.children}
                 </div>

--- a/src/shared/components/cnSegments/CNSegmentsDownloader.tsx
+++ b/src/shared/components/cnSegments/CNSegmentsDownloader.tsx
@@ -51,6 +51,7 @@ export default class CNSegmentsDownloader extends React.Component<
                     className={this.props.buttonClassName}
                     onClick={this.handleDownload}
                     disabled={this.downloading}
+                    data-test={'downloadButton'}
                 >
                     <i
                         className={classnames({

--- a/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { Modal, Button } from 'react-bootstrap';
+import { Button, Modal } from 'react-bootstrap';
 import { ThreeBounce } from 'better-react-spinkit';
-import { If } from 'react-if';
 import fileDownload from 'react-file-download';
-import { action, observable, makeObservable } from 'mobx';
+import { action, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
-const Clipboard = require('clipboard');
-
 import copyDownloadStyles from './copyDownloadControls.module.scss';
 import { CopyDownloadButtons } from './CopyDownloadButtons';
 import { ICopyDownloadControlsProps } from './ICopyDownloadControls';
-import autobind from 'autobind-decorator';
+
+const Clipboard = require('clipboard');
 
 export interface IAsyncCopyDownloadControlsProps
     extends ICopyDownloadControlsProps {

--- a/src/shared/components/copyDownloadControls/CopyDownloadQueryLinks.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadQueryLinks.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { If } from 'react-if';
 import { ICopyDownloadInputsProps } from './ICopyDownloadControls';
 import classnames from 'classnames';
 import styles from './copyDownloadControls.module.scss';

--- a/src/shared/components/cosmic/CosmicMutationTable.tsx
+++ b/src/shared/components/cosmic/CosmicMutationTable.tsx
@@ -5,6 +5,8 @@ import {
     Column,
     default as LazyMobXTable,
 } from '../lazyMobXTable/LazyMobXTable';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 // TODO interface ICosmicTableProps extends IMSKTableProps<CosmicMutation>
 // To avoid duplication, it would be nice here to have an extendable interface for LazyMobXTableProps
@@ -92,7 +94,7 @@ export default class CosmicMutationTable extends React.Component<
                     initialSortColumn={initialSortColumn}
                     initialSortDirection={initialSortDirection}
                     initialItemsPerPage={initialItemsPerPage}
-                    showCopyDownload={false}
+                    showCopyDownload={shouldShowDownloadAndCopyControls()}
                     showColumnVisibility={false}
                     showFilter={false}
                     showPagination={showPagination}

--- a/src/shared/components/enhancedReactTable/EnhancedReactTable.tsx
+++ b/src/shared/components/enhancedReactTable/EnhancedReactTable.tsx
@@ -22,6 +22,7 @@ import {
     ColumnVisibility,
 } from './IColumnFormatter';
 import './styles.css';
+import AppConfig from 'appConfig';
 
 /**
  * @author Selcuk Onur Sumer
@@ -263,7 +264,9 @@ export default class EnhancedReactTable<T> extends React.Component<
         return (
             <div className={className}>
                 <TableHeaderControls
-                    showCopyAndDownload={true}
+                    showCopyAndDownload={
+                        !AppConfig.serverConfig.skin_hide_download_controls
+                    }
                     showHideShowColumnButton={true}
                     handleInput={this.handleFilterInput}
                     downloadDataGenerator={this.handleDownload}

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -43,6 +43,7 @@ import {
 import { ILazyMobXTableApplicationLazyDownloadDataFetcher } from '../../lib/ILazyMobXTableApplicationLazyDownloadDataFetcher';
 import { maxPage } from './utils';
 import { inputBoxChangeTimeoutEvent } from '../../lib/EventUtils';
+import AppConfig from 'appConfig';
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -1190,7 +1191,8 @@ export default class LazyMobXTable<T> extends React.Component<
                     ) : (
                         ''
                     )}
-                    {this.props.showCopyDownload ? (
+                    {this.props.showCopyDownload &&
+                    !AppConfig.serverConfig.skin_hide_download_controls ? (
                         this.props.downloadDataFetcher ? (
                             <CopyDownloadControls
                                 className="pull-right"

--- a/src/shared/components/mutationMapper/MutationMapper.tsx
+++ b/src/shared/components/mutationMapper/MutationMapper.tsx
@@ -44,6 +44,7 @@ import styles from './mutationMapper.module.scss';
 import { ProteinImpactType } from 'cbioportal-frontend-commons';
 import { AnnotatedMutation } from 'pages/resultsView/ResultsViewPageStore';
 import DriverAnnotationProteinImpactTypeBadgeSelector from 'pages/resultsView/mutation/DriverAnnotationProteinImpactTypeBadgeSelector';
+import AppConfig from 'appConfig';
 import { PtmSource } from 'cbioportal-utils';
 
 export interface IMutationMapperProps {
@@ -539,6 +540,9 @@ export default class MutationMapper<
                         : undefined
                 }
                 legend={this.legendColorCodes}
+                showDownloadControls={
+                    !AppConfig.serverConfig.skin_hide_download_controls
+                }
             />
         );
     }

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -35,6 +35,7 @@ import {
     IDriverAnnotationControlsState,
 } from 'shared/alterationFiltering/AnnotationFilteringSettings';
 import DriverAnnotationControls from 'shared/components/driverAnnotations/DriverAnnotationControls';
+import AppConfig from 'appConfig';
 
 export interface IOncoprintControlsHandlers
     extends IDriverAnnotationControlsHandlers {
@@ -1199,7 +1200,9 @@ export default class OncoprintControls extends React.Component<
                     <this.SortMenu />
                     <this.MutationColorMenu />
                     <this.ViewMenu />
-                    <this.DownloadMenu />
+                    {!AppConfig.serverConfig.skin_hide_download_controls && (
+                        <this.DownloadMenu />
+                    )}
                     <this.HorzZoomControls />
                     {this.minimapButton}
                     <ConfirmNgchmModal

--- a/src/shared/components/proteinChainPanel/PdbChainTable.tsx
+++ b/src/shared/components/proteinChainPanel/PdbChainTable.tsx
@@ -10,6 +10,8 @@ import { PdbHeader } from 'genome-nexus-ts-api-client';
 import OrganismColumnFormatter from './column/OrganismColumnFormatter';
 import LazyLoadedTableCell from 'shared/lib/LazyLoadedTableCell';
 import { generatePdbInfoSummary } from '../../lib/PdbUtils';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 class PdbChainTableComponent extends LazyMobXTable<IPdbChain> {}
 
@@ -200,7 +202,7 @@ export default class PdbChainTable extends React.Component<
         return (
             <PdbChainTableComponent
                 showColumnVisibility={false}
-                showCopyDownload={false}
+                showCopyDownload={shouldShowDownloadAndCopyControls()}
                 itemsLabel="PDB chain"
                 itemsLabelPlural="PDB chains"
                 paginationProps={{

--- a/src/shared/components/query/GenesetsVolcanoSelector.tsx
+++ b/src/shared/components/query/GenesetsVolcanoSelector.tsx
@@ -19,6 +19,8 @@ import {
 } from 'victory';
 import { QueryStoreComponent } from './QueryStore';
 import { CBIOPORTAL_VICTORY_THEME } from 'cbioportal-frontend-commons';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 class GenesetsVolcanoTable extends LazyMobXTable<Geneset> {}
 
@@ -345,7 +347,7 @@ export default class GenesetsVolcanoSelector extends QueryStoreComponent<
                                 initialItemsPerPage={100}
                                 showColumnVisibility={false}
                                 showFilter={true}
-                                showCopyDownload={false}
+                                showCopyDownload={shouldShowDownloadAndCopyControls()}
                             />
                         )}
                 </div>

--- a/src/shared/components/query/GisticGeneSelector.tsx
+++ b/src/shared/components/query/GisticGeneSelector.tsx
@@ -17,6 +17,8 @@ import classNames from 'classnames';
 import { IColumnDefMap } from '../enhancedReactTable/IEnhancedReactTableProps';
 import { toPrecision } from '../../lib/FormatUtils';
 import { getGeneSymbols, sortByCytoband } from '../../lib/GisticUtils';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 const DEFAULT_NUM_GENES_SHOWN = 5;
 
@@ -169,7 +171,7 @@ export default class GisticGeneSelector extends React.Component<
                     columns={this.columns}
                     rawData={this.props.data}
                     headerControlsProps={{
-                        showCopyAndDownload: false,
+                        showCopyAndDownload: shouldShowDownloadAndCopyControls(),
                         showHideShowColumnButton: false,
                         showPagination: true,
                     }}

--- a/src/shared/components/query/MutSigGeneSelector.tsx
+++ b/src/shared/components/query/MutSigGeneSelector.tsx
@@ -18,6 +18,8 @@ import { IColumnFormatterData } from '../enhancedReactTable/IColumnFormatter';
 import { IColumnDefMap } from '../enhancedReactTable/IEnhancedReactTableProps';
 import { Td } from 'reactable';
 import { toPrecision } from '../../lib/FormatUtils';
+import AppConfig from 'appConfig';
+import { shouldShowDownloadAndCopyControls } from 'shared/lib/DownloadControlsUtils';
 
 class MutSigTable extends EnhancedReactTable<MutSig> {}
 
@@ -155,7 +157,7 @@ export default class MutSigGeneSelector extends React.Component<
                     columns={this.columns}
                     rawData={this.props.data}
                     headerControlsProps={{
-                        showCopyAndDownload: false,
+                        showCopyAndDownload: shouldShowDownloadAndCopyControls(),
                         showHideShowColumnButton: false,
                         showPagination: true,
                     }}

--- a/src/shared/components/structureViewer/StructureViewerPanel.tsx
+++ b/src/shared/components/structureViewer/StructureViewerPanel.tsx
@@ -35,6 +35,7 @@ import {
 import PyMolScriptGenerator from './PyMolScriptGenerator';
 
 import styles from './structureViewer.module.scss';
+import AppConfig from 'appConfig';
 
 export interface IStructureViewerPanelProps extends IProteinImpactTypeColors {
     pdbChainDataStore: ILazyMobXTableApplicationDataStore<IPdbChain>;
@@ -414,19 +415,21 @@ export default class StructureViewerPanel extends React.Component<
         return (
             <div className="row">
                 <div className="col col-sm-6">
-                    <ButtonGroup>
-                        <DefaultTooltip
-                            overlay={<span>Download PyMol script</span>}
-                            placement="top"
-                        >
-                            <Button
-                                className="btn-sm"
-                                onClick={this.handlePyMolDownload}
+                    {!AppConfig.serverConfig.skin_hide_download_controls && (
+                        <ButtonGroup>
+                            <DefaultTooltip
+                                overlay={<span>Download PyMol script</span>}
+                                placement="top"
                             >
-                                <i className="fa fa-cloud-download" /> PyMol
-                            </Button>
-                        </DefaultTooltip>
-                    </ButtonGroup>
+                                <Button
+                                    className="btn-sm"
+                                    onClick={this.handlePyMolDownload}
+                                >
+                                    <i className="fa fa-cloud-download" /> PyMol
+                                </Button>
+                            </DefaultTooltip>
+                        </ButtonGroup>
+                    )}
                 </div>
                 <div className="col col-sm-6">
                     <span className="pull-right">

--- a/src/shared/components/tableHeaderControls/TableHeaderControls.tsx
+++ b/src/shared/components/tableHeaderControls/TableHeaderControls.tsx
@@ -21,6 +21,7 @@ import {
     IColumnVisibilityControlsProps,
     ColumnVisibilityControls,
 } from '../columnVisibilityControls/ColumnVisibilityControls';
+import AppConfig from 'appConfig';
 
 export interface ITableHeaderControlsProps {
     tableData?: Array<any>;
@@ -100,7 +101,8 @@ export default class TableHeaderControls extends React.Component<
 
     public static defaultProps: ITableHeaderControlsProps = {
         showSearch: false,
-        showCopyAndDownload: true,
+        showCopyAndDownload: !AppConfig.serverConfig
+            .skin_hide_download_controls,
         showPagination: false,
         searchClassName: '',
         copyDownloadClassName: '',

--- a/src/shared/lib/DownloadControlsUtils.ts
+++ b/src/shared/lib/DownloadControlsUtils.ts
@@ -1,0 +1,6 @@
+export function shouldShowDownloadAndCopyControls() {
+    // for now, we are always hiding copy controls, but in the future we will use the
+    //    app config to determine whether we show them:
+    // return !AppConfig.serverConfig.skin_hide_download_controls
+    return false;
+}


### PR DESCRIPTION
Rebased cherry pick of Pim's work seen here: https://github.com/cBioPortal/cbioportal-frontend/pull/3716

This PR will hide all download and copy-to-clipboard options from cBioPortal.
This behavior is controlled by a new skin_hide_download_controls property
in serverConfig. The removed download options include:

- Download tab in Studies Overview page.
- Download tab in Results View.
- Download action button in Study View.
- Download options in Charts and Tables.
