### PR TITLE
changes for #9943 on frontend

### DIFF
--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsTable.tsx
@@ -189,7 +189,7 @@ export default class AlterationEnrichmentTable extends React.Component<
                         Derived from{' '}
                         {_.values(this.props.data[0].groupsSet).length > 2
                             ? 'Chi-squared test'
-                            : 'one-sided Fisher Exact test'}
+                            : 'two-sided Fisher Exact test'}
                     </span>
                 ) : (
                     undefined

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityTable.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityTable.tsx
@@ -181,7 +181,7 @@ export default class MutualExclusivityTable extends React.Component<
             render: (d: MutualExclusivity) => (
                 <span>{formatPValue(d.pValue)}</span>
             ),
-            tooltip: <span>Derived from one-sided Fisher Exact Test</span>,
+            tooltip: <span>Derived from two-sided Fisher Exact Test</span>,
             sortBy: (d: MutualExclusivity) => d.pValue,
             download: (d: MutualExclusivity) => formatPValue(d.pValue),
         };

--- a/src/shared/lib/FisherExactTestCalculator.ts
+++ b/src/shared/lib/FisherExactTestCalculator.ts
@@ -1,3 +1,5 @@
+// Calculates the probability of observing the observed counts (a,b,c,d) in a 2x2 contingency table
+// given the total count (n) and the factorial of the counts (logFactorial).
 function getProbability(
     a: number,
     b: number,
@@ -19,6 +21,7 @@ function getProbability(
     return Math.exp(p);
 }
 
+// Cumulative p-value for a 2x2 contingency table using Fisher's exact test
 export function getCumulativePValue(
     a: number,
     b: number,
@@ -35,7 +38,9 @@ export function getCumulativePValue(
         logFactorial[j] = logFactorial[j - 1] + Math.log(j);
     }
 
+    // probability for the given contingency table
     p += getProbability(a, b, c, d, logFactorial);
+    // cumulative p-value for all tables with greater proportion of observations in 1st row and 1st column
     if (a * d >= b * c) {
         min = c < b ? c : b;
         for (i = 0; i < min; i++) {
@@ -43,6 +48,7 @@ export function getCumulativePValue(
         }
     }
 
+    // cumulative p-value for all tables with greater proportion of observations in 2nd row and 2nd column
     if (a * d < b * c) {
         min = a < d ? a : d;
         for (i = 0; i < min; i++) {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9943

Describe changes proposed in this pull request:
- Fisher's exact test is giving the two-sided value
- changed mutual exclusivity tab and comparison tab to now show "2-sided fisher's exact test" instead of 1-sided to users
- added in comments to walk future developers through 

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!  (This PR is not adding logic based on one or more clinical attributes in the backend repo)

## Notify reviewers
Doing this through Slack, I've been actively communicating with the team to resolve this issue.
