### PR TITLE
Default axis scale to frequency in group comparison lollipop plot

### DIFF
--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -124,7 +124,10 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                             plotLollipopTooltipCountInfo={
                                 plotLollipopTooltipCountInfo
                             }
-                            axisMode={this.props.store.userSelectedAxisMode}
+                            axisMode={
+                                this.props.store.userSelectedAxisMode ||
+                                AxisScale.PERCENT
+                            }
                             onScaleToggle={this.props.onScaleToggle}
                             plotYAxisLabelFormatter={plotYAxisLabelFormatter}
                         />

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -77,7 +77,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         mutations: Mutation[],
         group: string
     ) {
-        return this.props.store.userSelectedAxisMode === AxisScale.COUNT
+        return this.props.store.axisMode === AxisScale.COUNT
             ? countUniqueMutations(mutations)
             : (countUniqueMutations(mutations) /
                   this.props.store.groupToProfiledSamples.result![group]
@@ -124,10 +124,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                             plotLollipopTooltipCountInfo={
                                 plotLollipopTooltipCountInfo
                             }
-                            axisMode={
-                                this.props.store.userSelectedAxisMode ||
-                                AxisScale.PERCENT
-                            }
+                            axisMode={this.props.store.axisMode}
                             onScaleToggle={this.props.onScaleToggle}
                             plotYAxisLabelFormatter={plotYAxisLabelFormatter}
                         />

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -39,7 +39,7 @@ import {
 } from 'shared/api/session-service/sessionServiceModels';
 import ComplexKeySet from 'shared/lib/complexKeyDataStructures/ComplexKeySet';
 import { REQUEST_ARG_ENUM } from 'shared/constants';
-import { DataFilter } from 'react-mutation-mapper';
+import { AxisScale, DataFilter } from 'react-mutation-mapper';
 import { getAllGenes } from 'shared/lib/StoreUtils';
 import {
     CoverageInformation,
@@ -458,8 +458,8 @@ export default class GroupComparisonStore extends ComparisonStore {
         return this.urlWrapper.query.selectedGene;
     }
 
-    @computed get userSelectedAxisMode() {
-        return this.urlWrapper.query.axisMode;
+    @computed get axisMode() {
+        return this.urlWrapper.query.axisMode || AxisScale.PERCENT;
     }
 
     @computed get activeMutationMapperGene() {


### PR DESCRIPTION
Fixes issue when there is no selected axis scale. When there is no selected axis scale, it should default to frequency mode.