### PR TITLE
Add docs/help links to various tabs using the new HelpWidget

### DIFF
--- a/src/globalStyles/e2etest.scss
+++ b/src/globalStyles/e2etest.scss
@@ -42,4 +42,8 @@
     .tabAnchor_heatmaps {
         display: none !important;
     }
+
+    .helpWidget {
+        display: none;
+    }
 }

--- a/src/pages/groupComparison/GroupComparisonPage.tsx
+++ b/src/pages/groupComparison/GroupComparisonPage.tsx
@@ -47,6 +47,7 @@ import {
     prepareCustomTabConfigurations,
 } from 'shared/lib/customTabs/customTabHelpers';
 import { deriveDisplayTextFromGenericAssayType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import { HelpWidget } from 'shared/components/HelpWidget/HelpWidget';
 
 export interface IGroupComparisonPageProps {
     routing: any;
@@ -138,6 +139,11 @@ export default class GroupComparisonPage extends React.Component<
                     onTabClick={this.urlWrapper.setTabId}
                     className="primaryTabs mainTabs"
                     hrefRoot={buildCBioPortalPageUrl('comparison')}
+                    contentWindowExtra={
+                        <HelpWidget
+                            path={this.props.routing.location.pathname}
+                        />
+                    }
                 >
                     <MSKTab id={GroupComparisonTab.OVERLAP} linkText="Overlap">
                         <Overlap

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -183,7 +183,7 @@ export function getMutationAlignerUrlTemplate() {
 }
 
 export function getOncoQueryDocUrl() {
-    return buildCBioPortalPageUrl('/oql');
+    return 'https://docs.cbioportal.org/user-guide/by-page/#oql';
 }
 
 export function trimProtocol(url: string) {

--- a/src/shared/components/HelpWidget/HelpWidget.tsx
+++ b/src/shared/components/HelpWidget/HelpWidget.tsx
@@ -5,6 +5,7 @@ import { getServerConfig } from 'config/config';
 import classNames from 'classnames';
 
 import { isWebdriver } from 'cbioportal-frontend-commons';
+import { serializeEvent } from 'shared/lib/tracking';
 
 interface IHelpWidgetProps {
     path: string;
@@ -63,7 +64,14 @@ export const HelpWidget: React.FunctionComponent<IHelpWidgetProps> = function({
     );
 
     return (
-        <div className={classNames('helpWidget', styles['widget-wrapper'])}>
+        <div
+            data-event={serializeEvent({
+                action: 'featureSpecificHelpClick',
+                label: conf.regexp,
+                category: 'linkout',
+            })}
+            className={classNames('helpWidget', styles['widget-wrapper'])}
+        >
             {el}
         </div>
     );

--- a/src/shared/components/HelpWidget/HelpWidget.tsx
+++ b/src/shared/components/HelpWidget/HelpWidget.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import styles from './styles.module.scss';
 import ReactMarkdown from 'react-markdown';
-import { useState } from 'react';
-import { Modal } from 'react-bootstrap';
 import { getServerConfig } from 'config/config';
+import classNames from 'classnames';
+
+import { isWebdriver } from 'cbioportal-frontend-commons';
 
 interface IHelpWidgetProps {
     path: string;
@@ -14,8 +15,12 @@ function parseConfiguration(markdown: string) {
 
     const parsed = items.reduce((ret: any[], s) => {
         if (s.length) {
+            let regexp = s.match(/[^\n]*/)![0];
+
+            regexp = regexp.replace(/\//, '/?');
+
             ret.push({
-                regexp: s.match(/[^\n]*/)![0],
+                regexp,
                 markdown: s.substr(s.indexOf('\n')),
             });
         }
@@ -28,8 +33,9 @@ function parseConfiguration(markdown: string) {
 export const HelpWidget: React.FunctionComponent<IHelpWidgetProps> = function({
     path,
 }: IHelpWidgetProps) {
-    // temporarily hide all help links
-    return null;
+    if (isWebdriver()) {
+        return null;
+    }
 
     // only show this on public portal right now
     // this should ultimately be by configuration
@@ -47,42 +53,60 @@ export const HelpWidget: React.FunctionComponent<IHelpWidgetProps> = function({
 
     const md = conf.markdown.trim();
 
-    const [modalOpenState, setModalOpenState] = useState(false);
-
     let el: JSX.Element;
 
-    if (/\n/.test(md)) {
-        el = <a onClick={() => setModalOpenState(true)}>Oncoprint Help</a>;
-    } else {
-        el = (
-            <>
-                <ReactMarkdown linkTarget={'_blank'}>{md}</ReactMarkdown>{' '}
-                <i className={'fa fa-video-camera'} />
-            </>
-        );
-    }
+    el = (
+        <>
+            <ReactMarkdown linkTarget={'_blank'}>{md}</ReactMarkdown>{' '}
+            <i className={'fa fa-book'} />
+        </>
+    );
 
     return (
-        <div className={styles['widget-wrapper']}>
+        <div className={classNames('helpWidget', styles['widget-wrapper'])}>
             {el}
-            <Modal
-                show={modalOpenState}
-                onHide={() => setModalOpenState(false)}
-            >
-                <Modal.Header closeButton={true}>cBioPortal Help</Modal.Header>
-                <Modal.Body>
-                    <ReactMarkdown>{md}</ReactMarkdown>
-                </Modal.Body>
-            </Modal>
         </div>
     );
 };
 
 const markdown = `
-
 URLMATCH:results/mutations
-[How-to: filtering clinical data](https://www.youtube.com/watch?v=q9No2073c5o) 
+[Mutations Tab Help](https://docs.cbioportal.org/user-guide/by-page/#mutations) 
+
+URLMATCH:results/oncoprint
+[Oncoprint Help](https://docs.cbioportal.org/user-guide/by-page/#oncoprint)
+
+URLMATCH:results/cancerTypesSummary
+[Cancer Type Summary Help](https://docs.cbioportal.org/user-guide/by-page/#cancer-types-summary)
+
+URLMATCH:results/mutualExclusivity
+[Mutual Exclusivity Help](https://docs.cbioportal.org/user-guide/by-page/#mutual-exclusivity)
+
+URLMATCH:results/plots
+[Plots Help](https://docs.cbioportal.org/user-guide/by-page/#plots)
+
+URLMATCH:results/coexpression
+[Coexpression Help](https://docs.cbioportal.org/user-guide/by-page/#co-expression)
+
+URLMATCH:results/comparison
+[Comparison/Survival Help](https://docs.cbioportal.org/user-guide/by-page/#comparisonsurvival)
+
+URLMATCH:results/cnSegments
+[CN Segments Help](https://docs.cbioportal.org/user-guide/by-page/#cn-segments)
+
+URLMATCH:results/pathways
+[Pathways Help](https://docs.cbioportal.org/user-guide/by-page/#pathways)
+
+URLMATCH:results/download
+[Download Help](https://docs.cbioportal.org/user-guide/by-page/#downloads)
+
+URLMATCH:comparison/.*
+[Group Comparison Help](https://docs.cbioportal.org/user-guide/by-page/#group-comparison)
 
 URLMATCH:study/.*
-[How-to: expression-based comparisons](https://www.youtube.com/watch?v=HTiKUXk0j0s)
+[Study Page Help](https://docs.cbioportal.org/user-guide/by-page/#study-view)
+
+URLMATCH:patient/.*
+[Patient Page Help](https://docs.cbioportal.org/user-guide/by-page/#patient-view)
+
 `;

--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -211,7 +211,8 @@ export default class CancerStudySelector extends React.Component<
                             this.store.cancerStudies,
                         ]}
                     >
-                        Select Studies for Visualization & Analysis:
+                        Select Studies for Visualization & Analysis: (
+                        <a href={'#'}>Help</a>)
                     </SectionHeader>
 
                     {this.store.selectableStudiesSet.isComplete && (

--- a/src/shared/lib/tracking.ts
+++ b/src/shared/lib/tracking.ts
@@ -15,7 +15,8 @@ export type GAEvent = {
         | 'download'
         | 'groupComparison'
         | 'homePage'
-        | 'patientView';
+        | 'patientView'
+        | 'linkout';
     action: string;
     label?: string | string[];
     fieldsObject?: { [key: string]: string | number };


### PR DESCRIPTION
Add tab specific help links that link out to documentation site

<img width="370" alt="image" src="https://user-images.githubusercontent.com/186521/169144530-106e8f0a-2858-4a75-843a-cb6385c81286.png">
