### PR TITLE
Calculate heatmap values per group

### DIFF
--- a/src/shared/components/plots/MultipleCategoryHeatmap.tsx
+++ b/src/shared/components/plots/MultipleCategoryHeatmap.tsx
@@ -7,7 +7,7 @@ import Oncoprint, {
     IHeatmapTrackSpec,
 } from 'shared/components/oncoprint/Oncoprint';
 import autobind from 'autobind-decorator';
-import { OncoprintJS, InitParams } from 'oncoprintjs';
+import { InitParams, OncoprintJS } from 'oncoprintjs';
 import _ from 'lodash';
 import { IStringAxisData } from 'pages/resultsView/plots/PlotsTabUtils';
 
@@ -38,7 +38,6 @@ export default class MultipleCategoryHeatmap extends React.Component<
 
     constructor(props: any) {
         super(props);
-        makeObservable(this);
     }
 
     @autobind
@@ -114,60 +113,62 @@ function toHeatmapTracks(
         return [];
     }
 
-    const result = props.horzData.reduce(
-        (arr: IBaseHeatmapTrackSpec[], next) => {
-            const trackKey = Array.isArray(next.value)
-                ? next.value[0]
-                : next.value;
-            let track = arr.find(r => r.key === trackKey);
-            const column = props.vertData!.find(
-                vd => vd.uniqueSampleKey === next.uniqueSampleKey
-            );
-            if (!column) {
-                // When categories are filtered, i.e. when NA is not shown:
-                return arr;
-            }
-            const columnKey = Array.isArray(column.value)
-                ? column.value[0]
-                : column.value;
-            if (!track) {
-                track = createTrack(trackKey, categories, props);
-                arr.push(track);
-            }
-            let cell = track.data.find(gd => gd.uid === columnKey);
-            cell!.profile_data!++;
+    let groups = props.horzData.reduce((arr: IBaseHeatmapTrackSpec[], next) => {
+        const trackKey = Array.isArray(next.value) ? next.value[0] : next.value;
+        let track = arr.find(r => r.key === trackKey);
+        const column = props.vertData!.find(
+            vd => vd.uniqueSampleKey === next.uniqueSampleKey
+        );
+        if (!column) {
+            // When categories are filtered, i.e. when NA is not shown:
             return arr;
-        },
-        []
-    );
+        }
+        const columnKey = Array.isArray(column.value)
+            ? column.value[0]
+            : column.value;
+        if (!track) {
+            track = createTrack(trackKey, categories, props);
+            arr.push(track);
+        }
+        let cell = track.data.find(gd => gd.uid === columnKey);
+        cell!.profile_data!++;
+        return arr;
+    }, []);
 
-    const totalSamplesPerGroup = result.map(t =>
-        t.data
-            .map(d => d.profile_data)
-            .reduce((partialSum: number, d: number) => partialSum + d, 0)
-    ) as number[];
+    const groupsPercentages: number[][] = [];
 
-    const maxSamples = Math.max(
-        ...([] as any).concat(
-            ...result.map(t => t.data.map(d => d.profile_data))
-        )
-    );
+    // Create clone to prevent changing data
+    // that is used in other places as well:
+    groups = _.cloneDeep(groups);
 
-    result.forEach((r, index) =>
-        r.data.forEach(d => {
-            const samples = d.profile_data ? d.profile_data : 0;
+    groups.forEach(group => {
+        const groupSampleCount = group.data.reduce(
+            (partialSum: number, d) => partialSum + (d.profile_data || 0),
+            0
+        );
 
+        const groupPercentages: number[] = [];
+        groupsPercentages.push(groupPercentages);
+        group.data.forEach(d => {
+            const sampleCount = d.profile_data || 0;
+            const percentage = (sampleCount / groupSampleCount) * 100;
+            groupPercentages.push(percentage);
             // Tooltip label:
-            const percentage = (
-                (samples / totalSamplesPerGroup[index]) *
-                100
-            ).toFixed(1);
-            d.sample = `${d.sample}; ${samples} samples (${percentage}%)`;
-            // 'Heat' of heatmap cell:
-            d.profile_data = samples / maxSamples;
-        })
-    );
-    return result;
+            d.sample = `${
+                d.sample
+            }; ${sampleCount} samples (${percentage.toFixed(1)}%)`;
+        });
+    });
+
+    // Calculate 'heat' (value between 0 and 1) of heatmap cells:
+    const percentageMax = Math.max(..._.flatten(groupsPercentages));
+    groups.forEach((group, gi) => {
+        group.data.forEach((d, di) => {
+            d.profile_data = groupsPercentages[gi][di] / percentageMax;
+        });
+    });
+
+    return groups;
 }
 
 function createTrack(


### PR DESCRIPTION
# Summary
This PR will improve the percentage and color intensity of heatmap cells in the group comparision clinical attributes heatmap.

# Percentage calculation
Groups in the comparison most often do not have the same number of samples. In the old heatmap the value of the buckets or cells where calculated as:

`fraction = samples in bucket / total number of samples across all groups`.

This should be: 

`fraction = samples in bucket / number of samples in respective group`.

Now we can compare the fraction (displayed as percentage) across groups. 

# Color calculation
The color intensity is now scaled to the largest value in the heatmap in order to use the full color spectrum available.

