### PR TITLE
Fix default bins when user adjust bins in filter textbox

### DIFF
--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -3671,7 +3671,10 @@ export async function updateCustomIntervalFilter(
         chartMeta.uniqueKey,
         newBinBounds,
         BinMethodOption.CUSTOM,
-        undefined
+        {
+            anchorValue: 0,
+            binSize: 0,
+        }
     );
 
     // Now, we will use the custom bins to define the new filter.


### PR DESCRIPTION
Fix bin editing from filter textbox.   Was broken when advanced custom binning was introduced. 

[Fix study view filter editing](https://github.com/cbioportal/cbioportal/issues/9667)