### PR TITLE
Add driver annotation source selector and maintain track visibility in comparison view lollipop

### DIFF
--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -22,6 +22,7 @@ import {
     createAnnotatedProteinImpactTypeFilter,
 } from 'shared/lib/MutationUtils';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
+import SettingsMenuButton from 'shared/components/driverAnnotations/SettingsMenuButton';
 
 interface IGroupComparisonMutationsTabProps {
     store: GroupComparisonStore;
@@ -137,7 +138,11 @@ export default class GroupComparisonMutationsTab extends React.Component<
                                     .hugoGeneSymbol
                             }
                         />
-                        <div style={{ paddingRight: '5px' }}>
+                        <SettingsMenuButton
+                            store={this.props.store}
+                            comparisonView={true}
+                        />
+                        <div style={{ marginLeft: 5, paddingRight: '5px' }}>
                             Highest Frequency:
                         </div>
                         <div>

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -76,6 +76,11 @@ export default class GroupComparisonMutationsTab extends React.Component<
             : undefined;
     }
 
+    @action.bound
+    protected onClickSettingMenu(visible: boolean) {
+        this.props.store.isSettingsMenuVisible = visible;
+    }
+
     readonly tabUI = MakeMobxView({
         await: () => [
             this.props.store.genes,
@@ -138,11 +143,7 @@ export default class GroupComparisonMutationsTab extends React.Component<
                                     .hugoGeneSymbol
                             }
                         />
-                        <SettingsMenuButton
-                            store={this.props.store}
-                            comparisonView={true}
-                        />
-                        <div style={{ marginLeft: 5, paddingRight: '5px' }}>
+                        <div style={{ paddingRight: 5 }}>
                             Highest Frequency:
                         </div>
                         <div>
@@ -159,9 +160,19 @@ export default class GroupComparisonMutationsTab extends React.Component<
                             </MSKTabs>
                         </div>
                     </div>
+                    <div style={{ paddingTop: 10 }}>
+                        <SettingsMenuButton
+                            store={this.props.store}
+                            disableInfoIcon={true}
+                            showOnckbAnnotationControls={true}
+                            showFilterControls={false}
+                            showExcludeUnprofiledSamplesControl={false}
+                        />
+                    </div>
                     <GroupComparisonMutationsTabPlot
                         store={this.props.store}
                         onScaleToggle={this.onScaleToggle}
+                        onClickSettingMenu={this.onClickSettingMenu}
                         mutations={_(this.props.store.mutationsByGroup.result!)
                             .values()
                             .flatten()

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -17,6 +17,7 @@ import ErrorMessage from 'shared/components/ErrorMessage';
 import { AxisScale } from 'react-mutation-mapper';
 import { LollipopTooltipCountInfo } from './LollipopTooltipCountInfo';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
+import MutationMapperUserSelectionStore from 'shared/components/mutationMapper/MutationMapperUserSelectionStore';
 
 interface IGroupComparisonMutationsTabPlotProps {
     store: GroupComparisonStore;
@@ -30,9 +31,12 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
     IGroupComparisonMutationsTabPlotProps,
     {}
 > {
+    private userSelectionStore: MutationMapperUserSelectionStore;
+
     constructor(props: IGroupComparisonMutationsTabPlotProps) {
         super(props);
         makeObservable(this);
+        this.userSelectionStore = new MutationMapperUserSelectionStore();
     }
 
     @computed get mutationMapperToolStore() {
@@ -107,6 +111,11 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         }
     }
 
+    @action.bound
+    protected onClickSettingMenu(visible: boolean) {
+        this.props.store.isSettingsMenuVisible = visible;
+    }
+
     readonly plotUI = MakeMobxView({
         await: () => [
             this.props.store.mutations,
@@ -157,6 +166,10 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                                     .driversAnnotated
                                     ? (m: AnnotatedMutation) => m.putativeDriver
                                     : undefined
+                            }
+                            onClickSettingMenu={this.onClickSettingMenu}
+                            trackVisibility={
+                                this.userSelectionStore.trackVisibility
                             }
                         />
                     </>

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -22,6 +22,7 @@ import MutationMapperUserSelectionStore from 'shared/components/mutationMapper/M
 interface IGroupComparisonMutationsTabPlotProps {
     store: GroupComparisonStore;
     onScaleToggle: (selectedScale: AxisScale) => void;
+    onClickSettingMenu: (visible: boolean) => void;
     mutations?: Mutation[];
     filters?: any;
 }
@@ -111,11 +112,6 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
         }
     }
 
-    @action.bound
-    protected onClickSettingMenu(visible: boolean) {
-        this.props.store.isSettingsMenuVisible = visible;
-    }
-
     readonly plotUI = MakeMobxView({
         await: () => [
             this.props.store.mutations,
@@ -167,7 +163,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                                     ? (m: AnnotatedMutation) => m.putativeDriver
                                     : undefined
                             }
-                            onClickSettingMenu={this.onClickSettingMenu}
+                            onClickSettingMenu={this.props.onClickSettingMenu}
                             trackVisibility={
                                 this.userSelectionStore.trackVisibility
                             }

--- a/src/pages/groupComparison/GroupComparisonStore.ts
+++ b/src/pages/groupComparison/GroupComparisonStore.ts
@@ -52,6 +52,7 @@ import { FeatureFlagEnum } from 'shared/featureFlags';
 
 export default class GroupComparisonStore extends ComparisonStore {
     @observable private sessionId: string;
+    @observable public isSettingsMenuVisible = false;
 
     constructor(
         sessionId: string,

--- a/src/pages/groupComparison/LollipopGeneSelector.tsx
+++ b/src/pages/groupComparison/LollipopGeneSelector.tsx
@@ -38,7 +38,7 @@ export const LollipopGeneSelector: React.FC<ILollipopGeneSelectorProps> = observ
         };
 
         return (
-            <div style={{ width: 200, paddingRight: 10 }}>
+            <div style={{ width: 200 }}>
                 <AsyncSelect
                     name="Select gene"
                     onChange={(option: any | null) => {

--- a/src/pages/groupComparison/LollipopGeneSelector.tsx
+++ b/src/pages/groupComparison/LollipopGeneSelector.tsx
@@ -38,7 +38,7 @@ export const LollipopGeneSelector: React.FC<ILollipopGeneSelectorProps> = observ
         };
 
         return (
-            <div style={{ width: 200 }}>
+            <div style={{ width: 200, paddingRight: 10 }}>
                 <AsyncSelect
                     name="Select gene"
                     onChange={(option: any | null) => {

--- a/src/pages/resultsView/querySummary/QuerySummary.tsx
+++ b/src/pages/resultsView/querySummary/QuerySummary.tsx
@@ -314,7 +314,12 @@ export default class QuerySummary extends React.Component<
                                     </button>
                                     <SettingsMenuButton
                                         store={this.props.store}
-                                        resultsView={true}
+                                        disableInfoIcon={false}
+                                        showOnckbAnnotationControls={true}
+                                        showFilterControls={true}
+                                        showExcludeUnprofiledSamplesControl={
+                                            true
+                                        }
                                     />
                                 </div>
                             )}

--- a/src/pages/resultsView/settings/SettingsMenu.tsx
+++ b/src/pages/resultsView/settings/SettingsMenu.tsx
@@ -29,6 +29,7 @@ enum EVENT_KEY {
 export interface SettingsMenuProps {
     store: IAnnotationFilterSettings;
     resultsView?: boolean;
+    comparisonView?: boolean;
     disabled?: boolean;
 }
 
@@ -111,122 +112,136 @@ export default class SettingsMenu extends React.Component<
                 <h5 style={{ marginTop: 'auto', marginBottom: 'auto' }}>
                     Annotate Data
                 </h5>
-                <InfoIcon
-                    divStyle={{ display: 'inline-block', marginLeft: 6 }}
-                    style={{ color: 'rgb(54, 134, 194)' }}
-                    tooltip={
-                        <span>
-                            Putative driver vs VUS setings apply to every tab
-                            except{' '}
-                            <BoldedSpanList
-                                words={['Co-expression', 'CN Segments']}
-                            />
-                        </span>
-                    }
-                />
+                {!this.props.comparisonView && (
+                    <InfoIcon
+                        divStyle={{ display: 'inline-block', marginLeft: 6 }}
+                        style={{ color: 'rgb(54, 134, 194)' }}
+                        tooltip={
+                            <span>
+                                Putative driver vs VUS setings apply to every
+                                tab except{' '}
+                                <BoldedSpanList
+                                    words={['Co-expression', 'CN Segments']}
+                                />
+                            </span>
+                        }
+                    />
+                )}
                 <div style={{ marginLeft: 10 }}>
                     <DriverAnnotationControls
                         state={this.driverSettingsState}
                         handlers={this.driverSettingsHandlers}
                         resultsView={this.props.resultsView}
+                        comparisonView={this.props.comparisonView}
                     />
                 </div>
-
-                <hr />
-
-                <h5 style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    Filter Data
-                </h5>
-                <div style={{ marginLeft: 10 }}>
-                    <div className="checkbox">
-                        <label>
-                            <input
-                                data-test="HideVUS"
-                                type="checkbox"
-                                value={EVENT_KEY.hidePutativePassengers}
-                                checked={
-                                    !this.props.store.driverAnnotationSettings
-                                        .includeVUS
-                                }
-                                onClick={this.onInputClick}
-                                disabled={
-                                    !this.driverSettingsState.distinguishDrivers
-                                }
-                            />{' '}
-                            Exclude alterations (mutations, structural variants
-                            and copy number) of unknown significance
-                        </label>
-                    </div>
-                    <div className="checkbox">
-                        <label>
-                            <input
-                                data-test="HideGermline"
-                                type="checkbox"
-                                value={EVENT_KEY.showGermlineMutations}
-                                checked={
-                                    !this.props.store.includeGermlineMutations
-                                }
-                                onClick={this.onInputClick}
-                            />{' '}
-                            Exclude germline mutations
-                        </label>
-                    </div>
-                    {this.props.resultsView && (
-                        <div>
+                {!this.props.comparisonView && (
+                    <>
+                        <hr />
+                        <h5 style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                            Filter Data
+                        </h5>
+                        <div style={{ marginLeft: 10 }}>
                             <div className="checkbox">
                                 <label>
                                     <input
-                                        data-test="HideUnprofiled"
+                                        data-test="HideVUS"
                                         type="checkbox"
-                                        value={EVENT_KEY.hideUnprofiledSamples}
+                                        value={EVENT_KEY.hidePutativePassengers}
                                         checked={
-                                            this.props.store
-                                                .hideUnprofiledSamples !== false
+                                            !this.props.store
+                                                .driverAnnotationSettings
+                                                .includeVUS
+                                        }
+                                        onClick={this.onInputClick}
+                                        disabled={
+                                            !this.driverSettingsState
+                                                .distinguishDrivers
+                                        }
+                                    />{' '}
+                                    Exclude alterations (mutations, structural
+                                    variants and copy number) of unknown
+                                    significance
+                                </label>
+                            </div>
+                            <div className="checkbox">
+                                <label>
+                                    <input
+                                        data-test="HideGermline"
+                                        type="checkbox"
+                                        value={EVENT_KEY.showGermlineMutations}
+                                        checked={
+                                            !this.props.store
+                                                .includeGermlineMutations
                                         }
                                         onClick={this.onInputClick}
                                     />{' '}
-                                    Exclude unprofiled samples
+                                    Exclude germline mutations
                                 </label>
                             </div>
-                            <div style={{ marginLeft: 10 }}>
-                                <div className="radio">
-                                    <label>
-                                        <input
-                                            type="radio"
-                                            checked={
-                                                this.props.store
-                                                    .hideUnprofiledSamples ===
-                                                'any'
-                                            }
-                                            value={
-                                                EVENT_KEY.hideAnyUnprofiledSamples
-                                            }
-                                            onClick={this.onInputClick}
-                                        />
-                                        Exclude samples that are unprofiled in
-                                        any queried gene or profile
-                                    </label>
-                                    <label>
-                                        <input
-                                            type="radio"
-                                            checked={
-                                                this.props.store
-                                                    .hideUnprofiledSamples ===
-                                                'totally'
-                                            }
-                                            value={
-                                                EVENT_KEY.hideTotallyUnprofiledSamples
-                                            }
-                                            onClick={this.onInputClick}
-                                        />
-                                        Exclude samples that are unprofiled in
-                                        every queried gene and profile.
-                                    </label>
+                            {this.props.resultsView && (
+                                <div>
+                                    <div className="checkbox">
+                                        <label>
+                                            <input
+                                                data-test="HideUnprofiled"
+                                                type="checkbox"
+                                                value={
+                                                    EVENT_KEY.hideUnprofiledSamples
+                                                }
+                                                checked={
+                                                    this.props.store
+                                                        .hideUnprofiledSamples !==
+                                                    false
+                                                }
+                                                onClick={this.onInputClick}
+                                            />{' '}
+                                            Exclude unprofiled samples
+                                        </label>
+                                    </div>
+                                    <div style={{ marginLeft: 10 }}>
+                                        <div className="radio">
+                                            <label>
+                                                <input
+                                                    type="radio"
+                                                    checked={
+                                                        this.props.store
+                                                            .hideUnprofiledSamples ===
+                                                        'any'
+                                                    }
+                                                    value={
+                                                        EVENT_KEY.hideAnyUnprofiledSamples
+                                                    }
+                                                    onClick={this.onInputClick}
+                                                />
+                                                Exclude samples that are
+                                                unprofiled in any queried gene
+                                                or profile
+                                            </label>
+                                            <label>
+                                                <input
+                                                    type="radio"
+                                                    checked={
+                                                        this.props.store
+                                                            .hideUnprofiledSamples ===
+                                                        'totally'
+                                                    }
+                                                    value={
+                                                        EVENT_KEY.hideTotallyUnprofiledSamples
+                                                    }
+                                                    onClick={this.onInputClick}
+                                                />
+                                                Exclude samples that are
+                                                unprofiled in every queried gene
+                                                and profile.
+                                            </label>
+                                        </div>
+                                    </div>
                                 </div>
-                            </div>
+                            )}
                         </div>
-                    )}
-                </div>
+                    </>
+                )}
             </div>
         );
     }

--- a/src/shared/alterationFiltering/SettingsMenu.tsx
+++ b/src/shared/alterationFiltering/SettingsMenu.tsx
@@ -2,18 +2,16 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { makeObservable, observable } from 'mobx';
 import autobind from 'autobind-decorator';
+import classNames from 'classnames';
+import DriverAnnotationControls from 'shared/components/driverAnnotations/DriverAnnotationControls';
 import {
-    IDriverAnnotationControlsHandlers,
+    IAnnotationFilterSettings,
     IDriverAnnotationControlsState,
+    IDriverAnnotationControlsHandlers,
     buildDriverAnnotationControlsState,
     buildDriverAnnotationControlsHandlers,
-    IAnnotationFilterSettings,
-} from '../../../shared/alterationFiltering/AnnotationFilteringSettings';
-import DriverAnnotationControls from '../../../shared/components/driverAnnotations/DriverAnnotationControls';
-import InfoIcon from '../../../shared/components/InfoIcon';
-import styles from '../../../shared/components/driverAnnotations/styles.module.scss';
-import classNames from 'classnames';
-import { BoldedSpanList } from 'pages/resultsView/ResultsViewPageHelpers';
+} from './AnnotationFilteringSettings';
+import styles from 'shared/components/driverAnnotations/styles.module.scss';
 
 enum EVENT_KEY {
     hidePutativePassengers = '0',
@@ -28,8 +26,10 @@ enum EVENT_KEY {
 
 export interface SettingsMenuProps {
     store: IAnnotationFilterSettings;
-    resultsView?: boolean;
-    comparisonView?: boolean;
+    annotationTitleComponent?: JSX.Element;
+    showOnckbAnnotationControls?: boolean;
+    showFilterControls?: boolean;
+    showExcludeUnprofiledSamplesControl?: boolean;
     disabled?: boolean;
 }
 
@@ -109,33 +109,17 @@ export default class SettingsMenu extends React.Component<
                 )}
                 style={{ padding: 5 }}
             >
-                <h5 style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    Annotate Data
-                </h5>
-                {!this.props.comparisonView && (
-                    <InfoIcon
-                        divStyle={{ display: 'inline-block', marginLeft: 6 }}
-                        style={{ color: 'rgb(54, 134, 194)' }}
-                        tooltip={
-                            <span>
-                                Putative driver vs VUS setings apply to every
-                                tab except{' '}
-                                <BoldedSpanList
-                                    words={['Co-expression', 'CN Segments']}
-                                />
-                            </span>
-                        }
-                    />
-                )}
+                {this.props.annotationTitleComponent}
                 <div style={{ marginLeft: 10 }}>
                     <DriverAnnotationControls
                         state={this.driverSettingsState}
                         handlers={this.driverSettingsHandlers}
-                        resultsView={this.props.resultsView}
-                        comparisonView={this.props.comparisonView}
+                        showOnckbAnnotationControls={
+                            this.props.showOnckbAnnotationControls
+                        }
                     />
                 </div>
-                {!this.props.comparisonView && (
+                {this.props.showFilterControls && (
                     <>
                         <hr />
                         <h5 style={{ marginTop: 'auto', marginBottom: 'auto' }}>
@@ -179,7 +163,7 @@ export default class SettingsMenu extends React.Component<
                                     Exclude germline mutations
                                 </label>
                             </div>
-                            {this.props.resultsView && (
+                            {this.props.showExcludeUnprofiledSamplesControl && (
                                 <div>
                                     <div className="checkbox">
                                         <label>

--- a/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
+++ b/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
@@ -25,8 +25,7 @@ enum EVENT_KEY {
 export interface DriverAnnotationControlsProps {
     state: IDriverAnnotationControlsState;
     handlers: IDriverAnnotationControlsHandlers;
-    resultsView?: boolean;
-    comparisonView?: boolean;
+    showOnckbAnnotationControls?: boolean;
 }
 
 @observer
@@ -94,7 +93,7 @@ export default class DriverAnnotationControls extends React.Component<
                     </label>
                 </div>
                 <div style={{ marginLeft: '20px' }}>
-                    {(this.props.resultsView || this.props.comparisonView) && (
+                    {this.props.showOnckbAnnotationControls && (
                         <span>
                             {!this.props.state
                                 .annotateDriversOncoKbDisabled && (

--- a/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
+++ b/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
@@ -26,6 +26,7 @@ export interface DriverAnnotationControlsProps {
     state: IDriverAnnotationControlsState;
     handlers: IDriverAnnotationControlsHandlers;
     resultsView?: boolean;
+    comparisonView?: boolean;
 }
 
 @observer
@@ -93,7 +94,7 @@ export default class DriverAnnotationControls extends React.Component<
                     </label>
                 </div>
                 <div style={{ marginLeft: '20px' }}>
-                    {this.props.resultsView && (
+                    {(this.props.resultsView || this.props.comparisonView) && (
                         <span>
                             {!this.props.state
                                 .annotateDriversOncoKbDisabled && (

--- a/src/shared/components/driverAnnotations/SettingsMenuButton.tsx
+++ b/src/shared/components/driverAnnotations/SettingsMenuButton.tsx
@@ -13,6 +13,7 @@ export interface SettingsButtonProps {
         IExclusionSettings &
         ISettingsMenuButtonVisible;
     resultsView?: boolean;
+    comparisonView?: boolean;
     disabled?: boolean;
 }
 
@@ -54,6 +55,7 @@ export default class SettingsMenuButton extends React.Component<
             <SettingsMenu
                 store={this.props.store}
                 resultsView={this.props.resultsView}
+                comparisonView={this.props.comparisonView}
                 disabled={this.props.disabled}
             />
         );

--- a/src/shared/components/driverAnnotations/SettingsMenuButton.tsx
+++ b/src/shared/components/driverAnnotations/SettingsMenuButton.tsx
@@ -1,5 +1,4 @@
 import { DefaultTooltip, setArrowLeft } from 'cbioportal-frontend-commons';
-import SettingsMenu from '../../../pages/resultsView/settings/SettingsMenu';
 import * as React from 'react';
 import {
     IDriverSettingsProps,
@@ -7,13 +6,18 @@ import {
 } from 'shared/alterationFiltering/AnnotationFilteringSettings';
 import { observer } from 'mobx-react';
 import { action, computed, makeObservable, observable } from 'mobx';
+import InfoIcon from '../InfoIcon';
+import { BoldedSpanList } from 'pages/resultsView/ResultsViewPageHelpers';
+import SettingsMenu from 'shared/alterationFiltering/SettingsMenu';
 
 export interface SettingsButtonProps {
     store: IDriverSettingsProps &
         IExclusionSettings &
         ISettingsMenuButtonVisible;
-    resultsView?: boolean;
-    comparisonView?: boolean;
+    disableInfoIcon?: boolean;
+    showOnckbAnnotationControls?: boolean;
+    showFilterControls?: boolean;
+    showExcludeUnprofiledSamplesControl: boolean;
     disabled?: boolean;
 }
 
@@ -50,12 +54,43 @@ export default class SettingsMenuButton extends React.Component<
         }
     }
 
+    @computed get annotationTitleComponent() {
+        return (
+            <>
+                <h5 style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                    Annotate Data
+                </h5>
+                {!this.props.disableInfoIcon && (
+                    <InfoIcon
+                        divStyle={{ display: 'inline-block', marginLeft: 6 }}
+                        style={{ color: 'rgb(54, 134, 194)' }}
+                        tooltip={
+                            <span>
+                                Putative driver vs VUS setings apply to every
+                                tab except{' '}
+                                <BoldedSpanList
+                                    words={['Co-expression', 'CN Segments']}
+                                />
+                            </span>
+                        }
+                    />
+                )}
+            </>
+        );
+    }
+
     @computed get overlay() {
         return (
             <SettingsMenu
                 store={this.props.store}
-                resultsView={this.props.resultsView}
-                comparisonView={this.props.comparisonView}
+                annotationTitleComponent={this.annotationTitleComponent}
+                showOnckbAnnotationControls={
+                    this.props.showOnckbAnnotationControls
+                }
+                showFilterControls={this.props.showFilterControls}
+                showExcludeUnprofiledSamplesControl={
+                    this.props.showExcludeUnprofiledSamplesControl
+                }
                 disabled={this.props.disabled}
             />
         );

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -745,7 +745,7 @@ export default class OncoprintControls extends React.Component<
                                 } as Partial<IDriverAnnotationControlsHandlers>,
                                 this.props.handlers
                             )}
-                            resultsView={true}
+                            showOnckbAnnotationControls={true}
                         />
                     </div>
 


### PR DESCRIPTION
Adds features in https://github.com/cBioPortal/cbioportal/issues/9901

- Add driver annotation source selector between gene selector and tabs
- Keep annotation tracks visible when enabled and switching between genes