### PR TITLE
Fix request body compression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
           environment:
             JUNIT_REPORT_PATH: ./junit/
             JUNIT_REPORT_NAME: test-results.xml
+            NODE_OPTIONS: --max-old-space-size=4096
             DISABLE_SOURCEMAP: true
             WEBPACK_PARALLEL: false
           when: always

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -1,4 +1,4 @@
-import { ServerConfigHelpers } from './config';
+import { ServerConfigHelpers, UrlParamPair, pairMatchesPath } from './config';
 import { assert } from 'chai';
 
 describe('ServerConfigHelpers', () => {
@@ -27,6 +27,56 @@ describe('ServerConfigHelpers', () => {
                     'acc_tcga_pan_can_atlas_2018',
                 ],
             });
+        });
+    });
+
+    describe('pairMatchesPath', () => {
+        it('should match exact match', () => {
+            const pair: UrlParamPair = { url: '/foo/', params: { a: '1' } };
+            const ans = pairMatchesPath(pair, '/foo/bar/baz', { a: '1' });
+
+            assert.isTrue(ans);
+        });
+
+        it('should match exact match with empty params', () => {
+            const pair: UrlParamPair = { url: '/foo/', params: {} };
+            const ans = pairMatchesPath(pair, '/foo/bar/baz', {});
+
+            assert.isTrue(ans);
+        });
+
+        it('should match exact match with extra params', () => {
+            const pair: UrlParamPair = { url: '/foo/', params: { a: '1' } };
+            const ans = pairMatchesPath(pair, '/foo/bar/baz', {
+                a: '1',
+                b: '1',
+            });
+
+            assert.isTrue(ans);
+        });
+
+        it('should not match exact when missing all params', () => {
+            const pair: UrlParamPair = { url: '/foo/', params: { a: '1' } };
+            const ans = pairMatchesPath(pair, '/foo/bar/baz', {});
+
+            assert.isFalse(ans);
+        });
+
+        it('should not match exact when missing some params', () => {
+            const pair: UrlParamPair = {
+                url: '/foo/',
+                params: { a: '1', b: '1' },
+            };
+            const ans = pairMatchesPath(pair, '/foo/bar/baz', { a: '1' });
+
+            assert.isFalse(ans);
+        });
+
+        it('should not match when param has different val', () => {
+            const pair: UrlParamPair = { url: '/foo/', params: { a: '1' } };
+            const ans = pairMatchesPath(pair, '/foo/bar/baz', { a: '2' });
+
+            assert.isFalse(ans);
         });
     });
 });


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Url params are now omitted from the url passed to the api client
- This was breaking some startsWith logic for requests that we compress
based on both url params and the uri
- To fix this, we now match against both the url string and the param
object