### PR TITLE
Show both tooltips on hover when lollipop exists in both groups in comparison view lollipop

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/HitZone.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/HitZone.tsx
@@ -17,8 +17,8 @@ type HitZoneProps = {
 export type HitZoneConfig = {
     hitRect: { x: number; y: number; width: number; height: number };
     content?: JSX.Element;
-    mirrorHitRect?: { x: number; y: number; width: number; height: number };
-    mirrorContent?: JSX.Element;
+    mirrorHitRect?: { x: number; y: number; width: number; height: number }; // mirror lollipop component location and dimensions
+    mirrorContent?: JSX.Element; // mirror lollipop component tooltip contents
     tooltipPlacement?: string;
     cursor?: string;
     onMouseOver?: () => void;

--- a/packages/cbioportal-frontend-commons/src/components/HitZone.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/HitZone.tsx
@@ -17,6 +17,8 @@ type HitZoneProps = {
 export type HitZoneConfig = {
     hitRect: { x: number; y: number; width: number; height: number };
     content?: JSX.Element;
+    mirrorHitRect?: { x: number; y: number; width: number; height: number };
+    mirrorContent?: JSX.Element;
     tooltipPlacement?: string;
     cursor?: string;
     onMouseOver?: () => void;
@@ -33,6 +35,8 @@ export function defaultHitzoneConfig(): HitZoneConfig {
             height: 0,
         },
         content: <span />,
+        mirrorHitRect: undefined,
+        mirrorContent: undefined,
         tooltipPlacement: 'top',
         cursor: 'pointer',
         onMouseOver: () => 0,

--- a/packages/react-mutation-mapper/src/component/lollipopPlot/LollipopPlot.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopPlot/LollipopPlot.tsx
@@ -45,7 +45,7 @@ export default class LollipopPlot extends React.Component<
     {}
 > {
     @observable private hitZoneConfig: HitZoneConfig = defaultHitzoneConfig();
-    @observable private mirrorVisible: boolean = false;
+    @observable private mirrorVisible: boolean = false; // lollipop and mirror lollipop share tooltip visibility
 
     private plot: LollipopPlotNoTooltip | undefined;
     private handlers: any;
@@ -121,6 +121,8 @@ export default class LollipopPlot extends React.Component<
         return initHitZoneFromConfig(this.hitZoneConfig);
     }
 
+    // hit zone of mirror lollipop component initialized using config's mirrorHitRect (mirror lollipop location)
+    // used to determine where to apply the mirror lollipop tooltip
     @computed private get mirrorHitZone() {
         return initHitZoneFromConfig({
             ...this.hitZoneConfig,
@@ -128,6 +130,8 @@ export default class LollipopPlot extends React.Component<
         });
     }
 
+    // handles lollipop and mirror lollipop component simultaneous tooltip visibility
+    // if lollipop tooltip is visible, make mirror lollipop tooltip visible as well
     @action.bound
     private onTooltipVisibleChange(visible: boolean) {
         this.mirrorVisible = visible;

--- a/packages/react-mutation-mapper/src/component/lollipopPlot/LollipopPlotNoTooltip.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopPlot/LollipopPlotNoTooltip.tsx
@@ -145,6 +145,8 @@ export default class LollipopPlotNoTooltip extends React.Component<
         if (lollipopIndex !== null) {
             const lollipopComponent = this.lollipopComponents[lollipopIndex];
             if (lollipopComponent) {
+                // mirrorLollipopComponent refers to the lollipop component, if it exists, in the other group at the same lollipopIndex
+                // this is needed to show tooltips of both lollipop components at same index
                 const mirrorLollipopComponent = _.find(
                     this.lollipopComponents,
                     l =>
@@ -152,19 +154,13 @@ export default class LollipopPlotNoTooltip extends React.Component<
                             lollipopComponent.props.spec.codon &&
                         l !== lollipopComponent
                 );
-                // console.log(lollipopComponent);
-                // console.log(mirrorLollipopComponent)
                 lollipopComponent.isHovered = true;
                 if (this.props.setHitZone) {
                     this.props.setHitZone(
                         lollipopComponent.circleHitRect,
                         lollipopComponent.props.spec.tooltip,
-                        mirrorLollipopComponent
-                            ? mirrorLollipopComponent.circleHitRect
-                            : undefined,
-                        mirrorLollipopComponent
-                            ? mirrorLollipopComponent.props.spec.tooltip
-                            : undefined,
+                        mirrorLollipopComponent?.circleHitRect,
+                        mirrorLollipopComponent?.props.spec.tooltip,
                         action(() => {
                             if (this.props.dataStore) {
                                 updatePositionHighlightFilters(

--- a/packages/react-mutation-mapper/src/component/lollipopPlot/LollipopPlotNoTooltip.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopPlot/LollipopPlotNoTooltip.tsx
@@ -28,6 +28,8 @@ export type LollipopPlotNoTooltipProps = LollipopPlotProps & {
     setHitZone?: (
         hitRect: { x: number; y: number; width: number; height: number },
         tooltipContent?: JSX.Element,
+        mirrorHitRect?: { x: number; y: number; width: number; height: number },
+        mirrorTooltipContent?: JSX.Element,
         onMouseOver?: () => void,
         onClick?: () => void,
         onMouseOut?: () => void,
@@ -143,11 +145,26 @@ export default class LollipopPlotNoTooltip extends React.Component<
         if (lollipopIndex !== null) {
             const lollipopComponent = this.lollipopComponents[lollipopIndex];
             if (lollipopComponent) {
+                const mirrorLollipopComponent = _.find(
+                    this.lollipopComponents,
+                    l =>
+                        l.props.spec.codon ===
+                            lollipopComponent.props.spec.codon &&
+                        l !== lollipopComponent
+                );
+                // console.log(lollipopComponent);
+                // console.log(mirrorLollipopComponent)
                 lollipopComponent.isHovered = true;
                 if (this.props.setHitZone) {
                     this.props.setHitZone(
                         lollipopComponent.circleHitRect,
                         lollipopComponent.props.spec.tooltip,
+                        mirrorLollipopComponent
+                            ? mirrorLollipopComponent.circleHitRect
+                            : undefined,
+                        mirrorLollipopComponent
+                            ? mirrorLollipopComponent.props.spec.tooltip
+                            : undefined,
                         action(() => {
                             if (this.props.dataStore) {
                                 updatePositionHighlightFilters(
@@ -161,7 +178,13 @@ export default class LollipopPlotNoTooltip extends React.Component<
                             this.onLollipopClick(
                                 lollipopComponent.props.spec.codon
                             )
-                        )
+                        ),
+                        undefined,
+                        'pointer',
+                        lollipopComponent.circleHitRect.y >
+                            lollipopComponent.props.stickBaseY
+                            ? 'bottom'
+                            : 'top'
                     );
                 }
             }
@@ -176,6 +199,8 @@ export default class LollipopPlotNoTooltip extends React.Component<
                     this.props.setHitZone(
                         domainComponent.hitRect,
                         domainComponent.props.spec.tooltip,
+                        undefined,
+                        undefined,
                         undefined,
                         undefined,
                         undefined,
@@ -196,6 +221,8 @@ export default class LollipopPlotNoTooltip extends React.Component<
                         sequenceComponent.props.spec
                             ? sequenceComponent.props.spec.tooltip
                             : undefined,
+                        undefined,
+                        undefined,
                         undefined,
                         undefined,
                         undefined,


### PR DESCRIPTION
Adds feature in https://github.com/cBioPortal/cbioportal/issues/9901

- When hovering over a lollipop which exists in both groups, show both tooltips at once