### PR TITLE
Tweak style of oncoprint controls

### DIFF
--- a/packages/oncoprintjs/src/js/oncoprintzoomslider.ts
+++ b/packages/oncoprintjs/src/js/oncoprintzoomslider.ts
@@ -60,6 +60,7 @@ export default class OncoprintZoomSlider {
     private initialize(params: OncoprintZoomSliderParams) {
         var $ctr = this.$div;
         var icon_size = Math.round(params.btn_size * 0.7);
+        var icon_div_border_size = 1;
         var icon_padding = Math.round((params.btn_size - icon_size) / 2);
         var $slider_bar = $('<div>')
             .css({
@@ -84,7 +85,7 @@ export default class OncoprintZoomSlider {
                 'min-height': params.btn_size,
                 'min-width': params.btn_size,
                 'background-color': '#ffffff',
-                border: 'solid 1px black',
+                border: `solid ${icon_div_border_size}px black`,
                 'border-radius': '3px',
                 cursor: 'pointer',
             })
@@ -93,8 +94,8 @@ export default class OncoprintZoomSlider {
             .addClass('icon fa fa-plus')
             .css({
                 position: 'absolute',
-                top: icon_padding,
-                left: icon_padding,
+                top: icon_padding - icon_div_border_size,
+                left: icon_padding - icon_div_border_size,
                 'min-width': icon_size,
                 'min-height': icon_size,
             })
@@ -105,7 +106,7 @@ export default class OncoprintZoomSlider {
                 'min-height': params.btn_size,
                 'min-width': params.btn_size,
                 'background-color': '#ffffff',
-                border: 'solid 1px black',
+                border: `solid ${icon_div_border_size}px black`,
                 'border-radius': '3px',
                 cursor: 'pointer',
             })
@@ -114,8 +115,8 @@ export default class OncoprintZoomSlider {
             .addClass('icon fa fa-minus')
             .css({
                 position: 'absolute',
-                top: icon_padding,
-                left: icon_padding,
+                top: icon_padding - icon_div_border_size,
+                left: icon_padding - icon_div_border_size,
                 'min-width': icon_size,
                 'min-height': icon_size,
             })


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10086

Describe changes proposed in this pull request:
Updated the centering of the +, and - buttons in the oncoprinter config button, which earlier was not looking good. This was due to the border width as it was not subtracted from the initial positioning of the pseudo icon.

Before:
<img width="1440" alt="Screenshot 2023-03-16 at 16 49 19" src="https://user-images.githubusercontent.com/98523623/225606272-7bfbcf9d-33aa-4946-a07f-aa0fd2f19e06.png">

After:
<img width="1440" alt="Screenshot 2023-03-16 at 17 11 37" src="https://user-images.githubusercontent.com/98523623/225606335-a7bc1094-6d8b-42f0-8f44-8d451b9bcc4e.png">


