### PR TITLE
Oncoprint tooltip should properly display "fusion partner message"

### DIFF
--- a/src/shared/components/oncoprint/makeGeneticTrackTooltip.tsx
+++ b/src/shared/components/oncoprint/makeGeneticTrackTooltip.tsx
@@ -427,9 +427,13 @@ export function makeGeneticTrackTooltip(
             ret.append('<br>');
         } else if (noneProfiledCount === dataUnderMouse.length) {
             // the moused over sample/case is not profiled
+            // but there IS a structural variant
+            // it means that the fusion partner of the structural variant
+            // is profiled
             if (
-                profiledGenePanelEntries.length ||
-                notProfiledGenePanelEntries.length
+                (profiledGenePanelEntries.length ||
+                    notProfiledGenePanelEntries.length) &&
+                structuralVariants.length
             ) {
                 // there is assumption that if the above condition is true
                 // the gene must be a fusion partner of a gene which IS profiled


### PR DESCRIPTION
We were showing a tooltip suggesting that all unprofiled samples were profiled via their fusion partner, even when there was no sv data.  This makes sure that we check for presence of the sv alteration.

Fixes https://github.com/cbioportal/cbioportal/issues/9694

Testing link:
https://www.cbioportal.org/results/oncoprint?cancer_study_list=msk_impact_2017&tab_index=tab_visualize&case_set_id=msk_impact_2017_all&Action=Submit&gene_list=FGF19%250APBRM1%250ACCDC6&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=structural_variants&geneset_list=%20

A sample WITH a profiled fusion parter:
<img width="666" alt="image" src="https://user-images.githubusercontent.com/186521/187299716-d60f8218-b3af-4ea8-adb2-b72af92ac882.png">

No fusion event detected:
<img width="552" alt="image" src="https://user-images.githubusercontent.com/186521/187300344-177067a7-b2ee-449a-a624-c8821eaa314b.png">

