### PR TITLE
Add discrete_long cna data type

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -245,6 +245,7 @@ import {
     AlterationTypeConstants,
     CLINICAL_ATTRIBUTE_FIELD_ENUM,
     CLINICAL_ATTRIBUTE_ID_ENUM,
+    CnaDataTypes,
     DataTypeConstants,
     GENETIC_PROFILE_FIELD_ENUM,
     GENOME_NEXUS_ARG_FIELD_ENUM,
@@ -2694,7 +2695,7 @@ export class ResultsViewPageStore
                 profile =>
                     profile.molecularAlterationType ===
                         AlterationTypeConstants.COPY_NUMBER_ALTERATION &&
-                    profile.datatype === DataTypeConstants.DISCRETE
+                    CnaDataTypes.includes(profile.datatype)
             );
         },
         onError: error => {},
@@ -4472,8 +4473,7 @@ export class ResultsViewPageStore
                 for (const molecularProfile of this.molecularProfilesInStudies
                     .result) {
                     if (
-                        molecularProfile.datatype ===
-                            DataTypeConstants.DISCRETE &&
+                        CnaDataTypes.includes(molecularProfile.datatype) &&
                         molecularProfile.molecularAlterationType ===
                             AlterationTypeConstants.COPY_NUMBER_ALTERATION
                     ) {

--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
@@ -11,7 +11,11 @@ import {
 } from 'shared/model/EnrichmentRow';
 import { formatLogOddsRatio, roundLogRatio } from 'shared/lib/FormatUtils';
 import _ from 'lodash';
-import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
+import {
+    AlterationTypeConstants,
+    CnaDataTypes,
+    DataTypeConstants,
+} from 'shared/constants';
 import { filterAndSortProfiles } from '../coExpression/CoExpressionTabUtils';
 import { IMiniFrequencyScatterChartData } from './MiniFrequencyScatterChart';
 import {
@@ -510,7 +514,7 @@ export function pickCopyNumberEnrichmentProfiles(profiles: MolecularProfile[]) {
         (profile: MolecularProfile) =>
             profile.molecularAlterationType ===
                 AlterationTypeConstants.COPY_NUMBER_ALTERATION &&
-            profile.datatype === 'DISCRETE'
+            CnaDataTypes.includes(profile.datatype)
     );
 }
 

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -44,7 +44,11 @@ import {
     AnnotatedNumericGeneMolecularData,
     CustomDriverNumericGeneMolecularData,
 } from '../ResultsViewPageStore';
-import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
+import {
+    AlterationTypeConstants,
+    CnaDataTypes,
+    DataTypeConstants,
+} from 'shared/constants';
 
 import numeral from 'numeral';
 import GenesetMolecularDataCache from '../../../shared/cache/GenesetMolecularDataCache';
@@ -131,7 +135,7 @@ export function sortMolecularProfilesForDisplay(profiles: MolecularProfile[]) {
     let sortBy: (p: MolecularProfile) => any;
     switch (type) {
         case AlterationTypeConstants.COPY_NUMBER_ALTERATION:
-            sortBy = p => (p.datatype === 'DISCRETE' ? 0 : 1);
+            sortBy = p => (CnaDataTypes.includes(p.datatype) ? 0 : 1);
             break;
         default:
             sortBy = p => p.name;
@@ -1077,7 +1081,7 @@ function makeAxisDataPromise_Molecular(
                     profile =>
                         profile.molecularAlterationType ===
                             AlterationTypeConstants.COPY_NUMBER_ALTERATION &&
-                        profile.datatype === 'DISCRETE'
+                        CnaDataTypes.includes(profile.datatype)
                 );
 
                 const data: NumericGeneMolecularData[] = _.flatMap(

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -197,7 +197,11 @@ import {
 } from '../groupComparison/comparisonGroupManager/ComparisonGroupManagerUtils';
 import { IStudyViewScatterPlotData } from './charts/scatterPlot/StudyViewScatterPlotUtils';
 import { StudyViewPageTabKeyEnum } from 'pages/studyView/StudyViewPageTabs';
-import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
+import {
+    AlterationTypeConstants,
+    CnaDataTypes,
+    DataTypeConstants,
+} from 'shared/constants';
 import {
     createSurvivalAttributeIdsDict,
     generateStudyViewSurvivalPlotTitle,
@@ -4829,7 +4833,7 @@ export class StudyViewPageStore
                 getFilteredMolecularProfilesByAlterationType(
                     this.studyIdToMolecularProfiles.result,
                     AlterationTypeConstants.COPY_NUMBER_ALTERATION,
-                    [DataTypeConstants.DISCRETE]
+                    CnaDataTypes
                 )
             );
         },

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -94,7 +94,11 @@ import {
 import { remoteData, toPromise } from 'cbioportal-frontend-commons';
 import { autorun, observable, runInAction } from 'mobx';
 
-import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
+import {
+    AlterationTypeConstants,
+    CnaDataTypes,
+    DataTypeConstants,
+} from 'shared/constants';
 
 describe('StudyViewUtils', () => {
     const emptyStudyViewFilter: StudyViewFilter = {
@@ -4903,7 +4907,7 @@ describe('StudyViewUtils', () => {
                 getFilteredMolecularProfilesByAlterationType(
                     studyIdToMolecularProfiles,
                     AlterationTypeConstants.COPY_NUMBER_ALTERATION,
-                    [DataTypeConstants.DISCRETE]
+                    CnaDataTypes
                 ),
                 result
             );

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -116,6 +116,7 @@ export const AlterationTypeConstants = {
 
 export const DataTypeConstants = {
     DISCRETE: 'DISCRETE',
+    DISCRETE_LONG: 'DISCRETE_LONG',
     CONTINUOUS: 'CONTINUOUS',
     ZSCORE: 'Z-SCORE',
     MAF: 'MAF',
@@ -127,3 +128,8 @@ export const DataTypeConstants = {
     BINARY: 'BINARY',
     CATEGORICAL: 'CATEGORICAL',
 };
+
+export const CnaDataTypes = [
+    DataTypeConstants.DISCRETE,
+    DataTypeConstants.DISCRETE_LONG,
+];

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -65,6 +65,7 @@ import { IGisticData } from 'shared/model/Gistic';
 import { IMutSigData } from 'shared/model/MutSig';
 import {
     CLINICAL_ATTRIBUTE_ID_ENUM,
+    CnaDataTypes,
     GENOME_NEXUS_ARG_FIELD_ENUM,
 } from 'shared/constants';
 import {
@@ -1028,7 +1029,7 @@ export function findDiscreteMolecularProfile(
     }
 
     return molecularProfilesInStudy.result.find((p: MolecularProfile) => {
-        return p.datatype === 'DISCRETE';
+        return CnaDataTypes.includes(p.datatype);
     });
 }
 

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -77,7 +77,11 @@ import {
 } from 'shared/lib/StoreUtils';
 import MobxPromise from 'mobxpromise';
 import { ResultsViewPageStore } from '../../../pages/resultsView/ResultsViewPageStore';
-import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
+import {
+    AlterationTypeConstants,
+    CnaDataTypes,
+    DataTypeConstants,
+} from 'shared/constants';
 import { getSurvivalStatusBoolean } from 'pages/resultsView/survival/SurvivalUtil';
 import { onMobxPromise } from 'cbioportal-frontend-commons';
 import {
@@ -2211,8 +2215,9 @@ export default abstract class ComparisonStore
                             // discrete CNA's
                             (molecularProfile.molecularAlterationType ===
                                 AlterationTypeConstants.COPY_NUMBER_ALTERATION &&
-                                molecularProfile.datatype ===
-                                    DataTypeConstants.DISCRETE) ||
+                                CnaDataTypes.includes(
+                                    molecularProfile.datatype
+                                )) ||
                             // mutations
                             molecularProfile.molecularAlterationType ===
                                 AlterationTypeConstants.MUTATION_EXTENDED ||


### PR DESCRIPTION
Add `DISCRETE_LONG` as a possible CNA data type.

Fixes e2e test failures introduced by the new CNA long format of https://github.com/cBioPortal/cbioportal/pull/9847

## Changes
- Add `DISCRETE_LONG` to data types
- Add `CnaDataTypes` that contains both possible cna data types
