### PR TITLE
Fix IGV sample names displayed next to tracks

### DIFF
--- a/src/pages/patientView/genomicOverview/GenomicOverview.tsx
+++ b/src/pages/patientView/genomicOverview/GenomicOverview.tsx
@@ -104,8 +104,8 @@ function getGenePanelInfoForIgvTrack(
     );
 }
 
-function getUniqSampleKeys(sortedSamples: { uniqueSampleKey: string }[]) {
-    return _.uniq(sortedSamples.map(s => s.uniqueSampleKey));
+function getSampleIds(sortedSamples: { sampleId: string }[]) {
+    return _.uniq(sortedSamples.map(s => s.sampleId));
 }
 
 // TODO see if it is possible to pass custom components for "customButtons"
@@ -190,7 +190,7 @@ export default class GenomicOverview extends React.Component<
                 sampleExpandHeight: IGV_TRACK_SAMPLE_EXPAND_HEIGHT,
                 height: mutHeight,
                 features: mutFeatures,
-                samples: getUniqSampleKeys(sortedMutations),
+                samples: getSampleIds(sortedMutations),
             });
         }
 
@@ -213,7 +213,7 @@ export default class GenomicOverview extends React.Component<
                 sampleExpandHeight: IGV_TRACK_SAMPLE_EXPAND_HEIGHT,
                 height: segHeight,
                 features: segFeatures,
-                samples: getUniqSampleKeys(sortedSegments),
+                samples: getSampleIds(sortedSegments),
             });
         }
 

--- a/src/shared/lib/IGVUtils.spec.ts
+++ b/src/shared/lib/IGVUtils.spec.ts
@@ -147,7 +147,7 @@ describe('IGVUtils', () => {
                 featuresWithoutFunctions(generateSegmentFeatures(segments)),
                 [
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 3218610,
                         end: 4734076,
@@ -158,7 +158,7 @@ describe('IGVUtils', () => {
                         numberOfProbes: 941,
                     },
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 4734514,
                         end: 4735056,
@@ -169,7 +169,7 @@ describe('IGVUtils', () => {
                         numberOfProbes: 2,
                     },
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 4735908,
                         end: 12155936,
@@ -180,7 +180,7 @@ describe('IGVUtils', () => {
                         numberOfProbes: 3984,
                     },
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 12156236,
                         end: 12262792,
@@ -191,7 +191,7 @@ describe('IGVUtils', () => {
                         numberOfProbes: 77,
                     },
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 12264355,
                         end: 26281561,
@@ -202,7 +202,7 @@ describe('IGVUtils', () => {
                         numberOfProbes: 7347,
                     },
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 26282396,
                         end: 26355640,
@@ -213,7 +213,7 @@ describe('IGVUtils', () => {
                         numberOfProbes: 41,
                     },
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 26361404,
                         end: 30593096,
@@ -224,7 +224,7 @@ describe('IGVUtils', () => {
                         numberOfProbes: 1833,
                     },
                     {
-                        sampleKey: 'VENHQS0xMy0xNTEwLTAxOm92X3RjZ2FfcHVi',
+                        sampleKey: 'TCGA-13-1510-01',
                         patient: 'TCGA-13-1510',
                         start: 30593355,
                         end: 35255680,

--- a/src/shared/lib/IGVUtils.ts
+++ b/src/shared/lib/IGVUtils.ts
@@ -162,7 +162,7 @@ export function generateSegmentFeatures(
         patient: segment.patientId,
         study: segment.studyId,
         numberOfProbes: segment.numberOfProbes,
-        sampleKey: segment.uniqueSampleKey,
+        sampleKey: segment.sampleId,
         popupData: () => segmentPopupData(segment),
     }));
 }
@@ -172,7 +172,7 @@ export function generateMutationFeatures(
 ): MutationTrackFeatures[] {
     return mutations.map(mutation => ({
         value: mutation.mutationType,
-        sampleKey: mutation.uniqueSampleKey,
+        sampleKey: mutation.sampleId,
         sample: mutation.sampleId,
         start: mutation.startPosition - 1,
         end: mutation.endPosition,


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9683

![IGV_sample_names](https://user-images.githubusercontent.com/3604198/180479323-c7f72a99-46e3-4095-aae6-63437183e5b2.png)

