### PR TITLE
Filter SV by custom driver annotations in oncoprint and study page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
                   - v10-cbio-database-files-{{ checksum "/tmp/db_data_md5key" }}
             - restore_cache:
                 keys:
-                  - v11-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
+                  - v12-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
             - run:
                 name: Init database
                 command: |
@@ -329,7 +329,7 @@ jobs:
             - save_cache:
                 paths:
                   - /tmp/repo/e2e-localdb-workspace/kc_db_data
-                key: v11-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
+                key: v12-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
             - run:
                 name: Run end-2-end tests with studies in local database
                 command: |

--- a/end-to-end-test/local/specs/annotation-filter-menu.spec.js
+++ b/end-to-end-test/local/specs/annotation-filter-menu.spec.js
@@ -13,6 +13,7 @@ const studyViewUrl = `${CBIOPORTAL_URL}/study/summary?id=study_es_0`;
 const comparisonResultsViewUrl = `${CBIOPORTAL_URL}/results/comparison?genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&cancer_study_list=study_es_0&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=0&case_set_id=study_es_0_cnaseq&gene_list=ABLIM1%2520TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit&comparison_subtab=alterations`;
 const selectSamplesButton = 'button=Select Samples';
 
+// Note: not all SV elements outside of visible area are rendered:
 const SV_COUNTS = {
     AGAP3: '2',
     AGK: '4',
@@ -26,10 +27,10 @@ const SV_COUNTS = {
     FAM131B: '1',
     GIPC2: '1',
     MKRN1: '2',
-    NCOA4: '2',
+    NCOA4: '3',
+    PIEZO1: '1',
     PRKAR2B: '1',
     RBM33: '1',
-    RET: '1',
     SND1: '10',
     TMPRSS2: '2',
     TNS3: '1',
@@ -197,10 +198,9 @@ describe('alteration filter menu', function() {
                     MSH3: '1',
                     MYB: '1',
                 });
-                assert.deepStrictEqual(
-                    geneTableCounts('structural variants-table'),
-                    SV_COUNTS
-                );
+
+                // For Structural Variants: see custom-driver-annotations-in-study-view.spec.js
+
                 assert.deepStrictEqual(
                     geneTableCounts('copy number alterations-table'),
                     {
@@ -235,10 +235,9 @@ describe('alteration filter menu', function() {
                     ADAMTS20: '1',
                     OR11H1: '1',
                 });
-                assert.deepStrictEqual(
-                    geneTableCounts('structural variants-table'),
-                    SV_COUNTS
-                );
+
+                // For Structural Variants: see custom-driver-annotations-in-study-view.spec.js
+
                 assert.deepStrictEqual(
                     geneTableCounts('copy number alterations-table'),
                     {
@@ -274,10 +273,9 @@ describe('alteration filter menu', function() {
                     OR11H1: '1',
                     TMEM247: '1',
                 });
-                assert.deepStrictEqual(
-                    geneTableCounts('structural variants-table'),
-                    SV_COUNTS
-                );
+
+                // For Structural Variants: see custom-driver-annotations-in-study-view.spec.js
+
                 assert.deepStrictEqual(
                     geneTableCounts('copy number alterations-table'),
                     {

--- a/end-to-end-test/local/specs/custom-driver-annotations-in-result-view.spec.js
+++ b/end-to-end-test/local/specs/custom-driver-annotations-in-result-view.spec.js
@@ -14,7 +14,11 @@ const oncoprintTabUrlCna =
     CBIOPORTAL_URL +
     '/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=study_es_0&case_set_id=study_es_0_cnaseq&data_priority=0&gene_list=ACAP3%2520AGRN&geneset_list=%20&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&profileFilter=0&tab_index=tab_visualize&show_samples=true';
 
-describe('custom driver annotations feature', function() {
+const oncoprintTabUrlStructVar =
+    CBIOPORTAL_URL +
+    '/results/oncoprint?Action=Submit&cancer_study_list=study_es_0&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cstructural_variants%2Cgistic&case_set_id=study_es_0_cnaseq&gene_list=TMPRSS2&geneset_list=%20&tab_index=tab_visualize';
+
+describe('custom driver annotations feature in result view', function() {
     describe('oncoprint tab - mutations', () => {
         beforeEach(() => {
             goToUrlAndSetLocalStorage(oncoprintTabUrl, true);
@@ -58,7 +62,6 @@ describe('custom driver annotations feature', function() {
             $('input[data-test=HideVUS]').click();
             waitForOncoprint();
             assert($('div.alert-info*=1 mutation').isExisting());
-
             $('label*=Class 1')
                 .$('input')
                 .click();
@@ -170,6 +173,60 @@ describe('custom driver annotations feature', function() {
             assert(topCheckBox.isSelected());
             assert(tiersCheckboxes[0].isSelected());
             assert(tiersCheckboxes[1].isSelected());
+        });
+    });
+
+    describe('oncoprint tab - structural variants', () => {
+        beforeEach(() => {
+            goToUrlAndSetLocalStorage(oncoprintTabUrlStructVar, true);
+            waitForOncoprint();
+            setSettingsMenuOpen(true, 'GlobalSettingsButton');
+        });
+
+        it('shows custom driver annotation elements in config menu', () => {
+            var topCheckBox = $('input[data-test=annotateCustomBinary]');
+            assert(topCheckBox.isSelected());
+
+            var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$(
+                'input'
+            );
+            assert(tiersCheckboxes[0].isSelected());
+        });
+
+        it('allows deselection of Tiers checkboxes', () => {
+            var class1Checkbox = $('label*=Class 1').$('input');
+            class1Checkbox.click();
+            waitForOncoprint();
+            assert(!class1Checkbox.isSelected());
+        });
+
+        it('updates selected samples when VUS alterations are excluded', () => {
+            $('input[data-test=annotateHotspots]').click();
+            $('input[data-test=annotateOncoKb]').click();
+            $('input[data-test=HideVUS]').click();
+            waitForOncoprint();
+            assert($('div.alert-info*=1 structural variant').isExisting());
+
+            $('label*=Class 1')
+                .$('input')
+                .click();
+            waitForOncoprint();
+            assert($('div.alert-info*=2 structural variants').isExisting());
+        });
+
+        it('(de-)selects custom driver checkboxes with main annotation select option', () => {
+            $('input[data-test=ColorByDriver]').click();
+            waitForOncoprint();
+            var topCheckBox = $('input[data-test=annotateCustomBinary]');
+            var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$(
+                'input'
+            );
+            assert(!topCheckBox.isSelected());
+            assert(!tiersCheckboxes[0].isSelected());
+
+            $('input[data-test=ColorByDriver]').click();
+            assert(topCheckBox.isSelected());
+            assert(tiersCheckboxes[0].isSelected());
         });
     });
 });

--- a/end-to-end-test/local/specs/custom-driver-annotations-in-study-view.spec.js
+++ b/end-to-end-test/local/specs/custom-driver-annotations-in-study-view.spec.js
@@ -1,0 +1,116 @@
+const assert = require('assert');
+const { waitForNetworkQuiet } = require('../../shared/specUtils');
+const goToUrlAndSetLocalStorage = require('../../shared/specUtils')
+    .goToUrlAndSetLocalStorage;
+
+const CBIOPORTAL_URL = process.env.CBIOPORTAL_URL.replace(/\/$/, '');
+const STUDY_VIEW_URL = `${CBIOPORTAL_URL}/study/summary?id=study_es_0`;
+const ALTERATION_MENU_BTN = `button[data-test="AlterationFilterButton"]`;
+const SHOW_UNKNOWN_TIER = `input[data-test="ShowUnknownTier"]`;
+const SV_TABLE = `div[data-test="structural variants-table"]`;
+const ANY_ROW = `div[aria-rowindex]`;
+const BRAF_ROW = `div[aria-rowindex="1"]`;
+const GENE_NAME = `div[data-test="geneNameCell"]`;
+const ALTERATIONS_TOTAL = `span[data-test="numberOfAlterations"]`;
+const ALTERATION_CASES = `span[data-test="numberOfAlteredCasesText"]`;
+const SHOW_CLASS_3 = `input[data-test="Class_3"]`;
+const SHOW_CLASS_4 = `input[data-test="Class_4"]`;
+const SHOW_PUTATIVE_DRIVERS = `input[data-test="ShowDriver"]`;
+const SHOW_UNKNOWN_ONCOGENICITY = `input[data-test="ShowUnknownOncogenicity"]`;
+
+describe('custom driver annotations feature in study view', function() {
+    describe('structural variants', () => {
+        beforeEach(() => {
+            goToUrlAndSetLocalStorage(STUDY_VIEW_URL, true);
+            waitForNetworkQuiet();
+        });
+
+        it('shows all structural variants', () => {
+            $(SV_TABLE)
+                .$(BRAF_ROW)
+                .waitForDisplayed();
+            assert($(SV_TABLE).$$(ANY_ROW).length === 21);
+            let geneName = $(SV_TABLE)
+                .$(BRAF_ROW)
+                .$(GENE_NAME)
+                .getText();
+            assert(geneName === 'BRAF');
+            const alterations = $(SV_TABLE)
+                .$(BRAF_ROW)
+                .$(ALTERATIONS_TOTAL);
+            assert(alterations.getText() === '36');
+            const alterationCases = $(SV_TABLE)
+                .$(BRAF_ROW)
+                .$(ALTERATION_CASES)
+                .getText();
+            assert(alterationCases === '35');
+        });
+
+        it('can exclude unknown (and NULL) driver tiers', () => {
+            $(ALTERATION_MENU_BTN).click();
+            $(SHOW_UNKNOWN_TIER).waitForDisplayed(5000);
+            assert($(SHOW_UNKNOWN_TIER).isSelected());
+            $(SHOW_UNKNOWN_TIER).click();
+            $(SV_TABLE)
+                .$(BRAF_ROW)
+                .waitForDisplayed();
+            assert($(SV_TABLE).$$(ANY_ROW).length === 10);
+            const alterations = $(SV_TABLE)
+                .$(BRAF_ROW)
+                .$(ALTERATIONS_TOTAL)
+                .getText();
+            assert(alterations === '1');
+            const brafCases = $(SV_TABLE)
+                .$(BRAF_ROW)
+                .$(ALTERATION_CASES)
+                .getText();
+            assert(brafCases === '1');
+        });
+
+        it('can exclude custom driver tiers', () => {
+            $(ALTERATION_MENU_BTN).click();
+            $(SHOW_UNKNOWN_TIER).waitForDisplayed(5000);
+            assert($(SHOW_UNKNOWN_TIER).isSelected());
+            $(SHOW_UNKNOWN_TIER).click();
+
+            assert($(SHOW_CLASS_3).isSelected());
+            $(SHOW_CLASS_3).click();
+
+            assert($(SHOW_CLASS_4).isSelected());
+            $(SHOW_CLASS_4).click();
+
+            $(SV_TABLE)
+                .$(ANY_ROW)
+                .waitForDisplayed();
+
+            assert($(SV_TABLE).$$(ANY_ROW).length === 5);
+            assert(getAllGeneNames() === 'ALK,EGFR,EML4,ERG,TMPRSS2');
+        });
+
+        it('can exclude custom drivers', () => {
+            $(ALTERATION_MENU_BTN).click();
+            $(SHOW_UNKNOWN_TIER).waitForDisplayed(5000);
+
+            assert($(SHOW_PUTATIVE_DRIVERS).isSelected());
+            $(SHOW_PUTATIVE_DRIVERS).click();
+
+            assert($(SHOW_UNKNOWN_ONCOGENICITY).isSelected());
+            $(SHOW_UNKNOWN_ONCOGENICITY).click();
+
+            $(SV_TABLE)
+                .$(ANY_ROW)
+                .waitForDisplayed();
+
+            assert($(SV_TABLE).$$(ANY_ROW).length === 2);
+            assert(getAllGeneNames() === 'NCOA4,RET');
+        });
+    });
+});
+
+function getAllGeneNames() {
+    return $(SV_TABLE)
+        .$$(ANY_ROW)
+        .map(e => e.$(GENE_NAME).getText())
+        .sort()
+        .join();
+}

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -55,8 +55,6 @@ import CancerTypeCache from 'shared/cache/CancerTypeCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
 import {
     concatMutationData,
-    evaluateDiscreteCNAPutativeDriverInfo,
-    evaluateMutationPutativeDriverInfo,
     existsSomeMutationWithAscnPropertyInCollection,
     fetchClinicalData,
     fetchClinicalDataForPatient,
@@ -105,6 +103,8 @@ import {
     fetchStructuralVariantOncoKbData,
     parseOtherBiomarkerQueryId,
     tumorTypeResolver,
+    evaluatePutativeDriverInfoWithHotspots,
+    evaluatePutativeDriverInfo,
 } from 'shared/lib/StoreUtils';
 import {
     computeGenePanelInformation,
@@ -157,10 +157,6 @@ import {
 import { makeGeneticTrackData } from 'shared/components/oncoprint/DataUtils';
 import { GeneticTrackDatum } from 'shared/components/oncoprint/Oncoprint';
 import {
-    AnnotatedExtendedAlteration,
-    CustomDriverNumericGeneMolecularData,
-} from 'pages/resultsView/ResultsViewPageStore';
-import {
     cna_profile_data_to_string,
     getMutationSubType,
     getSimplifiedMutationType,
@@ -197,6 +193,8 @@ import { IGenePanelDataByProfileIdAndSample } from 'shared/lib/isSampleProfiled'
 import { NamespaceColumnConfig } from 'shared/components/namespaceColumns/NamespaceColumnConfig';
 import { buildNamespaceColumnConfig } from 'shared/components/namespaceColumns/namespaceColumnsUtils';
 import { SiteError } from 'shared/model/appMisc';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
 
 type PageMode = 'patient' | 'sample';
 type ResourceId = string;
@@ -2059,7 +2057,7 @@ export class PatientViewPageStore {
                         getOncoKBAnnotationFunc(cnaDatum);
 
                     // Note: custom driver annotations are part of the incoming datum
-                    return evaluateDiscreteCNAPutativeDriverInfo(
+                    return evaluatePutativeDriverInfo(
                         cnaDatum,
                         oncoKbDatum,
                         false,
@@ -2521,13 +2519,15 @@ export class PatientViewPageStore {
                 // - custom driver annotations are part of the incoming datum
                 // - cbio counts, cosmic and custom driver annnotations are
                 //   not used for driver evaluation
-                return evaluateMutationPutativeDriverInfo(
+                return evaluatePutativeDriverInfoWithHotspots(
                     mutation,
                     oncoKbDatum,
-                    true,
-                    isHotspotDriver,
                     false,
-                    undefined
+                    undefined,
+                    {
+                        hotspotAnnotationsActive: true,
+                        hotspotDriver: isHotspotDriver,
+                    }
                 );
             });
         },

--- a/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageStoreUtils.spec.ts
@@ -26,11 +26,6 @@ import {
     parseGenericAssayGroups,
 } from './ResultsViewPageStoreUtils';
 import {
-    AnnotatedExtendedAlteration,
-    CustomDriverNumericGeneMolecularData,
-    IQueriedMergedTrackCaseData,
-} from './ResultsViewPageStore';
-import {
     MergedTrackLineFilterOutput,
     OQLLineFilterOutput,
 } from '../../shared/lib/oql/oqlfilter';
@@ -55,6 +50,9 @@ import {
 } from 'shared/api/session-service/sessionServiceModels';
 import $ from 'jquery';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
+import { IQueriedMergedTrackCaseData } from 'shared/model/IQueriedMergedTrackCaseData';
 
 describe('ResultsViewPageStoreUtils', () => {
     describe('computeCustomDriverAnnotationReport', () => {

--- a/src/pages/resultsView/cancerSummary/CancerSummaryContainer.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryContainer.tsx
@@ -4,7 +4,7 @@ import { action, computed, observable, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { MSKTabs, MSKTab } from 'shared/components/MSKTabs/MSKTabs';
 import { CancerSummaryContent, IAlterationData } from './CancerSummaryContent';
-import { ExtendedSample, ResultsViewPageStore } from '../ResultsViewPageStore';
+import { ResultsViewPageStore } from '../ResultsViewPageStore';
 import { default as LoadingIndicator } from '../../../shared/components/loadingIndicator/LoadingIndicator';
 import { Gene } from 'cbioportal-ts-api-client';
 import './styles.scss';
@@ -21,6 +21,7 @@ import autobind from 'autobind-decorator';
 import { OncoprintAnalysisCaseType } from '../ResultsViewPageStoreUtils';
 import CaseFilterWarning from '../../../shared/components/banners/CaseFilterWarning';
 import { shortenStudyName } from '../../../shared/lib/FormatUtils';
+import { ExtendedSample } from 'shared/model/ExtendedSample';
 
 interface ICancerSummaryContainerProps {
     store: ResultsViewPageStore;

--- a/src/pages/resultsView/coExpression/CoExpressionPlot.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionPlot.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { computed, makeObservable } from 'mobx';
 import { observer, Observer } from 'mobx-react';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
-import { GeneticEntity } from '../ResultsViewPageStore';
 import { getSampleViewUrl } from '../../../shared/api/urls';
 import './styles.scss';
 import { bind } from 'bind-decorator';
@@ -17,6 +16,7 @@ import _ from 'lodash';
 import { scatterPlotSize } from '../../../shared/components/plots/PlotUtils';
 import { IAxisLogScaleParams } from 'pages/resultsView/plots/PlotsTabUtils';
 import autobind from 'autobind-decorator';
+import { GeneticEntity } from 'shared/model/GeneticEntity';
 
 export interface ICoExpressionPlotProps {
     xAxisGeneticEntity: GeneticEntity;

--- a/src/pages/resultsView/coExpression/CoExpressionPlotUtils.ts
+++ b/src/pages/resultsView/coExpression/CoExpressionPlotUtils.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { IAxisLogScaleParams } from 'pages/resultsView/plots/PlotsTabUtils';
 import { CoExpressionPlotData } from 'pages/resultsView/coExpression/CoExpressionPlot';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
-import { GeneticEntity } from 'pages/resultsView/ResultsViewPageStore';
+import { GeneticEntity } from 'shared/model/GeneticEntity';
 
 export function getUniquePrecision(
     value: number,

--- a/src/pages/resultsView/coExpression/CoExpressionTab.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionTab.tsx
@@ -4,7 +4,6 @@ import { action, computed, observable, makeObservable } from 'mobx';
 import { observer, Observer } from 'mobx-react';
 import {
     ResultsViewPageStore,
-    GeneticEntity,
     GeneticEntityType,
 } from '../ResultsViewPageStore';
 import Select from 'react-select1';
@@ -34,6 +33,7 @@ import { getRemoteDataGroupStatus } from 'cbioportal-utils';
 import AlterationFilterWarning from '../../../shared/components/banners/AlterationFilterWarning';
 import CaseFilterWarning from '../../../shared/components/banners/CaseFilterWarning';
 import { AlterationTypeConstants } from 'shared/constants';
+import { GeneticEntity } from 'shared/model/GeneticEntity';
 
 export interface ICoExpressionTabProps {
     store: ResultsViewPageStore;

--- a/src/pages/resultsView/coExpression/CoExpressionViz.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionViz.tsx
@@ -34,7 +34,7 @@ import _ from 'lodash';
 import { calculateQValues } from '../../../shared/lib/calculation/BenjaminiHochbergFDRCalculator';
 import { CoExpressionWithQ } from './CoExpressionTabUtils';
 import { GenesetMolecularData } from 'cbioportal-ts-api-client';
-import { GeneticEntity } from '../ResultsViewPageStore';
+import { GeneticEntity } from 'shared/model/GeneticEntity';
 
 export interface ICoExpressionVizProps {
     plotState: {

--- a/src/pages/resultsView/comparison/ResultsViewComparisonUtils.ts
+++ b/src/pages/resultsView/comparison/ResultsViewComparisonUtils.ts
@@ -6,7 +6,6 @@ import {
 } from '../../groupComparison/GroupComparisonUtils';
 import { getStudiesAttr } from '../../groupComparison/comparisonGroupManager/ComparisonGroupManagerUtils';
 import { Sample } from 'cbioportal-ts-api-client';
-import { IQueriedMergedTrackCaseData } from '../ResultsViewPageStore';
 import {
     isMergedTrackFilter,
     UnflattenedOQLLineFilterOutput,
@@ -17,6 +16,7 @@ import oql_parser from '../../../shared/lib/oql/oql-parser';
 import _ from 'lodash';
 import { DEFAULT_NA_COLOR } from 'shared/lib/Colors';
 import { SessionGroupData } from 'shared/api/session-service/sessionServiceModels';
+import { IQueriedMergedTrackCaseData } from 'shared/model/IQueriedMergedTrackCaseData';
 
 export type ResultsViewComparisonGroup = ComparisonGroup & {
     nameOfEnrichmentDirection: string;

--- a/src/pages/resultsView/download/CaseAlterationTable.tsx
+++ b/src/pages/resultsView/download/CaseAlterationTable.tsx
@@ -10,10 +10,6 @@ import {
     UnflattenedOQLLineFilterOutput,
     MergedTrackLineFilterOutput,
 } from 'shared/lib/oql/oqlfilter';
-import {
-    AnnotatedExtendedAlteration,
-    IQueriedMergedTrackCaseData,
-} from '../ResultsViewPageStore';
 import { StudyLink } from 'shared/components/StudyLink/StudyLink';
 import { getPatientViewUrl, getSampleViewUrl } from 'shared/api/urls';
 import styles from './styles.module.scss';
@@ -23,6 +19,7 @@ import { AlteredStatus } from 'pages/resultsView/mutualExclusivity/MutualExclusi
 import { Alteration } from 'shared/lib/oql/oql-parser';
 import { parsedOQLAlterationToSourceOQL } from 'shared/lib/oql/oqlfilter';
 import { insertBetween } from 'shared/lib/ArrayUtils';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
 
 export interface ISubAlteration {
     type: string;

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -4,11 +4,8 @@ import { action, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import fileDownload from 'react-file-download';
 import {
-    AnnotatedExtendedAlteration,
-    ExtendedAlteration,
     ResultsViewPageStore,
     ModifyQueryParams,
-    CaseAggregatedData,
 } from '../ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import {
@@ -77,6 +74,9 @@ import FontAwesome from 'react-fontawesome';
 import CaseFilterWarning from '../../../shared/components/banners/CaseFilterWarning';
 import { If, Then, Else } from 'react-if';
 import { ResultsViewTab } from '../ResultsViewPageHelpers';
+import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 export interface IDownloadTabProps {
     store: ResultsViewPageStore;

--- a/src/pages/resultsView/download/DownloadUtils.spec.ts
+++ b/src/pages/resultsView/download/DownloadUtils.spec.ts
@@ -16,12 +16,12 @@ import {
     decideMolecularProfileSortingOrder,
     generateStructuralDownloadData,
 } from './DownloadUtils';
-import { ExtendedAlteration } from '../ResultsViewPageStore';
 import oql_parser, { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
 import {
     AnnotatedMutation,
     AnnotatedStructuralVariant,
 } from 'shared/model/AnnotatedMutation';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 describe('DownloadUtils', () => {
     const genes = [

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -1,11 +1,4 @@
 import _ from 'lodash';
-import {
-    AnnotatedExtendedAlteration,
-    CaseAggregatedData,
-    ExtendedAlteration,
-    IQueriedCaseData,
-    IQueriedMergedTrackCaseData,
-} from '../ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import { alterationInfoForCaseAggregatedDataByOQLLine } from 'shared/components/oncoprint/OncoprintUtils';
 import { makeGeneticTrackData } from 'shared/components/oncoprint/DataUtils';
@@ -46,6 +39,11 @@ import client from 'shared/api/cbioportalClientInstance';
 import { REQUEST_ARG_ENUM } from 'shared/constants';
 import fileDownload from 'react-file-download';
 import { GENERIC_ASSAY_CONFIG } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
+import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
+import { IQueriedCaseData } from 'shared/model/IQueriedCaseData';
+import { IQueriedMergedTrackCaseData } from 'shared/model/IQueriedMergedTrackCaseData';
 
 export interface IDownloadFileRow {
     studyId: string;

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsBoxPlot.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsBoxPlot.tsx
@@ -25,7 +25,6 @@ import { remoteData, DownloadControls } from 'cbioportal-frontend-commons';
 import client from 'shared/api/cbioportalClientInstance';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
-import { ExtendedAlteration } from '../ResultsViewPageStore';
 import { getSampleViewUrl } from 'shared/api/urls';
 import classNames from 'classnames';
 import { getGeneSummary } from '../querySummary/QuerySummaryUtils';
@@ -35,6 +34,7 @@ import {
     formatGenericAssayCompactLabelByNameAndId,
     getGenericAssayPropertyOrDefault,
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 class EnrichmentsBoxPlotComponent extends BoxScatterPlot<
     IBoxScatterPlotPoint

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsContainer.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsContainer.tsx
@@ -25,9 +25,9 @@ import {
     EllipsisTextTooltip,
     Option,
 } from 'cbioportal-frontend-commons';
-import { ExtendedAlteration } from '../ResultsViewPageStore';
 import ExpressionEnrichmentsBoxPlot from './ExpressionEnrichmentsBoxPlot';
 import { EnrichmentAnalysisComparisonGroup } from 'pages/groupComparison/GroupComparisonUtils';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 export interface IExpressionEnrichmentContainerProps {
     data: ExpressionEnrichmentWithQ[];

--- a/src/pages/resultsView/plots/PlotsTabUtils.spec.ts
+++ b/src/pages/resultsView/plots/PlotsTabUtils.spec.ts
@@ -22,7 +22,6 @@ import {
     logScalePossible,
 } from './PlotsTabUtils';
 import { Mutation, Sample, Gene } from 'cbioportal-ts-api-client';
-import { AnnotatedNumericGeneMolecularData } from '../ResultsViewPageStore';
 import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
 import { MutationCountBy, AxisMenuSelection } from './PlotsTab';
 import {
@@ -38,6 +37,7 @@ import {
 import _ from 'lodash';
 import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
+import { AnnotatedNumericGeneMolecularData } from 'shared/model/AnnotatedNumericGeneMolecularData';
 
 describe('PlotsTabUtils', () => {
     describe('makeClinicalAttributeOptions', () => {

--- a/src/pages/resultsView/plots/PlotsTabUtils.tsx
+++ b/src/pages/resultsView/plots/PlotsTabUtils.tsx
@@ -40,10 +40,6 @@ import { BLACK, DEFAULT_GREY, LIGHT_GREY } from 'shared/lib/Colors';
 import { CoverageInformation } from '../../../shared/lib/GenePanelUtils';
 import { IBoxScatterPlotData } from '../../../shared/components/plots/BoxScatterPlot';
 import {
-    AnnotatedNumericGeneMolecularData,
-    CustomDriverNumericGeneMolecularData,
-} from '../ResultsViewPageStore';
-import {
     AlterationTypeConstants,
     DataTypeConstants,
     CLINICAL_ATTRIBUTE_FIELD_ENUM,
@@ -87,6 +83,8 @@ import {
 } from 'cbioportal-frontend-commons';
 import { getCategoryOrderByGenericAssayType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
+import { AnnotatedNumericGeneMolecularData } from 'shared/model/AnnotatedNumericGeneMolecularData';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
 
 export const CLIN_ATTR_DATA_TYPE = 'clinical_attribute';
 export const GENESET_DATA_TYPE = 'GENESET_SCORE';

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -147,8 +147,8 @@ import {
     statusFilterActive,
     StudyWithSamples,
     submitToPage,
-    updateCustomIntervalFilter,
     transformSampleDataToSelectedSampleClinicalData,
+    updateCustomIntervalFilter,
 } from './StudyViewUtils';
 import MobxPromise from 'mobxpromise';
 import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
@@ -176,7 +176,6 @@ import {
 } from '../../shared/api/urls';
 import {
     DataType as DownloadDataType,
-    getBrowserWindow,
     onMobxPromise,
     pluralize,
     remoteData,
@@ -270,8 +269,6 @@ import intersect from 'fast_array_intersect';
 import { PillStore } from 'shared/components/PillTag/PillTag';
 
 export const STUDY_VIEW_FILTER_AUTOSUBMIT = 'study_view_filter_autosubmit';
-import { Simulate } from 'react-dom/test-utils';
-import select = Simulate.select;
 
 type ChartUniqueKey = string;
 type ResourceId = string;
@@ -3679,8 +3676,6 @@ export class StudyViewPageStore
     get filtersProxy(): StudyViewFilter {
         const filters: Partial<StudyViewFilter> = {};
 
-        const clinicalDataFilters = this.clinicalDataFilters;
-
         const genomicDataIntervalFilters = this.genomicDataIntervalFilters;
         if (genomicDataIntervalFilters.length > 0) {
             filters.genomicDataFilters = genomicDataIntervalFilters;
@@ -3691,8 +3686,8 @@ export class StudyViewPageStore
             filters.genericAssayDataFilters = genericAssayDataFilters;
         }
 
-        if (clinicalDataFilters.length > 0) {
-            filters.clinicalDataFilters = clinicalDataFilters;
+        if (this.clinicalDataFilters.length > 0) {
+            filters.clinicalDataFilters = this.clinicalDataFilters;
         }
 
         if (this.customDataFilters.length > 0) {

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -13,7 +13,6 @@ import {
     IGenesetHeatmapTrackDatum,
     IGenericAssayHeatmapTrackDatum,
 } from 'shared/components/oncoprint/Oncoprint';
-import { AnnotatedExtendedAlteration } from '../../../pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import {
     ClinicalAttribute,
@@ -25,6 +24,7 @@ import {
 } from 'cbioportal-ts-api-client';
 import { MutationSpectrum } from 'cbioportal-ts-api-client';
 import { SpecialAttribute } from '../../cache/ClinicalDataCache';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
 
 /* Type assertions are used throughout this file to force functions to accept
 /* mocked parameters known to be sufficient. */

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -1,8 +1,3 @@
-import {
-    AnnotatedExtendedAlteration,
-    CaseAggregatedData,
-    CustomDriverNumericGeneMolecularData,
-} from '../../../pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import {
     ClinicalAttribute,
@@ -32,6 +27,9 @@ import { CoverageInformation } from '../../lib/GenePanelUtils';
 import { MUTATION_STATUS_GERMLINE } from 'shared/constants';
 import { SpecialAttribute } from '../../cache/ClinicalDataCache';
 import { stringListToIndexSet } from 'cbioportal-frontend-commons';
+import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
 
 const cnaDataToString: { [integerCNA: string]: string | undefined } = {
     '-2': 'homdel',

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -13,10 +13,6 @@ import { observer } from 'mobx-react';
 import { computed, makeObservable } from 'mobx';
 import { transition } from './DeltaUtils';
 import _ from 'lodash';
-import {
-    CustomDriverNumericGeneMolecularData,
-    ExtendedAlteration,
-} from '../../../pages/resultsView/ResultsViewPageStore';
 import './styles.scss';
 import { ShapeParams } from 'oncoprintjs/dist/js/oncoprintshape';
 import { SpecialAttribute } from 'shared/cache/ClinicalDataCache';
@@ -24,6 +20,8 @@ import {
     AnnotatedMutation,
     AnnotatedStructuralVariant,
 } from 'shared/model/AnnotatedMutation';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 export type CategoricalTrackDatum = {
     entity: string;

--- a/src/shared/components/oncoprint/OncoprintUtils.spec.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.spec.ts
@@ -12,12 +12,12 @@ import {
 import { IKeyValueMap, observable } from 'mobx';
 import _ from 'lodash';
 import { assert } from 'chai';
-import { IQueriedMergedTrackCaseData } from '../../../pages/resultsView/ResultsViewPageStore';
 import { splitHeatmapTextField } from 'shared/components/oncoprint/OncoprintUtils';
 import { ISelectOption } from 'shared/components/oncoprint/controls/OncoprintControls';
 import { IHeatmapTrackSpec, IBaseHeatmapTrackDatum } from './Oncoprint';
 import { IGradientAndCategoricalRuleSetParams } from 'oncoprintjs';
 import { isMutationProfile } from 'shared/lib/StoreUtils';
+import { IQueriedMergedTrackCaseData } from 'shared/model/IQueriedMergedTrackCaseData';
 
 describe('OncoprintUtils', () => {
     describe('alterationInfoForCaseAggregatedDataByOQLLine', () => {

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -23,12 +23,6 @@ import {
     genetic_rule_set_same_color_for_all_recurrence,
     germline_rule_params,
 } from './geneticrules';
-import {
-    AnnotatedExtendedAlteration,
-    CaseAggregatedData,
-    IQueriedCaseData,
-    IQueriedMergedTrackCaseData,
-} from '../../../pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import { CoverageInformation } from '../../lib/GenePanelUtils';
 import { remoteData } from 'cbioportal-frontend-commons';
@@ -74,6 +68,10 @@ import {
     isGenericAssayHeatmapProfile,
 } from 'shared/components/oncoprint/ResultsViewOncoprintUtils';
 import { ExtendedClinicalAttribute } from 'pages/resultsView/ResultsViewPageStoreUtils';
+import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { IQueriedCaseData } from 'shared/model/IQueriedCaseData';
+import { IQueriedMergedTrackCaseData } from 'shared/model/IQueriedMergedTrackCaseData';
 
 interface IGenesetExpansionMap {
     [genesetTrackKey: string]: IHeatmapTrackSpec[];

--- a/src/shared/components/oncoprint/TooltipUtils.spec.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.spec.ts
@@ -5,7 +5,6 @@ import {
     makeGeneticTrackTooltip_getCoverageInformation,
     makeHeatmapTrackTooltip,
 } from './TooltipUtils';
-import { AnnotatedExtendedAlteration } from '../../../pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import $ from 'jquery';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
@@ -15,6 +14,7 @@ import ServerConfigDefaults from 'config/serverConfigDefaults';
 import { PUTATIVE_DRIVER, PUTATIVE_PASSENGER } from 'shared/lib/StoreUtils';
 import { makeGeneticTrackTooltip } from 'shared/components/oncoprint/makeGeneticTrackTooltip';
 import { AnnotatedStructuralVariant } from 'shared/model/AnnotatedMutation';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
 
 describe('Oncoprint TooltipUtils', () => {
     describe('getCaseViewElt', () => {

--- a/src/shared/components/oncoprint/makeGeneticTrackTooltip.tsx
+++ b/src/shared/components/oncoprint/makeGeneticTrackTooltip.tsx
@@ -2,7 +2,6 @@ import { ListIndexedMapOfCounts } from 'shared/lib/ListIndexedMap';
 import $ from 'jquery';
 import { PUTATIVE_DRIVER, PUTATIVE_PASSENGER } from 'shared/lib/StoreUtils';
 import { GeneticTrackDatum } from 'shared/components/oncoprint/Oncoprint';
-import { CustomDriverNumericGeneMolecularData } from 'pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import { isNotGermlineMutation } from 'shared/lib/MutationUtils';
 import {
@@ -14,6 +13,7 @@ import {
 import { MolecularProfile, StructuralVariant } from 'cbioportal-ts-api-client';
 
 import { deriveStructuralVariantType } from 'oncokb-frontend-commons';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
 
 const hotspotsImg = require('../../../rootImages/cancer-hotspots.svg');
 const oncokbImg = require('oncokb-styles/images/oncogenic.svg');

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -1,5 +1,5 @@
 import {
-    evaluateDiscreteCNAPutativeDriverInfo,
+    evaluatePutativeDriverInfo,
     fetchCosmicData,
     fetchGermlineConsentedSamples,
     fetchOncoKbData,
@@ -30,14 +30,12 @@ import {
     Sample,
 } from 'cbioportal-ts-api-client';
 import { initMutation } from 'test/MutationMockUtils';
-import {
-    AnnotatedNumericGeneMolecularData,
-    CustomDriverNumericGeneMolecularData,
-} from 'pages/resultsView/ResultsViewPageStore';
 import { IndicatorQueryResp } from 'oncokb-ts-api-client';
 import { observable } from 'mobx';
 import { getSimplifiedMutationType } from 'shared/lib/oql/AccessorsForOqlFilter';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
+import { AnnotatedNumericGeneMolecularData } from 'shared/model/AnnotatedNumericGeneMolecularData';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
 
 describe('StoreUtils', () => {
     let emptyMutationData: MobxPromise<Mutation[]>;
@@ -903,7 +901,7 @@ describe('StoreUtils', () => {
     describe('evaluateDiscreteCNAPutativeDriverInfo', () => {
         it('no driver annotations present', () => {
             assert.deepEqual(
-                evaluateDiscreteCNAPutativeDriverInfo(
+                evaluatePutativeDriverInfo(
                     {
                         entrezGeneId: 1,
                         value: 0,
@@ -927,7 +925,7 @@ describe('StoreUtils', () => {
         });
         it('OncoKb', () => {
             assert.deepEqual(
-                evaluateDiscreteCNAPutativeDriverInfo(
+                evaluatePutativeDriverInfo(
                     {
                         entrezGeneId: 1,
                         value: 0,
@@ -951,7 +949,7 @@ describe('StoreUtils', () => {
         });
         it('custom driver annnotation', () => {
             assert.deepEqual(
-                evaluateDiscreteCNAPutativeDriverInfo(
+                evaluatePutativeDriverInfo(
                     {
                         entrezGeneId: 1,
                         value: 0,
@@ -973,7 +971,7 @@ describe('StoreUtils', () => {
                 }
             );
             assert.deepEqual(
-                evaluateDiscreteCNAPutativeDriverInfo(
+                evaluatePutativeDriverInfo(
                     {
                         entrezGeneId: 1,
                         value: 0,
@@ -997,7 +995,7 @@ describe('StoreUtils', () => {
         });
         it('custom tiers active', () => {
             assert.deepEqual(
-                evaluateDiscreteCNAPutativeDriverInfo(
+                evaluatePutativeDriverInfo(
                     {
                         entrezGeneId: 1,
                         value: 0,
@@ -1019,7 +1017,7 @@ describe('StoreUtils', () => {
                 }
             );
             assert.deepEqual(
-                evaluateDiscreteCNAPutativeDriverInfo(
+                evaluatePutativeDriverInfo(
                     {
                         entrezGeneId: 1,
                         value: 0,

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import $ from 'jquery';
 import localForage from 'localforage';
 import {
     fetchVariantAnnotationsByMutation as fetchDefaultVariantAnnotationsByMutation,
@@ -32,6 +31,7 @@ import {
     ReferenceGenomeGene,
     Sample,
     SampleFilter,
+    StructuralVariant,
 } from 'cbioportal-ts-api-client';
 import defaultClient from 'shared/api/cbioportalClientInstance';
 import client from 'shared/api/cbioportalClientInstance';
@@ -46,17 +46,19 @@ import {
 import oncokbClient from 'shared/api/oncokbClientInstance';
 import genomeNexusClient from 'shared/api/genomeNexusClientInstance';
 import {
+    chunkCalls,
     EvidenceType,
     IHotspotIndex,
     IOncoKbData,
     isLinearClusterHotspot,
 } from 'cbioportal-utils';
 import {
-    generateQueryVariantId,
-    generateProteinChangeQuery,
-    generateIdToIndicatorMap,
-    generateCopyNumberAlterationQuery,
     generateAnnotateStructuralVariantQuery,
+    generateCopyNumberAlterationQuery,
+    generateIdToIndicatorMap,
+    generateProteinChangeQuery,
+    generateQueryVariantId,
+    OtherBiomarkersQueryType,
 } from 'oncokb-frontend-commons';
 import { getAlterationString } from 'shared/lib/CopyNumberUtils';
 import { MobxPromise } from 'mobxpromise';
@@ -65,22 +67,18 @@ import { indexPdbAlignments } from 'shared/lib/PdbUtils';
 import { IGisticData } from 'shared/model/Gistic';
 import { IMutSigData } from 'shared/model/MutSig';
 import {
+    AlterationTypeConstants,
     CLINICAL_ATTRIBUTE_ID_ENUM,
     DataTypeConstants,
     GENOME_NEXUS_ARG_FIELD_ENUM,
 } from 'shared/constants';
-import {
-    AnnotatedNumericGeneMolecularData,
-    CustomDriverNumericGeneMolecularData,
-} from '../../pages/resultsView/ResultsViewPageStore';
-import { AlterationTypeConstants } from 'shared/constants';
 import { normalizeMutations } from '../components/mutationMapper/MutationMapperUtils';
 import { getServerConfig } from 'config/config';
 import {
     AnnotateCopyNumberAlterationQuery,
     AnnotateStructuralVariantQuery,
-    IndicatorQueryResp,
     CancerGene,
+    IndicatorQueryResp,
     OncoKbAPI,
     OncoKBInfo,
 } from 'oncokb-ts-api-client';
@@ -103,15 +101,17 @@ import {
     isNotGermlineMutation,
 } from 'shared/lib/MutationUtils';
 import { ObservableMap } from 'mobx';
-import { chunkCalls } from 'cbioportal-utils';
-import { StructuralVariant } from 'cbioportal-ts-api-client';
-import eventBus from 'shared/events/eventBus';
 
 import { ErrorMessages } from 'shared/errorMessages';
-import { OtherBiomarkersQueryType } from 'oncokb-frontend-commons';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
 import { FilteredAndAnnotatedMutationsReport } from './comparison/AnalysisStoreUtils';
-import { SiteError } from 'shared/model/appMisc';
+import {
+    CustomDriverFilterEvent,
+    DriverInfo,
+    DriverInfoWithHotspots,
+    HotSpotInfo,
+} from 'shared/model/CustomDriverAnnotationInfo';
+import { AnnotatedNumericGeneMolecularData } from 'shared/model/AnnotatedNumericGeneMolecularData';
 
 export const MolecularAlterationType_filenameSuffix: {
     [K in MolecularProfile['molecularAlterationType']]?: string;
@@ -1856,74 +1856,57 @@ export function getOncoKbOncogenic(response: IndicatorQueryResp): string {
     }
 }
 
-export function evaluateDiscreteCNAPutativeDriverInfo(
-    cnaDatum: CustomDriverNumericGeneMolecularData,
+export function evaluatePutativeDriverInfoWithHotspots(
+    event: CustomDriverFilterEvent,
     oncoKbDatum: IndicatorQueryResp | undefined | null | false,
     customDriverAnnotationsActive: boolean,
-    customDriverTierSelection: ObservableMap<string, boolean> | undefined
-) {
-    const oncoKb = oncoKbDatum ? getOncoKbOncogenic(oncoKbDatum) : '';
-
-    // Set driverFilter to true when:
-    // (1) custom drivers active in settings menu
-    // (2) the datum has a custom driver annotation
-    const customDriverBinary: boolean =
-        (customDriverAnnotationsActive &&
-            cnaDatum.driverFilter === PUTATIVE_DRIVER) ||
-        false;
-
-    // Set tier information to the tier name when the tiers checkbox
-    // is selected for the corresponding tier of the datum in settings menu.
-    // This forces the CNA to be counted as a driver mutation.
-    const customDriverTier: string | undefined =
-        cnaDatum.driverTiersFilter &&
-        customDriverTierSelection &&
-        customDriverTierSelection.get(cnaDatum.driverTiersFilter)
-            ? cnaDatum.driverTiersFilter
-            : undefined;
-
+    customDriverTierSelection: ObservableMap<string, boolean> | undefined,
+    hotspotInfo: HotSpotInfo
+): DriverInfoWithHotspots {
+    const hotspots =
+        hotspotInfo.hotspotAnnotationsActive && hotspotInfo.hotspotDriver;
     return {
-        oncoKb,
-        customDriverBinary,
-        customDriverTier,
+        ...evaluatePutativeDriverInfo(
+            event,
+            oncoKbDatum,
+            customDriverAnnotationsActive,
+            customDriverTierSelection
+        ),
+        hotspots,
     };
 }
 
-export function evaluateMutationPutativeDriverInfo(
-    mutation: Mutation,
+export function evaluatePutativeDriverInfo(
+    event: CustomDriverFilterEvent,
     oncoKbDatum: IndicatorQueryResp | undefined | null | false,
-    hotspotAnnotationsActive: boolean,
-    hotspotDriver: boolean,
     customDriverAnnotationsActive: boolean,
     customDriverTierSelection: ObservableMap<string, boolean> | undefined
-) {
+): DriverInfo {
     const oncoKb = oncoKbDatum ? getOncoKbOncogenic(oncoKbDatum) : '';
-    const hotspots = hotspotAnnotationsActive && hotspotDriver;
 
     // Set driverFilter to true when:
     // (1) custom drivers active in settings menu
     // (2) the datum has a custom driver annotation
     const customDriverBinary: boolean =
         (customDriverAnnotationsActive &&
-            mutation.driverFilter === PUTATIVE_DRIVER) ||
+            event.driverFilter === PUTATIVE_DRIVER) ||
         false;
 
     // Set tier information to the tier name when the tiers checkbox
     // is selected for the corresponding tier of the datum in settings menu.
     // This forces the Mutation to be counted as a driver mutation.
     const customDriverTier: string | undefined =
-        mutation.driverTiersFilter &&
+        event.driverTiersFilter &&
         customDriverTierSelection &&
-        customDriverTierSelection.get(mutation.driverTiersFilter)
-            ? mutation.driverTiersFilter
+        customDriverTierSelection.get(event.driverTiersFilter)
+            ? event.driverTiersFilter
             : undefined;
 
     return {
         oncoKb,
-        hotspots,
         customDriverBinary,
         customDriverTier,
-    };
+    } as DriverInfo;
 }
 
 export function filterAndAnnotateMolecularData(

--- a/src/shared/lib/alterationCountHelpers.ts
+++ b/src/shared/lib/alterationCountHelpers.ts
@@ -1,7 +1,3 @@
-import {
-    ExtendedAlteration,
-    ExtendedSample,
-} from '../../pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import {
     IAlterationCountMap,
@@ -11,6 +7,8 @@ import { Sample, MolecularProfile } from 'cbioportal-ts-api-client';
 import _ from 'lodash';
 import { CoverageInformation } from './GenePanelUtils';
 import { isSampleProfiledInMultiple } from './isSampleProfiled';
+import { ExtendedSample } from 'shared/model/ExtendedSample';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 export function getAlterationCountsForCancerTypesByGene(
     alterationsByGeneBySampleKey: {

--- a/src/shared/lib/calculation/BenjaminiHochbergFDRCalculator.spec.ts
+++ b/src/shared/lib/calculation/BenjaminiHochbergFDRCalculator.spec.ts
@@ -1,6 +1,6 @@
-import { ExtendedSample } from '../../../pages/resultsView/ResultsViewPageStore';
 import { calculateQValues } from './BenjaminiHochbergFDRCalculator';
 import { assert } from 'chai';
+import { ExtendedSample } from 'shared/model/ExtendedSample';
 
 const exampleData = [];
 

--- a/src/shared/lib/comparison/AnalysisStore.ts
+++ b/src/shared/lib/comparison/AnalysisStore.ts
@@ -10,7 +10,8 @@ import { computed, makeObservable, observable } from 'mobx';
 import _ from 'lodash';
 import internalClient from '../../api/cbioportalInternalClientInstance';
 import {
-    evaluateMutationPutativeDriverInfo,
+    evaluatePutativeDriverInfo,
+    evaluatePutativeDriverInfoWithHotspots,
     fetchOncoKbCancerGenes,
     fetchOncoKbDataForOncoprint,
     filterAndAnnotateMutations,
@@ -205,13 +206,16 @@ export default abstract class AnalysisStore {
                     this.isHotspotForOncoprint.result!(mutation);
 
                 // Note: custom driver annotations are part of the incoming datum
-                return evaluateMutationPutativeDriverInfo(
+                return evaluatePutativeDriverInfoWithHotspots(
                     mutation,
                     oncoKbDatum,
-                    this.driverAnnotationSettings.hotspots,
-                    isHotspotDriver,
                     this.driverAnnotationSettings.customBinary,
-                    this.driverAnnotationSettings.driverTiers
+                    this.driverAnnotationSettings.driverTiers,
+                    {
+                        hotspotDriver: isHotspotDriver,
+                        hotspotAnnotationsActive: this.driverAnnotationSettings
+                            .hotspots,
+                    }
                 );
             });
         },

--- a/src/shared/lib/oql/AccessorsForOqlFilter.ts
+++ b/src/shared/lib/oql/AccessorsForOqlFilter.ts
@@ -6,10 +6,6 @@ import {
 import { StructuralVariant } from 'cbioportal-ts-api-client';
 
 import _ from 'lodash';
-import {
-    CustomDriverNumericGeneMolecularData,
-    AnnotatedNumericGeneMolecularData,
-} from '../../../pages/resultsView/ResultsViewPageStore';
 import { isNotGermlineMutation } from '../MutationUtils';
 import { IAccessorsForOqlFilter } from './oqlfilter';
 import { AlterationTypeConstants } from 'shared/constants';
@@ -18,6 +14,8 @@ import {
     AnnotatedStructuralVariant,
     SimplifiedMutationType,
 } from 'shared/model/AnnotatedMutation';
+import { AnnotatedNumericGeneMolecularData } from 'shared/model/AnnotatedNumericGeneMolecularData';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
 
 export const cna_profile_data_to_string: any = {
     '-2': 'homdel',

--- a/src/shared/lib/oql/annotateAlterationTypes.ts
+++ b/src/shared/lib/oql/annotateAlterationTypes.ts
@@ -2,9 +2,9 @@ import AccessorsForOqlFilter from './AccessorsForOqlFilter';
 import { NumericGeneMolecularData } from 'cbioportal-ts-api-client';
 import { StructuralVariant } from 'cbioportal-ts-api-client';
 
-import { ExtendedAlteration } from '../../../pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import { AnnotatedMutation } from 'shared/model/AnnotatedMutation';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 export function annotateAlterationTypes(
     datum: (AnnotatedMutation | NumericGeneMolecularData | StructuralVariant) &

--- a/src/shared/lib/oql/oqlfilter.spec.ts
+++ b/src/shared/lib/oql/oqlfilter.spec.ts
@@ -13,12 +13,12 @@ import {
 } from 'cbioportal-ts-api-client';
 import AccessorsForOqlFilter from './AccessorsForOqlFilter';
 import { assert } from 'chai';
-import { CustomDriverNumericGeneMolecularData } from '../../../pages/resultsView/ResultsViewPageStore';
 import { AlterationTypeConstants } from 'shared/constants';
 import {
     AnnotatedMutation,
     AnnotatedStructuralVariant,
 } from 'shared/model/AnnotatedMutation';
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
 
 // This file uses type assertions to force functions that use overly specific
 // Swagger-generated types as parameters to accept mocked literals believed to

--- a/src/shared/lib/oql/oqlfilter.ts
+++ b/src/shared/lib/oql/oqlfilter.ts
@@ -17,7 +17,6 @@ import oql_parser, {
     SingleGeneQuery,
 } from './oql-parser';
 import { annotateAlterationTypes } from './annotateAlterationTypes';
-import { ExtendedAlteration } from '../../../pages/resultsView/ResultsViewPageStore';
 import {
     Gene,
     Mutation,
@@ -34,6 +33,7 @@ import {
     AnnotatedStructuralVariant,
     SimplifiedMutationType,
 } from 'shared/model/AnnotatedMutation';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
 
 export interface IAccessorsForOqlFilter<T> {
     // a null return for an attribute means that attribute

--- a/src/shared/model/AnnotatedExtendedAlteration.ts
+++ b/src/shared/model/AnnotatedExtendedAlteration.ts
@@ -1,0 +1,12 @@
+import {
+    AnnotatedMutation,
+    AnnotatedStructuralVariant,
+} from 'shared/model/AnnotatedMutation';
+import { AnnotatedNumericGeneMolecularData } from 'shared/model/AnnotatedNumericGeneMolecularData';
+import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
+
+export interface AnnotatedExtendedAlteration
+    extends ExtendedAlteration,
+        AnnotatedMutation,
+        AnnotatedStructuralVariant,
+        AnnotatedNumericGeneMolecularData {}

--- a/src/shared/model/AnnotatedNumericGeneMolecularData.ts
+++ b/src/shared/model/AnnotatedNumericGeneMolecularData.ts
@@ -1,0 +1,8 @@
+import { CustomDriverNumericGeneMolecularData } from 'shared/model/CustomDriverNumericGeneMolecularData';
+
+export interface AnnotatedNumericGeneMolecularData
+    extends CustomDriverNumericGeneMolecularData {
+    hugoGeneSymbol: string;
+    oncoKbOncogenic: string;
+    putativeDriver: boolean;
+}

--- a/src/shared/model/CaseAggregatedData.ts
+++ b/src/shared/model/CaseAggregatedData.ts
@@ -1,0 +1,4 @@
+export type CaseAggregatedData<T> = {
+    samples: { [uniqueSampleKey: string]: T[] };
+    patients: { [uniquePatientKey: string]: T[] };
+};

--- a/src/shared/model/CustomDriverAnnotationInfo.tsx
+++ b/src/shared/model/CustomDriverAnnotationInfo.tsx
@@ -1,0 +1,20 @@
+export type HotSpotInfo = {
+    hotspotAnnotationsActive: boolean;
+    hotspotDriver: boolean;
+};
+
+export type DriverInfo = {
+    oncoKb: string;
+    customDriverBinary: boolean;
+    customDriverTier?: string;
+    hotspots?: boolean;
+};
+
+export type CustomDriverFilterEvent = {
+    driverFilter: string;
+    driverTiersFilter: string;
+};
+
+export type DriverInfoWithHotspots = DriverInfo & {
+    hotspots: boolean;
+};

--- a/src/shared/model/CustomDriverNumericGeneMolecularData.ts
+++ b/src/shared/model/CustomDriverNumericGeneMolecularData.ts
@@ -1,0 +1,9 @@
+import { NumericGeneMolecularData } from 'cbioportal-ts-api-client';
+
+export interface CustomDriverNumericGeneMolecularData
+    extends NumericGeneMolecularData {
+    driverFilter: string;
+    driverFilterAnnotation: string;
+    driverTiersFilter: string;
+    driverTiersFilterAnnotation: string;
+}

--- a/src/shared/model/ExtendedAlteration.ts
+++ b/src/shared/model/ExtendedAlteration.ts
@@ -1,0 +1,18 @@
+import {
+    MolecularProfile,
+    Mutation,
+    NumericGeneMolecularData,
+    StructuralVariant,
+} from 'cbioportal-ts-api-client';
+
+export interface ExtendedAlteration
+    extends Mutation,
+        NumericGeneMolecularData,
+        StructuralVariant {
+    hugoGeneSymbol: string;
+    molecularProfileAlterationType: MolecularProfile['molecularAlterationType'];
+    // TODO: what is difference molecularProfileAlterationType and
+    // alterationType?
+    alterationType: string;
+    alterationSubType: string;
+}

--- a/src/shared/model/ExtendedSample.ts
+++ b/src/shared/model/ExtendedSample.ts
@@ -1,0 +1,6 @@
+import { Sample } from 'cbioportal-ts-api-client';
+
+export interface ExtendedSample extends Sample {
+    cancerType: string;
+    cancerTypeDetailed: string;
+}

--- a/src/shared/model/GeneticEntity.ts
+++ b/src/shared/model/GeneticEntity.ts
@@ -1,0 +1,10 @@
+import { Gene, Geneset } from 'cbioportal-ts-api-client';
+import { GeneticEntityType } from 'pages/resultsView/ResultsViewPageStore';
+
+export type GeneticEntity = {
+    geneticEntityName: string; // hugo gene symbol for gene, gene set name for geneset
+    geneticEntityType: GeneticEntityType;
+    geneticEntityId: string | number; //entrezGeneId (number) for "gene", genesetId (string) for "geneset"
+    cytoband: string; //will be "" for "geneset"
+    geneticEntityData: Gene | Geneset;
+};

--- a/src/shared/model/IQueriedCaseData.ts
+++ b/src/shared/model/IQueriedCaseData.ts
@@ -1,0 +1,12 @@
+/*
+ * OQL-queried data by patient and sample, along with the query metadata and,
+ * if specified in the type argument, a non-aggregated copy of the data
+ */
+import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { OQLLineFilterOutput } from 'shared/lib/oql/oqlfilter';
+
+export interface IQueriedCaseData<DataInOQL> {
+    cases: CaseAggregatedData<AnnotatedExtendedAlteration>;
+    oql: OQLLineFilterOutput<DataInOQL>;
+}

--- a/src/shared/model/IQueriedMergedTrackCaseData.ts
+++ b/src/shared/model/IQueriedMergedTrackCaseData.ts
@@ -1,0 +1,15 @@
+/*
+ * OQL-queried data by patient and sample, along with the query metadata and a
+ * non-aggregated copy of the data and, in case of a merged track, an array of
+ * records per individual gene queried
+ */
+import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
+import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { UnflattenedOQLLineFilterOutput } from 'shared/lib/oql/oqlfilter';
+import { IQueriedCaseData } from 'shared/model/IQueriedCaseData';
+
+export interface IQueriedMergedTrackCaseData {
+    cases: CaseAggregatedData<AnnotatedExtendedAlteration>;
+    oql: UnflattenedOQLLineFilterOutput<AnnotatedExtendedAlteration>;
+    mergedTrackOqlList?: IQueriedCaseData<object>[];
+}


### PR DESCRIPTION
Filter structural variants by custom driver annotations in oncoprint and on study page.

Depends on backend PR https://github.com/cBioPortal/cbioportal/pull/10092 for query and es_0 data changes.

# Changes

- Implement custom driver filtering for structural variants in `ResultsViewPageStore` analogous to CNA and mutations.
- Fix incomplete filter bug
  - Bug: when changing the tier selection using the annotation menu, the updated filters are not (always) send to backend. This is because the list of tiers first needs to be requested from the backend. When creating the `StudyViewPageStore.filters` these tiers are requested, but subsequent api calls depending on `filters` are not waiting for this info. 
  - This PR introduces the async `initialFiltersRemote` and `filtersRemote`, which allows api calls to wait for a fully loaded `filters`. 
  - There might be a better solution?
- Test filtering of structural variants by custom driver annotations in oncoprint, in `custom-driver-annotations.spec.js`
 
## Study View

1 - All tiers selected |  2 - Exclude unknown 
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/3323006/226357474-c88f4940-5b0b-49cc-bb3a-277e7da837d3.png)  | ![image](https://user-images.githubusercontent.com/3323006/226358320-c5218266-d475-4a57-b4b5-f16399c0cb90.png)
**3 - Exclude `Class 2` and `Class 4`** | **4 - Exclude putative drivers**
![image](https://user-images.githubusercontent.com/3323006/226361709-a75bf89e-9514-46cb-8581-0147a54d2889.png) | ![image](https://user-images.githubusercontent.com/3323006/226362028-a519f494-2f6b-4cb5-8a3b-44aff5288056.png)

## Oncoprint

1 - Default: Use custom and oncokb drivers | 2 - Disable oncokb annotations 
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/3323006/226898967-e0bc4fc0-2d5b-405e-9808-59a447160913.png) | ![image](https://user-images.githubusercontent.com/3323006/226899561-7efafdc8-02c4-40d2-93d4-00909e668498.png)
**3 - Hide alterations of unknown significance** | **4 - Disable custom driver tier**
![image](https://user-images.githubusercontent.com/3323006/226899898-25877968-6bd9-4503-9d28-8814eb7503f1.png) | ![image](https://user-images.githubusercontent.com/3323006/226900228-16471915-c167-4ae6-bae3-97acd70ae1ab.png)


