### PR TITLE
Fix hidden columns when switching transcripts

### DIFF
--- a/packages/cbioportal-frontend-commons/src/lib/ColumnVisibilityResolver.ts
+++ b/packages/cbioportal-frontend-commons/src/lib/ColumnVisibilityResolver.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export interface ISimpleColumnVisibilityDef {
     name: string;
     id?: string;
@@ -27,25 +29,28 @@ export function resolveColumnVisibilityByColumnDefinition(
 }
 
 export function resolveColumnVisibility(
-    columnVisibilityByColumnDefinition: { [columnId: string]: boolean },
-    columnVisibility?: { [columnId: string]: boolean },
-    columnVisibilityOverride?: { [columnId: string]: boolean }
+    defaultColumnVisibility: { [columnId: string]: boolean },
+    currentColumnVisibility?: { [columnId: string]: boolean },
+    userSelectionColumnVisibility?: { [columnId: string]: boolean }
 ): { [columnId: string]: boolean } {
     let colVis: { [columnId: string]: boolean };
 
-    if (columnVisibility) {
+    if (currentColumnVisibility) {
         colVis = {
-            // if a custom columnVisibility object is provided use that one
-            ...columnVisibility,
-            // if exists override with the state from the latest user selection
-            ...(columnVisibilityOverride || {}),
+            // if currentColumnVisibility object is provided (e.g. when swtiching transcripts), override corresponding default visibility
+            // so if defaultColumnVisibility contains more columns than currentColumnVisibility
+            // the extra columns can still keep the default visibility and prevent being lost
+            ...defaultColumnVisibility,
+            ...currentColumnVisibility,
+            // if userSelectionColumnVisibility exists, override to the latest user selection
+            ...(userSelectionColumnVisibility || {}),
         };
     } else {
         colVis = {
-            // resolve visibility by column definition
-            ...columnVisibilityByColumnDefinition,
-            // if exists override with the state from the latest user selection
-            ...(columnVisibilityOverride || {}),
+            // resolve visibility by default column definition
+            ...defaultColumnVisibility,
+            // if userSelectionColumnVisibility exists, override to the latest user selection
+            ...(userSelectionColumnVisibility || {}),
         };
     }
 

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -910,10 +910,7 @@ export default class LazyMobXTable<T> extends React.Component<
     }
 
     protected updateColumnVisibility(id: string, visible: boolean) {
-        // ignore undefined columns
-        if (this.store.columnVisibility[id] !== undefined) {
-            this.store.updateColumnVisibility(id, visible);
-        }
+        this.store.updateColumnVisibility(id, visible);
     }
 
     constructor(props: LazyMobXTableProps<T>) {


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/9755

Reason:
Annotation column is excluded when go to non-canonical transcript, so there is no visibility setting for annotation column in user selection store. 
When switching to canonical transcript, the annotation column is available now, but store doesn't have an existing visibility setting for annotation column. The logic simply replaces default visibility setting with setting we have in user selection store, so the annotation column is missing in the new visibility setting, therefore it's always hidden

Fix:
Merge user selection store visibility with default visibility, so "new" columns' can also be in the list and their visibility can be updated.