### PR TITLE
Optimize namespace column configuration for mutation tables

### DIFF
--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -43,11 +43,7 @@ import {
     submitToStudyViewPage,
 } from '../querySummary/QuerySummaryUtils';
 import { ExtendedMutationTableColumnType } from 'shared/components/mutationTable/MutationTable';
-import {
-    buildNamespaceColumnConfig,
-    createNamespaceColumnName,
-    extractColumnNames,
-} from 'shared/components/mutationMapper/MutationMapperUtils';
+import { extractColumnNames } from 'shared/components/mutationMapper/MutationMapperUtils';
 
 export interface IResultsViewMutationMapperProps extends IMutationMapperProps {
     store: ResultsViewMutationMapperStore;

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
@@ -10,10 +10,7 @@ import MutationMapperDataStore from 'shared/components/mutationMapper/MutationMa
 import { computed } from 'mobx';
 import { ExtendedMutationTableColumnType } from 'shared/components/mutationTable/MutationTable';
 import _ from 'lodash';
-import {
-    createNamespaceColumnName,
-    extractColumnNames,
-} from 'shared/components/mutationMapper/MutationMapperUtils';
+import { extractColumnNames } from 'shared/components/mutationMapper/MutationMapperUtils';
 import ResultsViewMutationTable from 'pages/resultsView/mutation/ResultsViewMutationTable';
 
 export interface IStandaloneMutationMapperProps extends IMutationMapperProps {

--- a/src/shared/components/mutationMapper/MutationMapperUtils.spec.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUtils.spec.ts
@@ -50,7 +50,7 @@ describe('MutationMapperUtils', () => {
                 createMutation({ myNamespace: {} }),
             ] as Mutation[];
             const columnConfig = buildNamespaceColumnConfig(mutations);
-            assert.deepEqual(columnConfig, { myNamespace: {} });
+            assert.deepEqual(columnConfig, {});
         });
 
         it('derives namespace config from mutation data - no namespace data', () => {

--- a/src/shared/components/mutationMapper/MutationMapperUtils.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUtils.ts
@@ -41,19 +41,26 @@ export function buildNamespaceColumnConfig(
     if (!mutations) {
         return {};
     }
-    const namespaceConfig: NamespaceColumnConfig = {};
-    const nameSpaces = _.flatMap(mutations, m => _.keys(m.namespaceColumns));
-    nameSpaces.forEach(nameSpace => {
-        let columnCollapse: any = {};
-        _(mutations)
-            .map(m => _.get(m.namespaceColumns, nameSpace))
-            .forEach(column => _.mergeWith(columnCollapse, column, fMerge));
-        columnCollapse = _.mapValues(columnCollapse, (values: any[]) => {
-            return !values.some(_.isString) ? 'number' : 'string';
+    const columnTypes: any = {};
+    mutations.forEach(m => {
+        _.forIn(m.namespaceColumns, (columns, namespace) => {
+            _.forIn(columns, (value, columnName) => {
+                if (columnTypes[namespace] === undefined) {
+                    columnTypes[namespace] = {};
+                }
+                if (columnTypes[namespace][columnName] === undefined) {
+                    columnTypes[namespace][columnName] = 'number';
+                }
+                if (
+                    _.isString(value) &&
+                    columnTypes[namespace][columnName] === 'number'
+                ) {
+                    columnTypes[namespace][columnName] = 'string';
+                }
+            });
         });
-        namespaceConfig[nameSpace] = columnCollapse;
     });
-    return namespaceConfig;
+    return columnTypes;
 }
 
 export function createNamespaceColumnName(


### PR DESCRIPTION
# Problem
For namespace columns there is a data-dependent evaluation of the data type per column (_numeric_ or _categorical_). The current implementation was very slow for ~100k samples/mutations.

# Solution
The algorithm was updated to handle large number of mutations.