### PR TITLE
Rename 'user email' variables to 'user display name' for consistency

### DIFF
--- a/end-to-end-test/local/specs/user-display-name.spec.js
+++ b/end-to-end-test/local/specs/user-display-name.spec.js
@@ -1,0 +1,39 @@
+var assert = require('assert');
+var goToUrlAndSetLocalStorageWithProperty = require('../../shared/specUtils')
+    .goToUrlAndSetLocalStorageWithProperty;
+var useExternalFrontend = require('../../shared/specUtils').useExternalFrontend;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+
+describe('displays appropriate user name/email', function() {
+    it('shows email in the logged-in button with deprecated value defined', function() {
+        userEmailAddress = 'test@email.com';
+        goToUrlAndSetLocalStorageWithProperty(CBIOPORTAL_URL, true, {
+            user_email_address: userEmailAddress,
+        });
+        assert.equal(
+            $('#dat-dropdown.btn-sm.dropdown-toggle.btn.btn-default').getText(),
+            'Logged in as ' + userEmailAddress + ' '
+        );
+    });
+
+    it('shows email in the logged-in button with new value defined', function() {
+        userEmailAddress = 'other@email.com';
+        goToUrlAndSetLocalStorageWithProperty(CBIOPORTAL_URL, true, {
+            user_display_name: userEmailAddress,
+        });
+        assert.equal(
+            $('#dat-dropdown.btn-sm.dropdown-toggle.btn.btn-default').getText(),
+            'Logged in as ' + userEmailAddress + ' '
+        );
+    });
+
+    it('does not display login button if no value defined', function() {
+        goToUrlAndSetLocalStorageWithProperty(CBIOPORTAL_URL, true, {
+            user_display_name: null,
+            user_email_address: null,
+        });
+        $('#rightHeaderContent').waitForExist();
+        !$('#dat-dropdown.btn-sm.dropdown-toggle.btn.btn-default').isExisting();
+    });
+});

--- a/end-to-end-test/shared/specUtils.js
+++ b/end-to-end-test/shared/specUtils.js
@@ -520,7 +520,9 @@ function checkElementWithElementHidden(selector, selectorToHide, options) {
 }
 
 function clickQueryByGeneButton() {
-    $('a=Query By Gene').waitForEnabled();
+    $('.disabled[data-test=queryByGeneButton]').waitForExist({
+        reverse: true,
+    });
     $('a=Query By Gene').click();
     $('body').scrollIntoView();
 }

--- a/packages/oncokb-frontend-commons/src/components/OncoKB.tsx
+++ b/packages/oncokb-frontend-commons/src/components/OncoKB.tsx
@@ -30,7 +30,7 @@ export interface IOncoKbProps {
     isCancerGene: boolean;
     geneNotExist: boolean;
     hugoGeneSymbol: string;
-    userEmailAddress?: string;
+    userDisplayName?: string;
     disableFeedback?: boolean;
     contentPadding?: number;
 }
@@ -252,7 +252,7 @@ export const OncoKB: React.FunctionComponent<IOncoKbProps> = (
                 <span>
                     {oncoKbContent}
                     <OncoKbFeedback
-                        userEmailAddress={props.userEmailAddress}
+                        userDisplayName={props.userDisplayName}
                         hugoSymbol={props.hugoGeneSymbol}
                         alteration={
                             props.indicator

--- a/packages/oncokb-frontend-commons/src/components/OncoKbFeedback.tsx
+++ b/packages/oncokb-frontend-commons/src/components/OncoKbFeedback.tsx
@@ -5,7 +5,7 @@ interface IOncoKbFeedbackProps {
     showFeedback: boolean;
     hugoSymbol?: string;
     alteration?: string;
-    userEmailAddress?: string;
+    userDisplayName?: string;
     handleFeedbackClose: () => void;
 }
 
@@ -19,7 +19,7 @@ export default class OncoKbFeedback extends React.Component<
         const geneParam = `entry.1744186665=${this.props.hugoSymbol || ''}`;
         const alterationParam = `entry.1671960263=${this.props.alteration ||
             ''}`;
-        const userParam = `entry.1381123986=${this.props.userEmailAddress ||
+        const userParam = `entry.1381123986=${this.props.userDisplayName ||
             ''}`;
         const uriParam = `entry.1083850662=${encodeURIComponent(
             window.location.href

--- a/packages/react-mutation-mapper/src/component/column/Annotation.tsx
+++ b/packages/react-mutation-mapper/src/component/column/Annotation.tsx
@@ -57,7 +57,7 @@ export type AnnotationProps = {
     myCancerGenomeData?: IMyCancerGenomeData;
     civicGenes?: RemoteData<ICivicGeneIndex | undefined>;
     civicVariants?: RemoteData<ICivicVariantIndex | undefined>;
-    userEmailAddress?: string;
+    userDisplayName?: string;
 };
 
 export type GenericAnnotationProps = {
@@ -69,7 +69,7 @@ export type GenericAnnotationProps = {
     mergeOncoKbIcons?: boolean;
     oncoKbContentPadding?: number;
     pubMedCache?: MobxCache;
-    userEmailAddress?: string;
+    userDisplayName?: string;
 };
 
 export interface IAnnotation {
@@ -308,7 +308,7 @@ export function GenericAnnotation(props: GenericAnnotationProps): JSX.Element {
         enableMyCancerGenome,
         enableOncoKb,
         pubMedCache,
-        userEmailAddress,
+        userDisplayName,
         mergeOncoKbIcons,
         oncoKbContentPadding,
     } = props;
@@ -327,7 +327,7 @@ export function GenericAnnotation(props: GenericAnnotationProps): JSX.Element {
                     indicator={annotation.oncoKbIndicator}
                     availableDataTypes={annotation.oncoKbAvailableDataTypes}
                     mergeAnnotationIcons={mergeOncoKbIcons}
-                    userEmailAddress={userEmailAddress}
+                    userDisplayName={userDisplayName}
                     contentPadding={oncoKbContentPadding}
                 />
             )}

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -137,7 +137,8 @@ export interface IServerConfig {
     query_sets_of_genes: string | null;
     skin_quick_select_buttons: string | null;
     base_url: string | null;
-    user_email_address: string;
+    user_email_address: string; //Property to be completely replaced by user_display_name when backend PR #9986 is merged
+    user_display_name: string;
     sessionServiceEnabled: boolean;
     session_url_length_threshold: string;
     mskWholeSlideViewerToken: string;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -131,11 +131,18 @@ export class ServerConfigHelpers {
         return getServerConfig().sessionServiceEnabled;
     }
 
-    static getUserEmailAddress(): string | undefined {
-        return getServerConfig().user_email_address &&
-            getServerConfig().user_email_address !== 'anonymousUser'
-            ? getServerConfig().user_email_address
-            : undefined;
+    static getUserDisplayName(): string | undefined {
+        if (getServerConfig().user_email_address) {
+            return getServerConfig().user_email_address &&
+                getServerConfig().user_email_address !== 'anonymousUser'
+                ? getServerConfig().user_email_address
+                : undefined;
+        } else {
+            return getServerConfig().user_display_name &&
+                getServerConfig().user_display_name !== 'anonymousUser'
+                ? getServerConfig().user_display_name
+                : undefined;
+        }
     }
 }
 
@@ -369,5 +376,7 @@ export function fetchServerConfig() {
 
 export function initializeAppStore(appStore: AppStore) {
     appStore.authMethod = getServerConfig().authenticationMethod;
-    appStore.userName = getServerConfig().user_email_address;
+    appStore.userName = getServerConfig().user_display_name
+        ? getServerConfig().user_display_name
+        : getServerConfig().user_email_address;
 }

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -269,7 +269,9 @@ export default class CopyNumberTableWrapper extends React.Component<
                         enableCivic: getServerConfig().show_civic as boolean,
                         enableMyCancerGenome: false,
                         enableHotspot: false,
-                        userEmailAddress: getServerConfig().user_email_address,
+                        userDisplayName: getServerConfig().user_display_name
+                            ? getServerConfig().user_display_name
+                            : getServerConfig().user_email_address,
                         studyIdToStudy: this.pageStore.studyIdToStudy.result,
                     })}
                 </span>

--- a/src/pages/patientView/mutation/MutationTableWrapper.tsx
+++ b/src/pages/patientView/mutation/MutationTableWrapper.tsx
@@ -73,7 +73,7 @@ type IMutationTableWrapperProps = {
     onOncoKbIconToggle: (mergeIcons: boolean) => void;
     civicGenes?: RemoteData<ICivicGeneIndex | undefined>;
     civicVariants?: RemoteData<ICivicVariantIndex | undefined>;
-    userEmailAddress?: string | undefined;
+    userDisplayName?: string | undefined;
     enableOncoKb?: boolean;
     enableCivic?: boolean;
     columnVisibility?: { [columnId: string]: boolean };
@@ -267,7 +267,7 @@ export default class MutationTableWrapper extends React.Component<
                                 }
                                 civicGenes={this.pageStore.civicGenes}
                                 civicVariants={this.pageStore.civicVariants}
-                                userEmailAddress={ServerConfigHelpers.getUserEmailAddress()}
+                                userDisplayName={ServerConfigHelpers.getUserDisplayName()}
                                 enableOncoKb={getServerConfig().show_oncokb}
                                 enableFunctionalImpact={
                                     getServerConfig().show_genomenexus

--- a/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
@@ -329,7 +329,7 @@ export default class PatientViewMutationsTab extends React.Component<
                     civicVariants={
                         this.props.patientViewPageStore.civicVariants
                     }
-                    userEmailAddress={ServerConfigHelpers.getUserEmailAddress()}
+                    userDisplayName={ServerConfigHelpers.getUserDisplayName()}
                     enableOncoKb={getServerConfig().show_oncokb}
                     enableFunctionalImpact={getServerConfig().show_genomenexus}
                     enableHotspot={getServerConfig().show_hotspot}

--- a/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
+++ b/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
@@ -298,7 +298,7 @@ export default class StructuralVariantTableWrapper extends React.Component<
                             enableCivic: false,
                             enableMyCancerGenome: false,
                             enableHotspot: false,
-                            userEmailAddress: ServerConfigHelpers.getUserEmailAddress(),
+                            userDisplayName: ServerConfigHelpers.getUserDisplayName(),
                             studyIdToStudy: this.props.store.studyIdToStudy
                                 .result,
                         })}

--- a/src/pages/patientView/trialMatch/TrialMatchFeedback.tsx
+++ b/src/pages/patientView/trialMatch/TrialMatchFeedback.tsx
@@ -8,7 +8,7 @@ interface ITrialMatchFeedbackProps {
     data?: ISelectedTrialFeedbackFormData;
     isTrialFeedback?: boolean;
     title: string;
-    userEmailAddress: string;
+    userDisplayName: string;
     onHide: () => void;
 }
 
@@ -26,7 +26,7 @@ export default class TrialMatchFeedback extends React.Component<
                 const url =
                     'https://docs.google.com/forms/d/e/1FAIpQLSfcoLRG0iWO_qUb4hfzWFQ1toP575EKCTwqPcXE9DmMzuS34w/viewform';
                 const userParam = `entry.1655318994=${this.props
-                    .userEmailAddress || ''}`;
+                    .userDisplayName || ''}`;
                 const uriParam = `entry.1782078941=${encodeURIComponent(
                     window.location.href
                 )}`;
@@ -42,7 +42,7 @@ export default class TrialMatchFeedback extends React.Component<
                 const url =
                     'https://docs.google.com/forms/d/e/1FAIpQLSes1WuMattmo_aT8-34LaPRTC47vVzvdWMgYZ5tSuw8EHoLZw/viewform';
                 const userParam = `entry.251841421=${this.props
-                    .userEmailAddress || ''}`;
+                    .userDisplayName || ''}`;
                 const uriParam = `entry.1295500928=${encodeURIComponent(
                     window.location.href
                 )}`;

--- a/src/pages/patientView/trialMatch/TrialMatchTable.tsx
+++ b/src/pages/patientView/trialMatch/TrialMatchTable.tsx
@@ -636,7 +636,11 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                         show={this.showGeneralFeedback}
                         onHide={() => (this.showGeneralFeedback = false)}
                         title="OncoKB Matched Trials General Feedback"
-                        userEmailAddress={getServerConfig().user_email_address}
+                        userDisplayName={
+                            getServerConfig().user_display_name
+                                ? getServerConfig().user_display_name
+                                : getServerConfig().user_email_address
+                        }
                     />
                 )}
                 {this.selectedTrialFeedbackFormData && (
@@ -646,7 +650,11 @@ export default class TrialMatchTable extends React.Component<ITrialMatchProps> {
                         onHide={() => this.openCloseFeedbackForm()}
                         isTrialFeedback={true}
                         title="OncoKB Matched Trial Feedback"
-                        userEmailAddress={getServerConfig().user_email_address}
+                        userDisplayName={
+                            getServerConfig().user_display_name
+                                ? getServerConfig().user_display_name
+                                : getServerConfig().user_email_address
+                        }
                     />
                 )}
                 <TrialMatchTableComponent

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -254,7 +254,7 @@ export default class Mutations extends React.Component<
                             this.props.store.genomeNexusMutationAssessorCache
                         }
                         pdbHeaderCache={this.props.store.pdbHeaderCache}
-                        userEmailAddress={this.props.appStore.userName!}
+                        userDisplayName={this.props.appStore.userName!}
                         generateGenomeNexusHgvsgUrl={
                             this.props.store.generateGenomeNexusHgvsgUrl
                         }

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -50,7 +50,7 @@ export interface IResultsViewMutationMapperProps extends IMutationMapperProps {
     mutationCountCache?: MutationCountCache;
     clinicalAttributeCache?: ClinicalAttributeCache;
     existsSomeMutationWithAscnProperty: { [property: string]: boolean };
-    userEmailAddress: string;
+    userDisplayName: string;
     onClickSettingMenu?: (visible: boolean) => void;
 }
 
@@ -221,7 +221,7 @@ export default class ResultsViewMutationMapper extends MutationMapper<
                 onOncoKbIconToggle={this.props.onOncoKbIconToggle}
                 civicGenes={this.props.store.civicGenes}
                 civicVariants={this.props.store.civicVariants}
-                userEmailAddress={this.props.userEmailAddress}
+                userDisplayName={this.props.userDisplayName}
                 enableOncoKb={this.props.enableOncoKb}
                 enableFunctionalImpact={this.props.enableGenomeNexus}
                 enableHotspot={this.props.enableHotspot}

--- a/src/pages/studyView/virtualStudy/VirtualStudy.tsx
+++ b/src/pages/studyView/virtualStudy/VirtualStudy.tsx
@@ -208,7 +208,7 @@ export default class VirtualStudy extends React.Component<
     }
 
     @computed get showSaveButton() {
-        //default value of userEmailAddress is anonymousUser. see my-index.ejs
+        //default value of userDisplayName is anonymousUser. see my-index.ejs
         return !(
             _.isUndefined(this.props.user) ||
             _.isEmpty(this.props.user) ||

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -126,7 +126,7 @@ export interface IMutationTableProps {
     initialItemsPerPage?: number;
     itemsLabel?: string;
     itemsLabelPlural?: string;
-    userEmailAddress?: string;
+    userDisplayName?: string;
     initialSortColumn?: string;
     initialSortDirection?: SortDirection;
     paginationProps?: IPaginationControlsProps;
@@ -888,7 +888,7 @@ export default class MutationTable<
                         enableMyCancerGenome: this.props
                             .enableMyCancerGenome as boolean,
                         enableHotspot: this.props.enableHotspot as boolean,
-                        userEmailAddress: this.props.userEmailAddress,
+                        userDisplayName: this.props.userDisplayName,
                         resolveTumorType: this.resolveTumorType,
                     })}
                 </span>

--- a/src/shared/lib/openSocialAuthWindow.ts
+++ b/src/shared/lib/openSocialAuthWindow.ts
@@ -22,7 +22,7 @@ export function openSocialAuthWindow(appStore: AppStore) {
                 _window.close();
 
                 fetchServerConfig().then((config: IServerConfig) => {
-                    appStore.userName = config.user_email_address;
+                    appStore.userName = config.user_display_name;
                     appStore.authMethod = config.authenticationMethod;
                 });
             }


### PR DESCRIPTION
Frontend PR for cbioportal/cbioportal#9986. This PR allows to choose the "display name" of an authenticated user (email or user name), therefore for consistency 'user email' variables are renamed to the more generic 'user display name'. The property 'user email address' is kept for backwards-compatibility until the backend PR is merged.

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
