### PR TITLE
Fix profiles filtering method

### DIFF
--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -32,6 +32,7 @@ import {
     getDataIntervalFilterValues,
     getDefaultChartTypeByClinicalAttribute,
     getExponent,
+    getFilteredMolecularProfilesByAlterationType,
     getFilteredSampleIdentifiers,
     getFilteredStudiesWithSamples,
     getFrequencyStr,
@@ -69,6 +70,7 @@ import {
     CancerStudy,
     ClinicalAttribute,
     DataFilterValue,
+    MolecularProfile,
     Sample,
     StudyViewFilter,
 } from 'cbioportal-ts-api-client';
@@ -91,6 +93,10 @@ import {
 } from 'shared/api/session-service/sessionServiceModels';
 import { remoteData, toPromise } from 'cbioportal-frontend-commons';
 import { autorun, observable, runInAction } from 'mobx';
+import {
+    AlterationTypeConstants,
+    DataTypeConstants,
+} from 'pages/resultsView/ResultsViewPageStore';
 
 describe('StudyViewUtils', () => {
     const emptyStudyViewFilter: StudyViewFilter = {
@@ -4821,6 +4827,88 @@ describe('StudyViewUtils', () => {
             ];
 
             assert.deepEqual(actual.sort(), expected.sort());
+        });
+    });
+
+    describe('getFilteredMolecularProfilesByAlterationType', () => {
+        const studyIdToMolecularProfiles: any = {
+            study_1: [
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'DISCRETE',
+                    molecularProfileId: 'study_1_cna',
+                    studyId: 'study_1',
+                },
+            ],
+            study_2: [
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'DISCRETE',
+                    molecularProfileId: 'study_2_cna',
+                    studyId: 'study_2',
+                },
+            ],
+            study_3: [
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'LOG2-VALUE',
+                    molecularProfileId: 'study_3_log2_cna',
+                    studyId: 'study_3',
+                },
+            ],
+        };
+        it('filter profiles by alteration type', () => {
+            const result = [
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'DISCRETE',
+                    molecularProfileId: 'study_1_cna',
+                    studyId: 'study_1',
+                },
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'DISCRETE',
+                    molecularProfileId: 'study_2_cna',
+                    studyId: 'study_2',
+                },
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'LOG2-VALUE',
+                    molecularProfileId: 'study_3_log2_cna',
+                    studyId: 'study_3',
+                },
+            ];
+            assert.deepEqual(
+                getFilteredMolecularProfilesByAlterationType(
+                    studyIdToMolecularProfiles,
+                    AlterationTypeConstants.COPY_NUMBER_ALTERATION
+                ),
+                result
+            );
+        });
+        it('filter profiles by alteration type, also filte by allowed data types', () => {
+            const result = [
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'DISCRETE',
+                    molecularProfileId: 'study_1_cna',
+                    studyId: 'study_1',
+                },
+                {
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    datatype: 'DISCRETE',
+                    molecularProfileId: 'study_2_cna',
+                    studyId: 'study_2',
+                },
+            ];
+            assert.deepEqual(
+                getFilteredMolecularProfilesByAlterationType(
+                    studyIdToMolecularProfiles,
+                    AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+                    [DataTypeConstants.DISCRETE]
+                ),
+                result
+            );
         });
     });
 });

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -3538,7 +3538,7 @@ export function getFilteredMolecularProfilesByAlterationType(
                         profile.molecularAlterationType === alterationType;
                     if (!_.isEmpty(allowedDataTypes)) {
                         isFiltered =
-                            isFiltered ||
+                            isFiltered &&
                             allowedDataTypes!.includes(profile.datatype);
                     }
                     return isFiltered;


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9658

Fix profiles filtering method: `getFilteredMolecularProfilesByAlterationType` and add unit tests for it.

How to test:

1. Go to [combined study](https://deploy-preview-4355--cbioportalfrontend.netlify.app/study/summary?id=acbc_mskcc_2015%2Cbrca_hta9_htan_2022%2Cbrca_metabric%2Cbrca_pareja_msk_2020%2Cbrca_mskcc_2019%2Cbrca_smc_2018%2Cbrca_bccrc_xenograft_2014%2Cbrca_bccrc%2Cbrca_broad%2Cbrca_sanger%2Cbrca_tcga_pub2015%2Cbrca_tcga%2Cbrca_tcga_pub%2Cbrca_tcga_pan_can_atlas_2018%2Cbrca_jup_msk_2020%2Cbrca_mapk_hp_msk_2021%2Cbrca_igr_2015%2Cbrca_cptac_2020%2Cbrca_mbcproject_wagle_2017)
2. Select `MET` in `CNA genes` table
3. Click `select samples`