### PR TITLE
Remove samples of overlapping patients in patient-level analysis

### DIFF
--- a/src/pages/groupComparison/ClinicalData.tsx
+++ b/src/pages/groupComparison/ClinicalData.tsx
@@ -35,8 +35,6 @@ import {
     CLINICAL_TAB_NOT_ENOUGH_GROUPS_MSG,
     ClinicalDataEnrichmentWithQ,
     getStatisticalCautionInfo,
-    getOverlappingPatients,
-    getOverlappingSamples,
 } from './GroupComparisonUtils';
 import ReactSelect from 'react-select1';
 import { MakeMobxView } from 'shared/components/MobxView';
@@ -44,16 +42,15 @@ import OverlapExclusionIndicator from './OverlapExclusionIndicator';
 import { RESERVED_CLINICAL_VALUE_COLORS } from '../../shared/lib/Colors';
 import ErrorMessage from '../../shared/components/ErrorMessage';
 import ComplexKeyMap from 'shared/lib/complexKeyDataStructures/ComplexKeyMap';
-import {
-    PatientIdentifier,
-    Sample,
-    SampleIdentifier,
-} from 'cbioportal-ts-api-client';
+import { Sample } from 'cbioportal-ts-api-client';
 import ComparisonStore, {
     OverlapStrategy,
 } from '../../shared/lib/comparison/ComparisonStore';
 import { createSurvivalAttributeIdsDict } from 'pages/resultsView/survival/SurvivalUtil';
-import { getComparisonCategoricalNaValue } from './ClinicalDataUtils';
+import {
+    filterSampleList,
+    getComparisonCategoricalNaValue,
+} from './ClinicalDataUtils';
 import {
     ClinicalNumericalDataVisualisation,
     ClinicalNumericalVisualisationType,
@@ -347,53 +344,23 @@ export default class ClinicalData extends React.Component<
             // for string like values include NA values if requested
             // TODO: implement for numbers
             // Compare clinical data(axisData) samples with sample list, assign NA to difference
-            // If exclude overlapped patients and samples, remove overlapped samples from sample list
             // If include overlapped patients and samples, keep all sample in sample list
-            let filteredSamples: Sample[] = [];
-            if (this.props.store.overlapStrategy === OverlapStrategy.EXCLUDE) {
-                const overlappingPatients = getOverlappingPatients(
-                    this.props.store._activeGroupsNotOverlapRemoved.result!
-                );
-                const overlappingPatientsMap: {
-                    [studyId: string]: Set<string>;
-                } = {};
-                overlappingPatients.map(p => {
-                    if (!(p.studyId in overlappingPatientsMap)) {
-                        overlappingPatientsMap[p.studyId] = new Set<string>();
-                    }
-                    overlappingPatientsMap[p.studyId].add(p.patientId);
-                });
-                const overlappingSamples = getOverlappingSamples(
-                    this.props.store._activeGroupsNotOverlapRemoved.result!
-                );
-                const overlappingSamplesMap: {
-                    [studyId: string]: Set<string>;
-                } = {};
-                overlappingSamples.map(s => {
-                    if (!(s.studyId in overlappingSamplesMap)) {
-                        overlappingSamplesMap[s.studyId] = new Set<string>();
-                    }
-                    overlappingSamplesMap[s.studyId].add(s.sampleId);
-                });
-                filteredSamples = this.props.store.samples.result!.filter(
-                    sample =>
-                        !overlappingPatientsMap[sample.studyId]?.has(
-                            sample.patientId
-                        ) &&
-                        !overlappingSamplesMap[sample.studyId]?.has(
-                            sample.sampleId
-                        )
-                );
-            } else {
-                filteredSamples = this.props.store.samples.result!;
-            }
+            // If exclude overlapped patients and samples, remove overlapped samples from sample list
+            const sampleList: Sample[] =
+                this.props.store.overlapStrategy === OverlapStrategy.EXCLUDE
+                    ? filterSampleList(
+                          this.props.store.samples.result!,
+                          this.props.store._activeGroupsNotOverlapRemoved
+                              .result!
+                      )
+                    : this.props.store.samples.result!;
             if (
                 this.showNA &&
                 axisData.datatype === 'string' &&
-                filteredSamples.length > 0
+                sampleList.length > 0
             ) {
                 const naSamples = _.difference(
-                    _.uniq(filteredSamples.map(x => x.uniqueSampleKey)),
+                    _.uniq(sampleList.map(x => x.uniqueSampleKey)),
                     _.uniq(axisData.data.map(x => x.uniqueSampleKey))
                 );
                 return Promise.resolve({

--- a/src/pages/groupComparison/ClinicalDataUtils.spec.ts
+++ b/src/pages/groupComparison/ClinicalDataUtils.spec.ts
@@ -1,0 +1,148 @@
+import { assert } from 'chai';
+import {
+    PatientIdentifier,
+    Sample,
+    SampleIdentifier,
+} from 'cbioportal-ts-api-client/dist';
+import {
+    filterSampleList,
+    getOverlappingPatientsMap,
+    getOverlappingSamplesMap,
+} from './ClinicalDataUtils';
+import { ComparisonGroup } from './GroupComparisonUtils';
+
+describe('ClinicalDataUtils', () => {
+    const overlappingSamples: SampleIdentifier[] = [
+        {
+            sampleId: 'sample1',
+            studyId: 'study1',
+        },
+        {
+            sampleId: 'sample2',
+            studyId: 'study1',
+        },
+        {
+            sampleId: 'sample1',
+            studyId: 'study2',
+        },
+        {
+            sampleId: 'sample2',
+            studyId: 'study2',
+        },
+    ];
+    const overlappingPatients: PatientIdentifier[] = [
+        {
+            patientId: 'patient1',
+            studyId: 'study1',
+        },
+        {
+            patientId: 'patient2',
+            studyId: 'study1',
+        },
+        {
+            patientId: 'patient1',
+            studyId: 'study2',
+        },
+        {
+            patientId: 'patient2',
+            studyId: 'study2',
+        },
+    ];
+    const sampleList: Sample[] = [
+        {
+            copyNumberSegmentPresent: false,
+            patientId: 'patient1',
+            sampleId: 'sample1',
+            sampleType: 'BLOOD_NORMAL',
+            sequenced: false,
+            studyId: 'study1',
+            uniquePatientKey: 'fakekey',
+            uniqueSampleKey: 'fakekey',
+        },
+        {
+            copyNumberSegmentPresent: false,
+            patientId: 'patient_n',
+            sampleId: 'sample1',
+            sampleType: 'BLOOD_NORMAL',
+            sequenced: false,
+            studyId: 'study1',
+            uniquePatientKey: 'fakekey',
+            uniqueSampleKey: 'fakekey',
+        },
+        {
+            copyNumberSegmentPresent: false,
+            patientId: 'patient1',
+            sampleId: 'sample_n',
+            sampleType: 'BLOOD_NORMAL',
+            sequenced: false,
+            studyId: 'study1',
+            uniquePatientKey: 'fakekey',
+            uniqueSampleKey: 'fakekey',
+        },
+        {
+            copyNumberSegmentPresent: false,
+            patientId: 'patient1',
+            sampleId: 'sample1',
+            sampleType: 'BLOOD_NORMAL',
+            sequenced: false,
+            studyId: 'study_n',
+            uniquePatientKey: 'fakekey',
+            uniqueSampleKey: 'fakekey',
+        },
+    ];
+    const group = [
+        {
+            studies: [
+                {
+                    id: 'study1',
+                    samples: ['sample1', 'sample2'],
+                    patients: ['patient1'],
+                },
+            ],
+        },
+        {
+            studies: [
+                {
+                    id: 'study1',
+                    samples: ['sample1'],
+                    patients: ['patient1', 'patient2'],
+                },
+            ],
+        },
+    ] as ComparisonGroup[];
+
+    describe('getOverlappingPatientsMap', () => {
+        it('overlappingPatientsMap, key: study id, value: set of patient ids', () => {
+            assert.deepEqual(getOverlappingPatientsMap(overlappingPatients), {
+                study1: new Set(['patient1', 'patient2']),
+                study2: new Set(['patient1', 'patient2']),
+            });
+        });
+    });
+
+    describe('getOverlappingSamplesMap', () => {
+        it('overlappingSamplesMap, key: study id, value: set of sample ids', () => {
+            assert.deepEqual(getOverlappingSamplesMap(overlappingSamples), {
+                study1: new Set(['sample1', 'sample2']),
+                study2: new Set(['sample1', 'sample2']),
+            });
+        });
+    });
+
+    describe('filterSampleList', () => {
+        it('filter overlapping samples', () => {
+            assert.deepEqual(filterSampleList(sampleList, group), [
+                {
+                    copyNumberSegmentPresent: false,
+                    patientId: 'patient1',
+                    sampleId: 'sample1',
+                    sampleType: 'BLOOD_NORMAL',
+                    sequenced: false,
+                    studyId: 'study_n',
+                    uniquePatientKey: 'fakekey',
+                    uniqueSampleKey: 'fakekey',
+                },
+            ]);
+        });
+    });
+});

--- a/src/pages/groupComparison/ClinicalDataUtils.ts
+++ b/src/pages/groupComparison/ClinicalDataUtils.ts
@@ -1,4 +1,15 @@
 import { getServerConfig } from 'config/config';
+import {
+    PatientIdentifier,
+    Sample,
+    SampleIdentifier,
+} from 'cbioportal-ts-api-client/dist';
+import _ from 'lodash';
+import {
+    ComparisonGroup,
+    getOverlappingPatients,
+    getOverlappingSamples,
+} from './GroupComparisonUtils';
 
 const NA_VALUES_DELIMITER = '|';
 
@@ -6,4 +17,48 @@ export function getComparisonCategoricalNaValue(): string[] {
     const rawString = getServerConfig().comparison_categorical_na_values;
     const naValues = rawString.split(NA_VALUES_DELIMITER);
     return naValues;
+}
+
+export function getOverlappingPatientsMap(
+    overlappingPatients: PatientIdentifier[]
+): { [studyId: string]: Set<string> } {
+    const overlappingPatientsMap: { [studyId: string]: Set<string> } = {};
+    _.groupBy(overlappingPatients, p => {
+        if (!(p.studyId in overlappingPatientsMap)) {
+            overlappingPatients;
+            overlappingPatientsMap[p.studyId] = new Set<string>();
+        }
+        overlappingPatientsMap[p.studyId].add(p.patientId);
+    });
+    return overlappingPatientsMap;
+}
+
+export function getOverlappingSamplesMap(
+    overlappingSamples: SampleIdentifier[]
+): { [studyId: string]: Set<string> } {
+    const overlappingSamplesMap: { [studyId: string]: Set<string> } = {};
+    _.groupBy(overlappingSamples, s => {
+        if (!(s.studyId in overlappingSamplesMap)) {
+            overlappingSamplesMap[s.studyId] = new Set<string>();
+        }
+        overlappingSamplesMap[s.studyId].add(s.sampleId);
+    });
+    return overlappingSamplesMap;
+}
+
+export function filterSampleList(
+    allSamples: Sample[],
+    groups: ComparisonGroup[]
+): Sample[] {
+    const overlappingPatientsMap = getOverlappingPatientsMap(
+        getOverlappingPatients(groups)
+    );
+    const overlappingSamplesMap = getOverlappingSamplesMap(
+        getOverlappingSamples(groups)
+    );
+    return allSamples.filter(
+        sample =>
+            !overlappingPatientsMap[sample.studyId]?.has(sample.patientId) &&
+            !overlappingSamplesMap[sample.studyId]?.has(sample.sampleId)
+    );
 }

--- a/src/pages/groupComparison/ClinicalDataUtils.ts
+++ b/src/pages/groupComparison/ClinicalDataUtils.ts
@@ -22,28 +22,19 @@ export function getComparisonCategoricalNaValue(): string[] {
 export function getOverlappingPatientsMap(
     overlappingPatients: PatientIdentifier[]
 ): { [studyId: string]: Set<string> } {
-    const overlappingPatientsMap: { [studyId: string]: Set<string> } = {};
-    _.groupBy(overlappingPatients, p => {
-        if (!(p.studyId in overlappingPatientsMap)) {
-            overlappingPatients;
-            overlappingPatientsMap[p.studyId] = new Set<string>();
-        }
-        overlappingPatientsMap[p.studyId].add(p.patientId);
-    });
-    return overlappingPatientsMap;
+    return _.chain(overlappingPatients)
+        .groupBy(p => p.studyId)
+        .mapValues(arr => new Set(arr.map(p => p.patientId)))
+        .value();
 }
 
 export function getOverlappingSamplesMap(
     overlappingSamples: SampleIdentifier[]
 ): { [studyId: string]: Set<string> } {
-    const overlappingSamplesMap: { [studyId: string]: Set<string> } = {};
-    _.groupBy(overlappingSamples, s => {
-        if (!(s.studyId in overlappingSamplesMap)) {
-            overlappingSamplesMap[s.studyId] = new Set<string>();
-        }
-        overlappingSamplesMap[s.studyId].add(s.sampleId);
-    });
-    return overlappingSamplesMap;
+    return _.chain(overlappingSamples)
+        .groupBy(s => s.studyId)
+        .mapValues(arr => new Set(arr.map(p => p.sampleId)))
+        .value();
 }
 
 export function filterSampleList(


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/9824

If choose "Exclude overlapping patients and samples", filter out overlapped samples from sample list
Results:
Exclude overlapping patients and samples:
![image](https://user-images.githubusercontent.com/16869603/194818989-8943c2b9-3908-4a16-9fba-79ccaf7cb02c.png)

Include overlapping patients and samples:
![image](https://user-images.githubusercontent.com/16869603/194819020-5632d65d-4680-4618-9f38-f2a3829bbf54.png)
