### PR TITLE
Show p value tooltip based on group size in comparison page

### DIFF
--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.spec.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.spec.tsx
@@ -13,11 +13,14 @@ import {
     getEnrichmentBarPlotData,
     getGeneListOptions,
     pickGenericAssayEnrichmentProfiles,
+    ContinousDataPvalueTooltip,
 } from './EnrichmentsUtil';
 import expect from 'expect';
 import expectJSX from 'expect-jsx';
 import _ from 'lodash';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
+import { render } from '@testing-library/react';
+import React from 'react';
 
 expect.extend(expectJSX);
 
@@ -944,6 +947,44 @@ describe('EnrichmentsUtil', () => {
             const result = pickGenericAssayEnrichmentProfiles(profiles);
             assert.equal(result.length, 1);
             assert.deepEqual(result, expectedResult);
+        });
+    });
+
+    describe('#ContinousDataPvalueTooltip()', () => {
+        const DEFAULT_PROPS = {};
+        const LESS_THAN_THREE_GROUP_PROPS = { groupSize: 2 };
+        const GREATER_THAN_OR_EQUAL_TO_THREE_GROUP_PROPS = { groupSize: 3 };
+
+        it("returns Student's t-test by default", () => {
+            const component = render(
+                <ContinousDataPvalueTooltip {...DEFAULT_PROPS} />
+            );
+            assert.equal(
+                component.container.textContent,
+                "Derived from Student's t-test"
+            );
+        });
+
+        it("returns Student's t-test tooltip for group size < 3", () => {
+            const component = render(
+                <ContinousDataPvalueTooltip {...LESS_THAN_THREE_GROUP_PROPS} />
+            );
+            assert.equal(
+                component.container.textContent,
+                "Derived from Student's t-test"
+            );
+        });
+
+        it('returns one-way ANOVA tooltip for group size >= 3', () => {
+            const component = render(
+                <ContinousDataPvalueTooltip
+                    {...GREATER_THAN_OR_EQUAL_TO_THREE_GROUP_PROPS}
+                />
+            );
+            assert.equal(
+                component.container.textContent,
+                'Derived from one-way ANOVA'
+            );
         });
     });
 });

--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
@@ -50,12 +50,17 @@ export type GenericAssayEnrichmentWithQ = GenericAssayEnrichment & {
     qValue: number;
 };
 
+export type ContinousDataPvalueTooltipProps = {
+    groupSize?: number;
+};
+
 export const CNA_AMP_VALUE = 2;
 export const CNA_HOMDEL_VALUE = -2;
 export const CNA_TO_ALTERATION: { [cna: number]: string } = {
     [CNA_AMP_VALUE]: 'AMP',
     [CNA_HOMDEL_VALUE]: 'HOMDEL',
 };
+export const PVALUE_TEST_GROUP_SIZE_THRESHOLD = 3;
 
 export enum GeneOptionLabel {
     USER_DEFINED_OPTION = 'User-defined genes',
@@ -1148,3 +1153,15 @@ export function getGeneListOptions(
         },
     ];
 }
+
+export const ContinousDataPvalueTooltip: React.FunctionComponent<ContinousDataPvalueTooltipProps> = ({
+    groupSize,
+}) => {
+    return (
+        <span>
+            {groupSize && groupSize >= PVALUE_TEST_GROUP_SIZE_THRESHOLD
+                ? 'Derived from one-way ANOVA'
+                : "Derived from Student's t-test"}
+        </span>
+    );
+};

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsContainer.tsx
@@ -375,6 +375,7 @@ export default class ExpressionEnrichmentContainer extends React.Component<
                             this.customColumns,
                             column => column.uniqueName || column.name
                         )}
+                        groupSize={this.props.groups.length}
                     />
                 </div>
             </div>

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsTable.tsx
@@ -13,6 +13,7 @@ import { ExpressionEnrichmentRow } from 'shared/model/EnrichmentRow';
 import { cytobandFilter } from 'pages/resultsView/ResultsViewTableUtils';
 import autobind from 'autobind-decorator';
 import { EnrichmentsTableDataStore } from 'pages/resultsView/enrichments/EnrichmentsTableDataStore';
+import { ContinousDataPvalueTooltip } from './EnrichmentsUtil';
 
 export interface IExpressionEnrichmentTableProps {
     visibleOrderedColumnNames?: string[];
@@ -24,6 +25,7 @@ export interface IExpressionEnrichmentTableProps {
     onGeneNameClick?: (hugoGeneSymbol: string, entrezGeneId: number) => void;
     checkedGenes?: string[];
     mutexTendency?: boolean;
+    groupSize?: number;
 }
 
 export enum ExpressionEnrichmentTableColumnType {
@@ -140,7 +142,9 @@ export default class ExpressionEnrichmentTable extends React.Component<
                     {toConditionalPrecision(d.pValue, 3, 0.01)}
                 </span>
             ),
-            tooltip: <span>Derived from Student's t-test</span>,
+            tooltip: (
+                <ContinousDataPvalueTooltip groupSize={this.props.groupSize} />
+            ),
             sortBy: (d: ExpressionEnrichmentRow) => d.pValue,
             download: (d: ExpressionEnrichmentRow) =>
                 toConditionalPrecision(d.pValue, 3, 0.01),

--- a/src/pages/resultsView/enrichments/GenericAssayEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/GenericAssayEnrichmentsContainer.tsx
@@ -286,6 +286,7 @@ export default class GenericAssayEnrichmentsContainer extends React.Component<
                             column => column.uniqueName || column.name
                         )}
                         genericAssayType={this.props.genericAssayType}
+                        groupSize={this.props.groups.length}
                     />
                 </div>
             </div>

--- a/src/pages/resultsView/enrichments/GenericAssayEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/GenericAssayEnrichmentsTable.tsx
@@ -16,6 +16,7 @@ import {
     deriveDisplayTextFromGenericAssayType,
     formatGenericAssayCompactLabelByNameAndId,
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import { ContinousDataPvalueTooltip } from './EnrichmentsUtil';
 
 export interface IGenericAssayEnrichmentTableProps {
     genericAssayType: string;
@@ -26,6 +27,7 @@ export interface IGenericAssayEnrichmentTableProps {
     dataStore: GenericAssayEnrichmentsTableDataStore;
     onEntityClick?: (stableId: string) => void;
     mutexTendency?: boolean;
+    groupSize?: number;
 }
 
 export enum GenericAssayEnrichmentTableColumnType {
@@ -116,7 +118,9 @@ export default class GenericAssayEnrichmentsTable extends React.Component<
                     {toConditionalPrecision(d.pValue, 3, 0.01)}
                 </span>
             ),
-            tooltip: <span>Derived from Student's t-test</span>,
+            tooltip: (
+                <ContinousDataPvalueTooltip groupSize={this.props.groupSize} />
+            ),
             sortBy: (d: GenericAssayEnrichmentRow) => d.pValue,
             download: (d: GenericAssayEnrichmentRow) =>
                 toConditionalPrecision(d.pValue, 3, 0.01),


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9818

Describe changes proposed in this pull request:

- Update p value tooltip based on group size
  - group size < 3: showing `Derived from Student's t-test`
  - group size >= 3: showing `Derived from one-way ANOVA`
- Including unit tests