### PR TITLE
Fix AnnotationFilteringSettings defaults from portal.properties

### DIFF
--- a/end-to-end-test/local/specs/core/settings-menu.spec.js
+++ b/end-to-end-test/local/specs/core/settings-menu.spec.js
@@ -1,0 +1,85 @@
+var assert = require('assert');
+const {
+    waitForOncoprint,
+    setSettingsMenuOpen,
+} = require('../../../shared/specUtils');
+var goToUrlAndSetLocalStorageWithProperty = require('../../../shared/specUtils')
+    .goToUrlAndSetLocalStorageWithProperty;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+const oncoprintTabUrl =
+    CBIOPORTAL_URL +
+    '/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=study_es_0&case_set_id=study_es_0_all&data_priority=0&gene_list=ABLIM1%250ATMEM247&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&profileFilter=0&tab_index=tab_visualize';
+
+describe('results view settings/annotation menu', function() {
+    const oncoprintCheckbox = '[data-test=annotateOncoKb]';
+    const hotspotsCheckbox = '[data-test=annotateHotspots]';
+    const customAnnotationCheckbox = '[data-test=annotateCustomBinary]';
+    const excludeVusCheckbox = '[data-test=HideVUS]';
+
+    describe('configuration by portal.properties', () => {
+        it('does not select oncokb, hotspots, custom drivers by default when property set', () => {
+            openOncoprint(oncoprintTabUrl, {
+                oncoprint_oncokb_default: false,
+                oncoprint_hotspots_default: false,
+                oncoprint_custom_driver_annotation_binary_default: false,
+            });
+            assert(!$(oncoprintCheckbox).isSelected());
+            assert(!$(hotspotsCheckbox).isSelected());
+            assert(!$(customAnnotationCheckbox).isSelected());
+        });
+
+        it('does select oncokb by default when property set', () => {
+            openOncoprint(oncoprintTabUrl, {
+                oncoprint_oncokb_default: true,
+                oncoprint_hotspots_default: false,
+                oncoprint_custom_driver_annotation_binary_default: false,
+            });
+            assert($(oncoprintCheckbox).isSelected());
+            assert(!$(hotspotsCheckbox).isSelected());
+            assert(!$(customAnnotationCheckbox).isSelected());
+        });
+
+        it('does select hotspots by default when property set', () => {
+            openOncoprint(oncoprintTabUrl, {
+                oncoprint_oncokb_default: false,
+                oncoprint_hotspots_default: true,
+                oncoprint_custom_driver_annotation_binary_default: false,
+            });
+            assert(!$(oncoprintCheckbox).isSelected());
+            assert($(hotspotsCheckbox).isSelected());
+            assert(!$(customAnnotationCheckbox).isSelected());
+        });
+
+        it('does select custom driver annotations by default when property set', () => {
+            openOncoprint(oncoprintTabUrl, {
+                oncoprint_oncokb_default: false,
+                oncoprint_hotspots_default: false,
+                oncoprint_custom_driver_annotation_binary_default: true,
+            });
+            assert(!$(oncoprintCheckbox).isSelected());
+            assert(!$(hotspotsCheckbox).isSelected());
+            assert($(customAnnotationCheckbox).isSelected());
+        });
+
+        it('does not select VUS exclusion by default when property set', () => {
+            openOncoprint(oncoprintTabUrl, {
+                oncoprint_hide_vus_default: false,
+            });
+            assert(!$(excludeVusCheckbox).isSelected());
+        });
+
+        it('does select VUS exclusion by default when property set', () => {
+            openOncoprint(oncoprintTabUrl, {
+                oncoprint_hide_vus_default: true,
+            });
+            assert($(excludeVusCheckbox).isSelected());
+        });
+    });
+});
+
+const openOncoprint = (url, property) => {
+    goToUrlAndSetLocalStorageWithProperty(url, true, property);
+    waitForOncoprint(100000);
+    setSettingsMenuOpen(true, 'GlobalSettingsButton');
+};

--- a/end-to-end-test/shared/specUtils.js
+++ b/end-to-end-test/shared/specUtils.js
@@ -85,7 +85,7 @@ function setSettingsMenuOpen(open, buttonId = 'GlobalSettingsButton') {
                 return true;
             } else {
                 $(button).click();
-                $('[data-test=GlobalSettingsDropdown]').waitForDisplayed({
+                $(dropdown).waitForDisplayed({
                     timeout: 6000,
                     reverse: !open,
                 });

--- a/src/shared/alterationFiltering/AnnotationFilteringSettings.ts
+++ b/src/shared/alterationFiltering/AnnotationFilteringSettings.ts
@@ -80,12 +80,13 @@ export function buildDriverAnnotationSettings(
         cosmicCountThreshold: 0,
         driverTiers: observable.map<string, boolean>({}, { deep: true }),
 
-        _hotspots: true,
-        _oncoKb: true,
+        _hotspots: getServerConfig().oncoprint_hotspots_default,
+        _oncoKb: getServerConfig().oncoprint_oncokb_default,
         _includeDriver: true,
-        _includeVUS: true,
+        _includeVUS: !getServerConfig().oncoprint_hide_vus_default,
         _includeUnknownOncogenicity: true,
-        _customBinary: undefined,
+        _customBinary: getServerConfig()
+            .oncoprint_custom_driver_annotation_binary_default,
         _includeUnknownTier: true,
 
         set hotspots(val: boolean) {
@@ -141,9 +142,7 @@ export function buildDriverAnnotationSettings(
             this._customBinary = val;
         },
         get customBinary() {
-            return this._customBinary === undefined
-                ? config.oncoprint_custom_driver_annotation_binary_default
-                : this._customBinary;
+            return this._customBinary;
         },
         get customTiersDefault() {
             return config.oncoprint_custom_driver_annotation_tiers_default;


### PR DESCRIPTION
This PR fixes the following settings from _portal.properties_:
- `oncoprint_oncokb_default`
- `oncoprint_hotspots_default`
- `oncoprint_custom_driver_annotation_binary_default`
- `oncoprint_hide_vus_default`

# Tests
e2e-localdb tests are included.