### PR TITLE
#9945 Mutational Signature Dependency

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -189,6 +189,7 @@ import {
     MutationalSignaturesVersion,
     MutationalSignatureStableIdKeyWord,
     validateMutationalSignatureRawData,
+    retrieveMutationalSignatureVersionFromData,
 } from 'shared/lib/GenericAssayUtils/MutationalSignaturesUtils';
 import { getServerConfig } from 'config/config';
 import { StructuralVariantFilter } from 'cbioportal-ts-api-client';
@@ -516,6 +517,7 @@ export class PatientViewPageStore {
                             });
                         }
                     );
+
                     const genericAssayRawData = await client.fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
                         {
                             genericAssayDataMultipleStudyFilter: {
@@ -718,11 +720,14 @@ export class PatientViewPageStore {
     readonly hasMutationalSignatureData = remoteData({
         await: () => [this.fetchAllMutationalSignatureData],
         invoke: async () => {
+            var profile_version=retrieveMutationalSignatureVersionFromData(this.fetchAllMutationalSignatureData.result.map(profile=>profile.molecularProfileId))
+            this.setMutationalSignaturesVersion(profile_version)
             return Promise.resolve(
                 this.fetchAllMutationalSignatureData.result &&
                     this.fetchAllMutationalSignatureData.result.length > 0
             );
         },
+
     });
 
     // set version 2 of the mutational signature as default

--- a/src/pages/patientView/mutationalSignatures/MutationalSignaturesContainer.tsx
+++ b/src/pages/patientView/mutationalSignatures/MutationalSignaturesContainer.tsx
@@ -34,8 +34,12 @@ export default class MutationalSignaturesContainer extends React.Component<
         // split the id by "_", the last part is the version info
         // we know split will always have results
         // use uniq function to get all unique versions
-        return _.chain(this.props.profiles)
-            .map(profile => _.last(profile.molecularProfileId.split('_'))!)
+
+        // not all patients have the newest mutational signatures --> check if data is present before giving the options
+        var possible_options= this.props.profiles
+            .map(profile => _.last(profile.molecularProfileId.split('_'))!);
+        possible_options=possible_options.filter(item => Object.keys(this.props.data).includes(item));
+        return _.chain(possible_options)
             .uniq()
             .value();
     }

--- a/src/shared/lib/GenericAssayUtils/MutationalSignaturesUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/MutationalSignaturesUtils.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import { GenericAssayData } from 'cbioportal-ts-api-client';
-import { validateMutationalSignatureRawData } from './MutationalSignaturesUtils';
+import { validateMutationalSignatureRawData,retrieveMutationalSignatureVersionFromData } from './MutationalSignaturesUtils';
 
 describe('MutationalSignaturesUtils', () => {
     describe('validateMutationalSignatureRawData()', () => {
@@ -124,4 +124,18 @@ describe('MutationalSignaturesUtils', () => {
             );
         });
     });
-});
+    describe('setMutationalSignatureVersion', () => {
+        it('Molecular profile Id _v2 sets MutationalSignature to .V2', () => {
+            var profile_test = ['study_test_v2']
+            assert.isTrue(retrieveMutationalSignatureVersionFromData(profile_test) == 'v2');
+        });
+        it('Molecular profile Id _v3 sets MutationalSignature to .V3', () => {
+            var profile_test = ['test_study_v3'];
+            assert.isTrue(retrieveMutationalSignatureVersionFromData(profile_test) == 'v3');
+        });
+        it('Studies with two version of mutational signatures is set to .V3', () => {
+            var profile_test = ['test_study_v2', 'test_study_v3']
+            assert.isTrue(retrieveMutationalSignatureVersionFromData(profile_test) == 'v3')
+        })
+    });
+})

--- a/src/shared/lib/GenericAssayUtils/MutationalSignaturesUtils.tsx
+++ b/src/shared/lib/GenericAssayUtils/MutationalSignaturesUtils.tsx
@@ -8,6 +8,9 @@ import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericA
 export enum MutationalSignaturesVersion {
     V2 = 'v2',
     V3 = 'v3',
+    SBS ='SBS',
+    DBS='DBS',
+    ID='ID'
 }
 
 export enum MutationalSignatureStableIdKeyWord {
@@ -162,4 +165,21 @@ export function validateMutationalSignatureRawData(
 
     // we are expecting contribution and pvalue profiles are in pairs
     return _.every(profileIdsGroupByVersion, ids => ids.length === 2);
+}
+
+export function retrieveMutationalSignatureVersionFromData(SignatureProfiles: any[]){
+    var value_to_set:string='v2';
+    var unique_profile_version=_.uniq(SignatureProfiles.map(function(obj){
+        return _.last(obj.split('_'))}))
+    if(unique_profile_version!==undefined) {
+        // give priority to version 3 over version 2
+        if(unique_profile_version.indexOf('v3')!== -1  && unique_profile_version.indexOf('v2') !==-1){
+            value_to_set=Object.values(MutationalSignaturesVersion)[unique_profile_version.indexOf('v3')]
+        }
+        else {
+            var version_to_set = Object.values(MutationalSignaturesVersion).indexOf(unique_profile_version[0] as unknown as MutationalSignaturesVersion);
+            value_to_set = Object.values(MutationalSignaturesVersion)[version_to_set];
+            }
+        }
+    return value_to_set
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal# (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- In the original frontend code, the mutational signature version would always default to version 2. This causes an error when there is only version 3 data. 
- The following four points are implemented to remove this dependency on version 2:

1.      retrieveMutationalSignatureVersionFromData() in MutationalSignaturesUtils.tsx: this function check which versions are available based on the MolecularProfileID and returns a string (which can be used for )
2.     When both version 3 and version 2 mutational signatures are available, priority is given to version 3.
3.     The dropdown menu which allows us to switch between versions is now depending on your mutational signature data available for the selected patient (and not for the overall study). This allows some patients to have only one type of data. (changes made in MutationalSignaturesContainer.tsx to the function availableVersions())
4.    Version 3 mutational signature data can also be subset to ID, SBS, and DBS files. If generic assays are loaded with _SBS, _DBS, or _ID suffix (instead of V3), it is possible to display those results in the mutational signature tab.

Unit test has been added to test the function (if v# is present -> should return v#). Functionality can also be tested with the lgg_ucsf_2014_test_generic_assay study in local/studies (data loading with and without a specific mutational signature version file present).

