### PR TITLE
Use MSKCC isoforms by default

### DIFF
--- a/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
+++ b/packages/react-mutation-mapper/src/store/DefaultMutationMapperDataFetcher.ts
@@ -126,7 +126,7 @@ export class DefaultMutationMapperDataFetcher
     public async fetchVariantAnnotationsIndexedByGenomicLocation(
         mutations: Partial<Mutation>[],
         fields: string[] = ['annotation_summary'],
-        isoformOverrideSource: string = 'uniprot',
+        isoformOverrideSource: string = 'mskcc',
         client: GenomeNexusAPI = this.genomeNexusClient
     ): Promise<{ [genomicLocation: string]: VariantAnnotation }> {
         return await fetchVariantAnnotationsIndexedByGenomicLocation(

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -39,7 +39,7 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
 
     pubmed_url: 'https://www.ncbi.nlm.nih.gov/pubmed/<%=pmid%>',
 
-    isoformOverrideSource: 'uniprot',
+    isoformOverrideSource: 'mskcc',
     show_hotspot: true,
     show_oncokb: true,
     show_civic: false,


### PR DESCRIPTION
We recently decided to retire use of the uniprot override source. MSKCC should be the new default set of transcripts everywhere