### PR TITLE
Capture selected scale in URL in group comparison lollipop plot

### DIFF
--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/AxisScaleSwitch.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/AxisScaleSwitch.tsx
@@ -55,6 +55,11 @@ export class AxisScaleSwitch extends React.Component<
                         this.props.selectedScale === scale
                             ? 'bolder'
                             : 'normal',
+                    color:
+                        this.props.selectedScale === scale ? '#fff' : '#6c757d',
+                    backgroundColor:
+                        this.props.selectedScale === scale ? '#6c757d' : '#fff',
+                    borderColor: '#6c757d',
                 }}
                 onClick={onClick}
             >

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -132,6 +132,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
                     </div>
                     <GroupComparisonMutationsTabPlot
                         store={this.props.store}
+                        urlWrapper={this.props.urlWrapper}
                         mutations={_(this.props.store.mutationsByGroup.result!)
                             .values()
                             .flatten()

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -16,6 +16,7 @@ import GroupComparisonMutationsTabPlot from './GroupComparisonMutationsTabPlot';
 import OverlapExclusionIndicator from './OverlapExclusionIndicator';
 import { MSKTab, MSKTabs } from 'shared/components/MSKTabs/MSKTabs';
 import GroupComparisonURLWrapper from './GroupComparisonURLWrapper';
+import { AxisScale } from 'react-mutation-mapper';
 
 interface IGroupComparisonMutationsTabProps {
     store: GroupComparisonStore;
@@ -58,6 +59,13 @@ export default class GroupComparisonMutationsTab extends React.Component<
                 .hugoGeneSymbol;
         }
         return activeTabId;
+    }
+
+    @action.bound
+    private onScaleToggle(selectedScale: AxisScale) {
+        this.props.urlWrapper.updateURL({
+            axisMode: selectedScale,
+        });
     }
 
     readonly tabUI = MakeMobxView({
@@ -132,7 +140,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
                     </div>
                     <GroupComparisonMutationsTabPlot
                         store={this.props.store}
-                        urlWrapper={this.props.urlWrapper}
+                        onScaleToggle={this.onScaleToggle}
                         mutations={_(this.props.store.mutationsByGroup.result!)
                             .values()
                             .flatten()

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -61,8 +61,6 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
     IGroupComparisonMutationsTabPlotProps,
     {}
 > {
-    @observable public axisMode: AxisScale =
-        this.props.urlWrapper.query.axisMode || AxisScale.PERCENT;
     constructor(props: IGroupComparisonMutationsTabPlotProps) {
         super(props);
         makeObservable(this);
@@ -81,7 +79,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         mutations: Mutation[],
         group: string
     ) {
-        return this.axisMode === AxisScale.PERCENT
+        return this.props.urlWrapper.query.axisMode === AxisScale.PERCENT
             ? (countUniqueMutations(mutations) /
                   this.props.store.groupToProfiledSamples.result![group]
                       .length) *
@@ -94,7 +92,6 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         this.props.urlWrapper.updateURL({
             axisMode: selectedScale,
         });
-        this.axisMode = selectedScale;
     }
 
     readonly plotUI = MakeMobxView({
@@ -136,7 +133,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                             plotLollipopTooltipCountInfo={
                                 plotLollipopTooltipCountInfo
                             }
-                            axisMode={this.axisMode}
+                            axisMode={this.props.urlWrapper.query.axisMode}
                             onScaleToggle={this.onScaleToggle}
                             plotYAxisLabelFormatter={plotYAxisLabelFormatter}
                         />

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -15,9 +15,11 @@ import { MakeMobxView } from 'shared/components/MobxView';
 import { countUniqueMutations } from 'shared/lib/MutationUtils';
 import ErrorMessage from 'shared/components/ErrorMessage';
 import { AxisScale, LollipopTooltipCountInfo } from 'react-mutation-mapper';
+import GroupComparisonURLWrapper from './GroupComparisonURLWrapper';
 
 interface IGroupComparisonMutationsTabPlotProps {
     store: GroupComparisonStore;
+    urlWrapper: GroupComparisonURLWrapper;
     mutations?: Mutation[];
     filters?: any;
 }
@@ -59,7 +61,8 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
     IGroupComparisonMutationsTabPlotProps,
     {}
 > {
-    @observable public axisMode: AxisScale = AxisScale.PERCENT;
+    @observable public axisMode: AxisScale =
+        this.props.urlWrapper.query.axisMode || AxisScale.PERCENT;
     constructor(props: IGroupComparisonMutationsTabPlotProps) {
         super(props);
         makeObservable(this);
@@ -88,6 +91,9 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
 
     @action.bound
     private onScaleToggle(selectedScale: AxisScale) {
+        this.props.urlWrapper.updateURL({
+            axisMode: selectedScale,
+        });
         this.axisMode = selectedScale;
     }
 

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -15,11 +15,10 @@ import { MakeMobxView } from 'shared/components/MobxView';
 import { countUniqueMutations } from 'shared/lib/MutationUtils';
 import ErrorMessage from 'shared/components/ErrorMessage';
 import { AxisScale, LollipopTooltipCountInfo } from 'react-mutation-mapper';
-import GroupComparisonURLWrapper from './GroupComparisonURLWrapper';
 
 interface IGroupComparisonMutationsTabPlotProps {
     store: GroupComparisonStore;
-    urlWrapper: GroupComparisonURLWrapper;
+    onScaleToggle: (selectedScale: AxisScale) => void;
     mutations?: Mutation[];
     filters?: any;
 }
@@ -78,19 +77,12 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         mutations: Mutation[],
         group: string
     ) {
-        return this.props.urlWrapper.query.axisMode === AxisScale.COUNT
+        return this.props.store.userSelectedAxisMode === AxisScale.COUNT
             ? countUniqueMutations(mutations)
             : (countUniqueMutations(mutations) /
                   this.props.store.groupToProfiledSamples.result![group]
                       .length) *
                   100;
-    }
-
-    @action.bound
-    private onScaleToggle(selectedScale: AxisScale) {
-        this.props.urlWrapper.updateURL({
-            axisMode: selectedScale,
-        });
     }
 
     readonly plotUI = MakeMobxView({
@@ -132,12 +124,8 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                             plotLollipopTooltipCountInfo={
                                 plotLollipopTooltipCountInfo
                             }
-                            axisMode={
-                                this.props.urlWrapper.query.axisMode
-                                    ? this.props.urlWrapper.query.axisMode
-                                    : AxisScale.PERCENT
-                            }
-                            onScaleToggle={this.onScaleToggle}
+                            axisMode={this.props.store.userSelectedAxisMode}
+                            onScaleToggle={this.props.onScaleToggle}
                             plotYAxisLabelFormatter={plotYAxisLabelFormatter}
                         />
                     </>

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -39,7 +39,6 @@ function plotYAxisLabelFormatter(symbol: string, groupName: string) {
         }
     }
     return `${symbol} ${label}`;
-    // return `${symbol} ${groupName}`;
 }
 
 function plotLollipopTooltipCountInfo(
@@ -79,12 +78,12 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         mutations: Mutation[],
         group: string
     ) {
-        return this.props.urlWrapper.query.axisMode === AxisScale.PERCENT
-            ? (countUniqueMutations(mutations) /
+        return this.props.urlWrapper.query.axisMode === AxisScale.COUNT
+            ? countUniqueMutations(mutations)
+            : (countUniqueMutations(mutations) /
                   this.props.store.groupToProfiledSamples.result![group]
                       .length) *
-                  100
-            : countUniqueMutations(mutations);
+                  100;
     }
 
     @action.bound
@@ -133,7 +132,11 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                             plotLollipopTooltipCountInfo={
                                 plotLollipopTooltipCountInfo
                             }
-                            axisMode={this.props.urlWrapper.query.axisMode}
+                            axisMode={
+                                this.props.urlWrapper.query.axisMode
+                                    ? this.props.urlWrapper.query.axisMode
+                                    : AxisScale.PERCENT
+                            }
                             onScaleToggle={this.onScaleToggle}
                             plotYAxisLabelFormatter={plotYAxisLabelFormatter}
                         />

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -458,6 +458,10 @@ export default class GroupComparisonStore extends ComparisonStore {
         return this.urlWrapper.query.selectedGene;
     }
 
+    @computed get userSelectedAxisMode() {
+        return this.urlWrapper.query.axisMode;
+    }
+
     @computed get activeMutationMapperGene() {
         let gene =
             this.availableGenes.result!.find(

--- a/src/pages/groupComparison/GroupComparisonURLWrapper.ts
+++ b/src/pages/groupComparison/GroupComparisonURLWrapper.ts
@@ -15,6 +15,7 @@ import {
 } from 'shared/lib/comparison/ComparisonStoreUtils';
 import { getServerConfig } from 'config/config';
 import { MapValues } from 'shared/lib/TypeScriptUtils';
+import { AxisScale } from 'react-mutation-mapper';
 
 export type GroupComparisonURLQuery = {
     comparisonId: string;
@@ -24,6 +25,7 @@ export type GroupComparisonURLQuery = {
     patientEnrichments?: string;
     selectedEnrichmentEventTypes: string;
     selectedGene?: string;
+    axisMode?: AxisScale;
 };
 
 export default class GroupComparisonURLWrapper
@@ -40,6 +42,7 @@ export default class GroupComparisonURLWrapper
                 patientEnrichments: { isSessionProp: false },
                 selectedEnrichmentEventTypes: { isSessionProp: true },
                 selectedGene: { isSessionProp: false },
+                axisMode: { isSessionProp: false },
             },
             true,
             getServerConfig().session_url_length_threshold


### PR DESCRIPTION
Fixes issue in https://github.com/cBioPortal/cbioportal/issues/9901

- Makes scale toggle icons clearer and captures state in URL