### PR TITLE
Impl. study search on Query Page using 'study tags'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,8 @@ jobs:
           command: "cat yarn.lock $(find src/ -type f | sort) $(find packages/ -type f | sort) webpack.config.js vendor-bundles.webpack.config.js > has_source_changed"
       - restore_cache:
           keys:
-            - v8-dependencies-plus-dist-{{ checksum "has_source_changed" }}
-            - v8-dependencies-{{ checksum "yarn.lock" }}
+            - v10-dependencies-plus-dist-{{ checksum "has_source_changed" }}
+            - v10-dependencies-{{ checksum "yarn.lock" }}
       # Download and cache dependencies
       - run: yarn
       - run: yarn buildModules
@@ -125,7 +125,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v8-dependencies-{{ checksum "yarn.lock" }}
+          key: v10-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: "Run build if no dist folder"
           command: 'ls dist || yarn run build'
@@ -139,7 +139,7 @@ jobs:
             - node_modules
             - dist
             - common-dist
-          key: v8-dependencies-plus-dist-{{ checksum "has_source_changed" }}
+          key: v10-dependencies-plus-dist-{{ checksum "has_source_changed" }}
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -297,10 +297,10 @@ jobs:
                   docker volume rm --force cbioportal-docker-compose_cbioportal_mysql_data && mkdir -p $CBIO_DB_DATA_DIR && rm -rf $CBIO_DB_DATA_DIR/*
             - restore_cache:
                 keys:
-                  - v8-cbio-database-files-{{ checksum "/tmp/db_data_md5key" }}
+                  - v10-cbio-database-files-{{ checksum "/tmp/db_data_md5key" }}
             - restore_cache:
                 keys:
-                  - v8-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
+                  - v11-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
             - run:
                 name: Init database
                 command: |
@@ -314,7 +314,7 @@ jobs:
             - save_cache:
                 paths:
                   - /tmp/repo/e2e-localdb-workspace/cbio_db_data
-                key: v9-cbio-database-files-{{ checksum "/tmp/db_data_md5key" }}
+                key: v10-cbio-database-files-{{ checksum "/tmp/db_data_md5key" }}
             - run:
                 name: Start cbioportal and other services
                 command: |
@@ -329,7 +329,7 @@ jobs:
             - save_cache:
                 paths:
                   - /tmp/repo/e2e-localdb-workspace/kc_db_data
-                key: v9-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
+                key: v11-keycloak-database-files-{{ checksum "e2e-localdb-workspace/keycloak/keycloak-config-generated.json" }}
             - run:
                 name: Run end-2-end tests with studies in local database
                 command: |

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI-docs.json
@@ -4524,6 +4524,9 @@
           "type": "integer",
           "format": "int32"
         },
+        "studyId": {
+          "type": "string"
+        },
         "tags": {
           "type": "string"
         }

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPI.ts
@@ -106,6 +106,8 @@ export type CancerStudy = {
 export type CancerStudyTags = {
     'cancerStudyId': number
 
+        'studyId': string
+
         'tags': string
 
 };

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -595,6 +595,7 @@ export class QueryStore {
         client.getAllStudiesUsingGET({ projection: 'SUMMARY' }),
         []
     );
+
     readonly cancerStudyIdsSet = remoteData<{ [studyId: string]: boolean }>({
         await: () => [this.cancerStudies],
         invoke: async () => {
@@ -603,6 +604,15 @@ export class QueryStore {
             );
         },
         default: {},
+    });
+
+    readonly cancerStudyTags = remoteData({
+        await: () => [this.cancerStudies],
+        invoke: async () => {
+            const studyIds = this.cancerStudies.result.map(s => s.studyId);
+            return client.getTagsForMultipleStudiesUsingPOST({ studyIds });
+        },
+        default: [],
     });
 
     private readonly physicalStudiesIdsSet = remoteData<{
@@ -1439,6 +1449,7 @@ export class QueryStore {
         return new CancerStudyTreeData({
             cancerTypes: this.cancerTypes.result,
             studies: this.cancerStudies.result,
+            allStudyTags: this.cancerStudyTags.result,
             priorityStudies: this.priorityStudies,
             virtualStudies: this.forDownloadTab
                 ? []

--- a/src/shared/components/query/StudyListLogic.ts
+++ b/src/shared/components/query/StudyListLogic.ts
@@ -46,10 +46,17 @@ export default class StudyListLogic {
         // first compute individual node match results
         let map_node_searchResult = new Map<CancerTreeNode, SearchResult>();
 
-        for (const study of this.store.treeData.map_node_meta.keys()) {
+        for (const [
+            study,
+            meta,
+        ] of this.store.treeData.map_node_meta.entries()) {
+            const fullTextSearchNode = { ...(study as CancerStudy), ...meta };
             map_node_searchResult.set(
                 study,
-                performSearchSingle(this.store.searchClauses, study)
+                performSearchSingle(
+                    this.store.searchClauses,
+                    fullTextSearchNode
+                )
             );
         }
 

--- a/src/shared/components/query/filteredSearch/Phrase.spec.tsx
+++ b/src/shared/components/query/filteredSearch/Phrase.spec.tsx
@@ -1,29 +1,29 @@
 import { ListPhrase } from 'shared/components/query/filteredSearch/Phrase';
-import { CancerTreeNode } from 'shared/components/query/CancerStudyTreeData';
+import { FullTextSearchNode } from 'shared/lib/query/textQueryUtils';
 
 describe('Phrase', () => {
     describe('ListPhrase', () => {
         it('should match when single element in phraseList', () => {
             const phrase = new ListPhrase('a', 'test:a', ['studyId']);
-            const study = { studyId: 'a' } as CancerTreeNode;
+            const study = { studyId: 'a' } as FullTextSearchNode;
             expect(phrase.match(study)).toBe(true);
         });
 
         it('should not match when single element in phraseList does not match', () => {
             const phrase = new ListPhrase('a', 'test:a', ['studyId']);
-            const study = { studyId: 'b' } as CancerTreeNode;
+            const study = { studyId: 'b' } as FullTextSearchNode;
             expect(phrase.match(study)).toBe(false);
         });
 
         it('should do a full (instead of partial) match', () => {
             const phrase = new ListPhrase('a', 'test:a', ['studyId']);
-            const study = { studyId: 'ab' } as CancerTreeNode;
+            const study = { studyId: 'ab' } as FullTextSearchNode;
             expect(phrase.match(study)).toBe(false);
         });
 
         it('should match when multiple elements in phraseList', () => {
             const phrase = new ListPhrase('a,b', 'test:a,b', ['studyId']);
-            const study = { studyId: 'a' } as CancerTreeNode;
+            const study = { studyId: 'a' } as FullTextSearchNode;
             expect(phrase.match(study)).toBe(true);
         });
     });

--- a/src/shared/components/query/filteredSearch/SearchClause.spec.tsx
+++ b/src/shared/components/query/filteredSearch/SearchClause.spec.tsx
@@ -4,13 +4,13 @@ import {
 } from 'shared/components/query/filteredSearch/SearchClause';
 import { CancerTreeNode } from 'shared/components/query/CancerStudyTreeData';
 import {
-    DefaultPhrase,
+    StringPhrase,
     ListPhrase,
     Phrase,
 } from 'shared/components/query/filteredSearch/Phrase';
 
 function createTestPhrase(): Phrase {
-    return new DefaultPhrase('a', 'a', ['studyId']);
+    return new StringPhrase('a', 'a', ['studyId']);
 }
 
 describe('ISearchClause', () => {
@@ -30,28 +30,28 @@ describe('ISearchClause', () => {
         it('should equal when same phrases', () => {
             const a = new AndSearchClause([createTestPhrase()]);
             const b = new AndSearchClause([
-                new DefaultPhrase('a', 'a', ['studyId']),
+                new StringPhrase('a', 'a', ['studyId']),
             ]);
             expect(a.equals(b)).toEqual(true);
         });
 
         it('returns true when calling contains() with contained phrase', () => {
             const a = new AndSearchClause([createTestPhrase()]);
-            expect(
-                a.contains(new DefaultPhrase('a', 'a', ['studyId']))
-            ).toEqual(true);
+            expect(a.contains(new StringPhrase('a', 'a', ['studyId']))).toEqual(
+                true
+            );
         });
 
         it('returns false when calling contains() with non contained phrase', () => {
             const a = new AndSearchClause([createTestPhrase()]);
-            let b: Phrase = new DefaultPhrase('b', 'a', ['studyId']);
+            let b: Phrase = new StringPhrase('b', 'a', ['studyId']);
             expect(a.contains(b)).toEqual(false);
         });
 
         it('returns false when calling contains() with faulty textRepresentation', () => {
             const a = new AndSearchClause([createTestPhrase()]);
             expect(
-                a.contains(new DefaultPhrase('a', 'faulty', ['studyId']))
+                a.contains(new StringPhrase('a', 'faulty', ['studyId']))
             ).toEqual(true);
         });
 
@@ -77,29 +77,29 @@ describe('ISearchClause', () => {
         it('should not equal when different phrases', () => {
             const a = new NotSearchClause(createTestPhrase());
             const b = new NotSearchClause(
-                new DefaultPhrase('different', 'a', ['studyId'])
+                new StringPhrase('different', 'a', ['studyId'])
             );
             expect(a.equals(b)).toEqual(false);
         });
 
         it('returns true when calling contains() with contained phrase', () => {
             const a = new NotSearchClause(createTestPhrase());
-            expect(
-                a.contains(new DefaultPhrase('a', 'a', ['studyId']))
-            ).toEqual(true);
+            expect(a.contains(new StringPhrase('a', 'a', ['studyId']))).toEqual(
+                true
+            );
         });
 
         it('returns false when calling contains() with non contained phrase', () => {
             const a = new NotSearchClause(createTestPhrase());
-            expect(
-                a.contains(new DefaultPhrase('b', 'a', ['studyId']))
-            ).toEqual(false);
+            expect(a.contains(new StringPhrase('b', 'a', ['studyId']))).toEqual(
+                false
+            );
         });
 
         it('ignores textRepresentation when calling contains()', () => {
             const a = new NotSearchClause(createTestPhrase());
             expect(
-                a.contains(new DefaultPhrase('a', 'faulty', ['studyId']))
+                a.contains(new StringPhrase('a', 'faulty', ['studyId']))
             ).toEqual(true);
         });
 

--- a/src/shared/lib/query/QueryParser.spec.ts
+++ b/src/shared/lib/query/QueryParser.spec.ts
@@ -1,5 +1,5 @@
 import {
-    defaultNodeFields,
+    searchNodeFields,
     toQueryString,
 } from 'shared/lib/query/textQueryUtils';
 import {
@@ -8,7 +8,7 @@ import {
     NotSearchClause,
 } from 'shared/components/query/filteredSearch/SearchClause';
 import { QueryParser } from 'shared/lib/query/QueryParser';
-import { DefaultPhrase } from 'shared/components/query/filteredSearch/Phrase';
+import { StringPhrase } from 'shared/components/query/filteredSearch/Phrase';
 
 describe('QueryParser', () => {
     const parser = new QueryParser(new Set<string>());
@@ -17,10 +17,10 @@ describe('QueryParser', () => {
     )!.nodeFields;
 
     describe('parseSearchQuery', () => {
-        const part1 = new DefaultPhrase('part1', 'part1', defaultNodeFields);
-        const part2 = new DefaultPhrase('part2', 'part2', defaultNodeFields);
-        const part3 = new DefaultPhrase('part3', 'part3', defaultNodeFields);
-        const hg42 = new DefaultPhrase(
+        const part1 = new StringPhrase('part1', 'part1', searchNodeFields);
+        const part2 = new StringPhrase('part2', 'part2', searchNodeFields);
+        const part3 = new StringPhrase('part3', 'part3', searchNodeFields);
+        const hg42 = new StringPhrase(
             'hg42',
             'reference-genome:hg42',
             referenceGenomeFields
@@ -65,10 +65,10 @@ describe('QueryParser', () => {
             const parsedQuery = parser.parseSearchQuery(query);
             const expected: SearchClause[] = [
                 new NotSearchClause(
-                    new DefaultPhrase(
+                    new StringPhrase(
                         'part2a part2b',
                         '"part2a part2b"',
-                        defaultNodeFields
+                        searchNodeFields
                     )
                 ),
             ];
@@ -98,15 +98,15 @@ describe('QueryParser', () => {
             const expected: SearchClause[] = [
                 new AndSearchClause([part1, hg42]),
                 new NotSearchClause(
-                    new DefaultPhrase('part4', 'part4', defaultNodeFields)
+                    new StringPhrase('part4', 'part4', searchNodeFields)
                 ),
                 new AndSearchClause([
-                    new DefaultPhrase(
+                    new StringPhrase(
                         'part5a part5b',
                         '"part5a part5b"',
-                        defaultNodeFields
+                        searchNodeFields
                     ),
-                    new DefaultPhrase('part6', 'part6', defaultNodeFields),
+                    new StringPhrase('part6', 'part6', searchNodeFields),
                 ]),
             ];
             expect(toQueryString(parsedQuery)).toEqual(toQueryString(expected));

--- a/src/shared/lib/query/QueryParser.ts
+++ b/src/shared/lib/query/QueryParser.ts
@@ -1,7 +1,7 @@
 import {
-    CancerTreeNodeFields,
+    FullTextSearchFields,
     CancerTreeSearchFilter,
-    defaultNodeFields,
+    searchNodeFields,
 } from 'shared/lib/query/textQueryUtils';
 import {
     AndSearchClause,
@@ -14,7 +14,7 @@ import { FilterCheckbox } from 'shared/components/query/filteredSearch/field/Che
 import { getServerConfig, ServerConfigHelpers } from 'config/config';
 import { FilterList } from 'shared/components/query/filteredSearch/field/ListFormField';
 import {
-    DefaultPhrase,
+    StringPhrase,
     ListPhrase,
     Phrase,
 } from 'shared/components/query/filteredSearch/Phrase';
@@ -32,7 +32,7 @@ export class QueryParser {
              */
             {
                 phrasePrefix: undefined,
-                nodeFields: defaultNodeFields,
+                nodeFields: searchNodeFields,
                 form: {
                     label: 'Example queries',
                     input: FilterList,
@@ -193,7 +193,7 @@ export class QueryParser {
     private createPhrase(data: string): Phrase {
         const parts: string[] = data.split(FILTER_SEPARATOR);
         let phrase: string;
-        let fields: CancerTreeNodeFields[];
+        let fields: FullTextSearchFields[];
         let filter = this._searchFilters.find(
             sf => sf.phrasePrefix === parts[0]
         );
@@ -203,8 +203,8 @@ export class QueryParser {
             return new ListPhrase(phrase, this.enquoteSpaces(data), fields);
         } else {
             phrase = parts[0];
-            fields = defaultNodeFields;
-            return new DefaultPhrase(phrase, this.enquoteSpaces(data), fields);
+            fields = searchNodeFields;
+            return new StringPhrase(phrase, this.enquoteSpaces(data), fields);
         }
     }
 


### PR DESCRIPTION
This PR allows users to search studies on the index page by their study tags. 

The study tags are now fetched in the QueryStore, and added to the study node metadata as a flat string.
To search in study tags, the `studyTags` metadata property is added to `searchNodeFields`, so the textQueryUtils includes it when searching.

PR depends on this [backend PR](https://github.com/cBioPortal/cbioportal/pull/10116) that adds studyId to the study tags entity.

## Changes

- Add study tags to study list metadata and to full text search fields
- Allow full text search not only in study nodes but also their metadata
- Update API: add study ID to study tags entity
- Refactorings:
  - Rename `DefaultPhrase` to more meaningful `StringPhrase` (vs `ListPhrase`)
  - Rename `defaultNodeFields` to `searchNodeFields`
  - Remove unused `searchTerms` property from study list metadata