### PR TITLE
Set data limit and add warning message for study view clinical tab

### DIFF
--- a/end-to-end-test/local/runtime-config/portal.properties
+++ b/end-to-end-test/local/runtime-config/portal.properties
@@ -330,6 +330,10 @@ ehcache.cache_type=none
 # This limit is enforced on the frontend.
 # query_product_limit=1000000
 
+# Limit the size of samples in clinical tab in study view page. clinical attribute count * sample count < clinical_attribute_product_limit
+# This limit is enforced on the frontend.
+# clinical_attribute_product_limit=6500000
+
 # Enable gsva to query
 skin.show_gsva=true
 skin.show_settings_menu=true

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -142,6 +142,7 @@ export interface IServerConfig {
     session_url_length_threshold: string;
     mskWholeSlideViewerToken: string;
     query_product_limit: number;
+    clinical_attribute_product_limit: number;
     dat_method: string;
     skin_show_gsva: boolean;
     skin_geneset_hierarchy_default_gsva_score: number;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -175,6 +175,8 @@ const ServerConfigDefaults: Partial<IServerConfig> = {
 
     query_product_limit: 1000000,
 
+    clinical_attribute_product_limit: 6500000,
+
     skin_show_gsva: false,
 
     skin_geneset_hierarchy_default_gsva_score: 0.5,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -1910,6 +1910,11 @@ export class StudyViewPageStore
     }
 
     @action
+    handleTabChange(id: string) {
+        this.urlWrapper.setTab(id);
+    }
+
+    @action
     updateStoreByFilters(filters: Partial<StudyViewFilter>): void {
         // fixes filters in place to ensure backward compatiblity
         // as filter specification changes
@@ -8276,6 +8281,28 @@ export class StudyViewPageStore
             );
         },
         default: [],
+    });
+
+    readonly clinicalAttributeProduct = remoteData({
+        await: () => [this.clinicalAttributes, this.selectedSamples],
+        invoke: async () => {
+            return (
+                this.clinicalAttributes.result.length *
+                this.selectedSamples.result.length
+            );
+        },
+        default: 0,
+    });
+
+    readonly maxSamplesForClinicalTab = remoteData({
+        await: () => [this.clinicalAttributes],
+        invoke: async () => {
+            return Math.floor(
+                getServerConfig().clinical_attribute_product_limit /
+                    this.clinicalAttributes.result.length
+            );
+        },
+        default: 0,
     });
 
     readonly molecularProfileForGeneCharts = remoteData({

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -23,6 +23,8 @@ import ProgressIndicator, {
 } from '../../../shared/components/progressIndicator/ProgressIndicator';
 import autobind from 'autobind-decorator';
 import { WindowWidthBox } from '../../../shared/components/WindowWidthBox/WindowWidthBox';
+import { getServerConfig } from 'config/config';
+import { StudyViewPageTabKeyEnum } from '../StudyViewPageTabs';
 
 export interface IClinicalDataTabTable {
     store: StudyViewPageStore;
@@ -178,46 +180,119 @@ export class ClinicalDataTab extends React.Component<
                 <WindowWidthBox offset={60}>
                     <If
                         condition={
-                            this.columns.isPending ||
-                            this.props.store.getDataForClinicalDataTab.isPending
+                            this.props.store.clinicalAttributeProduct
+                                .isPending ||
+                            this.props.store.maxSamplesForClinicalTab
+                                .isPending ||
+                            this.props.store.selectedSamples.isPending
                         }
                     >
                         <Then>
                             <LoadingIndicator
                                 isLoading={
-                                    this.columns.isPending ||
-                                    this.props.store.getDataForClinicalDataTab
-                                        .isPending
+                                    this.props.store.clinicalAttributeProduct
+                                        .isPending ||
+                                    this.props.store.maxSamplesForClinicalTab
+                                        .isPending ||
+                                    this.props.store.selectedSamples.isPending
                                 }
                                 size={'big'}
                                 center={true}
-                            >
-                                <ProgressIndicator
-                                    getItems={this.getProgressItems}
-                                    show={
-                                        this.columns.isPending ||
-                                        this.props.store
-                                            .getDataForClinicalDataTab.isPending
-                                    }
-                                />
-                            </LoadingIndicator>
+                            />
                         </Then>
                         <Else>
-                            <ClinicalDataTabTableComponent
-                                initialItemsPerPage={20}
-                                showCopyDownload={true}
-                                showColumnVisibility={false}
-                                data={
-                                    this.props.store.getDataForClinicalDataTab
-                                        .result || []
+                            <If
+                                condition={
+                                    this.props.store.clinicalAttributeProduct
+                                        .result >
+                                    getServerConfig()
+                                        .clinical_attribute_product_limit
                                 }
-                                columns={this.columns.result}
-                                copyDownloadProps={{
-                                    showCopy: false,
-                                    downloadFilename: this.props.store
-                                        .clinicalDataDownloadFilename,
-                                }}
-                            />
+                            >
+                                <Then>
+                                    Too many samples selected. The maximum table
+                                    length is{' '}
+                                    <b>
+                                        {
+                                            this.props.store
+                                                .maxSamplesForClinicalTab.result
+                                        }
+                                    </b>{' '}
+                                    rows, but your current selection would be{' '}
+                                    <b>
+                                        {
+                                            this.props.store.selectedSamples
+                                                .result.length
+                                        }
+                                    </b>{' '}
+                                    rows. Select fewer samples on the{' '}
+                                    <a
+                                        onClick={() =>
+                                            this.props.store.handleTabChange(
+                                                StudyViewPageTabKeyEnum.SUMMARY
+                                            )
+                                        }
+                                    >
+                                        Summary tab
+                                    </a>
+                                    .{' '}
+                                </Then>
+                                <Else>
+                                    <If
+                                        condition={
+                                            this.columns.isPending ||
+                                            this.props.store
+                                                .getDataForClinicalDataTab
+                                                .isPending
+                                        }
+                                    >
+                                        <Then>
+                                            <LoadingIndicator
+                                                isLoading={
+                                                    this.columns.isPending ||
+                                                    this.props.store
+                                                        .getDataForClinicalDataTab
+                                                        .isPending
+                                                }
+                                                size={'big'}
+                                                center={true}
+                                            >
+                                                <ProgressIndicator
+                                                    getItems={
+                                                        this.getProgressItems
+                                                    }
+                                                    show={
+                                                        this.columns
+                                                            .isPending ||
+                                                        this.props.store
+                                                            .getDataForClinicalDataTab
+                                                            .isPending
+                                                    }
+                                                />
+                                            </LoadingIndicator>
+                                        </Then>
+                                        <Else>
+                                            <ClinicalDataTabTableComponent
+                                                initialItemsPerPage={20}
+                                                showCopyDownload={true}
+                                                showColumnVisibility={false}
+                                                data={
+                                                    this.props.store
+                                                        .getDataForClinicalDataTab
+                                                        .result || []
+                                                }
+                                                columns={this.columns.result}
+                                                copyDownloadProps={{
+                                                    showCopy: false,
+                                                    downloadFilename: this.props
+                                                        .store
+                                                        .clinicalDataDownloadFilename,
+                                                }}
+                                            />
+                                        </Else>
+                                    </If>
+                                </Else>
+                            </If>
                         </Else>
                     </If>
                 </WindowWidthBox>


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9702

![image](https://user-images.githubusercontent.com/15748980/183470246-5e305d9f-a7f4-4bae-a8cb-ffdb00c3af6b.png)

Testing instruction:
Set `localStorage.netlify ="deploy-preview-4343--cbioportalfrontend"` in browser console.

With warning: https://cbioportal.mskcc.org/study/clinicalData?id=mskimpact_test_june
Without warning: https://cbioportal.mskcc.org/study/clinicalData?id=mskimpact