### PR TITLE
Enable Mutation Assessor and remove unavailable fields

### DIFF
--- a/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
+++ b/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
@@ -80,12 +80,6 @@ export default class MutationAssessor extends React.Component<
     private tooltipContent() {
         if (this.props.mutationAssessor) {
             const maData = this.props.mutationAssessor;
-            const xVarLink = MutationAssessor.maLink(
-                `http://mutationassessor.org/r3/?cm=var&p=${maData.uniprotId}&var=${maData.variant}`
-            );
-            const msaLink = MutationAssessor.maLink(maData.msaLink);
-            const pdbLink = MutationAssessor.maLink(maData.pdbLink);
-
             const impact = maData.functionalImpact ? (
                 <div>
                     <table className={tooltipStyles['ma-tooltip-table']}>
@@ -128,74 +122,7 @@ export default class MutationAssessor extends React.Component<
                 </div>
             ) : null;
 
-            const xVar = xVarLink ? (
-                <div className={tooltipStyles['mutation-assessor-link']}>
-                    <a href={xVarLink} target="_blank">
-                        <img
-                            height="15"
-                            width="19"
-                            src={require('./../../mutationTable/column/mutationAssessor.png')}
-                            className={
-                                tooltipStyles['mutation-assessor-main-img']
-                            }
-                            alt="Mutation Assessor"
-                        />
-                        Go to Mutation Assessor
-                    </a>
-                </div>
-            ) : null;
-
-            const msa = msaLink ? (
-                <div className={tooltipStyles['mutation-assessor-link']}>
-                    <a href={msaLink} target="_blank">
-                        <span
-                            className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-msa-icon']}`}
-                        >
-                            msa
-                        </span>
-                        Multiple Sequence Alignment
-                    </a>
-                </div>
-            ) : null;
-
-            const pdb = pdbLink ? (
-                <div className={tooltipStyles['mutation-assessor-link']}>
-                    <a href={pdbLink} target="_blank">
-                        <span
-                            className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-3d-icon']}`}
-                        >
-                            3D
-                        </span>
-                        Mutation Assessor 3D View
-                    </a>
-                </div>
-            ) : null;
-
-            return (
-                <span>
-                    {impact}
-                    {msa}
-                    {pdb}
-                    {xVar}
-                </span>
-            );
+            return impact;
         }
-    }
-    // This is mostly to make the legacy MA links work
-    public static maLink(link: string | undefined) {
-        let url = null;
-
-        // ignore invalid links ("", "NA", "Not Available")
-        if (link) {
-            // getma.org is the legacy link, need to replace it with the actual value
-            url = link.replace('getma.org', 'mutationassessor.org/r3');
-
-            // prepend "http://" if needed
-            if (url.indexOf('http://') !== 0) {
-                url = `http://${url}`;
-            }
-        }
-
-        return url;
     }
 }


### PR DESCRIPTION
Part of: https://github.com/genome-nexus/genome-nexus/issues/634
Test: 
Not sure why Netlify preview is not working. 
Instead: go to cbioportal, run `localStorage.setItem('netlify', 'deploy-preview-4376--cbioportalfrontend')`, then `localStorage.frontendConfig = '{"serverConfig":{"show_genomenexus_annotation_sources":"mutation_assessor"}}'`. Add Functional Impact column.

https://www.cbioportal.org/results/mutations?cancer_study_list=metastatic_solid_tumors_mich_2017&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cstructural_variants&case_set_id=metastatic_solid_tumors_mich_2017_sequenced&gene_list=TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit

![image](https://user-images.githubusercontent.com/16869603/191570699-c3c98197-0e78-42ee-bc7f-8098be3518ed.png)

Download file:
<img width="798" alt="image" src="https://user-images.githubusercontent.com/16869603/191570905-52051b3e-772d-4bdc-b33a-d81ce028741c.png">
