### PR TITLE
Add numeral into the portal commons package dependency

### DIFF
--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.17.15",
     "measure-text": "0.0.4",
     "mobxpromise": "github:cbioportal/mobxpromise#303db72588860bff0a6862a4f07a4e8a3578c94f",
+    "numeral": "^2.0.6",
     "object-sizeof": "^1.2.0",
     "oncokb-ts-api-client": "^1.3.1",
     "rc-tooltip": "^5.0.2",


### PR DESCRIPTION
The package is using the dependency from the root which will run into issue when other projects, like GenomeNexus, importing commons separately.