### PR TITLE
Add abstract reference linkouts in OncoKB Card

### DIFF
--- a/packages/oncokb-frontend-commons/src/components/RefComponent.tsx
+++ b/packages/oncokb-frontend-commons/src/components/RefComponent.tsx
@@ -11,46 +11,75 @@ export default class RefComponent extends React.Component<{
     componentType: 'tooltip' | 'linkout';
 }> {
     render() {
-        const parts = this.props.content.split(/pmid|nct/i);
+        const parts = this.props.content.split(/pmid|nct|abstract/i);
 
         if (parts.length < 2) {
             return <span>{this.props.content}</span>;
         }
 
+        // Slicing from index 1 to end to rejoin the abstract title and link
+        // when there's the case that they also contain the string 'Abstract'
+        // Example :
+        //     (Abstract: Fakih et al. Abstract# 3003, ASCO 2019. https://meetinglibrary.asco.org/record/12411/Abstract)
+        const abstractParts = parts
+            .slice(1)
+            .join('Abstract')
+            .split(/(?=http)/i);
+        const isAbstract = !(abstractParts.length < 2);
+
+        let abstract = '';
+        let abstractLink = '';
         const ids = parts[1].match(/[0-9]+/g);
-
-        if (!ids) {
-            return <span>{this.props.content}</span>;
-        }
-
         let prefix: string | undefined;
-
-        if (this.props.content.toLowerCase().indexOf('pmid') >= 0) {
-            prefix = 'PMID: ';
-        } else if (this.props.content.toLowerCase().indexOf('nct') >= 0) {
-            prefix = 'NCT';
-        }
-
         let link: JSX.Element | undefined;
 
-        if (prefix) {
+        if (isAbstract) {
+            abstract = abstractParts[0].replace(/^[:\s]*/g, '').trim();
+            abstractLink = abstractParts[1].replace(/[\\)]*$/g, '').trim();
+            prefix = 'Abstract: ';
             link = (
                 <a
                     target="_blank"
-                    href={getNCBIlink(`/pubmed/${ids.join(',')}`)}
+                    rel="noopener noreferrer"
+                    href={abstractLink}
                 >
-                    {`${prefix}${ids.join(',')}`}
+                    {`${prefix}${abstract}`}
                 </a>
             );
+        } else {
+            if (!ids) {
+                return <span>{this.props.content}</span>;
+            }
+
+            if (this.props.content.toLowerCase().includes('pmid')) {
+                prefix = 'PMID: ';
+            } else if (this.props.content.toLowerCase().includes('nct')) {
+                prefix = 'NCT';
+            }
+
+            if (prefix) {
+                link = (
+                    <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href={getNCBIlink(`/pubmed/${ids.join(',')}`)}
+                    >
+                        {`${prefix}${ids.join(', ')}`}
+                    </a>
+                );
+            }
         }
 
         if (this.props.componentType === 'tooltip') {
+            const pmids = isAbstract
+                ? []
+                : ids!.map((id: string) => parseInt(id, 10));
+            const abstracts = isAbstract
+                ? [{ abstract, link: abstractLink }]
+                : [];
             const tooltipContent = () => (
                 <div className={mainStyles['tooltip-refs']}>
-                    <ReferenceList
-                        pmids={ids.map((id: string) => parseInt(id))}
-                        abstracts={[]}
-                    />
+                    <ReferenceList pmids={pmids} abstracts={abstracts} />
                 </div>
             );
 

--- a/packages/oncokb-frontend-commons/src/components/RefComponent.tsx
+++ b/packages/oncokb-frontend-commons/src/components/RefComponent.tsx
@@ -27,25 +27,17 @@ export default class RefComponent extends React.Component<{
             .split(/(?=http)/i);
         const isAbstract = !(abstractParts.length < 2);
 
-        let abstract = '';
-        let abstractLink = '';
         const ids = parts[1].match(/[0-9]+/g);
+
         let prefix: string | undefined;
-        let link: JSX.Element | undefined;
+        let linkComponent: JSX.Element | undefined;
+        let link: string | undefined;
+        let linkText: string | undefined;
 
         if (isAbstract) {
-            abstract = abstractParts[0].replace(/^[:\s]*/g, '').trim();
-            abstractLink = abstractParts[1].replace(/[\\)]*$/g, '').trim();
+            linkText = abstractParts[0].replace(/^[:\s]*/g, '').trim();
+            link = abstractParts[1].replace(/[\\)]*$/g, '').trim();
             prefix = 'Abstract: ';
-            link = (
-                <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={abstractLink}
-                >
-                    {`${prefix}${abstract}`}
-                </a>
-            );
         } else {
             if (!ids) {
                 return <span>{this.props.content}</span>;
@@ -57,26 +49,23 @@ export default class RefComponent extends React.Component<{
                 prefix = 'NCT';
             }
 
-            if (prefix) {
-                link = (
-                    <a
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        href={getNCBIlink(`/pubmed/${ids.join(',')}`)}
-                    >
-                        {`${prefix}${ids.join(', ')}`}
-                    </a>
-                );
-            }
+            linkText = ids.join(', ');
+            link = getNCBIlink(`/pubmed/${ids.join(',')}`);
+        }
+
+        if (prefix) {
+            linkComponent = (
+                <a target="_blank" rel="noopener noreferrer" href={link}>
+                    {`${prefix}${linkText}`}
+                </a>
+            );
         }
 
         if (this.props.componentType === 'tooltip') {
             const pmids = isAbstract
                 ? []
                 : ids!.map((id: string) => parseInt(id, 10));
-            const abstracts = isAbstract
-                ? [{ abstract, link: abstractLink }]
-                : [];
+            const abstracts = isAbstract ? [{ abstract: linkText, link }] : [];
             const tooltipContent = () => (
                 <div className={mainStyles['tooltip-refs']}>
                     <ReferenceList pmids={pmids} abstracts={abstracts} />
@@ -97,11 +86,11 @@ export default class RefComponent extends React.Component<{
                     {`)`}
                 </span>
             );
-        } else if (link) {
+        } else if (linkComponent) {
             return (
                 <span key={this.props.content}>
                     {parts[0]}
-                    {link}
+                    {linkComponent}
                     {`)`}
                 </span>
             );

--- a/packages/oncokb-frontend-commons/src/components/SummaryWithRefs.tsx
+++ b/packages/oncokb-frontend-commons/src/components/SummaryWithRefs.tsx
@@ -21,7 +21,8 @@ export default class SummaryWithRefs extends React.Component<
         //     (PMID: 11753428, 16007150, 21467160)
         //     (cBioPortal, MSKCC, May 2015, PMID: 24718888)
         //     (NCT1234567)
-        const regex = /(\(.*?[PMID|NCT].*?\))/i;
+        //     (Abstract: Fakih et al. Abstract# 3003, ASCO 2019. https://meetinglibrary.asco.org/record/12411/Abstract)
+        const regex = /(\(.*?[PMID|NCT|Abstract].*?\))/i;
 
         // split the string with delimiters included
         const parts = this.props.content.split(regex);

--- a/packages/oncokb-frontend-commons/src/util/OncoKbUtils.spec.tsx
+++ b/packages/oncokb-frontend-commons/src/util/OncoKbUtils.spec.tsx
@@ -6,6 +6,7 @@ import {
     defaultOncoKbIndicatorFilter,
     getPositionalVariant,
     groupOncoKbIndicatorDataByMutations,
+    parseOncoKBAbstractReference,
 } from './OncoKbUtils';
 
 describe('OncoKbUtils', () => {
@@ -239,6 +240,59 @@ describe('OncoKbUtils', () => {
                 getPositionalVariant(missenseAlteration),
                 undefined,
                 'V600 should be returned'
+            );
+        });
+    });
+
+    describe('parseOncoKBAbstractReference', () => {
+        it('Valid abstract reference passed', () => {
+            const abstractReference =
+                '(Abstract: Hunger et al. ASH 2017. http://www.bloodjournal.org/content/130/Suppl_1/98)';
+            const expectedOutput = {
+                abstractTitle: 'Hunger et al. ASH 2017.',
+                abstractLink:
+                    'http://www.bloodjournal.org/content/130/Suppl_1/98',
+            };
+            assert.deepEqual(
+                parseOncoKBAbstractReference(abstractReference),
+                expectedOutput
+            );
+        });
+        it('Invalid abstract reference containing abstract string', () => {
+            const abstractReference =
+                '(Abstract: Fakih et al. Abstract# 3003, ASCO 2019. https://meetinglibrary.asco.org/record/12411/Abstract)';
+            const expectedOutput = {
+                abstractTitle: 'Fakih et al. Abstract# 3003, ASCO 2019.',
+                abstractLink:
+                    'https://meetinglibrary.asco.org/record/12411/Abstract',
+            };
+            assert.deepEqual(
+                parseOncoKBAbstractReference(abstractReference),
+                expectedOutput
+            );
+        });
+        it('Undefined returned for abstract with missing link', () => {
+            const abstractReference = '(Abstract: Hunger et al. ASH 2017.)';
+            assert.equal(
+                parseOncoKBAbstractReference(abstractReference),
+                undefined,
+                'undefined should be returned'
+            );
+        });
+        it('Undefined returned for non-abstract reference', () => {
+            const pmidReference = '(PMID: 11753428)';
+            assert.equal(
+                parseOncoKBAbstractReference(pmidReference),
+                undefined,
+                'undefined should be returned'
+            );
+        });
+        it('Undefined returned for empty string', () => {
+            const abstractReference = '';
+            assert.equal(
+                parseOncoKBAbstractReference(abstractReference),
+                undefined,
+                'undefined should be returned'
             );
         });
     });

--- a/packages/oncokb-frontend-commons/src/util/OncoKbUtils.ts
+++ b/packages/oncokb-frontend-commons/src/util/OncoKbUtils.ts
@@ -774,3 +774,40 @@ export function defaultArraySortMethod<U extends number | string>(
 
     return result;
 }
+
+/**
+ * Parses OncoKB abstract reference (ie. found in biological effect summaries) into an
+ * object containing the abstract's title and link.
+ * Example input: "(Abstract: Hunger et al. ASH 2017. http://www.bloodjournal.org/content/130/Suppl_1/98)"
+ * Example output: {abstractTitle: "Hunger et al. ASH 2017.", abstractLink: "http://www.bloodjournal.org/content/130/Suppl_1/98"}
+ */
+export function parseOncoKBAbstractReference(abstractRef: string) {
+    try {
+        const parts = abstractRef.split(/abstract/i);
+
+        if (parts.length < 2) {
+            return undefined;
+        }
+
+        // Slicing from index 1 to end to rejoin the abstract title and link
+        // when there's the case that they also contain the string 'Abstract'
+        // Example :
+        //     (Abstract: Fakih et al. Abstract# 3003, ASCO 2019. https://meetinglibrary.asco.org/record/12411/Abstract)
+        const abstractParts = parts
+            .slice(1)
+            .join('Abstract')
+            .split(/(?=http)/i);
+
+        if (abstractParts.length < 2) {
+            return undefined;
+        }
+
+        return {
+            abstractTitle: abstractParts[0].replace(/^[:\s]*/g, '').trim(),
+            abstractLink: abstractParts[1].replace(/[\\)]*$/g, '').trim(),
+        };
+    } catch (ex) {
+        // Encountered a parsing error
+        return undefined;
+    }
+}


### PR DESCRIPTION
When hovering over the oncokb annotation icon and on the `Biological Effect` tab, the summaries currently do not have the abstract references parsed(only PMID and NCT). 

### Before changes
![image](https://user-images.githubusercontent.com/59149377/209718947-0b2e0757-ee2e-48f8-99ad-6fb06583eda0.png)

### After changes
![image](https://user-images.githubusercontent.com/59149377/209719121-625609bb-5ecd-4676-877b-09145ade8eed.png)


This fixes https://github.com/oncokb/oncokb/issues/3350