### PR TITLE
Don't fetch ndex status unless Pathways tab is active

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -33,7 +33,6 @@ import Helmet from 'react-helmet';
 import {
     parseConfigDisabledTabs,
     ResultsViewTab,
-    ResultsViewPathwaysSubTab,
 } from './ResultsViewPageHelpers';
 import {
     buildResultsViewPageTitle,
@@ -70,6 +69,7 @@ import {
 import { buildCBioPortalPageUrl } from 'shared/api/urls';
 import IFrameLoader from 'shared/components/iframeLoader/IFrameLoader';
 import { AppContext } from 'cbioportal-frontend-commons';
+import PathWayMapperContainer from 'pages/resultsView/pathwayMapper/PathWayMapperContainer';
 
 export function initStore(
     appStore: AppStore,
@@ -116,8 +116,6 @@ export default class ResultsViewPage extends React.Component<
     @observable.ref quickOQLQueryStore: QueryStore | null = null;
 
     @observable showTabs = true;
-
-    @observable activePathwaysTab = ResultsViewPathwaysSubTab.PATHWAY_MAPPER;
 
     constructor(props: IResultsViewPageProps) {
         super(props);
@@ -410,123 +408,10 @@ export default class ResultsViewPage extends React.Component<
                             linkText={'Pathways'}
                         >
                             {showPathwaysTab ? (
-                                <>
-                                    <span
-                                        style={{
-                                            float: 'left',
-                                            paddingRight: 10,
-                                        }}
-                                    >
-                                        Choose Pathway Source:
-                                    </span>
-                                    <MSKTabs
-                                        id="pathwaysPageTabs"
-                                        activeTabId={this.activePathwaysTab}
-                                        onTabClick={(
-                                            id: ResultsViewPathwaysSubTab
-                                        ) => {
-                                            this.activePathwaysTab = id;
-                                        }}
-                                        className="pillTabs resultsPagePathwaysTabs"
-                                        arrowStyle={{ 'line-height': 0.8 }}
-                                        tabButtonStyle="pills"
-                                        unmountOnHide={true}
-                                    >
-                                        <MSKTab
-                                            key={
-                                                ResultsViewPathwaysSubTab.PATHWAY_MAPPER
-                                            }
-                                            id={
-                                                ResultsViewPathwaysSubTab.PATHWAY_MAPPER
-                                            }
-                                            linkText={
-                                                ResultsViewPathwaysSubTab.PATHWAY_MAPPER
-                                            }
-                                            linkTooltip={
-                                                <div style={{ maxWidth: 400 }}>
-                                                    <a
-                                                        href="https://www.pathwaymapper.org/"
-                                                        target="_blank"
-                                                    >
-                                                        PathwayMapper
-                                                    </a>{' '}
-                                                    shows pathways from over
-                                                    fifty cancer related
-                                                    pathways and provides a
-                                                    collaborative web-based
-                                                    editor for creating new
-                                                    ones.
-                                                </div>
-                                            }
-                                            hide={
-                                                !getServerConfig()
-                                                    .show_pathway_mapper
-                                            }
-                                        >
-                                            <ResultsViewPathwayMapper
-                                                store={store}
-                                                appStore={this.appStore}
-                                                urlWrapper={this.urlWrapper}
-                                            />
-                                        </MSKTab>
-                                        <MSKTab
-                                            key={ResultsViewPathwaysSubTab.NDEX}
-                                            id={ResultsViewPathwaysSubTab.NDEX}
-                                            linkText={
-                                                ResultsViewPathwaysSubTab.NDEX
-                                            }
-                                            linkTooltip={
-                                                <div style={{ maxWidth: 400 }}>
-                                                    <a
-                                                        href="https://www.ndexbio.org/"
-                                                        target="_blank"
-                                                    >
-                                                        NDEx
-                                                    </a>{' '}
-                                                    shows 966 pathways:
-                                                    <ul>
-                                                        <li>
-                                                            211 from{' '}
-                                                            <a
-                                                                href="https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/NCI_PID/index.html"
-                                                                target="_blank"
-                                                            >
-                                                                NCI-PID
-                                                            </a>
-                                                        </li>
-                                                        <li>
-                                                            69 from{' '}
-                                                            <a
-                                                                href="https://signor.uniroma2.it/"
-                                                                target="_blank"
-                                                            >
-                                                                Signor
-                                                            </a>
-                                                        </li>
-                                                        <li>
-                                                            686 from{' '}
-                                                            <a href="https://www.wikipathways.org/">
-                                                                WikiPathways
-                                                            </a>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                            }
-                                            hide={
-                                                !getServerConfig().show_ndex ||
-                                                !this.resultsViewPageStore
-                                                    .remoteNdexUrl.isComplete ||
-                                                !this.resultsViewPageStore
-                                                    .remoteNdexUrl.result
-                                            }
-                                        >
-                                            <IFrameLoader
-                                                height={800}
-                                                url={`${this.resultsViewPageStore.remoteNdexUrl.result}`}
-                                            />
-                                        </MSKTab>
-                                    </MSKTabs>
-                                </>
+                                <PathWayMapperContainer
+                                    resultsViewPageStore={store}
+                                    appStore={this.appStore}
+                                />
                             ) : (
                                 <LoadingIndicator
                                     isLoading={true}

--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -1,0 +1,128 @@
+import { MSKTab, MSKTabs } from 'shared/components/MSKTabs/MSKTabs';
+import { ResultsViewPathwaysSubTab } from 'pages/resultsView/ResultsViewPageHelpers';
+import { getServerConfig } from 'config/config';
+import ResultsViewPathwayMapper from 'pages/resultsView/pathwayMapper/ResultsViewPathwayMapper';
+import IFrameLoader from 'shared/components/iframeLoader/IFrameLoader';
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { ResultsViewPageStore } from 'pages/resultsView/ResultsViewPageStore';
+import { AppStore } from 'AppStore';
+import { useLocalObservable } from 'mobx-react-lite';
+import { runInAction } from 'mobx';
+
+interface IPathwayMapperContainerProps {
+    resultsViewPageStore: ResultsViewPageStore;
+    appStore: AppStore;
+}
+
+const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerProps> = observer(
+    function({ resultsViewPageStore, appStore }: IPathwayMapperContainerProps) {
+        const store = useLocalObservable(() => ({
+            activeTab: ResultsViewPathwaysSubTab.PATHWAY_MAPPER,
+        }));
+
+        return (
+            <>
+                <span
+                    style={{
+                        float: 'left',
+                        paddingRight: 10,
+                    }}
+                >
+                    Choose Pathway Source:
+                </span>
+                <MSKTabs
+                    id="pathwaysPageTabs"
+                    activeTabId={store.activeTab}
+                    onTabClick={(id: ResultsViewPathwaysSubTab) => {
+                        runInAction(() => (store.activeTab = id));
+                    }}
+                    className="pillTabs resultsPagePathwaysTabs"
+                    arrowStyle={{ 'line-height': 0.8 }}
+                    tabButtonStyle="pills"
+                    unmountOnHide={true}
+                >
+                    <MSKTab
+                        key={ResultsViewPathwaysSubTab.PATHWAY_MAPPER}
+                        id={ResultsViewPathwaysSubTab.PATHWAY_MAPPER}
+                        linkText={ResultsViewPathwaysSubTab.PATHWAY_MAPPER}
+                        linkTooltip={
+                            <div style={{ maxWidth: 400 }}>
+                                <a
+                                    href="https://www.pathwaymapper.org/"
+                                    target="_blank"
+                                >
+                                    PathwayMapper
+                                </a>{' '}
+                                shows pathways from over fifty cancer related
+                                pathways and provides a collaborative web-based
+                                editor for creating new ones.
+                            </div>
+                        }
+                        hide={!getServerConfig().show_pathway_mapper}
+                    >
+                        <ResultsViewPathwayMapper
+                            store={resultsViewPageStore}
+                            appStore={appStore}
+                            urlWrapper={resultsViewPageStore.urlWrapper}
+                        />
+                    </MSKTab>
+                    <MSKTab
+                        key={ResultsViewPathwaysSubTab.NDEX}
+                        id={ResultsViewPathwaysSubTab.NDEX}
+                        linkText={ResultsViewPathwaysSubTab.NDEX}
+                        linkTooltip={
+                            <div style={{ maxWidth: 400 }}>
+                                <a
+                                    href="https://www.ndexbio.org/"
+                                    target="_blank"
+                                >
+                                    NDEx
+                                </a>{' '}
+                                shows 966 pathways:
+                                <ul>
+                                    <li>
+                                        211 from{' '}
+                                        <a
+                                            href="https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/NCI_PID/index.html"
+                                            target="_blank"
+                                        >
+                                            NCI-PID
+                                        </a>
+                                    </li>
+                                    <li>
+                                        69 from{' '}
+                                        <a
+                                            href="https://signor.uniroma2.it/"
+                                            target="_blank"
+                                        >
+                                            Signor
+                                        </a>
+                                    </li>
+                                    <li>
+                                        686 from{' '}
+                                        <a href="https://www.wikipathways.org/">
+                                            WikiPathways
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                        }
+                        hide={
+                            !getServerConfig().show_ndex ||
+                            !resultsViewPageStore.remoteNdexUrl.isComplete ||
+                            !resultsViewPageStore.remoteNdexUrl.result
+                        }
+                    >
+                        <IFrameLoader
+                            height={800}
+                            url={`${resultsViewPageStore.remoteNdexUrl.result}`}
+                        />
+                    </MSKTab>
+                </MSKTabs>
+            </>
+        );
+    }
+);
+
+export default PathWayMapperContainer;


### PR DESCRIPTION
We need to wait until user navigates to the pathways tab before we call ndex service