### PR TITLE
Add spinner to iFrame of Resource Tabs

### DIFF
--- a/src/shared/components/iframeLoader/IFrameLoader.tsx
+++ b/src/shared/components/iframeLoader/IFrameLoader.tsx
@@ -8,13 +8,18 @@ interface FrameLoaderProps {
     url: string;
     className?: string;
     iframeId?: string;
-    height?: number;
+    height?: number | string;
+    width?: number | string;
 }
 @observer
 export default class IFrameLoader extends React.Component<
     FrameLoaderProps,
     {}
 > {
+    public static defaultProps = {
+        width: '',
+    };
+
     @observable iframeLoaded = false;
 
     constructor(props: FrameLoaderProps) {
@@ -30,7 +35,7 @@ export default class IFrameLoader extends React.Component<
     //NOTE: we need zindex to be higher than that of global loader
     render() {
         return (
-            <div style={{ position: 'relative' }}>
+            <div style={{ position: 'relative', width: this.props.width }}>
                 <LoadingIndicator
                     center={true}
                     size={'big'}

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -9,6 +9,8 @@ import autobind from 'autobind-decorator';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { ResourceData } from 'cbioportal-ts-api-client';
 import { buildPDFUrl, getFileExtension } from './ResourcesTableUtils';
+import IFrameLoader from 'shared/components/iframeLoader/IFrameLoader';
+import { getDigitalSlideArchiveIFrameUrl } from 'shared/api/urls';
 
 export interface IResourceTabProps {
     resourceData: ResourceData[];
@@ -140,12 +142,10 @@ export default class ResourceTab extends React.Component<
                             </a>
                         </div>
                     ) : (
-                        <iframe
-                            src={this.iframeUrl}
-                            style={{
-                                width: '100%',
-                                height: '100%',
-                            }}
+                        <IFrameLoader
+                            url={this.iframeUrl}
+                            height={this.iframeHeight}
+                            width={'100%'}
                         />
                     )}
                     {multipleData && (


### PR DESCRIPTION
# Problem

When loading resources from external URL in a Resource Tab there it is not communicated to the user that the page is loading.

# Solution

Use the existing IFrameLoader component for loading the resources in the Resource Tab. This shows a spinner while the page waits for data.

# Example
![Peek 2022-10-28 10-27](https://user-images.githubusercontent.com/745885/198542421-acdb8d76-2010-4ce3-88a0-fc37f901d786.gif)
