### PR TITLE
Fix missing oncokb-frontend-commons dependency and styles

### DIFF
--- a/packages/oncokb-frontend-commons/package.json
+++ b/packages/oncokb-frontend-commons/package.json
@@ -40,6 +40,7 @@
     "lodash": "^4.17.15",
     "oncokb-styles": "~1.4.2",
     "oncokb-ts-api-client": "^1.3.2",
+    "rc-tooltip": "^5.0.2",
     "react-bootstrap": "^0.31.5",
     "react-collapse": "^4.0.3",
     "react-if": "^2.1.0",

--- a/packages/oncokb-frontend-commons/src/components/oncokb.scss
+++ b/packages/oncokb-frontend-commons/src/components/oncokb.scss
@@ -19,10 +19,15 @@
         > li {
             > a {
                 padding: 7px 10px;
+                display: block;
             }
 
             a:focus {
                 outline-width: 0;
+            }
+
+            a:hover {
+                text-decoration: none;
             }
 
             &:not(.active) {
@@ -45,6 +50,12 @@
         padding: 10px 0;
         min-height: 50px;
         position: relative;
+
+        > .fade {
+            &.in {
+                opacity: 1;
+            }
+        }
     }
 
     // Default left align all react-table headers under oncokb-card-tabs


### PR DESCRIPTION
Related to https://github.com/knowledgesystems/signal/pull/152#issuecomment-1380941913

Seems like oncokb-frontend-commons relies on some styles inherited from the `cbioportal-frontend` css class. Outside the cBioPortal context these styles do not exist and results in partially broken tooltip.