### PR TITLE
Add user selected gene to the URL in group comparison lollipop plot

### DIFF
--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -27,7 +27,6 @@ export default class GroupComparisonMutationsTab extends React.Component<
     IGroupComparisonMutationsTabProps,
     {}
 > {
-    @observable public geneTab: string | undefined;
     constructor(props: IGroupComparisonMutationsTabProps) {
         super(props);
         makeObservable(this);
@@ -35,7 +34,6 @@ export default class GroupComparisonMutationsTab extends React.Component<
 
     @action.bound
     protected handleGeneChange(id: string) {
-        this.geneTab = id;
         this.props.urlWrapper.updateURL({
             selectedGene: id,
         });
@@ -53,9 +51,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
 
     @computed get activeTabId(): string | undefined {
         let activeTabId;
-        if (this.geneTab) {
-            activeTabId = this.geneTab;
-        } else if (this.props.store.userSelectedMutationMapperGene) {
+        if (this.props.store.userSelectedMutationMapperGene) {
             activeTabId = this.props.store.userSelectedMutationMapperGene;
         } else {
             activeTabId = this.props.store.activeMutationMapperGene!

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -15,9 +15,11 @@ import { LollipopGeneSelector } from './LollipopGeneSelector';
 import GroupComparisonMutationsTabPlot from './GroupComparisonMutationsTabPlot';
 import OverlapExclusionIndicator from './OverlapExclusionIndicator';
 import { MSKTab, MSKTabs } from 'shared/components/MSKTabs/MSKTabs';
+import GroupComparisonURLWrapper from './GroupComparisonURLWrapper';
 
 interface IGroupComparisonMutationsTabProps {
     store: GroupComparisonStore;
+    urlWrapper: GroupComparisonURLWrapper;
 }
 
 @observer
@@ -32,9 +34,11 @@ export default class GroupComparisonMutationsTab extends React.Component<
     }
 
     @action.bound
-    protected handleGeneChange(id: string | undefined) {
+    protected handleGeneChange(id: string) {
         this.geneTab = id;
-        this.props.store.setSelectedMutationMapperGene(id);
+        this.props.urlWrapper.updateURL({
+            selectedGene: id,
+        });
     }
 
     @computed get tabs() {

--- a/src/pages/groupComparison/GroupComparisonPage.tsx
+++ b/src/pages/groupComparison/GroupComparisonPage.tsx
@@ -226,6 +226,7 @@ export default class GroupComparisonPage extends React.Component<
                             >
                                 <GroupComparisonMutationsTab
                                     store={this.store}
+                                    urlWrapper={this.urlWrapper}
                                 />
                                 {/* stacked lollipop plots for > 2 groups */}
                                 {/* {this.store.activeGroups.result!.map(g => {

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -51,7 +51,6 @@ import { FeatureFlagEnum } from 'shared/featureFlags';
 
 export default class GroupComparisonStore extends ComparisonStore {
     @observable private sessionId: string;
-    @observable private _userSelectedMutationMapperGene: string | undefined;
 
     constructor(
         sessionId: string,
@@ -435,7 +434,7 @@ export default class GroupComparisonStore extends ComparisonStore {
     });
 
     @computed get userSelectedMutationMapperGene() {
-        return this._userSelectedMutationMapperGene;
+        return this.urlWrapper.query.selectedGene;
     }
 
     @computed get activeMutationMapperGene() {
@@ -449,11 +448,6 @@ export default class GroupComparisonStore extends ComparisonStore {
                     this.genesWithMaxFrequency[0].hugoGeneSymbol
             );
         return gene;
-    }
-
-    @action.bound
-    public setSelectedMutationMapperGene(gene: string | undefined) {
-        this._userSelectedMutationMapperGene = gene;
     }
 
     @autobind

--- a/src/pages/groupComparison/GroupComparisonURLWrapper.ts
+++ b/src/pages/groupComparison/GroupComparisonURLWrapper.ts
@@ -23,6 +23,7 @@ export type GroupComparisonURLQuery = {
     overlapStrategy?: OverlapStrategy;
     patientEnrichments?: string;
     selectedEnrichmentEventTypes: string;
+    selectedGene?: string;
 };
 
 export default class GroupComparisonURLWrapper
@@ -38,6 +39,7 @@ export default class GroupComparisonURLWrapper
                 overlapStrategy: { isSessionProp: false },
                 patientEnrichments: { isSessionProp: false },
                 selectedEnrichmentEventTypes: { isSessionProp: true },
+                selectedGene: { isSessionProp: false },
             },
             true,
             getServerConfig().session_url_length_threshold


### PR DESCRIPTION
Capture selected gene in URL for shareability for group comparison lollipop plot

Fixes: https://github.com/cbioportal/cbioportal/issues/9899