### PR TITLE
Show reference genome in study list 

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -158,6 +158,7 @@ export interface IServerConfig {
     enable_treatment_groups: boolean;
     referenceGenomeVersion: string;
     skin_home_page_show_unauthorized_studies: boolean;
+    skin_home_page_show_reference_genome: string;
     skin_home_page_unauthorized_studies_global_message: string;
     skin_mutation_table_namespace_column_show_by_default: boolean;
     skin_patient_view_mutation_table_columns_show_on_init: string;

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -250,6 +250,15 @@ export class QueryStore {
         return referenceGenomes.length === 1;
     }
 
+    @computed
+    get multipleReferenceGenomesPresentInAllStudies() {
+        const allStudies = this.treeData.map_studyId_cancerStudy;
+        const referenceGenomes = _.uniq(
+            Array.from(allStudies.values()).map(s => s.referenceGenome)
+        );
+        return referenceGenomes.length > 1;
+    }
+
     ////////////////////////////////////////////////////////////////////////////////
     // QUERY PARAMETERS
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -61,6 +61,10 @@ export default class StudyList extends QueryStoreComponent<
         if (this.props.showSelectedStudiesOnly) this._view = this.view;
     }
 
+    @computed get shouldShowRefGenome() {
+        return this.store.multipleReferenceGenomesPresentInAllStudies;
+    }
+
     render() {
         let studyList = this.renderCancerType(this.rootCancerType);
 
@@ -238,6 +242,8 @@ export default class StudyList extends QueryStoreComponent<
                                 {!this.store.isDeletedVirtualStudy(
                                     study.studyId
                                 ) && this.renderSamples(study)}
+                                {this.shouldShowRefGenome &&
+                                    this.renderReferenceGenomeLabel(study)}
                                 {this.renderStudyLinks(study)}
                             </div>
                         );
@@ -246,17 +252,6 @@ export default class StudyList extends QueryStoreComponent<
             </li>
         );
     };
-
-    // renderStudyName = (study:CancerStudy, afterName?:any) =>
-    // {
-    // 	return (
-    // 		<CancerTreeCheckbox view={this.view} node={study}>
-    // 			<span className={styles.StudyName}>
-    // 				{study.name} {afterName || null}
-    // 			</span>
-    // 		</CancerTreeCheckbox>
-    // 	);
-    // }
 
     renderSamples = (study: CancerStudy) => {
         return (
@@ -445,6 +440,12 @@ export default class StudyList extends QueryStoreComponent<
             );
         }
     };
+
+    private renderReferenceGenomeLabel(study: CancerStudy) {
+        return study.referenceGenome ? (
+            <span> | {study.referenceGenome} </span>
+        ) : null;
+    }
 }
 
 export interface ICancerTreeCheckboxProps {

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -62,7 +62,10 @@ export default class StudyList extends QueryStoreComponent<
     }
 
     @computed get shouldShowRefGenome() {
-        return this.store.multipleReferenceGenomesPresentInAllStudies;
+        return (
+            getServerConfig().skin_home_page_show_reference_genome &&
+            this.store.multipleReferenceGenomesPresentInAllStudies
+        );
     }
 
     render() {


### PR DESCRIPTION
To assist the user in selecting compatible studies, the study list now shows a ~badge~ text of the used reference genome. It is only shown when a cbioportal instance uses multiple reference genomes.


![Screenshot from 2023-02-01 15-46-20](https://user-images.githubusercontent.com/3323006/216076561-84d17646-84db-47d2-ac49-f72b4931be2c.png)
_Dummy study list to illustrate label_

Changes:
- Label that shows used reference genome (when multiple reference genomes are available)

- Label is disabled by default using property `skin_home_page_show_reference_genome` (backend property can be added in the future).