### PR TITLE
Fix infinite loop when study search query consists of single "or"

### DIFF
--- a/src/shared/components/query/filteredSearch/SearchClause.tsx
+++ b/src/shared/components/query/filteredSearch/SearchClause.tsx
@@ -1,6 +1,4 @@
-import { CancerTreeNodeFields } from 'shared/lib/query/textQueryUtils';
 import _ from 'lodash';
-import { CancerTreeNode } from 'shared/components/query/CancerStudyTreeData';
 import { Phrase } from 'shared/components/query/filteredSearch/Phrase';
 
 export const FILTER_SEPARATOR = `:`;

--- a/src/shared/lib/query/QueryParser.spec.ts
+++ b/src/shared/lib/query/QueryParser.spec.ts
@@ -112,5 +112,19 @@ describe('QueryParser', () => {
             expect(toQueryString(parsedQuery)).toEqual(toQueryString(expected));
             expect(toQueryString(parsedQuery)).toEqual(query);
         });
+
+        it('interprets or as search phrase when query consists of single or', () => {
+            const query = 'or';
+            const result = parser.parseSearchQuery(query);
+            const expected = 'or';
+            expect(toQueryString(result)).toEqual(expected);
+        });
+
+        it('interprets or as search phrase when query ends with or', () => {
+            const query = 'part1 or';
+            const result = parser.parseSearchQuery(query);
+            const expected = 'part1 or';
+            expect(toQueryString(result)).toEqual(expected);
+        });
     });
 });

--- a/src/shared/lib/query/QueryParser.ts
+++ b/src/shared/lib/query/QueryParser.ts
@@ -162,8 +162,18 @@ export class QueryParser {
                 this.createAndClause(phrases.slice(currInd, nextDash))
             );
             return nextDash;
-        } else if (nextOr > 0 && nextDash === -1) {
-            clauses.push(this.createAndClause(phrases.slice(currInd, nextOr)));
+        } else if (nextOr >= 0 && nextDash === -1) {
+            if (nextOr === phrases.length - 1) {
+                // When query ends with 'or', interpret 'or' as a phrase:
+                clauses.push(
+                    this.createAndClause(phrases.slice(currInd, nextOr + 1))
+                );
+            } else {
+                // When 'or' is between phrases, interpret 'or' as separator of and-clauses:
+                clauses.push(
+                    this.createAndClause(phrases.slice(currInd, nextOr))
+                );
+            }
             return nextOr + 1;
         } else {
             if (nextOr < nextDash) {


### PR DESCRIPTION
When entering 'or' in the study search field index page crashes due to an infinite loop.
This is because the search query parser interprets the 'or' as a separator between two search and-clauses (and no next search query can be found).
To fix this, the search query parser now interprets a single 'or' as a search term. This logic is also applied to search queries ending in a single or (e.g. 'tcga or').
Another solution would have been removing the trailing 'or', but this would also modify the search query shown in the search box, which is undesirable.

## Testing
- tests added to [QueryParser.spec.ts](https://github.com/cBioPortal/cbioportal-frontend/compare/master...BasLee:cbioportal-frontend:fix-or-study-search-query?expand=1#diff-b92cb20ed9172a3a50b4b04781a6309cb9e2d79f5b88a12a2bfdb3db61a28b11)