### PR TITLE
Prevent clinical columns from disappearing

### DIFF
--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -83,41 +83,27 @@ export default class ResultsViewMutationTable extends MutationTable<
         super(props);
         this.props.columnVisibilityProps!.customDropdown = (
             columnVisibilityControlsProps: IColumnVisibilityControlsProps
-        ) => {
-            const resetColumnVisibility = () => {
-                if (columnVisibilityControlsProps.resetColumnVisibility) {
-                    columnVisibilityControlsProps.resetColumnVisibility();
+        ) => (
+            <AddColumns
+                className={columnVisibilityControlsProps.className}
+                columnVisibility={
+                    columnVisibilityControlsProps.columnVisibility
                 }
-
-                // resetting the controls is not enough,
-                // we need to also reset the column visibility stored in the user selection store
-                if (this.props.storeColumnVisibility) {
-                    this.props.storeColumnVisibility(undefined); // reset
+                onColumnToggled={columnVisibilityControlsProps.onColumnToggled}
+                resetColumnVisibility={
+                    columnVisibilityControlsProps.resetColumnVisibility
                 }
-            };
-
-            return (
-                <AddColumns
-                    className={columnVisibilityControlsProps.className}
-                    columnVisibility={
-                        columnVisibilityControlsProps.columnVisibility
-                    }
-                    onColumnToggled={
-                        columnVisibilityControlsProps.onColumnToggled
-                    }
-                    resetColumnVisibility={resetColumnVisibility}
-                    showResetColumnsButton={
-                        columnVisibilityControlsProps.showResetColumnsButton
-                    }
-                    clinicalAttributes={
-                        this.props.mutationsTabClinicalAttributes.result!
-                    }
-                    clinicalAttributeIdToAvailableFrequency={
-                        this.props.clinicalAttributeIdToAvailableFrequency
-                    }
-                />
-            );
-        };
+                showResetColumnsButton={
+                    columnVisibilityControlsProps.showResetColumnsButton
+                }
+                clinicalAttributes={
+                    this.props.mutationsTabClinicalAttributes.result!
+                }
+                clinicalAttributeIdToAvailableFrequency={
+                    this.props.clinicalAttributeIdToAvailableFrequency
+                }
+            />
+        );
     }
 
     componentWillUpdate(nextProps: IResultsViewMutationTableProps) {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9869

The issue seems to have been introduced by commit 31876041e087a7a3741883fd88852b778a60f769. I'm not sure what fixes that commit was meant to implement, but effectively reverting that commit by removing the reset call to `this.props.storeColumnVisibility(undefined)` within the results view mutation table's `resetColumnVisibility()` function seems to fix the issue linked at the top, and when I play around with the column visibility, I don't see any new issues arising.