### PR TITLE
Allow custom href for news pages while handling deprecated .md files

### DIFF
--- a/src/appBootstrapper.tsx
+++ b/src/appBootstrapper.tsx
@@ -238,8 +238,6 @@ $(document).ready(async () => {
 
     initializeServerConfiguration(initialServerConfig);
 
-    //setConfigDefaults();
-
     initializeGenericAssayServerConfig();
 
     initializeAPIClients();

--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -60,7 +60,7 @@ export default class PortalHeader extends React.Component<
             {
                 id: 'news',
                 text: 'News',
-                address: 'https://docs.cbioportal.org/news/',
+                address: getServerConfig().skin_documentation_news!,
                 internal: false,
                 hide: () => getServerConfig().skin_show_news_tab === false,
             },

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -337,7 +337,21 @@ export function initializeServerConfiguration(rawConfiguration: any) {
         localStorageOverride.serverConfig
     );
 
+    // apply custom corrections for deprecated
+    // configurations
+    applyCorrections(mergedConfig);
+
     setServerConfig(mergedConfig);
+}
+
+function applyCorrections(config: IServerConfig) {
+    // we no longer support markdown files (7/30/2022)
+    // we only support hyper links to externally hosted pages
+    // if we detect a custom configured MD file, correct it to use default new link
+    // otherwise, string will be used as link href
+    if (/\.md$/i.test(config.skin_documentation_news || '')) {
+        config.skin_documentation_news = ServerConfigDefaults.skin_documentation_news!;
+    }
 }
 
 export function setLoadConfig(obj: Partial<ILoadConfig>) {

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -1,6 +1,6 @@
 import { IServerConfig } from './IAppConfig';
 
-const ServerConfigDefaults: Partial<IServerConfig> = {
+export const ServerConfigDefaults: Partial<IServerConfig> = {
     app_version: '1.0',
     api_cache_limit: 450,
     dat_method: 'none',
@@ -67,7 +67,7 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
     skin_documentation_faq: 'user-guide/faq.md',
     skin_footer_show_dev: false,
     skin_login_saml_registration_html: 'Sign in with MSK',
-    skin_documentation_news: 'News.md',
+    skin_documentation_news: 'https://docs.cbioportal.org/news/',
     skin_documentation_oql: 'user-guide/oql.md',
     skin_query_max_tree_depth: '3',
     skin_right_nav_show_data_sets: true,


### PR DESCRIPTION
We no longer support custom .md files in skin.documenation.news configuration property.  A custom string will be used as a link to an externally hosted page.  If we encounter a link to an .md file, we will substitute the default news page