### PR TITLE
Improve Pathway Mapper default genes of interest list to include all alteration types

### DIFF
--- a/src/pages/groupComparison/GroupComparisonPage.tsx
+++ b/src/pages/groupComparison/GroupComparisonPage.tsx
@@ -265,6 +265,7 @@ export default class GroupComparisonPage extends React.Component<
                             <GroupComparisonPathwayMapper
                                 genomicData={
                                     this.store.alterationEnrichmentRowData
+                                        .result || []
                                 }
                                 activeGroups={this.store.activeGroups.result}
                                 store={this.store}

--- a/src/pages/groupComparison/pathwayMapper/GroupComparisonPathwayMapper.tsx
+++ b/src/pages/groupComparison/pathwayMapper/GroupComparisonPathwayMapper.tsx
@@ -54,7 +54,7 @@ export default class GroupComparisonPathwayMapper extends React.Component<
     @computed get activeGenes() {
         return (
             this._userSelectedGenes ||
-            this.props.store.genesSortedByMutationFrequency.result?.slice(
+            this.props.store.genesSortedByAlterationFrequency.result?.slice(
                 0,
                 10
             ) ||
@@ -63,7 +63,9 @@ export default class GroupComparisonPathwayMapper extends React.Component<
     }
 
     @computed get alterationEnrichmentRowData(): AlterationEnrichmentRow[] {
-        return this.props.store.alterationEnrichmentRowData.filter(gene => {
+        return (
+            this.props.store.alterationEnrichmentRowData.result || []
+        ).filter(gene => {
             return this.activeGenes.includes(gene.hugoGeneSymbol);
         });
     }

--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsContainer.tsx
@@ -114,7 +114,9 @@ export default class AlterationEnrichmentContainer extends React.Component<
     }
 
     @computed get data(): AlterationEnrichmentRow[] {
-        return this.props.comparisonStore?.alterationEnrichmentRowData || [];
+        return (
+            this.props.comparisonStore?.alterationEnrichmentRowData.result || []
+        );
     }
 
     @computed get filteredData(): AlterationEnrichmentRow[] {

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -1126,11 +1126,14 @@ export default abstract class ComparisonStore extends AnalysisStore
         },
     });
 
-    @computed get alterationEnrichmentRowData(): AlterationEnrichmentRow[] {
-        if (
-            this.alterationsEnrichmentData.isComplete &&
-            this.alterationsEnrichmentAnalysisGroups.isComplete
-        )
+    public readonly alterationEnrichmentRowData = remoteData<
+        AlterationEnrichmentRow[]
+    >({
+        await: () => [
+            this.alterationsEnrichmentData,
+            this.alterationsEnrichmentAnalysisGroups,
+        ],
+        invoke: async () => {
             return getAlterationRowData(
                 this.alterationsEnrichmentData.result!,
                 this.resultsViewStore
@@ -1138,8 +1141,8 @@ export default abstract class ComparisonStore extends AnalysisStore
                     : [],
                 this.alterationsEnrichmentAnalysisGroups.result!
             );
-        return [];
-    }
+        },
+    });
 
     public readonly mutationsEnrichmentData = makeEnrichmentDataPromise({
         await: () => [this.mutationsEnrichmentDataRequestGroups],
@@ -1203,6 +1206,19 @@ export default abstract class ComparisonStore extends AnalysisStore
                     : [],
                 this.alterationsEnrichmentAnalysisGroups.result!
             );
+            alterationRowData.sort(compareByAlterationPercentage);
+            return alterationRowData.map(a => a.hugoGeneSymbol);
+        },
+    });
+
+    readonly genesSortedByAlterationFrequency = remoteData<string[]>({
+        await: () => [
+            this.alterationEnrichmentRowData,
+            this.alterationsEnrichmentAnalysisGroups,
+        ],
+        invoke: async () => {
+            const alterationRowData: AlterationEnrichmentRow[] = this
+                .alterationEnrichmentRowData.result!;
             alterationRowData.sort(compareByAlterationPercentage);
             return alterationRowData.map(a => a.hugoGeneSymbol);
         },


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9974

Looks like currently we are relying on genes sorted by mutation frequency for Pathways tab. Actually we need all alterations, not just mutations. So, we need to get sort genes by alteration frequency instead to always get the desired list of genes.