### PR TITLE
fix result generic assay oncoprint issue

### DIFF
--- a/end-to-end-test/local/specs/treatment.screenshot.spec.js
+++ b/end-to-end-test/local/specs/treatment.screenshot.spec.js
@@ -14,9 +14,14 @@ var selectReactSelectOption = require('../../shared/specUtils')
 var goToTreatmentTab = require('./treatment.spec').goToTreatmentTab;
 var selectTreamentsBothAxes = require('./treatment.spec')
     .selectTreamentsBothAxes;
+var selectElementByText = require('../../shared/specUtils').selectElementByText;
 
+const TREATMENT_EC50_PROFILE_NAME =
+    'EC50 values of compounds on cellular phenotype readout';
 const GENERIC_ASSAY_ENTITY_SELECTOR =
     '[data-test="GenericAssayEntitySelection"]';
+const GENERIC_ASSAY_PROFILE_SELECTOR =
+    '[data-test="GenericAssayProfileSelection"]';
 
 describe('treatment feature', () => {
     describe('oncoprint tab', () => {
@@ -27,6 +32,10 @@ describe('treatment feature', () => {
 
         it('shows treatment profile heatmap track for treatment', () => {
             goToTreatmentTab();
+            // change profile to EC50
+            $(GENERIC_ASSAY_PROFILE_SELECTOR).click();
+            selectElementByText(TREATMENT_EC50_PROFILE_NAME).waitForExist();
+            selectElementByText(TREATMENT_EC50_PROFILE_NAME).click();
             $(GENERIC_ASSAY_ENTITY_SELECTOR).click();
             $('[data-test="GenericAssayEntitySelection"] input').setValue(
                 '17-AAG'

--- a/end-to-end-test/local/specs/treatment.spec.js
+++ b/end-to-end-test/local/specs/treatment.spec.js
@@ -22,6 +22,8 @@ const TREATMENT_IC50_PROFILE_NAME =
     'IC50 values of compounds on cellular phenotype readout';
 const TREATMENT_EC50_PROFILE_NAME =
     'EC50 values of compounds on cellular phenotype readout';
+const GENERIC_ASSAY_PROFILE_SELECTOR =
+    '[data-test="GenericAssayProfileSelection"]';
 const GENERIC_ASSAY_ENTITY_SELECTOR =
     '[data-test="GenericAssayEntitySelection"]';
 
@@ -36,26 +38,26 @@ describe('treatment feature', function() {
 
         it('shows treatment data type option in heatmap menu', () => {
             goToTreatmentTab();
-            // change profile to IC50
-            selectElementByText(TREATMENT_EC50_PROFILE_NAME).waitForExist();
-            selectElementByText(TREATMENT_EC50_PROFILE_NAME).click();
+            // open treatment profile selection menu
+            $(GENERIC_ASSAY_PROFILE_SELECTOR).click();
             selectElementByText(TREATMENT_IC50_PROFILE_NAME).waitForExist();
-            selectElementByText(TREATMENT_IC50_PROFILE_NAME).click();
             assert($(`//*[text()="${TREATMENT_IC50_PROFILE_NAME}"]`));
-            // change profile to EC50
-            selectElementByText(TREATMENT_IC50_PROFILE_NAME).waitForExist();
-            selectElementByText(TREATMENT_IC50_PROFILE_NAME).click();
             selectElementByText(TREATMENT_EC50_PROFILE_NAME).waitForExist();
-            selectElementByText(TREATMENT_EC50_PROFILE_NAME).click();
             assert($(`//*[text()="${TREATMENT_EC50_PROFILE_NAME}"]`));
         });
 
         it('shows treatment selection box in heatmap menu when treatment data type is selected', () => {
             goToTreatmentTab();
-            // open profile dropdown menu
+            // change profile to IC50
+            $(GENERIC_ASSAY_PROFILE_SELECTOR).click();
+            selectElementByText(TREATMENT_IC50_PROFILE_NAME).waitForExist();
+            selectElementByText(TREATMENT_IC50_PROFILE_NAME).click();
+            assert($(`//*[text()="${TREATMENT_IC50_PROFILE_NAME}"]`));
+            // change profile to EC50
+            $(GENERIC_ASSAY_PROFILE_SELECTOR).click();
             selectElementByText(TREATMENT_EC50_PROFILE_NAME).waitForExist();
             selectElementByText(TREATMENT_EC50_PROFILE_NAME).click();
-            assert($(`//*[text()="${TREATMENT_IC50_PROFILE_NAME}"]`));
+            assert($(`//*[text()="${TREATMENT_EC50_PROFILE_NAME}"]`));
         });
 
         it('shows all treatments in generic assay selector', () => {
@@ -155,6 +157,11 @@ describe('treatment feature', function() {
 
         it('sets `generic_assay_groups` URL parameter', () => {
             goToTreatmentTab();
+            // Select treatment profile
+            $(GENERIC_ASSAY_PROFILE_SELECTOR).click();
+            selectElementByText(TREATMENT_EC50_PROFILE_NAME).waitForExist();
+            selectElementByText(TREATMENT_EC50_PROFILE_NAME).click();
+            // Select treatments
             $(GENERIC_ASSAY_ENTITY_SELECTOR).click();
             $('[data-test="GenericAssayEntitySelection"] input').setValue(
                 '17-AAG'

--- a/src/pages/resultsView/oncoprint/AddTracks.tsx
+++ b/src/pages/resultsView/oncoprint/AddTracks.tsx
@@ -62,6 +62,8 @@ export default class AddTracks extends React.Component<IAddTrackProps, {}> {
     private updateTabId(newId: Tab) {
         this.tabId = newId;
         // update profile if clicked Generic Assay tab
+        // This will update generic assay profile correctly
+        // Because if isGenericAssayDataComplete and profilesByGenericAssayType are falsy, tabs will not be shown
         if (!Object.values(Tab).includes(newId)) {
             if (
                 this.isGenericAssayDataComplete &&
@@ -84,15 +86,17 @@ export default class AddTracks extends React.Component<IAddTrackProps, {}> {
     }
 
     @computed get showGenericAssayTabs() {
-        // disable for multiple studies query
         if (this.isGenericAssayDataComplete) {
-            return (
+            const isSingleStudy =
                 _.chain(this.props.store.genericAssayProfiles.result!)
                     .map(profile => profile.studyId)
                     .uniq()
                     .size()
-                    .value() == 1
-            );
+                    .value() == 1;
+            // disable for multiple studies query
+            if (!_.isEmpty(this.profilesByGenericAssayType) && isSingleStudy) {
+                return true;
+            }
         } else {
             return false;
         }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9591

- Update a potential bug that may make the selection and oncoprint track update out of sync
- Update test scripts. We need to update test scripts because we didn’t select any profiles in the scripts, which we should. Because profiles order are likely to change when importing a study, if we don’t make a selection, we will get similar errors in the future.