### PR TITLE
Use profiled patients count in axis labels and tooltips in comparison view lollipop

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/SVGAxis.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/SVGAxis.tsx
@@ -146,17 +146,23 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                         : horizontalPadding);
                 transform = '';
             }
-            let wrappedLabel = this.props.label.split(/\n/g).map(l =>
-                l.includes('**') ? (
-                    <tspan x={x} dy="1em" fontWeight={'bold'}>
-                        {l.replace(/\*{2}/g, '')}
-                    </tspan>
-                ) : (
-                    <tspan x={x} dy="1em">
-                        {l}
-                    </tspan>
-                )
-            );
+            let count = 0;
+            let wrappedLabel = this.props.label.split(/\n/g).map(l => (
+                <tspan
+                    x={x}
+                    dy="1em"
+                    dangerouslySetInnerHTML={{
+                        __html: l.replace(/\*{2}/g, function() {
+                            count += 1;
+                            if (count % 2 === 1) {
+                                return '<tspan style="font-weight: bold;">';
+                            } else {
+                                return '</tspan>';
+                            }
+                        }),
+                    }}
+                ></tspan>
+            ));
             return (
                 <text
                     textAnchor="middle"
@@ -174,7 +180,7 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                             : transform
                     }
                 >
-                    {wrappedLabel}
+                    {wrappedLabel.length > 1 ? wrappedLabel : this.props.label}
                 </text>
             );
         } else {

--- a/packages/cbioportal-frontend-commons/src/components/SVGAxis.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/SVGAxis.tsx
@@ -146,6 +146,22 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                         : horizontalPadding);
                 transform = '';
             }
+            let wrappedLabel;
+            let symbolIndex = this.props.label.indexOf(' mutated') - 1;
+            if (symbolIndex !== -2) {
+                wrappedLabel = (
+                    <>
+                        <tspan x={x} dy="1em" fontWeight={'bold'}>
+                            {this.props.label.slice(0, symbolIndex - 1)}
+                        </tspan>
+                        <tspan x={x} dy="1em">
+                            {this.props.label.slice(symbolIndex)}
+                        </tspan>
+                    </>
+                );
+            } else {
+                wrappedLabel = <>{this.props.label}</>;
+            }
             return (
                 <text
                     textAnchor="middle"
@@ -157,9 +173,14 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                     fill="#2E3436"
                     x={x}
                     y={y}
-                    transform={transform}
+                    transform={
+                        symbolIndex !== -2
+                            ? transform + ' translate(0, -30)'
+                            : transform
+                    }
                 >
-                    {this.props.label}
+                    {wrappedLabel}
+                    {/* {this.props.label} */}
                 </text>
             );
         } else {

--- a/packages/cbioportal-frontend-commons/src/components/SVGAxis.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/SVGAxis.tsx
@@ -146,22 +146,17 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                         : horizontalPadding);
                 transform = '';
             }
-            let wrappedLabel;
-            let symbolIndex = this.props.label.indexOf(' mutated') - 1;
-            if (symbolIndex !== -2) {
-                wrappedLabel = (
-                    <>
-                        <tspan x={x} dy="1em" fontWeight={'bold'}>
-                            {this.props.label.slice(0, symbolIndex - 1)}
-                        </tspan>
-                        <tspan x={x} dy="1em">
-                            {this.props.label.slice(symbolIndex)}
-                        </tspan>
-                    </>
-                );
-            } else {
-                wrappedLabel = <>{this.props.label}</>;
-            }
+            let wrappedLabel = this.props.label.split(/\n/g).map(l =>
+                l.includes('**') ? (
+                    <tspan x={x} dy="1em" fontWeight={'bold'}>
+                        {l.replace(/\*{2}/g, '')}
+                    </tspan>
+                ) : (
+                    <tspan x={x} dy="1em">
+                        {l}
+                    </tspan>
+                )
+            );
             return (
                 <text
                     textAnchor="middle"
@@ -174,13 +169,12 @@ export default class SVGAxis extends React.Component<SVGAxisProps, {}> {
                     x={x}
                     y={y}
                     transform={
-                        symbolIndex !== -2
+                        wrappedLabel.length > 1
                             ? transform + ' translate(0, -30)'
                             : transform
                     }
                 >
                     {wrappedLabel}
-                    {/* {this.props.label} */}
                 </text>
             );
         } else {

--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -100,7 +100,8 @@ export type LollipopMutationPlotProps<T extends Mutation> = {
     lollipopTooltipCountInfo?: (
         count: number,
         mutations?: Partial<T>[],
-        axisMode?: AxisScale
+        axisMode?: AxisScale,
+        group?: string
     ) => JSX.Element;
     yAxisLabelFormatter?: (symbol?: string, groupName?: string) => string;
     axisMode?: AxisScale;
@@ -160,7 +161,8 @@ export default class LollipopMutationPlot<
 
     private lollipopTooltip(
         mutationsAtPosition: T[],
-        countsByPosition: { [pos: number]: number }
+        countsByPosition: { [pos: number]: number },
+        group?: string
     ): JSX.Element {
         const codon = mutationsAtPosition[0].proteinPosStart;
         const count = countsByPosition[codon];
@@ -168,7 +170,8 @@ export default class LollipopMutationPlot<
             this.props.lollipopTooltipCountInfo(
                 count,
                 mutationsAtPosition,
-                this.props.axisMode
+                this.props.axisMode,
+                group
             )
         ) : (
             <strong>
@@ -307,7 +310,11 @@ export default class LollipopMutationPlot<
                 group,
                 placement,
                 count: mutationCount,
-                tooltip: this.lollipopTooltip(mutations, countsByPosition),
+                tooltip: this.lollipopTooltip(
+                    mutations,
+                    countsByPosition,
+                    group
+                ),
                 color: this.props.getLollipopColor
                     ? this.props.getLollipopColor(mutations)
                     : getColorForProteinImpactType(

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -92,14 +92,14 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         }
         if (symbol === '%') {
             return (
-                `${label} ${symbol}` +
+                `**${label}**\n${symbol}` +
                 ' mutated of ' +
                 this.props.store.groupToProfiledPatients.result![groupName]
                     .length +
                 ' profiled pts'
             );
         } else {
-            return `${label} ${symbol} mutated`;
+            return `**${label}**\n${symbol} mutated`;
         }
     }
 

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -24,37 +24,6 @@ interface IGroupComparisonMutationsTabPlotProps {
     filters?: any;
 }
 
-function plotYAxisLabelFormatter(symbol: string, groupName: string) {
-    // lowercase = 1 and uppercase = 1.3 (based on 'w' and 'W'), if groupName >= 22 (13 + 9 leniency), stop and + "..."
-    let length = 0;
-    let label = '';
-    for (let c of groupName!) {
-        let value = c === c.toLowerCase() ? 1 : 1.3;
-        if (length + value >= 22) {
-            label += '...';
-            break;
-        } else {
-            label += c;
-            length += value;
-        }
-    }
-    return `${symbol} ${label}`;
-}
-
-function plotLollipopTooltipCountInfo(
-    count: number,
-    mutations?: Mutation[],
-    axisMode?: AxisScale
-): JSX.Element {
-    return (
-        <LollipopTooltipCountInfo
-            count={count}
-            mutations={mutations}
-            axisMode={axisMode}
-        />
-    );
-}
-
 @observer
 export default class GroupComparisonMutationsTabPlot extends React.Component<
     IGroupComparisonMutationsTabPlotProps,
@@ -81,9 +50,57 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         return this.props.store.axisMode === AxisScale.COUNT
             ? countUniqueMutations(mutations)
             : (countUniqueMutations(mutations) /
-                  this.props.store.groupToProfiledSamples.result![group]
+                  this.props.store.groupToProfiledPatients.result![group]
                       .length) *
                   100;
+    }
+
+    @autobind
+    protected plotLollipopTooltipCountInfo(
+        count: number,
+        mutations: Mutation[],
+        axisMode: AxisScale,
+        group: string
+    ): JSX.Element {
+        return (
+            <LollipopTooltipCountInfo
+                count={count}
+                mutations={mutations}
+                axisMode={axisMode}
+                patientCount={
+                    this.props.store.groupToProfiledPatients.result![group]
+                        .length
+                }
+            />
+        );
+    }
+
+    @autobind
+    protected plotYAxisLabelFormatter(symbol: string, groupName: string) {
+        // lowercase = 1 and uppercase = 1.3 (based on 'w' and 'W'), if groupName >= 22 (13 + 9 leniency), stop and + "..."
+        let length = 0;
+        let label = '';
+        for (let c of groupName) {
+            let value = c === c.toLowerCase() ? 1 : 1.3;
+            if (length + value >= 22) {
+                label += '...';
+                break;
+            } else {
+                label += c;
+                length += value;
+            }
+        }
+        if (symbol === '%') {
+            return (
+                `${label} ${symbol}` +
+                ' mutated of ' +
+                this.props.store.groupToProfiledPatients.result![groupName]
+                    .length +
+                ' profiled pts'
+            );
+        } else {
+            return `${label} ${symbol} mutated`;
+        }
     }
 
     readonly plotUI = MakeMobxView({
@@ -92,7 +109,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
             this.props.store.mutationsByGroup,
             this.mutationMapperToolStore.mutationMapperStores,
             this.props.store.coverageInformation,
-            this.props.store.groupToProfiledSamples,
+            this.props.store.groupToProfiledPatients,
         ],
         render: () => {
             if (
@@ -123,11 +140,13 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                             store={mutationMapperStore}
                             showTranscriptDropDown={true}
                             plotLollipopTooltipCountInfo={
-                                plotLollipopTooltipCountInfo
+                                this.plotLollipopTooltipCountInfo
                             }
                             axisMode={this.props.store.axisMode}
                             onScaleToggle={this.props.onScaleToggle}
-                            plotYAxisLabelFormatter={plotYAxisLabelFormatter}
+                            plotYAxisLabelFormatter={
+                                this.plotYAxisLabelFormatter
+                            }
                         />
                     </>
                 );

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -322,7 +322,7 @@ export default class GroupComparisonStore extends ComparisonStore {
         },
     });
 
-    public readonly groupToProfiledSamples = remoteData({
+    public readonly groupToProfiledPatients = remoteData({
         await: () => [
             this._originalGroups,
             this.sampleMap,
@@ -333,7 +333,7 @@ export default class GroupComparisonStore extends ComparisonStore {
             const sampleSet = this.sampleMap.result!;
             const groups = this._originalGroups.result!;
             const ret: {
-                [groupUid: string]: Sample[];
+                [groupUid: string]: string[];
             } = {};
             for (const group of groups) {
                 for (const studyObject of group.studies) {
@@ -353,10 +353,11 @@ export default class GroupComparisonStore extends ComparisonStore {
                             )
                         ) {
                             ret[group.name] = ret[group.name] || [];
-                            ret[group.name].push(sample);
+                            ret[group.name].push(sample.patientId);
                         }
                     }
                 }
+                ret[group.name] = _.uniq(ret[group.name]);
             }
             return Promise.resolve(ret);
         },

--- a/src/pages/groupComparison/LollipopTooltipCountInfo.tsx
+++ b/src/pages/groupComparison/LollipopTooltipCountInfo.tsx
@@ -11,30 +11,29 @@ import { countUniqueMutations } from 'shared/lib/MutationUtils';
 
 interface ILollipopTooltipCountInfoProps {
     count: number;
-    mutations?: Mutation[];
-    axisMode?: AxisScale;
+    mutations: Mutation[];
+    axisMode: AxisScale;
+    patientCount: number;
 }
 
 export const LollipopTooltipCountInfo: React.FC<ILollipopTooltipCountInfoProps> = ({
     count,
     mutations,
     axisMode,
+    patientCount,
 }: ILollipopTooltipCountInfoProps) => {
     const decimalZeros = numberOfLeadingDecimalZeros(count);
     const fractionDigits = decimalZeros < 0 ? 1 : decimalZeros + 2;
 
-    return mutations &&
-        mutations.length > 0 &&
-        axisMode === AxisScale.PERCENT ? (
+    return axisMode === AxisScale.PERCENT ? (
         <strong>
-            {formatPercentValue(count, fractionDigits)}% mutation rate (
-            {countUniqueMutations(mutations)} of{' '}
-            {Math.round((countUniqueMutations(mutations) / count) * 100)}{' '}
-            samples)
+            {formatPercentValue(count, fractionDigits)}% (
+            {countUniqueMutations(mutations)} mutated of {patientCount} profiled
+            patients)
         </strong>
     ) : (
         <strong>
-            {count} mutation{`${count !== 1 ? 's' : ''}`}
+            {count} mutated of {patientCount} profiled patients
         </strong>
     );
 };

--- a/src/shared/components/mutationMapper/MutationMapper.tsx
+++ b/src/shared/components/mutationMapper/MutationMapper.tsx
@@ -80,7 +80,8 @@ export interface IMutationMapperProps {
     plotLollipopTooltipCountInfo?: (
         count: number,
         mutations?: Partial<Mutation>[],
-        axisMode?: AxisScale
+        axisMode?: AxisScale,
+        group?: string
     ) => JSX.Element;
     plotYAxisLabelFormatter?: (symbol?: string, groupName?: string) => string;
     axisMode?: AxisScale;


### PR DESCRIPTION
Edits axis labels and lollipop tooltips so it uses and shows profiled patient counts instead of profiled sample counts