### PR TITLE
Add missing react-bootstrap dependency for cbioportal-frontend-commons

### DIFF
--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -50,6 +50,7 @@
     "rc-tooltip": "^5.0.2",
     "rc-trigger": "^5.2.1",
     "rc-util": "^5.8.0",
+    "react-bootstrap": "^0.31.5",
     "react-file-download": "^0.3.2",
     "react-overlays": "0.7.4",
     "react-select": "^3.0.4",


### PR DESCRIPTION
This missing dependency might be causing the problem observed in [this PR](https://github.com/knowledgesystems/signal/pull/152#issuecomment-1324343685)