### PR TITLE
Fix ability to log scale on plots tab for any clinical data type that is a number

### DIFF
--- a/end-to-end-test/remote/specs/core/plots.spec.js
+++ b/end-to-end-test/remote/specs/core/plots.spec.js
@@ -1,6 +1,7 @@
 var goToUrlAndSetLocalStorage = require('../../../shared/specUtils')
     .goToUrlAndSetLocalStorage;
 var assert = require('assert');
+const { getElementByTestHandle } = require('../../../shared/specUtils');
 const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
 
 describe('plots tab tests', function() {
@@ -24,6 +25,25 @@ describe('plots tab tests', function() {
         assert.equal(
             text,
             'Data availability per profile/axis:\nHorizontal Axis: 1164 samples from 2 studies\nVertical Axis: 1164 samples from 2 studies\nIntersection of the two axes: 1164 samples from 2 studies'
+        );
+    });
+    it('logscale available for all raw data types that are number', () => {
+        goToUrlAndSetLocalStorage(
+            `${CBIOPORTAL_URL}/results/plots?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=lgg_ucsf_2014%2Cbrca_tcga&case_set_id=all&data_priority=0&gene_list=TP53&geneset_list=%20&plots_coloring_selection=%7B%7D&plots_horz_selection=%7B"selectedGeneOption"%3A7157%2C"dataType"%3A"clinical_attribute"%2C"selectedDataSourceOption"%3A"TMB_NONSYNONYMOUS"%2C"logScale"%3A"false"%7D&plots_vert_selection=%7B"selectedGeneOption"%3A7157%2C"dataType"%3A"clinical_attribute"%2C"selectedDataSourceOption"%3A"CANCER_TYPE"%7D&profileFilter=0&tab_index=tab_visualize`
+        );
+
+        $('div[data-test="PlotsTabPlotDiv"]').waitForDisplayed({
+            timeout: 20000,
+        });
+
+        assert.equal(
+            getElementByTestHandle('HorizontalLogCheckbox').isExisting(),
+            true
+        );
+        assert.equal(
+            getElementByTestHandle('VerticalLogCheckbox').isExisting(),
+            false,
+            'Log Scale Checkbox should not be availble raw data type is not number'
         );
     });
 });

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -922,7 +922,11 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                 this._structuralVariantCountBy = s;
             },
             get logScale() {
-                return this._logScale && logScalePossible(this);
+                //const horzAxisData = self.horzAxisDataPromise.result;
+                const axisData = vertical
+                    ? self.vertAxisDataPromise.result
+                    : self.horzAxisDataPromise.result;
+                return this._logScale && logScalePossible(this, axisData);
             },
             set logScale(v: boolean) {
                 this._logScale = v;
@@ -3556,7 +3560,10 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                                 </div>
                             </div>
                         )}
-                    {logScalePossible(axisSelection) && (
+                    {logScalePossible(
+                        axisSelection,
+                        axisDataPromise.result
+                    ) && (
                         <div className="checkbox">
                             <label>
                                 <input
@@ -3565,7 +3572,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                                     name={
                                         vertical
                                             ? 'vert_logScale'
-                                            : 'vert_logScale'
+                                            : 'horz_logScale'
                                     }
                                     value={
                                         vertical

--- a/src/pages/resultsView/plots/PlotsTabUtils.spec.ts
+++ b/src/pages/resultsView/plots/PlotsTabUtils.spec.ts
@@ -19,6 +19,7 @@ import {
     MUT_PROFILE_COUNT_DRIVER,
     MUT_PROFILE_COUNT_VUS,
     mutDriverVsVUSCategoryOrder,
+    logScalePossible,
 } from './PlotsTabUtils';
 import { Mutation, Sample, Gene } from 'cbioportal-ts-api-client';
 import {
@@ -764,6 +765,20 @@ describe('PlotsTabUtils', () => {
             assert.equal(funcs!.fLogScale(0, 10), 1);
             assert.equal(funcs!.fLogScale(90, 10), 2);
             assert.equal(funcs!.fInvLogScale(11, 10), 10);
+        });
+    });
+
+    describe('logScalePossible', () => {
+        it('should return true when data is type number', () => {
+            const axisData = ({
+                datatype: 'number',
+                data: [{ value: 1 }, { value: -2 }],
+            } as any) as IAxisData;
+            const axisMenuSelection = ({
+                dataType: CLIN_ATTR_DATA_TYPE,
+                genericAssayDataType: DataTypeConstants.LIMITVALUE,
+            } as any) as AxisMenuSelection;
+            assert.isTrue(logScalePossible(axisMenuSelection, axisData));
         });
     });
 

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -44,7 +44,11 @@ import {
     AnnotatedNumericGeneMolecularData,
     CustomDriverNumericGeneMolecularData,
 } from '../ResultsViewPageStore';
-import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
+import {
+    AlterationTypeConstants,
+    DataTypeConstants,
+    CLINICAL_ATTRIBUTE_FIELD_ENUM,
+} from 'shared/constants';
 
 import numeral from 'numeral';
 import GenesetMolecularDataCache from '../../../shared/cache/GenesetMolecularDataCache';
@@ -2513,13 +2517,12 @@ export function logScalePossibleForProfile(profileId: string) {
     return !/zscore/i.test(profileId) && /rna_seq/i.test(profileId);
 }
 
-export function logScalePossible(axisSelection: AxisMenuSelection) {
-    if (axisSelection.dataType === CLIN_ATTR_DATA_TYPE) {
-        // clinical attribute
-        return (
-            axisSelection.dataSourceId ===
-            SpecialChartsUniqueKeyEnum.MUTATION_COUNT
-        );
+export function logScalePossible(
+    axisSelection: AxisMenuSelection,
+    axisData?: IAxisData
+) {
+    if (axisData && isNumberData(axisData)) {
+        return true;
     } else if (
         isGenericAssaySelected(axisSelection) &&
         axisSelection.genericAssayDataType === DataTypeConstants.LIMITVALUE


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9221

Describe changes proposed in this pull request:
- Updated logScalePossible function to check raw data type and if it is of type Number to allow the logscale checkbox to be enabled.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

