### PR TITLE
Enable request body compression for /clinical-attributes/counts/fetch endpoint

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -206,6 +206,7 @@ export function initializeAPIClients() {
             CBioPortalAPI,
             [
                 { url: '/mutations/fetch', params: {} },
+                { url: '/clinical-attributes/counts/fetch', params: {} },
                 { url: '/patients/fetch', params: {} },
                 { url: '/molecular-data/fetch', params: {} },
                 {


### PR DESCRIPTION
# Problem
When loading Oncoprint with a large number of samples (100.000) the upload of the request body takes 2.2 minute for the `/clinical-attributes/counts/fetch` endpoint. It turns out that the request is not yet listed in the urls that the frontend sends gzip compressed request bodies to.

![image](https://user-images.githubusercontent.com/745885/170997732-a6eddf8c-0ae9-4c04-83a7-e376eb7e3446.png)

# Solution
Activate gzip compression for `/clinical-attributes/counts/fetch` endpoint.