### PR TITLE
Format and fix gene selector and tab contents in group comparison lollipop plot

### DIFF
--- a/src/globalStyles/global.scss
+++ b/src/globalStyles/global.scss
@@ -256,6 +256,7 @@ th.reactable-header-sort-asc:after {
 
 .comparisonMutationMapperTabs {
     height: 0;
+    padding-top: 5px;
 }
 
 .mainTabs {

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -47,14 +47,8 @@ export default class GroupComparisonMutationsTab extends React.Component<
 
     @computed get tabs() {
         return this.props.store.genesWithHighestMutationFrequency
-            .slice(0, 10)
-            .map(g => (
-                <MSKTab
-                    key={g.hugoGeneSymbol}
-                    id={g.hugoGeneSymbol}
-                    linkText={g.hugoGeneSymbol}
-                />
-            ));
+            .result!.slice(0, 10)
+            .map(g => <MSKTab key={g} id={g} linkText={g} />);
     }
 
     @computed get activeTabId(): string | undefined {
@@ -85,6 +79,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
         await: () => [
             this.props.store.genes,
             this.props.store.genesWithMutations,
+            this.props.store.genesWithHighestMutationFrequency,
         ],
         render: () => {
             // We only want 2 groups for our mirrored lollipop plot. Display message if not 2 groups
@@ -128,20 +123,10 @@ export default class GroupComparisonMutationsTab extends React.Component<
                         store={this.props.store}
                         only="sample"
                     />
-                    {/* <LollipopGeneSelector
-                        store={this.props.store}
-                        genes={this.props.store.genes.result!}
-                        handleGeneChange={this.handleGeneChange}
-                        key={
-                            'comparisonLollipopGene' +
-                            this.props.store.activeMutationMapperGene!
-                                .hugoGeneSymbol
-                        }
-                    /> */}
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                         <LollipopGeneSelector
                             store={this.props.store}
-                            genes={this.props.store.availableGenes.result!}
+                            genes={this.props.store.genes.result!}
                             genesWithMutations={
                                 this.props.store.genesWithMutations.result!
                             }

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -46,13 +46,15 @@ export default class GroupComparisonMutationsTab extends React.Component<
     }
 
     @computed get tabs() {
-        return this.props.store.genesWithMaxFrequency.map(g => (
-            <MSKTab
-                key={g.hugoGeneSymbol}
-                id={g.hugoGeneSymbol}
-                linkText={g.hugoGeneSymbol}
-            />
-        ));
+        return this.props.store.genesWithHighestMutationFrequency
+            .slice(0, 10)
+            .map(g => (
+                <MSKTab
+                    key={g.hugoGeneSymbol}
+                    id={g.hugoGeneSymbol}
+                    linkText={g.hugoGeneSymbol}
+                />
+            ));
     }
 
     @computed get activeTabId(): string | undefined {
@@ -80,7 +82,10 @@ export default class GroupComparisonMutationsTab extends React.Component<
     }
 
     readonly tabUI = MakeMobxView({
-        await: () => [this.props.store.genes],
+        await: () => [
+            this.props.store.genes,
+            this.props.store.genesWithMutations,
+        ],
         render: () => {
             // We only want 2 groups for our mirrored lollipop plot. Display message if not 2 groups
             if (this.props.store.activeGroups.result!.length < 2) {
@@ -123,7 +128,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
                         store={this.props.store}
                         only="sample"
                     />
-                    <LollipopGeneSelector
+                    {/* <LollipopGeneSelector
                         store={this.props.store}
                         genes={this.props.store.genes.result!}
                         handleGeneChange={this.handleGeneChange}
@@ -132,22 +137,37 @@ export default class GroupComparisonMutationsTab extends React.Component<
                             this.props.store.activeMutationMapperGene!
                                 .hugoGeneSymbol
                         }
-                    />
-                    <div style={{ display: 'flex' }}>
+                    /> */}
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                        <LollipopGeneSelector
+                            store={this.props.store}
+                            genes={this.props.store.availableGenes.result!}
+                            genesWithMutations={
+                                this.props.store.genesWithMutations.result!
+                            }
+                            handleGeneChange={this.handleGeneChange}
+                            key={
+                                'comparisonLollipopGene' +
+                                this.props.store.activeMutationMapperGene!
+                                    .hugoGeneSymbol
+                            }
+                        />
                         <div style={{ paddingRight: '5px' }}>
                             Highest Frequency:
                         </div>
-                        <MSKTabs
-                            activeTabId={this.activeTabId}
-                            onTabClick={(id: string) =>
-                                this.handleGeneChange(id)
-                            }
-                            className="pillTabs comparisonMutationMapperTabs"
-                            tabButtonStyle="pills"
-                            defaultTabId={false}
-                        >
-                            {this.tabs}
-                        </MSKTabs>
+                        <div>
+                            <MSKTabs
+                                activeTabId={this.activeTabId}
+                                onTabClick={(id: string) =>
+                                    this.handleGeneChange(id)
+                                }
+                                className="pillTabs comparisonMutationMapperTabs"
+                                tabButtonStyle="pills"
+                                defaultTabId={false}
+                            >
+                                {this.tabs}
+                            </MSKTabs>
+                        </div>
                     </div>
                     <GroupComparisonMutationsTabPlot
                         store={this.props.store}

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -41,20 +41,14 @@ export default class GroupComparisonMutationsTab extends React.Component<
     @action.bound
     protected handleGeneChange(id: string) {
         this.props.urlWrapper.updateURL({
-            selectedGene: id ? id.replace('comp-tab-', '') : id,
+            selectedGene: id,
         });
     }
 
     @computed get tabs() {
         return this.props.store.genesSortedByMutationFrequency
             .result!.slice(0, 10)
-            .map(g => (
-                <MSKTab
-                    key={`comp-tab-${g}`}
-                    id={`comp-tab-${g}`}
-                    linkText={g}
-                />
-            ));
+            .map(g => <MSKTab key={`comp-tab-${g}`} id={g} linkText={g} />);
     }
 
     @computed get activeTabId(): string | undefined {
@@ -65,7 +59,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
             activeTabId = this.props.store.activeMutationMapperGene!
                 .hugoGeneSymbol;
         }
-        return `comp-tab-${activeTabId}`;
+        return activeTabId;
     }
 
     @action.bound

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -41,14 +41,20 @@ export default class GroupComparisonMutationsTab extends React.Component<
     @action.bound
     protected handleGeneChange(id: string) {
         this.props.urlWrapper.updateURL({
-            selectedGene: id,
+            selectedGene: id ? id.replace('comp-tab-', '') : id,
         });
     }
 
     @computed get tabs() {
-        return this.props.store.genesWithHighestMutationFrequency
+        return this.props.store.genesSortedByMutationFrequency
             .result!.slice(0, 10)
-            .map(g => <MSKTab key={g} id={g} linkText={g} />);
+            .map(g => (
+                <MSKTab
+                    key={`comp-tab-${g}`}
+                    id={`comp-tab-${g}`}
+                    linkText={g}
+                />
+            ));
     }
 
     @computed get activeTabId(): string | undefined {
@@ -59,7 +65,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
             activeTabId = this.props.store.activeMutationMapperGene!
                 .hugoGeneSymbol;
         }
-        return activeTabId;
+        return `comp-tab-${activeTabId}`;
     }
 
     @action.bound
@@ -79,7 +85,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
         await: () => [
             this.props.store.genes,
             this.props.store.genesWithMutations,
-            this.props.store.genesWithHighestMutationFrequency,
+            this.props.store.genesSortedByMutationFrequency,
         ],
         render: () => {
             // We only want 2 groups for our mirrored lollipop plot. Display message if not 2 groups

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -464,11 +464,10 @@ export default class GroupComparisonStore extends ComparisonStore {
     });
 
     readonly genesWithMutations = remoteData<Gene[]>({
+        await: () => [this.genesWithHighestMutationFrequency],
         invoke: async () => {
             const genes = await fetchGenes(
-                this.genesWithHighestMutationFrequency.map(
-                    g => g.hugoGeneSymbol
-                )
+                this.genesWithHighestMutationFrequency.result!
             );
             return genes;
         },
@@ -490,7 +489,7 @@ export default class GroupComparisonStore extends ComparisonStore {
             this.genes.result!.find(
                 g =>
                     g.hugoGeneSymbol ===
-                    this.genesWithHighestMutationFrequency[0].hugoGeneSymbol
+                    this.genesWithHighestMutationFrequency.result![0]
             );
         return gene;
     }

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -41,7 +41,7 @@ import {
 import ComplexKeySet from 'shared/lib/complexKeyDataStructures/ComplexKeySet';
 import { REQUEST_ARG_ENUM } from 'shared/constants';
 import { AxisScale, DataFilter } from 'react-mutation-mapper';
-import { getAllGenes } from 'shared/lib/StoreUtils';
+import { fetchGenes, getAllGenes } from 'shared/lib/StoreUtils';
 import {
     CoverageInformation,
     getCoverageInformation,
@@ -463,6 +463,17 @@ export default class GroupComparisonStore extends ComparisonStore {
         },
     });
 
+    readonly genesWithMutations = remoteData<Gene[]>({
+        invoke: async () => {
+            const genes = await fetchGenes(
+                this.genesWithHighestMutationFrequency.map(
+                    g => g.hugoGeneSymbol
+                )
+            );
+            return genes;
+        },
+    });
+
     @computed get userSelectedMutationMapperGene() {
         return this.urlWrapper.query.selectedGene;
     }
@@ -479,7 +490,7 @@ export default class GroupComparisonStore extends ComparisonStore {
             this.genes.result!.find(
                 g =>
                     g.hugoGeneSymbol ===
-                    this.genesWithMaxFrequency[0].hugoGeneSymbol
+                    this.genesWithHighestMutationFrequency[0].hugoGeneSymbol
             );
         return gene;
     }

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -464,12 +464,11 @@ export default class GroupComparisonStore extends ComparisonStore {
     });
 
     readonly genesWithMutations = remoteData<Gene[]>({
-        await: () => [this.genesWithHighestMutationFrequency],
+        await: () => [this.genesSortedByMutationFrequency, this.genes],
         invoke: async () => {
-            const genes = await fetchGenes(
-                this.genesWithHighestMutationFrequency.result!
+            return this.genesSortedByMutationFrequency.result!.map(
+                gene => this.genes.result!.find(g => gene === g.hugoGeneSymbol)!
             );
-            return genes;
         },
     });
 
@@ -489,7 +488,7 @@ export default class GroupComparisonStore extends ComparisonStore {
             this.genes.result!.find(
                 g =>
                     g.hugoGeneSymbol ===
-                    this.genesWithHighestMutationFrequency.result![0]
+                    this.genesSortedByMutationFrequency.result![0]
             );
         return gene;
     }

--- a/src/pages/groupComparison/LollipopGeneSelector.tsx
+++ b/src/pages/groupComparison/LollipopGeneSelector.tsx
@@ -8,11 +8,17 @@ import GroupComparisonStore from './GroupComparisonStore';
 interface ILollipopGeneSelectorProps {
     store: GroupComparisonStore;
     genes: Gene[];
+    genesWithMutations: Gene[];
     handleGeneChange: (id?: string) => void;
 }
 
 export const LollipopGeneSelector: React.FC<ILollipopGeneSelectorProps> = observer(
-    ({ store, genes, handleGeneChange }: ILollipopGeneSelectorProps) => {
+    ({
+        store,
+        genes,
+        genesWithMutations,
+        handleGeneChange,
+    }: ILollipopGeneSelectorProps) => {
         const loadOptions = (inputText: string, callback: any) => {
             if (!inputText) {
                 callback([]);
@@ -32,7 +38,7 @@ export const LollipopGeneSelector: React.FC<ILollipopGeneSelectorProps> = observ
         };
 
         return (
-            <div style={{ width: 200, paddingBottom: 10 }}>
+            <div style={{ width: 200, paddingRight: 10 }}>
                 <AsyncSelect
                     name="Select gene"
                     onChange={(option: any | null) => {
@@ -44,10 +50,12 @@ export const LollipopGeneSelector: React.FC<ILollipopGeneSelectorProps> = observ
                     }}
                     isClearable={true}
                     isSearchable={true}
-                    defaultOptions={genes.slice(0, 200).map(gene => ({
-                        label: gene.hugoGeneSymbol,
-                        value: gene,
-                    }))}
+                    defaultOptions={genesWithMutations
+                        .slice(0, 200)
+                        .map(gene => ({
+                            label: gene.hugoGeneSymbol,
+                            value: gene,
+                        }))}
                     value={
                         store.userSelectedMutationMapperGene
                             ? {

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -1175,12 +1175,12 @@ export default abstract class ComparisonStore extends AnalysisStore
         },
     });
 
-    @computed
-    get genesWithHighestMutationFrequency(): AlterationEnrichmentRow[] {
-        if (
-            this.mutationsEnrichmentData.isComplete &&
-            this.alterationsEnrichmentAnalysisGroups.isComplete
-        ) {
+    readonly genesWithHighestMutationFrequency = remoteData<string[]>({
+        await: () => [
+            this.mutationsEnrichmentData,
+            this.alterationsEnrichmentAnalysisGroups,
+        ],
+        invoke: async () => {
             const alterationRowData: AlterationEnrichmentRow[] = getAlterationRowData(
                 this.mutationsEnrichmentData.result!,
                 this.resultsViewStore
@@ -1189,10 +1189,9 @@ export default abstract class ComparisonStore extends AnalysisStore
                 this.alterationsEnrichmentAnalysisGroups.result!
             );
             alterationRowData.sort(compareByAlterationPercentage);
-            return alterationRowData;
-        }
-        return [];
-    }
+            return alterationRowData.map(a => a.hugoGeneSymbol);
+        },
+    });
 
     readonly mrnaEnrichmentAnalysisGroups = remoteData({
         await: () => [

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -1012,6 +1012,59 @@ export default abstract class ComparisonStore extends AnalysisStore
         },
     });
 
+    readonly mutationsEnrichmentDataRequestGroups = remoteData({
+        await: () => [
+            this.alterationsEnrichmentAnalysisGroups,
+            this.selectedStudyMutationEnrichmentProfileMap,
+        ],
+        invoke: () => {
+            if (
+                _(this.selectedMutationEnrichmentEventTypes)
+                    .values()
+                    .some()
+            ) {
+                return Promise.resolve(
+                    this.enrichmentAnalysisGroups.result!.reduce(
+                        (acc: MolecularProfileCasesGroupFilter[], group) => {
+                            let molecularProfileCaseIdentifiers: {
+                                caseId: string;
+                                molecularProfileId: string;
+                            }[] = [];
+                            group.samples.forEach(sample => {
+                                if (
+                                    this
+                                        .selectedStudyMutationEnrichmentProfileMap
+                                        .result![sample.studyId]
+                                ) {
+                                    molecularProfileCaseIdentifiers.push({
+                                        caseId: this.usePatientLevelEnrichments
+                                            ? sample.patientId
+                                            : sample.sampleId,
+                                        molecularProfileId: this
+                                            .selectedStudyMutationEnrichmentProfileMap
+                                            .result![sample.studyId]
+                                            .molecularProfileId,
+                                    });
+                                }
+                            });
+
+                            if (molecularProfileCaseIdentifiers.length > 0) {
+                                acc.push({
+                                    name: group.name,
+                                    molecularProfileCaseIdentifiers,
+                                });
+                            }
+                            return acc;
+                        },
+                        []
+                    )
+                );
+            } else {
+                return Promise.resolve([]);
+            }
+        },
+    });
+
     public readonly alterationsEnrichmentData = makeEnrichmentDataPromise({
         await: () => [this.alterationsEnrichmentDataRequestGroups],
         resultsViewPageStore: this.resultsViewStore,
@@ -1073,20 +1126,70 @@ export default abstract class ComparisonStore extends AnalysisStore
         },
     });
 
-    @computed get genesWithMaxFrequency(): AlterationEnrichmentRow[] {
+    public readonly mutationsEnrichmentData = makeEnrichmentDataPromise({
+        await: () => [this.mutationsEnrichmentDataRequestGroups],
+        resultsViewPageStore: this.resultsViewStore,
+        getSelectedProfileMaps: () => [
+            this.selectedStudyMutationEnrichmentProfileMap.result!,
+        ],
+        referenceGenesPromise: this.hugoGeneSymbolToReferenceGene,
+        fetchData: () => {
+            if (
+                this.mutationsEnrichmentDataRequestGroups.result &&
+                this.mutationsEnrichmentDataRequestGroups.result.length > 1 &&
+                _(this.selectedMutationEnrichmentEventTypes)
+                    .values()
+                    .some()
+            ) {
+                const groupsAndAlterationTypes = {
+                    molecularProfileCasesGroupFilter: this
+                        .mutationsEnrichmentDataRequestGroups.result!,
+                    alterationEventTypes: ({
+                        mutationEventTypes: getMutationEventTypesAPIParameter(
+                            this.selectedMutationEnrichmentEventTypes
+                        ),
+                        includeDriver: this.driverAnnotationSettings
+                            .includeDriver,
+                        includeVUS: this.driverAnnotationSettings.includeVUS,
+                        includeUnknownOncogenicity: this
+                            .driverAnnotationSettings
+                            .includeUnknownOncogenicity,
+                        tiersBooleanMap: this.selectedDriverTiersMap,
+                        includeUnknownTier: this.driverAnnotationSettings
+                            .includeUnknownTier,
+                        includeGermline: this.includeGermlineMutations,
+                        includeSomatic: this.includeSomaticMutations,
+                        includeUnknownStatus: this
+                            .includeUnknownStatusMutations,
+                    } as unknown) as AlterationFilter,
+                };
+
+                return internalClient.fetchAlterationEnrichmentsUsingPOST({
+                    enrichmentType: this.usePatientLevelEnrichments
+                        ? 'PATIENT'
+                        : 'SAMPLE',
+                    groupsAndAlterationTypes,
+                });
+            }
+            return Promise.resolve([]);
+        },
+    });
+
+    @computed
+    get genesWithHighestMutationFrequency(): AlterationEnrichmentRow[] {
         if (
-            this.alterationsEnrichmentData.isComplete &&
+            this.mutationsEnrichmentData.isComplete &&
             this.alterationsEnrichmentAnalysisGroups.isComplete
         ) {
             const alterationRowData: AlterationEnrichmentRow[] = getAlterationRowData(
-                this.alterationsEnrichmentData.result!,
+                this.mutationsEnrichmentData.result!,
                 this.resultsViewStore
                     ? this.resultsViewStore.hugoGeneSymbols
                     : [],
                 this.alterationsEnrichmentAnalysisGroups.result!
             );
             alterationRowData.sort(compareByAlterationPercentage);
-            return alterationRowData.slice(0, 10);
+            return alterationRowData;
         }
         return [];
     }

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -1175,7 +1175,7 @@ export default abstract class ComparisonStore extends AnalysisStore
         },
     });
 
-    readonly genesWithHighestMutationFrequency = remoteData<string[]>({
+    readonly genesSortedByMutationFrequency = remoteData<string[]>({
         await: () => [
             this.mutationsEnrichmentData,
             this.alterationsEnrichmentAnalysisGroups,


### PR DESCRIPTION
Fixes issues in https://github.com/cBioPortal/cbioportal/issues/9901

- Format gene selector and tabs so they are on the same line
- Fix gene tabs so they reflect highest mutation frequencies only (rather than mutation+sv+cna)
- Edit gene selector so it only shows genes with mutations and sort by frequency