### PR TITLE
Fix request body compression for /clinical-attributes/counts/fetch endpoint

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -207,7 +207,6 @@ export function initializeAPIClients() {
             [
                 { url: '/mutations/fetch', params: {} },
                 { url: '/structural-variant/fetch', params: {} },
-                { url: '/clinical-attributes/counts/fetch', params: {} },
                 { url: '/patients/fetch', params: {} },
                 { url: '/molecular-data/fetch', params: {} },
                 {
@@ -220,6 +219,11 @@ export function initializeAPIClients() {
                     params: { clinicalDataType: 'PATIENT' },
                 },
             ],
+            getCbioPortalApiUrl()
+        );
+        compressRequestBodies(
+            CBioPortalAPIInternal,
+            [{ url: '/clinical-attributes/counts/fetch', params: {} }],
             getCbioPortalApiUrl()
         );
     }


### PR DESCRIPTION
# Problem
PR #4279 did not activate request body compression for the `/clinical-attributes/counts/fetch` endpoint. The reason for this is that this endpoint is part of the _internal api_. Only the public api is covered by the request body compression mechanism.

# Solution
Correctly register the `/clinical-attributes/counts/fetch` endpoint of the internal API for request compression.