### PR TITLE
Results page: maintain tab when user edits query with quick gene selection

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -521,7 +521,9 @@ export default class ResultsViewPage extends React.Component<
 
     @action.bound
     handleQuickOQLSubmission() {
-        this.quickOQLQueryStore!.submit();
+        this.quickOQLQueryStore!.submit(
+            this.urlWrapper.tabId as ResultsViewTab
+        );
         this.showOQLEditor = false;
     }
 

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -70,6 +70,7 @@ import { toQueryString } from 'shared/lib/query/textQueryUtils';
 import { SearchClause } from 'shared/components/query/filteredSearch/SearchClause';
 import { QueryParser } from 'shared/lib/query/QueryParser';
 import { AppStore } from 'AppStore';
+import { ResultsViewTab } from 'pages/resultsView/ResultsViewPageHelpers';
 
 // interface for communicating
 export type CancerStudyQueryUrlParams = {
@@ -158,7 +159,8 @@ export class QueryStore {
     }
 
     public singlePageAppSubmitRoutine: (
-        query: CancerStudyQueryUrlParams
+        query: CancerStudyQueryUrlParams,
+        currentTab?: ResultsViewTab
     ) => void;
 
     @observable studiesHaveChangedSinceInitialization: boolean = false;
@@ -2250,7 +2252,7 @@ export class QueryStore {
         this.genesetQuery = genesetQuery;
     }
 
-    @action submit() {
+    @action submit(currentTab?: ResultsViewTab) {
         if (this.oql.error) {
             this.geneQueryErrorDisplayStatus = Focus.ShouldFocus;
             this.genesetQueryErrorDisplayStatus = Focus.ShouldFocus;
@@ -2270,7 +2272,7 @@ export class QueryStore {
                 'smart'
             );
         } else {
-            this.singlePageAppSubmitRoutine(urlParams.query);
+            this.singlePageAppSubmitRoutine(urlParams.query, currentTab);
         }
 
         return true;

--- a/src/shared/lib/createQueryStore.ts
+++ b/src/shared/lib/createQueryStore.ts
@@ -53,14 +53,23 @@ export function createQueryStore(
             }
         }
 
+        const wrapper =
+            urlWrapper || new ResultsViewURLWrapper(win.routingStore);
+
+        // Default to OncoPrint Tab if tabId is undefined or not of type ResultsViewTab
+        const currentTab =
+            wrapper.tabId &&
+            Object.values(ResultsViewTab).includes(
+                wrapper.tabId as ResultsViewTab
+            )
+                ? wrapper.tabId
+                : ResultsViewTab.ONCOPRINT;
+
         const tab =
             queryStore.physicalStudyIdsInSelection.length > 1 &&
             queryStore.geneIds.length === 1
                 ? ResultsViewTab.CANCER_TYPES_SUMMARY
-                : ResultsViewTab.ONCOPRINT;
-
-        const wrapper =
-            urlWrapper || new ResultsViewURLWrapper(win.routingStore);
+                : currentTab;
 
         wrapper.updateURL(query, `results/${tab}`, clearUrl, false);
 

--- a/src/shared/lib/createQueryStore.ts
+++ b/src/shared/lib/createQueryStore.ts
@@ -18,7 +18,8 @@ export function createQueryStore(
     const queryStore = new QueryStore(currentQuery);
 
     queryStore.singlePageAppSubmitRoutine = function(
-        query: CancerStudyQueryUrlParams
+        query: CancerStudyQueryUrlParams,
+        currentTab?: ResultsViewTab
     ) {
         // normalize this
         query.cancer_study_list =
@@ -53,23 +54,10 @@ export function createQueryStore(
             }
         }
 
+        const tab = currentTab ? currentTab : ResultsViewTab.ONCOPRINT;
+
         const wrapper =
             urlWrapper || new ResultsViewURLWrapper(win.routingStore);
-
-        // Default to OncoPrint Tab if tabId is undefined or not of type ResultsViewTab
-        const currentTab =
-            wrapper.tabId &&
-            Object.values(ResultsViewTab).includes(
-                wrapper.tabId as ResultsViewTab
-            )
-                ? wrapper.tabId
-                : ResultsViewTab.ONCOPRINT;
-
-        const tab =
-            queryStore.physicalStudyIdsInSelection.length > 1 &&
-            queryStore.geneIds.length === 1
-                ? ResultsViewTab.CANCER_TYPES_SUMMARY
-                : currentTab;
 
         wrapper.updateURL(query, `results/${tab}`, clearUrl, false);
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9935

Describe changes proposed in this pull request:
- Added logic to check currentTab first before defaulting to ONCOPRINT

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
