### PR TITLE
Fix gene panel column download in patient view page

### DIFF
--- a/src/shared/components/mutationTable/column/PanelColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/PanelColumnFormatter.spec.tsx
@@ -64,7 +64,7 @@ describe('PanelColumnFormatter', () => {
 
     it('returns a list of gene panel ids on download', () => {
         const genePanelIds = PanelColumnFormatter.download(mock);
-        assert.deepEqual(genePanelIds, ['genePanelId']);
+        assert.deepEqual(genePanelIds, 'genePanelId');
     });
 
     it('returns a list of gene panel ids on getGenePanelIds', () => {

--- a/src/shared/components/mutationTable/column/PanelColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/PanelColumnFormatter.tsx
@@ -131,6 +131,6 @@ export default {
     ),
     // Exclude not profiled gene panel ids for download
     download: (props: PanelColumnFormatterProps) =>
-        getGenePanelIds(props, true),
+        getGenePanelIds(props, true).join(','),
     getGenePanelIds,
 };


### PR DESCRIPTION
Fix cBioPortal/cbioportal#8944

Describe changes proposed in this pull request:
This pr fixes the gene panel column download in patient view page, this issue is caused by the gene panel column tried to provide array data to lazyMobxTable download function. But the array size is not compatible with requirement. So I changed download object from a array to a string by joining the array element.