### PR TITLE
MSKTabs should not interpret tooltip clicks as clicks on tab buttons

### DIFF
--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -114,7 +114,10 @@ const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerPro
                                     </li>
                                     <li>
                                         686 from{' '}
-                                        <a href="https://www.wikipathways.org/">
+                                        <a
+                                            href="https://www.wikipathways.org/"
+                                            target="_blank"
+                                        >
                                             WikiPathways
                                         </a>
                                     </li>

--- a/src/shared/components/MSKTabs/MSKTabs.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.tsx
@@ -409,18 +409,6 @@ export class MSKTabs extends React.Component<IMSKTabsProps> {
 
                 const href = this.getTabHref(tab.props.id);
 
-                const linkContent = tab.props.linkTooltip ? (
-                    <DefaultTooltip
-                        overlay={tab.props.linkTooltip}
-                        mouseEnterDelay={0}
-                        placement="top"
-                    >
-                        <span>{tab.props.linkText}</span>
-                    </DefaultTooltip>
-                ) : (
-                    tab.props.linkText
-                );
-
                 pages[currentPage - 1].push(
                     <li
                         key={tab.props.id}
@@ -428,19 +416,26 @@ export class MSKTabs extends React.Component<IMSKTabsProps> {
                         ref={this.tabRefHandler.bind(this, tab.props.id)}
                         className={activeClass}
                     >
-                        <a
-                            className={classnames(
-                                'tabAnchor',
-                                `tabAnchor_${tab.props.id}`,
-                                tab.props.anchorClassName
-                            )}
-                            onClick={this.tabClickHandlers(tab.props)}
-                            href={href}
-                            style={tab.props.anchorStyle}
+                        <DefaultTooltip
+                            overlay={tab.props.linkTooltip}
+                            mouseEnterDelay={0}
+                            placement="top"
+                            visible={tab.props.linkTooltip ? undefined : false}
                         >
-                            {linkContent}
-                            {closeButton}
-                        </a>
+                            <a
+                                className={classnames(
+                                    'tabAnchor',
+                                    `tabAnchor_${tab.props.id}`,
+                                    tab.props.anchorClassName
+                                )}
+                                onClick={this.tabClickHandlers(tab.props)}
+                                href={href}
+                                style={tab.props.anchorStyle}
+                            >
+                                {tab.props.linkText}
+                                {closeButton}
+                            </a>
+                        </DefaultTooltip>
                     </li>
                 );
             }


### PR DESCRIPTION
# Description
Fix cBioPortal/cbioportal#9946 

- Removed prevent default call from MSKTabs so that clicking an anchor with an href isn't ignored
- Added target blank to WikiPathways link so that it'll open a new tab (I'm assuming this is the desired behavior)

# Why I don't have tests
I did my best to add a test to MSKTabs.spec.tsx, but I couldn't trigger the tool tip to be visible in the DOM. 😭
I wanted to trigger a click event on a tool tip anchor and assert that the url changed.
I'm willing to fix this, but I'd appreciate it if you could point me in the right direction.

# Other issues (willing to fix myself if you're okay with me doing so)
-  The NCI-PID link results in a [404 error](https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/NCI_PID/index.html
- The template for PR's has a broken link to the CONTRIBUTING.md file


# Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

@adamabeshouse 
