### PR TITLE
Set max for number of categories in Plots tab

### DIFF
--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -43,11 +43,7 @@ import {
     submitToStudyViewPage,
 } from '../querySummary/QuerySummaryUtils';
 import { ExtendedMutationTableColumnType } from 'shared/components/mutationTable/MutationTable';
-import {
-    buildNamespaceColumnConfig,
-    createNamespaceColumnName,
-    extractColumnNames,
-} from 'shared/components/mutationMapper/MutationMapperUtils';
+import { extractColumnNames } from 'shared/components/mutationMapper/MutationMapperUtils';
 
 export interface IResultsViewMutationMapperProps extends IMutationMapperProps {
     store: ResultsViewMutationMapperStore;

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -4838,7 +4838,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                             className={'alert alert-info'}
                         >
                             There are too many unique categories in the data
-                            selected for horizontal or vertical axis. The
+                            selected for the horizontal or vertical axis. The
                             current threshold is set at
                             {DISCRETE_CATEGORY_LIMIT} categories to prevent the
                             browser from freezing. Please update you selection

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -263,6 +263,7 @@ export const ALL_SELECTED_OPTION_NUMERICAL_VALUE = -3;
 export const SAME_SELECTED_OPTION_STRING_VALUE = 'same';
 export const SAME_SELECTED_OPTION_NUMERICAL_VALUE = -2;
 const LEGEND_TO_BOTTOM_WIDTH_THRESHOLD = 550; // when plot is wider than this value, the legend moves from right to bottom of screen
+const DISCRETE_CATEGORY_LIMIT = 150; // when a discrete variable has more categories, the discrete plot will not be rendered.
 
 const mutationCountByOptions = [
     { value: MutationCountBy.MutationType, label: 'Mutation Type' },
@@ -4747,6 +4748,20 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
         ); // log scale selected
     }
 
+    @computed get tooManyDiscreteVariables() {
+        return (
+            this.plotType.result &&
+            this.horzAxisCategories.result &&
+            this.vertAxisCategories.result &&
+            this.plotType.result === PlotType.DiscreteVsDiscrete &&
+            this.discreteVsDiscretePlotType !==
+                DiscreteVsDiscretePlotType.Table &&
+            (this.horzAxisCategories.result!.length > DISCRETE_CATEGORY_LIMIT ||
+                this.vertAxisCategories.result!.length >
+                    DISCRETE_CATEGORY_LIMIT)
+        );
+    }
+
     @computed get coloringByGene() {
         return !!(
             this.coloringMenuSelection.selectedOption &&
@@ -4813,6 +4828,21 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                             className={'alert alert-info'}
                         >
                             No data to plot.
+                        </div>
+                    );
+                }
+                if (this.tooManyDiscreteVariables) {
+                    return (
+                        <div
+                            data-test="PlotsTabNoDataDiv"
+                            className={'alert alert-info'}
+                        >
+                            There are too many unique categories in the data
+                            selected for horizontal or vertical axis. The
+                            current threshold is set at
+                            {DISCRETE_CATEGORY_LIMIT} categories to prevent the
+                            browser from freezing. Please update you selection
+                            to a variable with less categories.
                         </div>
                     );
                 }

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationMapper.tsx
@@ -10,10 +10,7 @@ import MutationMapperDataStore from 'shared/components/mutationMapper/MutationMa
 import { computed } from 'mobx';
 import { ExtendedMutationTableColumnType } from 'shared/components/mutationTable/MutationTable';
 import _ from 'lodash';
-import {
-    createNamespaceColumnName,
-    extractColumnNames,
-} from 'shared/components/mutationMapper/MutationMapperUtils';
+import { extractColumnNames } from 'shared/components/mutationMapper/MutationMapperUtils';
 import ResultsViewMutationTable from 'pages/resultsView/mutation/ResultsViewMutationTable';
 
 export interface IStandaloneMutationMapperProps extends IMutationMapperProps {

--- a/src/shared/components/mutationMapper/MutationMapperUtils.spec.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUtils.spec.ts
@@ -50,7 +50,7 @@ describe('MutationMapperUtils', () => {
                 createMutation({ myNamespace: {} }),
             ] as Mutation[];
             const columnConfig = buildNamespaceColumnConfig(mutations);
-            assert.deepEqual(columnConfig, { myNamespace: {} });
+            assert.deepEqual(columnConfig, {});
         });
 
         it('derives namespace config from mutation data - no namespace data', () => {

--- a/src/shared/components/mutationMapper/MutationMapperUtils.ts
+++ b/src/shared/components/mutationMapper/MutationMapperUtils.ts
@@ -41,19 +41,26 @@ export function buildNamespaceColumnConfig(
     if (!mutations) {
         return {};
     }
-    const namespaceConfig: NamespaceColumnConfig = {};
-    const nameSpaces = _.flatMap(mutations, m => _.keys(m.namespaceColumns));
-    nameSpaces.forEach(nameSpace => {
-        let columnCollapse: any = {};
-        _(mutations)
-            .map(m => _.get(m.namespaceColumns, nameSpace))
-            .forEach(column => _.mergeWith(columnCollapse, column, fMerge));
-        columnCollapse = _.mapValues(columnCollapse, (values: any[]) => {
-            return !values.some(_.isString) ? 'number' : 'string';
+    const columnTypes: any = {};
+    mutations.forEach(m => {
+        _.forIn(m.namespaceColumns, (columns, namespace) => {
+            _.forIn(columns, (value, columnName) => {
+                if (columnTypes[namespace] === undefined) {
+                    columnTypes[namespace] = {};
+                }
+                if (columnTypes[namespace][columnName] === undefined) {
+                    columnTypes[namespace][columnName] = 'number';
+                }
+                if (
+                    _.isString(value) &&
+                    columnTypes[namespace][columnName] === 'number'
+                ) {
+                    columnTypes[namespace][columnName] = 'string';
+                }
+            });
         });
-        namespaceConfig[nameSpace] = columnCollapse;
     });
-    return namespaceConfig;
+    return columnTypes;
 }
 
 export function createNamespaceColumnName(


### PR DESCRIPTION
# Problem
When there there are a large number of samples and there is a clinical variable that is unique to each sample (e.g. sample identifier), the plots tab will lockup when rendering a Categorical plot. The cause of this is that there are too many elements that need to be rendered.

# Solution
In this PR we limit the number of categories for a categorical plot to _150_. This level was chosen based on the ability to render this number of elements. A warning message is shown to inform the user to select another variable:

![image](https://user-images.githubusercontent.com/745885/173552838-44dc59e6-9fa3-4109-8354-ed33712145e8.png)
 