### PR TITLE
Fix showNA undefined for numerical data type

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -442,7 +442,7 @@ export class StudyViewPageStore
             return filter === undefined ? true : (filter!.showNA as boolean);
         } else {
             const filter = this.getDataBinFilterSet(uniqueKey).get(uniqueKey)!;
-            return filter.showNA === undefined
+            return filter?.showNA === undefined
                 ? true
                 : (filter!.showNA as boolean);
         }


### PR DESCRIPTION
Update studyPageStore
Fix for the current error {"type":"ErrorBoundary","log":"TypeError: Cannot read properties of undefined (reading 'showNA')" for custom data.

Adresses: https://github.com/cBioPortal/cbioportal-frontend/pull/4533#issuecomment-1485196942