### PR TITLE
Fix quick submit when on results view default tab

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -521,9 +521,12 @@ export default class ResultsViewPage extends React.Component<
 
     @action.bound
     handleQuickOQLSubmission() {
-        this.quickOQLQueryStore!.submit(
+        const targetTab = Object.values(ResultsViewTab).includes(
             this.urlWrapper.tabId as ResultsViewTab
-        );
+        )
+            ? this.urlWrapper.tabId
+            : '';
+        this.quickOQLQueryStore!.submit(targetTab as ResultsViewTab);
         this.showOQLEditor = false;
     }
 


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/9975

When results view was in default tab, it was submitting redundant "result" path.