### PR TITLE
Do not show style attributes in timeline data table on patient page

### DIFF
--- a/src/pages/patientView/timeline/ClinicalEventsTables.tsx
+++ b/src/pages/patientView/timeline/ClinicalEventsTables.tsx
@@ -36,6 +36,9 @@ const ClinicalEventsTables: React.FunctionComponent<{
                         if (['PATIENT_ID'].includes(item)) {
                             aggr.push(i);
                         }
+                        if (/^STYLE_/.test(item)) {
+                            aggr.push(i);
+                        }
                         return aggr;
                     },
                     []


### PR DESCRIPTION
We don't want these little style attributes to show up in table

![image](https://user-images.githubusercontent.com/186521/203121534-466135f4-fdbe-4256-b7b4-3dca6148facf.png)
