### PR TITLE
Cloodge to get lgggbm study overlap detection (other tcga studies are prefixed "lgg")

### DIFF
--- a/src/shared/lib/getOverlappingStudies.ts
+++ b/src/shared/lib/getOverlappingStudies.ts
@@ -9,10 +9,15 @@ export default function getOverlappingStudies(
         (memo, study: CancerStudy) => {
             if (/_tcga/.test(study.studyId)) {
                 // we need to find when root of study name is in duplicate, so strip out the modifiers (pub or pancan)
-                const initial = study.studyId.replace(
-                    /(_\d\d\d\d|_pub|(_pub\d\d\d\d)|_pan_can_atlas_\d\d\d\d)$/g,
-                    ''
-                );
+                const initial = study.studyId
+                    .replace(
+                        /(_\d\d\d\d|_pub|(_pub\d\d\d\d)|_pan_can_atlas_\d\d\d\d)$/g,
+                        ''
+                    )
+                    // this is a cloodge for a tcga study which does not respect convention of it's siblings with
+                    // which it overlaps
+                    .replace('lgggbm_', 'lgg_');
+
                 if (initial) {
                     if (initial in memo) {
                         memo[initial].push(study);


### PR DESCRIPTION
Fixes [lgggbm_tcga_pub doesn't highlight as redundant with other TCGA studies](https://github.com/cbioportal/cbioportal/issues/9643)