### PR TITLE
[RFC 66] Display custom namespace columns in struct var table

### DIFF
--- a/end-to-end-test/local/specs/namespace-columns-in-struct-var-tables.spec.js
+++ b/end-to-end-test/local/specs/namespace-columns-in-struct-var-tables.spec.js
@@ -13,28 +13,28 @@ const {
 
 const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
 
-describe('namespace columns in cna tables', function() {
+describe('namespace columns in struct var tables', function() {
     describe('patient view', () => {
-        const patientViewUrl = `${CBIOPORTAL_URL}/patient?studyId=study_es_0&caseId=TCGA-A2-A04U`;
-        const namespaceColumn1 = 'MyNamespace Column1';
-        const namespaceValue1 = 'value1b';
-        const namespaceColumn2 = 'MyNamespace Column2';
-        const namespaceValue2 = 'value2b';
+        const patientViewUrl = `${CBIOPORTAL_URL}/patient?studyId=study_es_0&caseId=TCGA-A2-A04P`;
+        const namespaceColumn1 = 'StructVarNs Column1';
+        const namespaceValue1 = 'value1';
+        const namespaceColumn2 = 'StructVarNs Column2';
+        const namespaceValue2 = 'value2';
         const namespaceColumns = [namespaceColumn1, namespaceColumn2];
-        const patientCnaTable = 'patientview-copynumber-table';
-        const geneWithCustomNamespaceData = 'ACAP3';
+        const patientStructVarTable = 'patientview-structural-variant-table';
+        const geneWithCustomNamespaceData = 'KIAA1549';
 
         it('hides namespace columns when no property set', () => {
             goToUrlAndSetLocalStorageWithProperty(patientViewUrl, true, {});
-            waitForTable(patientCnaTable);
+            waitForTable(patientStructVarTable);
             assert(namespaceColumnsAreNotDisplayed(namespaceColumns));
         });
 
         it('shows columns when column menu is used', () => {
-            clickColumnSelectionButton(patientCnaTable);
+            clickColumnSelectionButton(patientStructVarTable);
             selectColumn(namespaceColumn1);
             selectColumn(namespaceColumn2);
-            clickColumnSelectionButton(patientCnaTable);
+            clickColumnSelectionButton(patientStructVarTable);
             assert(namespaceColumnsAreDisplayed(namespaceColumns));
         });
 
@@ -43,7 +43,7 @@ describe('namespace columns in cna tables', function() {
          */
         it('displays custom namespace data', () => {
             const rowWithNamespaceData = getRowByGene(
-                patientCnaTable,
+                patientStructVarTable,
                 geneWithCustomNamespaceData
             );
             assert(!!rowWithNamespaceData);

--- a/end-to-end-test/local/specs/namespace-columns-utils.js
+++ b/end-to-end-test/local/specs/namespace-columns-utils.js
@@ -1,0 +1,40 @@
+function clickColumnSelectionButton(patientCnaTable) {
+    $(`[data-test=${patientCnaTable}]`)
+        .$('button*=Columns')
+        .click();
+}
+
+function selectColumn(namespaceColumn1) {
+    $(`[data-id="${namespaceColumn1}"]`).click();
+}
+
+waitForTable = table => {
+    $(`[data-test=${table}]`).waitForDisplayed();
+};
+
+namespaceColumnsAreDisplayed = columns => {
+    for (const column of columns) {
+        if (!$(`//span[text()='${column}']`).isDisplayed()) {
+            return false;
+        }
+    }
+    return true;
+};
+
+namespaceColumnsAreNotDisplayed = columns => {
+    return !namespaceColumnsAreDisplayed(columns);
+};
+
+getRowByGene = (tableName, gene) => {
+    const tableRows = $$(`[data-test="${tableName}"] tr`);
+    return tableRows.find(r => r.$('td=' + gene).isExisting());
+};
+
+module.exports = {
+    getRowByGene,
+    namespaceColumnsAreNotDisplayed,
+    namespaceColumnsAreDisplayed,
+    waitForTable,
+    selectColumn,
+    clickColumnSelectionButton,
+};

--- a/src/pages/patientView/PatientViewPageTabs.tsx
+++ b/src/pages/patientView/PatientViewPageTabs.tsx
@@ -339,6 +339,10 @@ export function tabs(
                         ? sampleManager.getActiveSampleIdsInOrder()
                         : []
                 }
+                namespaceColumns={
+                    pageComponent.patientViewPageStore.namespaceColumnConfig
+                        .structVar
+                }
             />
 
             <hr />
@@ -402,7 +406,7 @@ export function tabs(
                                 onRowClick={pageComponent.onCnaTableRowClick}
                                 namespaceColumns={
                                     pageComponent.patientViewPageStore
-                                        .namespaceColumnConfig
+                                        .namespaceColumnConfig.cna
                                 }
                             />
                         </If>

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -199,6 +199,11 @@ import { buildNamespaceColumnConfig } from 'shared/components/namespaceColumns/n
 type PageMode = 'patient' | 'sample';
 type ResourceId = string;
 
+type NamespaceColumnConfigMap = {
+    cna: NamespaceColumnConfig;
+    structVar: NamespaceColumnConfig;
+};
+
 export async function checkForTissueImage(patientId: string): Promise<boolean> {
     if (/TCGA/.test(patientId) === false) {
         return false;
@@ -1353,8 +1358,13 @@ export class PatientViewPageStore {
         []
     );
 
-    @computed get namespaceColumnConfig(): NamespaceColumnConfig {
-        return buildNamespaceColumnConfig(this.discreteCNAData.result);
+    @computed get namespaceColumnConfig(): NamespaceColumnConfigMap {
+        return {
+            cna: buildNamespaceColumnConfig(this.discreteCNAData.result),
+            structVar: buildNamespaceColumnConfig(
+                this.structuralVariantData.result
+            ),
+        };
     }
 
     readonly molecularData = remoteData<NumericGeneMolecularData[]>(

--- a/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
+++ b/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
@@ -27,6 +27,8 @@ import { StructuralVariant } from 'cbioportal-ts-api-client';
 import { MutationStatus } from 'react-mutation-mapper';
 import { getSamplesProfiledStatus } from 'pages/patientView/PatientViewPageUtils';
 import SampleNotProfiledAlert from 'shared/components/SampleNotProfiledAlert';
+import { NamespaceColumnConfig } from 'shared/components/namespaceColumns/NamespaceColumnConfig';
+import { createNamespaceColumns } from 'shared/components/namespaceColumns/namespaceColumnsUtils';
 
 export interface IStructuralVariantTableWrapperProps {
     store: PatientViewPageStore;
@@ -34,6 +36,7 @@ export interface IStructuralVariantTableWrapperProps {
     mergeOncoKbIcons?: boolean;
     sampleIds: string[];
     onOncoKbIconToggle: (mergeIcons: boolean) => void;
+    namespaceColumns?: NamespaceColumnConfig;
 }
 
 type CNATableColumn = Column<StructuralVariant[]> & { order: number };
@@ -467,6 +470,10 @@ export default class StructuralVariantTableWrapper extends React.Component<
                 order: 80,
             });
 
+            columns.push(
+                ...createStructVarNamespaceColumns(this.props.namespaceColumns)
+            );
+
             return _.sortBy(columns, (c: CNATableColumn) => c.order);
         },
         default: [],
@@ -532,18 +539,21 @@ export default class StructuralVariantTableWrapper extends React.Component<
     });
 
     public render() {
-        return this.tableUI.component;
+        return (
+            <div data-test="patientview-structural-variant-table">
+                {this.tableUI.component}
+            </div>
+        );
     }
+}
 
-    // @action.bound
-    // private handleOncoKbIconModeToggle(mergeIcons: boolean) {
-    //     this.mergeOncoKbIcons = mergeIcons;
-    //     updateOncoKbIconStyle({ mergeIcons });
-    //
-    //     // we need to set the OncoKB width on the next render cycle, otherwise it is not updated yet
-    //     calculateOncoKbContentWidthOnNextFrame(
-    //         ANNOTATION_ELEMENT_ID,
-    //         width => (this.oncokbWidth = width || DEFAULT_ONCOKB_CONTENT_WIDTH)
-    //     );
-    // }
+function createStructVarNamespaceColumns(
+    config?: NamespaceColumnConfig
+): CNATableColumn[] {
+    const namespaceColumnRecords = createNamespaceColumns(config);
+    const namespaceColumns = Object.values(
+        namespaceColumnRecords
+    ) as CNATableColumn[];
+    namespaceColumns.forEach(c => (c.visible = false));
+    return namespaceColumns;
 }


### PR DESCRIPTION
Display custom namespace columns in structural variants table

Uses the backend changes made in https://github.com/cBioPortal/cbioportal/pull/9880

![image](https://user-images.githubusercontent.com/3323006/202415943-f98353a0-8a55-440a-8c43-a118958efbcc.png)

## Changes
- Display custom namespace columns in Structural Variant table
- Move shared e2e util function to `specUtils.js`

## Tests
- Added local e2e test `namespace-columns-in-struct-var-tables.spec.js`
