### PR TITLE
Add e2e tests for comparison view lollipop plot

### DIFF
--- a/end-to-end-test/remote/specs/core/groupComparisonLollipop.spec.js
+++ b/end-to-end-test/remote/specs/core/groupComparisonLollipop.spec.js
@@ -1,0 +1,234 @@
+var assert = require('assert');
+var goToUrlAndSetLocalStorage = require('../../../shared/specUtils')
+    .goToUrlAndSetLocalStorage;
+var waitForNetworkQuiet = require('../../../shared/specUtils')
+    .waitForNetworkQuiet;
+var setInputText = require('../../../shared/specUtils').setInputText;
+var setSettingsMenuOpen = require('../../../shared/specUtils')
+    .setSettingsMenuOpen;
+const { getElementByTestHandle } = require('../../../shared/specUtils');
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+
+describe('group comparison mutations tab tests', function() {
+    describe('lollipop alerts and plot display', function() {
+        before(function() {
+            goToUrlAndSetLocalStorage(
+                `${CBIOPORTAL_URL}/comparison?comparisonId=634006c24dd45f2bc4c3d4aa`
+            );
+            $('div[data-test="ComparisonPageOverlapTabDiv"]').waitForExist();
+        });
+
+        it('too many groups alert displayed when more than 2 groups selected', function() {
+            $('a.tabAnchor_mutations').waitForExist();
+            $('a.tabAnchor_mutations').click();
+            browser.pause(1000);
+            assert.equal(
+                $('[data-test="TooManyGroupsAlert"]').isDisplayed(),
+                true
+            );
+        });
+
+        it('not enough groups alert displayed when less than 2 groups selected', function() {
+            $('a=Deselect all').waitForExist();
+            $('a=Deselect all').click();
+            browser.pause(1000);
+            assert.equal(
+                $('[data-test="NotEnoughGroupsAlert"]').isDisplayed(),
+                true
+            );
+            $(
+                '[data-test="groupSelectorButtonColon Adenocarcinoma"]'
+            ).waitForExist();
+            $('[data-test="groupSelectorButtonColon Adenocarcinoma"]').click();
+            browser.pause(1000);
+            assert.equal(
+                $('[data-test="NotEnoughGroupsAlert"]').isDisplayed(),
+                true
+            );
+        });
+
+        it('lollipop plot displayed when 2 groups selected', function() {
+            $(
+                '[data-test="groupSelectorButtonColorectal Adenocarcinoma"]'
+            ).waitForExist();
+            $(
+                '[data-test="groupSelectorButtonColorectal Adenocarcinoma"]'
+            ).click();
+            $('[data-test="LollipopPlot"]').waitForExist({ timeout: 20000 });
+            assert.equal($('[data-test="LollipopPlot"]').isDisplayed(), true);
+        });
+    });
+
+    describe('lollipop tooltip display', function() {
+        it('displays double tooltip when lollipop is present in both plots at the same position', function() {
+            $('.lollipop-0').waitForExist();
+            $('.lollipop-0').moveTo();
+            $('[data-test="tooltip-1450-Colon Adenocarcinoma"]').waitForExist();
+            $(
+                '[data-test="tooltip-1450-Colorectal Adenocarcinoma"]'
+            ).waitForExist();
+            assert.equal(
+                $(
+                    '[data-test="tooltip-1450-Colon Adenocarcinoma"]'
+                ).isDisplayed(),
+                true
+            );
+            assert.equal(
+                $(
+                    '[data-test="tooltip-1450-Colorectal Adenocarcinoma"]'
+                ).isDisplayed(),
+                true
+            );
+        });
+        it("doesn't display % when axis scale # is toggled", function() {
+            $('[data-test="AxisScaleSwitch#"]').click();
+            $('.lollipop-6').waitForExist();
+            $('.lollipop-6').moveTo();
+            $('[data-test="tooltip-1378-Colon Adenocarcinoma"]').waitForExist();
+            assert.equal(
+                $('[data-test="tooltip-1378-Colon Adenocarcinoma"]')
+                    .getText()
+                    .includes('%'),
+                false
+            );
+        });
+        it('displays % when axis scale % is toggled', function() {
+            $('[data-test="AxisScaleSwitch%"]').click();
+            $('.lollipop-6').waitForExist();
+            $('.lollipop-6').moveTo();
+            $('[data-test="tooltip-1378-Colon Adenocarcinoma"]').waitForExist();
+            assert.equal(
+                $('[data-test="tooltip-1378-Colon Adenocarcinoma"]')
+                    .getText()
+                    .includes('%'),
+                true
+            );
+        });
+    });
+
+    describe('selecting gene with dropdown and tabs', function() {
+        it('clicking on gene tab sets the selected gene', function() {
+            $('a.tabAnchor_TP53').click();
+            waitForNetworkQuiet();
+            assert.equal(
+                $('[data-test="LollipopPlotTitle"]')
+                    .getText()
+                    .includes('TP53'),
+                true
+            );
+            assert.equal($('[data-test="GeneSelector"]').getText(), 'TP53');
+        });
+
+        it('selecting gene in gene selector sets the selected gene', function() {
+            setInputText(
+                'div[data-test=GeneSelector] input[type=text]',
+                'KRAS'
+            );
+            browser.keys('Enter');
+            waitForNetworkQuiet();
+            assert.equal(
+                $('[data-test="LollipopPlotTitle"]')
+                    .getText()
+                    .includes('KRAS'),
+                true
+            );
+            assert.equal(
+                $('a.tabAnchor_KRAS')
+                    .parentElement()
+                    .getAttribute('class')
+                    .includes('active'),
+                true
+            );
+        });
+    });
+
+    describe('adding annotation tracks', function() {
+        it('track visibility stays on gene change', function() {
+            $('div.css-dlmlqy-control').click();
+            $('[data-test="CancerHotspots"]').click();
+            waitForNetworkQuiet();
+            $('svg.css-tj5bde-Svg').click();
+            waitForNetworkQuiet();
+            assert.equal(
+                $('[data-test="AnnotationTracks"]').isDisplayed(),
+                true
+            );
+        });
+    });
+
+    describe('driver/vus and protein badge selecting', function() {
+        it('clicking badge filters both top and bottom plots', function() {
+            $('strong=Truncating').click();
+            // counts are unchanged
+            assert.equal(
+                $('[data-test="badge-truncating_putative_driver"]').getText(),
+                '115'
+            );
+            assert.equal(
+                $$(
+                    '[data-test="badge-truncating_putative_driver"]'
+                )[1].getText(),
+                '38'
+            );
+
+            assert.equal(
+                $(
+                    '[data-test="badge-truncating_putative_driver"]'
+                ).getCSSProperty('color').parsed.hex,
+                $$(
+                    '[data-test="badge-truncating_putative_driver"]'
+                )[1].getCSSProperty('color').parsed.hex
+            );
+            assert.equal(
+                $(
+                    'div.mutationMapper-module__filterResetPanel__2aFDu'
+                ).isDisplayed(),
+                true
+            );
+
+            // undo filter
+            $('strong=Truncating').click();
+            assert.equal(
+                $(
+                    '[data-test="badge-truncating_putative_driver"]'
+                ).getCSSProperty('color').parsed.hex,
+                $$(
+                    '[data-test="badge-truncating_putative_driver"]'
+                )[1].getCSSProperty('color').parsed.hex
+            );
+            assert.equal(
+                $(
+                    'div.mutationMapper-module__filterResetPanel__2aFDu'
+                ).isDisplayed(),
+                false
+            );
+        });
+
+        it('adjusts mutation counts based on driver annotation settings', function() {
+            getElementByTestHandle('badge-driver')
+                .$('span=116')
+                .waitForExist();
+
+            setSettingsMenuOpen(true);
+            getElementByTestHandle('annotateOncoKb').click();
+            setSettingsMenuOpen(false);
+
+            $('.lollipop-svgnode').waitForDisplayed();
+
+            getElementByTestHandle('badge-driver')
+                .$('span=0')
+                .waitForExist();
+
+            setSettingsMenuOpen(true);
+            getElementByTestHandle('annotateOncoKb').click();
+            setSettingsMenuOpen(false);
+
+            $('.lollipop-svgnode').waitForDisplayed();
+
+            getElementByTestHandle('badge-driver')
+                .$('span=116')
+                .waitForExist();
+        });
+    });
+});

--- a/end-to-end-test/remote/specs/core/groupComparisonLollipop.spec.js
+++ b/end-to-end-test/remote/specs/core/groupComparisonLollipop.spec.js
@@ -14,7 +14,7 @@ describe('group comparison mutations tab tests', function() {
             goToUrlAndSetLocalStorage(
                 `${CBIOPORTAL_URL}/comparison/mutations?comparisonId=634006c24dd45f2bc4c3d4aa`
             );
-            $('a.tabAnchor_mutations').waitForDisplayed(20000);
+            $('a.tabAnchor_mutations').waitForDisplayed({ timeout: 20000 });
         });
 
         it('too many groups alert displayed when more than 2 groups selected', function() {
@@ -36,7 +36,7 @@ describe('group comparison mutations tab tests', function() {
             ).click();
             getElementByTestHandle(
                 'ComparisonPageMutationsTabPlot'
-            ).waitForDisplayed(20000);
+            ).waitForDisplayed({ timeout: 25000 });
         });
     });
 

--- a/end-to-end-test/remote/specs/core/groupComparisonLollipop.spec.js
+++ b/end-to-end-test/remote/specs/core/groupComparisonLollipop.spec.js
@@ -1,8 +1,6 @@
 var assert = require('assert');
 var goToUrlAndSetLocalStorage = require('../../../shared/specUtils')
     .goToUrlAndSetLocalStorage;
-var waitForNetworkQuiet = require('../../../shared/specUtils')
-    .waitForNetworkQuiet;
 var setInputText = require('../../../shared/specUtils').setInputText;
 var setSettingsMenuOpen = require('../../../shared/specUtils')
     .setSettingsMenuOpen;
@@ -14,49 +12,31 @@ describe('group comparison mutations tab tests', function() {
     describe('lollipop alerts and plot display', function() {
         before(function() {
             goToUrlAndSetLocalStorage(
-                `${CBIOPORTAL_URL}/comparison?comparisonId=634006c24dd45f2bc4c3d4aa`
+                `${CBIOPORTAL_URL}/comparison/mutations?comparisonId=634006c24dd45f2bc4c3d4aa`
             );
-            $('div[data-test="ComparisonPageOverlapTabDiv"]').waitForExist();
+            $('a.tabAnchor_mutations').waitForDisplayed(20000);
         });
 
         it('too many groups alert displayed when more than 2 groups selected', function() {
-            $('a.tabAnchor_mutations').waitForExist();
-            $('a.tabAnchor_mutations').click();
-            browser.pause(1000);
-            assert.equal(
-                $('[data-test="TooManyGroupsAlert"]').isDisplayed(),
-                true
-            );
+            getElementByTestHandle('TooManyGroupsAlert').waitForDisplayed();
         });
 
         it('not enough groups alert displayed when less than 2 groups selected', function() {
-            $('a=Deselect all').waitForExist();
             $('a=Deselect all').click();
-            browser.pause(1000);
-            assert.equal(
-                $('[data-test="NotEnoughGroupsAlert"]').isDisplayed(),
-                true
-            );
-            $(
-                '[data-test="groupSelectorButtonColon Adenocarcinoma"]'
-            ).waitForExist();
-            $('[data-test="groupSelectorButtonColon Adenocarcinoma"]').click();
-            browser.pause(1000);
-            assert.equal(
-                $('[data-test="NotEnoughGroupsAlert"]').isDisplayed(),
-                true
-            );
+            getElementByTestHandle('NotEnoughGroupsAlert').waitForDisplayed();
+            getElementByTestHandle(
+                'groupSelectorButtonColon Adenocarcinoma'
+            ).click();
+            getElementByTestHandle('NotEnoughGroupsAlert').waitForDisplayed();
         });
 
         it('lollipop plot displayed when 2 groups selected', function() {
-            $(
-                '[data-test="groupSelectorButtonColorectal Adenocarcinoma"]'
-            ).waitForExist();
-            $(
-                '[data-test="groupSelectorButtonColorectal Adenocarcinoma"]'
+            getElementByTestHandle(
+                'groupSelectorButtonColorectal Adenocarcinoma'
             ).click();
-            $('[data-test="LollipopPlot"]').waitForExist({ timeout: 20000 });
-            assert.equal($('[data-test="LollipopPlot"]').isDisplayed(), true);
+            getElementByTestHandle(
+                'ComparisonPageMutationsTabPlot'
+            ).waitForDisplayed(20000);
         });
     });
 
@@ -64,28 +44,17 @@ describe('group comparison mutations tab tests', function() {
         it('displays double tooltip when lollipop is present in both plots at the same position', function() {
             $('.lollipop-0').waitForExist();
             $('.lollipop-0').moveTo();
-            $('[data-test="tooltip-1450-Colon Adenocarcinoma"]').waitForExist();
-            $(
-                '[data-test="tooltip-1450-Colorectal Adenocarcinoma"]'
-            ).waitForExist();
-            assert.equal(
-                $(
-                    '[data-test="tooltip-1450-Colon Adenocarcinoma"]'
-                ).isDisplayed(),
-                true
-            );
-            assert.equal(
-                $(
-                    '[data-test="tooltip-1450-Colorectal Adenocarcinoma"]'
-                ).isDisplayed(),
-                true
-            );
+            getElementByTestHandle(
+                'tooltip-1450-Colon Adenocarcinoma'
+            ).waitForDisplayed();
+            getElementByTestHandle(
+                'tooltip-1450-Colorectal Adenocarcinoma'
+            ).waitForDisplayed();
         });
         it("doesn't display % when axis scale # is toggled", function() {
-            $('[data-test="AxisScaleSwitch#"]').click();
+            getElementByTestHandle('AxisScaleSwitch#').click();
             $('.lollipop-6').waitForExist();
             $('.lollipop-6').moveTo();
-            $('[data-test="tooltip-1378-Colon Adenocarcinoma"]').waitForExist();
             assert.equal(
                 $('[data-test="tooltip-1378-Colon Adenocarcinoma"]')
                     .getText()
@@ -94,10 +63,9 @@ describe('group comparison mutations tab tests', function() {
             );
         });
         it('displays % when axis scale % is toggled', function() {
-            $('[data-test="AxisScaleSwitch%"]').click();
+            getElementByTestHandle('AxisScaleSwitch%').click();
             $('.lollipop-6').waitForExist();
             $('.lollipop-6').moveTo();
-            $('[data-test="tooltip-1378-Colon Adenocarcinoma"]').waitForExist();
             assert.equal(
                 $('[data-test="tooltip-1378-Colon Adenocarcinoma"]')
                     .getText()
@@ -110,14 +78,20 @@ describe('group comparison mutations tab tests', function() {
     describe('selecting gene with dropdown and tabs', function() {
         it('clicking on gene tab sets the selected gene', function() {
             $('a.tabAnchor_TP53').click();
-            waitForNetworkQuiet();
+            getElementByTestHandle('ComparisonPageMutationsTabPlot')
+                .$('h3')
+                .waitForExist();
             assert.equal(
-                $('[data-test="LollipopPlotTitle"]')
+                getElementByTestHandle('ComparisonPageMutationsTabPlot')
+                    .$('h3')
                     .getText()
                     .includes('TP53'),
                 true
             );
-            assert.equal($('[data-test="GeneSelector"]').getText(), 'TP53');
+            assert.equal(
+                getElementByTestHandle('GeneSelector').getText(),
+                'TP53'
+            );
         });
 
         it('selecting gene in gene selector sets the selected gene', function() {
@@ -126,9 +100,12 @@ describe('group comparison mutations tab tests', function() {
                 'KRAS'
             );
             browser.keys('Enter');
-            waitForNetworkQuiet();
+            getElementByTestHandle('ComparisonPageMutationsTabPlot')
+                .$('h3')
+                .waitForExist();
             assert.equal(
-                $('[data-test="LollipopPlotTitle"]')
+                getElementByTestHandle('ComparisonPageMutationsTabPlot')
+                    .$('h3')
                     .getText()
                     .includes('KRAS'),
                 true
@@ -145,15 +122,11 @@ describe('group comparison mutations tab tests', function() {
 
     describe('adding annotation tracks', function() {
         it('track visibility stays on gene change', function() {
-            $('div.css-dlmlqy-control').click();
-            $('[data-test="CancerHotspots"]').click();
-            waitForNetworkQuiet();
-            $('svg.css-tj5bde-Svg').click();
-            waitForNetworkQuiet();
-            assert.equal(
-                $('[data-test="AnnotationTracks"]').isDisplayed(),
-                true
-            );
+            $('div.annotation-track-selector').click();
+            getElementByTestHandle('CancerHotspots').click();
+            $('a.tabAnchor_APC').waitForDisplayed();
+            $('a.tabAnchor_APC').click();
+            getElementByTestHandle('AnnotationTracks').waitForDisplayed();
         });
     });
 
@@ -180,12 +153,7 @@ describe('group comparison mutations tab tests', function() {
                     '[data-test="badge-truncating_putative_driver"]'
                 )[1].getCSSProperty('color').parsed.hex
             );
-            assert.equal(
-                $(
-                    'div.mutationMapper-module__filterResetPanel__2aFDu'
-                ).isDisplayed(),
-                true
-            );
+            getElementByTestHandle('filter-reset-panel').waitForDisplayed();
 
             // undo filter
             $('strong=Truncating').click();
@@ -198,9 +166,7 @@ describe('group comparison mutations tab tests', function() {
                 )[1].getCSSProperty('color').parsed.hex
             );
             assert.equal(
-                $(
-                    'div.mutationMapper-module__filterResetPanel__2aFDu'
-                ).isDisplayed(),
+                getElementByTestHandle('filter-reset-panel').isDisplayed(),
                 false
             );
         });

--- a/end-to-end-test/shared/specUtils.js
+++ b/end-to-end-test/shared/specUtils.js
@@ -103,7 +103,7 @@ function setSettingsMenuOpen(open, buttonId = 'GlobalSettingsButton') {
 }
 
 function getElementByTestHandle(handle) {
-    return $(`[data-test=${handle}]`);
+    return $(`[data-test="${handle}"]`);
 }
 
 function setOncoprintMutationsMenuOpen(open) {

--- a/packages/react-mutation-mapper/src/component/filter/BadgeLabel.tsx
+++ b/packages/react-mutation-mapper/src/component/filter/BadgeLabel.tsx
@@ -7,6 +7,7 @@ export type BadgeLabelProps = {
     badgeStyleOverride?: CSSProperties;
     badgeClassName?: string;
     badgeFirst?: boolean;
+    value?: string;
 };
 
 export const DEFAULT_BADGE_STYLE = {
@@ -33,6 +34,7 @@ export class BadgeLabel extends React.Component<BadgeLabelProps, {}> {
             >
                 <span
                     className={this.props.badgeClassName}
+                    data-test={`badge-${this.props.value}`}
                     style={{
                         ...DEFAULT_BADGE_STYLE,
                         ...this.props.badgeStyleOverride,

--- a/packages/react-mutation-mapper/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
+++ b/packages/react-mutation-mapper/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
@@ -51,6 +51,7 @@ export function getProteinImpactTypeBadgeLabel(
             )}
             badgeClassName={badgeClassName}
             badgeFirst={true}
+            value={option.value}
         />
     );
 }

--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/AxisScaleSwitch.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/AxisScaleSwitch.tsx
@@ -45,6 +45,7 @@ export class AxisScaleSwitch extends React.Component<
                     'btn-sm',
                     'btn-axis-switch'
                 )}
+                data-test={`AxisScaleSwitch${scale}`}
                 style={{
                     lineHeight: 1,
                     cursor:

--- a/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
+++ b/packages/react-mutation-mapper/src/component/lollipopMutationPlot/LollipopMutationPlot.tsx
@@ -183,7 +183,7 @@ export default class LollipopMutationPlot<
         const label = lollipopLabelText(mutationsAtPosition);
 
         return (
-            <div>
+            <div data-test={`tooltip-${codon}${group ? `-${group}` : ''}`}>
                 {countInfo}
                 <br />
                 <span>AA Change: {label}</span>

--- a/packages/react-mutation-mapper/src/component/mutationMapper/FilterResetPanel.tsx
+++ b/packages/react-mutation-mapper/src/component/mutationMapper/FilterResetPanel.tsx
@@ -29,7 +29,10 @@ export class FilterResetPanel extends React.Component<
 
     public render() {
         return (
-            <div className={this.props.className}>
+            <div
+                className={this.props.className}
+                data-test="filter-reset-panel"
+            >
                 <span style={{ verticalAlign: 'middle' }}>
                     {this.props.filterInfo}
                     <button

--- a/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
+++ b/packages/react-mutation-mapper/src/component/track/TrackPanel.tsx
@@ -125,6 +125,7 @@ export default class TrackPanel extends React.Component<TrackPanelProps, {}> {
                     maxHeight: this.props.maxHeight,
                     position: 'relative',
                 }}
+                data-test="AnnotationTracks"
             >
                 {this.props
                     .tracks!.map(t => this.availableTracks[t])

--- a/packages/react-mutation-mapper/src/component/track/TrackSelector.tsx
+++ b/packages/react-mutation-mapper/src/component/track/TrackSelector.tsx
@@ -65,7 +65,7 @@ export default class TrackSelector extends React.Component<
         return {
             [TrackName.CancerHotspots]: {
                 label: (
-                    <span>
+                    <span data-test="CancerHotspots">
                         Cancer Hotspots
                         {this.isPending(TrackName.CancerHotspots) &&
                             this.loaderIcon()}

--- a/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTab.tsx
@@ -85,13 +85,19 @@ export default class GroupComparisonMutationsTab extends React.Component<
             // We only want 2 groups for our mirrored lollipop plot. Display message if not 2 groups
             if (this.props.store.activeGroups.result!.length < 2) {
                 return (
-                    <div className="alert alert-info">
+                    <div
+                        className="alert alert-info"
+                        data-test="NotEnoughGroupsAlert"
+                    >
                         {MUTATIONS_NOT_ENOUGH_GROUPS_MSG}
                     </div>
                 );
             } else if (this.props.store.activeGroups.result!.length > 2) {
                 return (
-                    <div className="alert alert-info">
+                    <div
+                        className="alert alert-info"
+                        data-test="TooManyGroupsAlert"
+                    >
                         {MUTATIONS_TOO_MANY_GROUPS_MSG}
                     </div>
                 );

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -135,7 +135,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                 );
                 return (
                     <>
-                        <h3>
+                        <h3 data-test="LollipopPlotTitle">
                             {this.props.store.activeMutationMapperGene
                                 ?.hugoGeneSymbol +
                                 ' mutations: ' +

--- a/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationsTabPlot.tsx
@@ -134,8 +134,11 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                     this.props.store.activeMutationMapperGene!.hugoGeneSymbol
                 );
                 return (
-                    <>
-                        <h3 data-test="LollipopPlotTitle">
+                    <div
+                        data-test="ComparisonPageMutationsTabPlot"
+                        style={{ marginTop: 20 }}
+                    >
+                        <h3>
                             {this.props.store.activeMutationMapperGene
                                 ?.hugoGeneSymbol +
                                 ' mutations: ' +
@@ -174,7 +177,7 @@ export default class GroupComparisonMutationsTabPlot extends React.Component<
                             groups={this.props.store.activeGroups.result!}
                             annotationFilterSettings={this.props.store}
                         />
-                    </>
+                    </div>
                 );
             } else {
                 if (

--- a/src/pages/groupComparison/LollipopGeneSelector.tsx
+++ b/src/pages/groupComparison/LollipopGeneSelector.tsx
@@ -38,7 +38,10 @@ export const LollipopGeneSelector: React.FC<ILollipopGeneSelectorProps> = observ
         };
 
         return (
-            <div style={{ width: 200, paddingRight: 10 }}>
+            <div
+                data-test="GeneSelector"
+                style={{ width: 200, paddingRight: 10 }}
+            >
                 <AsyncSelect
                     name="Select gene"
                     onChange={(option: any | null) => {


### PR DESCRIPTION
Add e2e tests for comparison view lollipop plot that test alerts, tooltips, gene selection, annotation tracks, and driver/vus and protein badge selections