### PR TITLE
#9925 Issue: Mass Spec label changed in dataset page

### DIFF
--- a/src/pages/staticPages/datasetView/DatasetList.tsx
+++ b/src/pages/staticPages/datasetView/DatasetList.tsx
@@ -197,7 +197,7 @@ export default class DataSetsPageTable extends React.Component<
                             },
                             { name: 'RPPA', type: 'rppa', visible: false },
                             {
-                                name: 'Mass Spectrometry',
+                                name: 'Protein Mass Spectrometry',
                                 type: 'massSpectrometry',
                                 visible: false,
                             },


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9925

Describe changes proposed in this pull request:
- a Column name of Mass Spectropmetry changed to Protein Mass Spectrometry in Dataset table.
