### PR TITLE
Fix download controls localdb tests

### DIFF
--- a/end-to-end-test/local/specs/hide-download-controls.spec.js
+++ b/end-to-end-test/local/specs/hide-download-controls.spec.js
@@ -7,12 +7,10 @@ var waitForOncoprint = require('../../shared/specUtils').waitForOncoprint;
 var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
 var waitForPatientView = require('../../shared/specUtils').waitForPatientView;
 var waitForStudyView = require('../../shared/specUtils').waitForStudyView;
-var studyViewChartHoverHamburgerIcon = require('../../shared/specUtils')
-    .studyViewChartHoverHamburgerIcon;
+var jsApiHover = require('../../shared/specUtils').jsApiHover;
 var setServerConfiguration = require('../../shared/specUtils')
     .setServerConfiguration;
 var openGroupComparison = require('../../shared/specUtils').openGroupComparison;
-var waitForNetworkQuiet = require('../../shared/specUtils').waitForNetworkQuiet;
 
 const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
 
@@ -54,6 +52,17 @@ const waitForTabs = count => {
         return $$('.tabAnchor').length >= count;
     }, 300000);
 };
+
+function studyViewChartHoverHamburgerIcon(chartDataTest, timeout) {
+    // move to the chart
+    const chart = '[data-test=' + chartDataTest + ']';
+    $(chart).waitForDisplayed({ timeout: timeout || 10000 });
+    jsApiHover(chart);
+
+    // move to hamburger icon
+    const hamburgerIcon = '[data-test=chart-header-hamburger-icon]';
+    jsApiHover(hamburgerIcon);
+}
 
 describe('hide download controls feature', function() {
     if (useExternalFrontend) {
@@ -113,6 +122,8 @@ describe('hide download controls feature', function() {
                 'Pathways',
             ];
             before(() => {
+                browser.setWindowSize(3200, 1000);
+
                 openAndSetProperty(
                     `${CBIOPORTAL_URL}/results/oncoprint?genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&cancer_study_list=study_es_0&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=mutations%2Cfusion%2Cgistic&case_set_id=study_es_0_cnaseq&gene_list=CREB3L1%2520RPS11%2520PNMA1%2520MMP2%2520ZHX3%2520ERCC5%2520TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit&comparison_subtab=mrna`,
                     { skin_hide_download_controls: true }
@@ -203,9 +214,9 @@ describe('hide download controls feature', function() {
                         'Genomic Alterations',
                         'mRNA',
                         'DNA Methylation',
-                        'Treatment Response',
-                        'Mutational Signature',
                         'Generic Assay Patient Test',
+                        'Mutational Signature',
+                        'Treatment Response',
                     ];
                     const observedTabNames = $$(
                         '[data-test=ComparisonTabDiv] .tabAnchor'
@@ -311,7 +322,7 @@ describe('hide download controls feature', function() {
                 });
                 // Activation of the 'Patient Test' tab results in a backend error. Omitting for now.
                 // Inactivation of download tabs is also covered by other Generic Assay tabs.
-                describe.omit('generic assay patient test tab', () => {
+                describe.skip('generic assay patient test tab', () => {
                     it('global check for icon and occurrence of "Download" as a word', () => {
                         $(
                             '.tabAnchor_generic_assay_generic_assay_patient_test'
@@ -543,9 +554,9 @@ describe('hide download controls feature', function() {
                 'Genomic Alterations',
                 'mRNA',
                 'DNA Methylation',
-                'Treatment Response',
-                'Mutational Signature',
                 'Generic Assay Patient Test',
+                'Mutational Signature',
+                'Treatment Response',
             ];
             before(() => {
                 openAndSetProperty(browser.getUrl(), {
@@ -661,7 +672,7 @@ describe('hide download controls feature', function() {
             });
             // Activation of the 'Patient Test' tab results in a backend error. Omitting for now.
             // Inactivation of download tabs is also covered by other Generic Assay tabs.
-            describe.omit('generic assay patient test tab', () => {
+            describe.skip('generic assay patient test tab', () => {
                 it('global check for icon and occurrence of "Download" as a word', () => {
                     $(
                         '.tabAnchor_generic_assay_generic_assay_patient_test'

--- a/src/pages/groupComparison/GroupComparisonPage.tsx
+++ b/src/pages/groupComparison/GroupComparisonPage.tsx
@@ -46,7 +46,7 @@ import {
     buildCustomTabs,
     prepareCustomTabConfigurations,
 } from 'shared/lib/customTabs/customTabHelpers';
-import { deriveDisplayTextFromGenericAssayType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import { getSortedGenericAssayTabSpecs } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { HelpWidget } from 'shared/components/HelpWidget/HelpWidget';
 
 export interface IGroupComparisonPageProps {
@@ -251,19 +251,17 @@ export default class GroupComparisonPage extends React.Component<
                         </MSKTab>
                     )}
                     {this.store.showGenericAssayTab &&
-                        _.keys(
+                        getSortedGenericAssayTabSpecs(
                             this.store
                                 .genericAssayEnrichmentProfilesGroupedByGenericAssayType
                                 .result
-                        ).map(genericAssayType => {
+                        ).map(genericAssayTabSpecs => {
                             return (
                                 <MSKTab
                                     id={`${
                                         GroupComparisonTab.GENERIC_ASSAY_PREFIX
-                                    }_${genericAssayType.toLowerCase()}`}
-                                    linkText={deriveDisplayTextFromGenericAssayType(
-                                        genericAssayType
-                                    )}
+                                    }_${genericAssayTabSpecs.genericAssayType.toLowerCase()}`}
+                                    linkText={genericAssayTabSpecs.linkText}
                                     anchorClassName={
                                         this.store.genericAssayTabUnavailable
                                             ? 'greyedOut'
@@ -272,7 +270,9 @@ export default class GroupComparisonPage extends React.Component<
                                 >
                                     <GenericAssayEnrichments
                                         store={this.store}
-                                        genericAssayType={genericAssayType}
+                                        genericAssayType={
+                                            genericAssayTabSpecs.genericAssayType
+                                        }
                                     />
                                 </MSKTab>
                             );

--- a/src/pages/resultsView/comparison/ComparisonTab.tsx
+++ b/src/pages/resultsView/comparison/ComparisonTab.tsx
@@ -35,7 +35,7 @@ import GenericAssayEnrichments from 'pages/groupComparison/GenericAssayEnrichmen
 import styles from 'pages/resultsView/comparison/styles.module.scss';
 import { getServerConfig } from 'config/config';
 import { AlterationFilterMenuSection } from 'pages/groupComparison/GroupComparisonUtils';
-import { deriveDisplayTextFromGenericAssayType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import { getSortedGenericAssayTabSpecs } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 
 export interface IComparisonTabProps {
     urlWrapper: ResultsViewURLWrapper;
@@ -264,19 +264,17 @@ export default class ComparisonTab extends React.Component<
                         </MSKTab>
                     )}
                     {this.store.showGenericAssayTab &&
-                        _.keys(
+                        getSortedGenericAssayTabSpecs(
                             this.store
                                 .genericAssayEnrichmentProfilesGroupedByGenericAssayType
                                 .result
-                        ).map(genericAssayType => {
+                        ).map(genericAssayTabSpecs => {
                             return (
                                 <MSKTab
                                     id={`${
                                         ResultsViewComparisonSubTab.GENERIC_ASSAY_PREFIX
-                                    }_${genericAssayType.toLowerCase()}`}
-                                    linkText={deriveDisplayTextFromGenericAssayType(
-                                        genericAssayType
-                                    )}
+                                    }_${genericAssayTabSpecs.genericAssayType.toLowerCase()}`}
+                                    linkText={genericAssayTabSpecs.linkText}
                                     anchorClassName={
                                         this.store.genericAssayTabUnavailable
                                             ? 'greyedOut'
@@ -285,7 +283,9 @@ export default class ComparisonTab extends React.Component<
                                 >
                                     <GenericAssayEnrichments
                                         store={this.store}
-                                        genericAssayType={genericAssayType}
+                                        genericAssayType={
+                                            genericAssayTabSpecs.genericAssayType
+                                        }
                                         resultsViewMode={true}
                                     />
                                 </MSKTab>

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
@@ -358,3 +358,21 @@ export function deriveDisplayTextFromGenericAssayType(
     }
     return derivedDisplayText;
 }
+
+export function getSortedGenericAssayTabSpecs(
+    genericAssayEnrichmentProfilesGroupedByGenericAssayType: {
+        [key: string]: MolecularProfile[];
+    } = {}
+): { genericAssayType: string; linkText: string }[] {
+    const genericAssayTabSpecs: {
+        genericAssayType: string;
+        linkText: string;
+    }[] = _.keys(genericAssayEnrichmentProfilesGroupedByGenericAssayType).map(
+        genericAssayType => ({
+            genericAssayType,
+            linkText: deriveDisplayTextFromGenericAssayType(genericAssayType),
+        })
+    );
+
+    return _.sortBy(genericAssayTabSpecs, specs => specs.linkText);
+}


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9608

- make sure that generic assay tab names are always sorted alphabetically.
- replace `describe.omit` with `describe.skip` since `describe.omit` is not a function
- implement a missing `studyViewChartHoverHamburgerIcon` function