### PR TITLE
Paginated clinical table by re-implementing data store

### DIFF
--- a/packages/cbioportal-ts-api-client/src/index.tsx
+++ b/packages/cbioportal-ts-api-client/src/index.tsx
@@ -1,5 +1,6 @@
 export * from './model/ClinicalDataBySampleId';
 export * from './model/RequestStatus';
+export * from './model/ClinicalDataCollection';
 
 export * from './generated/CBioPortalAPI';
 export { default as CBioPortalAPI } from './generated/CBioPortalAPI';

--- a/packages/cbioportal-ts-api-client/src/model/ClinicalDataCollection.ts
+++ b/packages/cbioportal-ts-api-client/src/model/ClinicalDataCollection.ts
@@ -1,0 +1,7 @@
+import { ClinicalData } from '../generated/CBioPortalAPIInternal';
+
+export type ClinicalDataCollection = {
+    patientClinicalData: Array<ClinicalData>;
+
+    sampleClinicalData: Array<ClinicalData>;
+};

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -2528,7 +2528,7 @@ export class StudyViewPageStore
             appendPosition: false,
             collapse: true,
             collapseDuration: 300,
-        });
+        } as any);
 
         toast.success(message, {
             delay: 0,
@@ -2540,7 +2540,8 @@ export class StudyViewPageStore
             draggable: true,
             progress: undefined,
             theme: 'light',
-        });
+        } as any);
+
         //only update geneQueryStr whenever a table gene is clicked.
         this.geneQueries = updateGeneQuery(this.geneQueries, hugoGeneSymbol);
         this.geneQueryStr = this.geneQueries
@@ -8763,39 +8764,6 @@ export class StudyViewPageStore
             );
         },
         default: {},
-    });
-
-    readonly getDataForClinicalDataTab = remoteData({
-        await: () => [
-            this.clinicalAttributes,
-            this.selectedSamples,
-            this.sampleSetByKey,
-        ],
-        onError: () => {},
-        invoke: async () => {
-            if (this.selectedSamples.result.length === 0) {
-                return Promise.resolve([]);
-            }
-            let sampleClinicalDataMap = await getAllClinicalDataByStudyViewFilter(
-                this.filters
-            );
-
-            const sampleClinicalDataArray = _.mapValues(
-                sampleClinicalDataMap,
-                (attrs, uniqueSampleId) => {
-                    const sample = this.sampleSetByKey.result![uniqueSampleId];
-                    return {
-                        studyId: sample.studyId,
-                        patientId: sample.patientId,
-                        sampleId: sample.sampleId,
-                        ...attrs,
-                    };
-                }
-            );
-
-            return _.values(sampleClinicalDataArray);
-        },
-        default: [],
     });
 
     readonly clinicalAttributeProduct = remoteData({

--- a/src/pages/studyView/table/FixedHeaderTable.tsx
+++ b/src/pages/studyView/table/FixedHeaderTable.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
     Column,
-    LazyMobXTableStore,
     SortDirection,
     lazyMobXTableSort,
 } from '../../../shared/components/lazyMobXTable/LazyMobXTable';
@@ -26,6 +25,7 @@ import { SimpleGetterLazyMobXTableApplicationDataStore } from 'shared/lib/ILazyM
 import { SelectionOperatorEnum } from '../TableUtils';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import classNames from 'classnames';
+import { LazyMobXTableStore } from 'shared/components/lazyMobXTable/LazyMobXTableStore';
 
 export type IFixedHeaderTableProps<T> = {
     columns: Column<T>[];

--- a/src/pages/studyView/tabs/PaginatedDownloadDataFetcher.ts
+++ b/src/pages/studyView/tabs/PaginatedDownloadDataFetcher.ts
@@ -1,0 +1,61 @@
+import { ILazyMobXTableApplicationLazyDownloadDataFetcher } from 'shared/lib/ILazyMobXTableApplicationLazyDownloadDataFetcher';
+import { TablePaginationStore } from 'shared/components/lazyMobXTable/TablePaginationStore';
+import { computed, makeObservable } from 'mobx';
+import { TablePaginationStoreAdaptor } from 'shared/components/lazyMobXTable/TablePaginationStoreAdaptor';
+import { onMobxPromise } from 'cbioportal-frontend-commons';
+import { TablePaginationParams } from 'shared/components/lazyMobXTable/TablePaginationParams';
+
+export default class PaginatedDownloadDataFetcher<T>
+    implements ILazyMobXTableApplicationLazyDownloadDataFetcher {
+    /**
+     * Use pageStore to download paginated
+     */
+    private pageStore: TablePaginationStore<T>;
+
+    /**
+     * Store downloaded data in dataStore
+     */
+    private dataStore: TablePaginationStoreAdaptor<T>;
+
+    constructor(
+        pageStore: TablePaginationStore<T>,
+        pageParams: TablePaginationParams,
+        dataStore: TablePaginationStoreAdaptor<T>
+    ) {
+        this.pageStore = pageStore;
+        this.dataStore = dataStore;
+        this.setPageParams(this.pageStore, pageParams);
+        makeObservable(this);
+    }
+
+    @computed get totalItems(): number | undefined {
+        return this.pageStore.totalItems;
+    }
+
+    fetchAndCacheAllLazyData(): Promise<T[]> {
+        if (this.dataStore.downloadedData) {
+            return Promise.resolve(this.dataStore.downloadedData);
+        }
+        return new Promise<T[]>(resolve => {
+            // Fetch first page to know totalItems:
+            onMobxPromise(this.pageStore.pageItems, () => {
+                this.pageStore.moreItemsPerPage = this.pageStore.totalItems;
+                // Fetch all items:
+                onMobxPromise(this.pageStore.pageItems, data => {
+                    this.dataStore.downloadedData = data;
+                    resolve(data);
+                });
+            });
+        });
+    }
+
+    private setPageParams(
+        pageStore: TablePaginationStore<T>,
+        pageParams: TablePaginationParams
+    ) {
+        pageStore.pageSize = pageParams.pageSize;
+        pageStore.pageNumber = pageParams.pageNumber;
+        pageStore.sortParam = pageParams.sortParam;
+        pageStore.direction = pageParams.direction;
+    }
+}

--- a/src/shared/components/lazyMobXTable/ClinicalTablePaginationStore.ts
+++ b/src/shared/components/lazyMobXTable/ClinicalTablePaginationStore.ts
@@ -1,0 +1,171 @@
+import { computed, makeObservable, observable } from 'mobx';
+import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
+import MobxPromise from 'mobxpromise';
+import {
+    ClinicalDataBySampleId,
+    getClinicalDataByStudyViewFilter,
+    isFirstPage,
+    isLastPage,
+    Page,
+} from 'pages/studyView/StudyViewUtils';
+import { remoteData } from 'cbioportal-frontend-commons';
+import {
+    PageDirection,
+    TablePaginationParams,
+} from 'shared/components/lazyMobXTable/TablePaginationParams';
+import _ from 'lodash';
+import { TablePaginationStore } from 'shared/components/lazyMobXTable/TablePaginationStore';
+
+export type ClinicalTableItem = { [key: string]: string };
+
+export class ClinicalTablePaginationStore
+    implements TablePaginationStore<ClinicalTableItem> {
+    @observable public direction: PageDirection = 'ASC';
+    @observable public sortParam: string | undefined;
+    @observable public pageNumber: number;
+    @observable public pageSize: number;
+    @observable public moreItemsPerPage: number | undefined;
+    @observable public searchTerm: string = '';
+
+    constructor(private store: StudyViewPageStore) {
+        makeObservable(this);
+    }
+
+    @computed get pageItems() {
+        return this.getDataForClinicalDataTab;
+    }
+
+    @computed get totalItems() {
+        return this.getSamplePageForClinicalDataTab.result?.totalItems || 0;
+    }
+
+    @computed get isFirst() {
+        return this.getSamplePageForClinicalDataTab.result?.isFirst || false;
+    }
+
+    @computed get isLast() {
+        return this.getSamplePageForClinicalDataTab.result?.isLast || false;
+    }
+
+    private prevPage: Page<ClinicalDataBySampleId> | undefined = undefined;
+
+    private readonly getSamplePageForClinicalDataTab: MobxPromise<
+        Page<ClinicalDataBySampleId> | undefined
+    > = remoteData({
+        await: () => [
+            this.store.clinicalAttributes,
+            this.store.selectedSamples,
+            this.store.sampleSetByKey,
+        ],
+        onError: () => {},
+        invoke: async () => {
+            if (this.store.selectedSamples.result.length === 0) {
+                return;
+            }
+            if (this.pageNumber === undefined || this.pageSize === undefined) {
+                return;
+            }
+            const page = this.moreItemsPerPage
+                ? await this.getMore(this.moreItemsPerPage)
+                : await this.getPage(this.pageNumber, this.pageSize);
+            this.prevPage = page;
+            return page;
+        },
+    });
+
+    private async getMore(
+        moreItemsPerPage: number
+    ): Promise<Page<ClinicalDataBySampleId>> {
+        const fetchedContent: ClinicalDataBySampleId = {};
+        const lastItem = this.pageNumber * this.pageSize + moreItemsPerPage;
+        let currentPageNumber = this.pageNumber;
+        let currentPage = undefined;
+
+        if (this.prevPage && this.prevPage.pageNumber === this.pageNumber) {
+            // Keep already fetched items:
+            Object.assign(fetchedContent, this.prevPage.content);
+            const alreadyFetchedItems = _.toPairs(this.prevPage.content);
+            currentPageNumber =
+                this.prevPage.pageNumber +
+                alreadyFetchedItems.length / this.pageSize;
+        }
+
+        while (currentPageNumber * this.pageSize < lastItem) {
+            currentPage = await this.getPage(currentPageNumber, this.pageSize);
+            Object.assign(fetchedContent, currentPage.content);
+            currentPageNumber++;
+        }
+        return this.toMorePage(fetchedContent, currentPage!);
+    }
+
+    private toMorePage(
+        fetchedContent: ClinicalDataBySampleId,
+        currentPage: Page<ClinicalDataBySampleId>
+    ): Page<ClinicalDataBySampleId> {
+        return {
+            content: fetchedContent,
+            pageSize: currentPage.totalItems,
+            pageNumber: this.pageNumber,
+            totalItems: currentPage.totalItems,
+            isFirst: isFirstPage(this.pageNumber),
+            isLast: isLastPage(
+                this.pageNumber,
+                this.pageSize,
+                currentPage.totalItems,
+                this.moreItemsPerPage
+            ),
+        } as Page<ClinicalDataBySampleId>;
+    }
+
+    private async getPage(
+        pageNumber: number,
+        pageSize: number
+    ): Promise<Page<ClinicalDataBySampleId>> {
+        const pageParams = {} as TablePaginationParams;
+        pageParams.pageSize = pageSize;
+        pageParams.pageNumber = pageNumber;
+        if (this.direction && this.sortParam) {
+            pageParams.direction = this.direction;
+            pageParams.sortParam = this.sortParam;
+        }
+        if (this.searchTerm) {
+            pageParams.searchTerm = this.searchTerm;
+        }
+        return await getClinicalDataByStudyViewFilter(
+            this.store.filters,
+            pageParams
+        );
+    }
+
+    private readonly getDataForClinicalDataTab = remoteData({
+        await: () => [
+            this.store.clinicalAttributes,
+            this.store.selectedSamples,
+            this.store.sampleSetByKey,
+            this.getSamplePageForClinicalDataTab,
+        ],
+        onError: () => {},
+        invoke: async () => {
+            if (!this.getSamplePageForClinicalDataTab.result) {
+                return Promise.resolve([]);
+            }
+            const sampleClinicalDataArray = _.mapValues(
+                this.getSamplePageForClinicalDataTab.result.content,
+                (attrs, uniqueSampleId) => {
+                    const sample = this.store.sampleSetByKey.result![
+                        uniqueSampleId
+                    ];
+                    return {
+                        studyId: sample.studyId,
+                        patientId: sample.patientId,
+                        sampleId: sample.sampleId,
+                        ...attrs,
+                    };
+                }
+            );
+
+            return _.values(sampleClinicalDataArray);
+        },
+        default: [],
+    });
+}

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -7,7 +7,6 @@ import {
     Column,
     default as LazyMobXTable,
     lazyMobXTableSort,
-    LazyMobXTableStore,
 } from './LazyMobXTable';
 import SimpleTable from '../simpleTable/SimpleTable';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
@@ -24,6 +23,7 @@ import { SimpleLazyMobXTableApplicationDataStore } from '../../lib/ILazyMobXTabl
 import cloneJSXWithoutKeyAndRef from 'shared/lib/cloneJSXWithoutKeyAndRef';
 import { filterNumericalColumn, maxPage, parseNumericalFilter } from './utils';
 import _ from 'lodash';
+import { LazyMobXTableStore } from 'shared/components/lazyMobXTable/LazyMobXTableStore';
 
 expect.extend(expectJSX);
 chai.use(chaiEnzyme());

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -1,5 +1,4 @@
 import SimpleTable from '../simpleTable/SimpleTable';
-import $ from 'jquery';
 import * as React from 'react';
 import {
     action,
@@ -43,6 +42,7 @@ import {
 import { ILazyMobXTableApplicationLazyDownloadDataFetcher } from '../../lib/ILazyMobXTableApplicationLazyDownloadDataFetcher';
 import { maxPage } from './utils';
 import { inputBoxChangeTimeoutEvent } from '../../lib/EventUtils';
+import { LazyMobXTableStore } from 'shared/components/lazyMobXTable/LazyMobXTableStore';
 import _ from 'lodash';
 
 export type SortDirection = 'asc' | 'desc';
@@ -68,6 +68,7 @@ export type Column<T> = {
         | ((data: T) => (number | null)[])
         | ((data: T) => (string | null)[])
         | ((data: T) => (string | number | null)[]);
+    sortParam?: string;
     render: (data: T, rowIndex?: number) => JSX.Element;
     download?: (data: T) => string | string[];
     tooltip?: JSX.Element;
@@ -77,7 +78,7 @@ export type Column<T> = {
     truncateOnResize?: boolean;
 };
 
-type LazyMobXTableProps<T> = {
+export type LazyMobXTableProps<T> = {
     className?: string;
     columns: Column<T>[];
     data?: T[];
@@ -223,8 +224,7 @@ function getListOfEmptyStrings<T>(maxColLength: number): string[] {
         .join('.')
         .split('.');
 }
-
-function getAsList<T>(
+export function getAsList<T>(
     data: Array<string | string[]>,
     maxColLength: number
 ): string[][] {
@@ -248,7 +248,7 @@ function getAsList<T>(
     return returnList;
 }
 
-function getDownloadObject<T>(columns: Column<T>[], rowData: T) {
+export function getDownloadObject<T>(columns: Column<T>[], rowData: T) {
     let downloadObject: {
         data: Array<string[] | string>;
         maxColLength: number;
@@ -269,580 +269,6 @@ function getDownloadObject<T>(columns: Column<T>[], rowData: T) {
     return downloadObject;
 }
 
-export class LazyMobXTableStore<T> {
-    @observable.ref public filterString: string | undefined = undefined;
-    @observable.ref private _itemsLabel: string | undefined = undefined;
-    @observable.ref private _itemsLabelPlural: string | undefined;
-    @observable.ref public sortColumn: string;
-    @observable public sortAscending: boolean;
-    @observable.ref public columns: Column<T>[];
-    @observable public dataStore: ILazyMobXTableApplicationDataStore<T>;
-    @observable public headerRefs: React.RefObject<any>[];
-    @observable public downloadDataFetcher:
-        | ILazyMobXTableApplicationLazyDownloadDataFetcher
-        | undefined;
-    @observable private onRowClick: ((d: T) => void) | undefined;
-    @observable private onRowMouseEnter: ((d: T) => void) | undefined;
-    @observable private onRowMouseLeave: ((d: T) => void) | undefined;
-
-    // this observable is intended to always refer to props.columnToHeaderFilterIconModal
-    @observable private _columnToHeaderFilterIconModal:
-        | ((column: Column<T>) => JSX.Element | undefined)
-        | undefined;
-    // this observable is intended to always refer to props.columnVisibility
-    // except possibly once "Reset columns" has been clicked
-    @observable private _columnVisibility:
-        | { [columnId: string]: boolean }
-        | undefined;
-    // this one keeps the state of the latest action (latest user selection)
-    @observable private _columnVisibilityOverride:
-        | { [columnId: string]: boolean }
-        | undefined;
-
-    @computed public get itemsPerPage() {
-        return this.dataStore.itemsPerPage;
-    }
-
-    public set itemsPerPage(i: number) {
-        this.dataStore.itemsPerPage = i;
-        this.page = this.page; // trigger clamping in page setter
-    }
-
-    @computed get firstHighlightedRowIndex() {
-        let index = -1;
-        for (let i = 0; i < this.displayData.length; i++) {
-            if (this.dataStore.isHighlighted(this.displayData[i])) {
-                index = i;
-                break;
-            }
-        }
-        return index;
-    }
-
-    @computed get displayData(): T[] {
-        return this.dataStore.tableData;
-    }
-
-    @computed get showingAllRows(): boolean {
-        return (
-            this.displayData.length <= this.itemsPerPage ||
-            this.itemsPerPage === -1
-        );
-    }
-
-    @computed public get page() {
-        return this.dataStore.page;
-    }
-    public set page(p: number) {
-        this.dataStore.page = this.clampPage(p);
-    }
-
-    private clampPage(p: number) {
-        p = Math.max(p, 0);
-        p = Math.min(p, this.maxPage);
-        return p;
-    }
-
-    @computed get maxPage() {
-        return maxPage(this.displayData.length, this.itemsPerPage);
-    }
-
-    @computed public get columnVisibility() {
-        return resolveColumnVisibility(
-            this.columnVisibilityByColumnDefinition,
-            this._columnVisibility,
-            this._columnVisibilityOverride
-        );
-    }
-
-    @computed public get columnVisibilityByColumnDefinition() {
-        return resolveColumnVisibilityByColumnDefinition(this.columns);
-    }
-
-    @computed public get showResetColumnsButton() {
-        return (
-            JSON.stringify(this.columnVisibility) !==
-            JSON.stringify(this.columnVisibilityByColumnDefinition)
-        );
-    }
-
-    @computed public get downloadData() {
-        const tableDownloadData: string[][] = [];
-
-        // add header (including hidden columns)
-        tableDownloadData[0] = this.columns
-            .filter(c => c.download)
-            .map(c => (c.headerDownload ? c.headerDownload(c.name) : c.name));
-
-        // add rows (including hidden columns). The purpose of this part is to ensure that
-        // if any element of rowData contains a column with multiple values, rowData is written as
-        // multiple rows in tableDownloadData
-        this.dataStore.sortedData.forEach((rowData: T) => {
-            // retrieve all the download information for each row and store it in an object,
-            // and calculate the maxColLength (max number of elements found in a column).
-            let downloadObject = getDownloadObject(this.columns, rowData);
-            // normalize the length of all columns based on the maxColLength (so that every column contains the
-            // same number of elements)
-            const rowDownloadData: string[][] = getAsList(
-                downloadObject.data,
-                downloadObject.maxColLength
-            );
-
-            //rowDownloadData is list of lists, containing all the elements per column.
-            //processedRowsDownloadData becomes the transposed of rowDownloadData.
-            let processedRowsDownloadData = rowDownloadData[0].map(function(
-                row: string,
-                i: number
-            ) {
-                return rowDownloadData.map(function(col) {
-                    return col[i];
-                });
-            });
-            //Writing the transposed list to tableDownloadData to build the final table.
-            processedRowsDownloadData.forEach(
-                (processedRowDownloadData: string[]) => {
-                    tableDownloadData.push(processedRowDownloadData);
-                }
-            );
-        });
-        return tableDownloadData;
-    }
-
-    @computed get sortColumnObject(): Column<T> | undefined {
-        return this.columns.find(
-            (col: Column<T>) => col.name === this.sortColumn
-        );
-    }
-
-    @computed get visibleData(): T[] {
-        return this.dataStore.visibleData;
-    }
-
-    private getNextSortAscending(clickedColumn: Column<T>) {
-        if (this.sortColumn === clickedColumn.name) {
-            // if current sort column is clicked column, simply toggle
-            return !this.sortAscending;
-        } else {
-            // otherwise, use columns initial sort direction, or default ascending
-            const sortDirection: SortDirection =
-                clickedColumn.defaultSortDirection || 'asc';
-            return sortDirection === 'asc';
-        }
-    }
-
-    @computed get sortMetric(): SortMetric<T> {
-        const sortColumnObject = this.sortColumnObject;
-        if (sortColumnObject && sortColumnObject.sortBy) {
-            return sortColumnObject.sortBy;
-        } else {
-            return () => 0;
-        }
-    }
-
-    @action
-    public defaultHeaderClick(column: Column<T>) {
-        this.sortAscending = this.getNextSortAscending(column);
-        this.dataStore.sortAscending = this.sortAscending;
-
-        this.sortColumn = column.name;
-        this.dataStore.sortMetric = this.sortMetric;
-        this.page = 0;
-    }
-
-    @computed
-    get headers(): JSX.Element[] {
-        return this.visibleColumns.map((column: Column<T>, index: number) => {
-            const headerProps: {
-                role?: 'button';
-                className?: 'sort-asc' | 'sort-des';
-                onClick?: (e: React.MouseEvent) => void;
-            } = {};
-            if (column.sortBy) {
-                headerProps.role = 'button';
-                headerProps.onClick = (e: React.MouseEvent) => {
-                    const target = e.target as HTMLElement;
-                    // Click of rc-tooltip in the header element bubbles the
-                    // on-click event, even though it is not a child of the
-                    // header cell in the DOM. The check below make sure the
-                    // click event originated from a a true child in the DOM.
-                    const parent = $(target).closest('.multilineHeader');
-                    if (parent && parent.length > 0) {
-                        this.defaultHeaderClick(column);
-                    }
-                };
-            }
-
-            let sortIcon = null;
-            if (this.sortColumn === column.name) {
-                if (this.sortAscending) {
-                    headerProps.className = 'sort-asc';
-                    sortIcon = (
-                        <i
-                            className={
-                                'fa fa-sort-asc lazyMobxTableSortArrowAsc'
-                            }
-                        />
-                    );
-                } else {
-                    headerProps.className = 'sort-des';
-                    sortIcon = (
-                        <i
-                            className={
-                                'fa fa-sort-desc lazyMobxTableSortArrowDesc'
-                            }
-                        />
-                    );
-                }
-            }
-
-            let label;
-            if (column.headerRender) {
-                label = column.headerRender(column.name);
-            } else {
-                label = <span>{column.name}</span>;
-            }
-            let thContents;
-
-            if (column.tooltip) {
-                thContents = (
-                    <DefaultTooltip placement="top" overlay={column.tooltip}>
-                        {label}
-                    </DefaultTooltip>
-                );
-            } else {
-                thContents = label;
-            }
-
-            thContents = (
-                <span {...headerProps}>
-                    {thContents}
-                    {sortIcon}
-                </span>
-            );
-
-            if (
-                this._columnToHeaderFilterIconModal &&
-                this._columnToHeaderFilterIconModal(column)
-            ) {
-                const alignToJustify = {
-                    left: 'flex-start',
-                    center: 'center',
-                    right: 'flex-end',
-                };
-                thContents = (
-                    <div
-                        style={{
-                            display: 'flex',
-                            justifyContent: column.align
-                                ? alignToJustify[column.align]
-                                : 'flex-start',
-                        }}
-                    >
-                        {thContents}
-                        {this._columnToHeaderFilterIconModal(column)}
-                    </div>
-                );
-            }
-
-            let style: any = {};
-            if (column.align) {
-                style.textAlign = column.align;
-            }
-            if (column.width) {
-                style.width = column.width;
-            }
-
-            return (
-                <React.Fragment key={index}>
-                    <th
-                        ref={this.headerRefs[index]}
-                        className="multilineHeader"
-                        style={style}
-                    >
-                        {thContents}
-                    </th>
-                    {column.resizable && (
-                        <ColumnResizer
-                            className="multilineHeader columnResizer"
-                            minWidth={0}
-                        />
-                    )}
-                </React.Fragment>
-            );
-        });
-    }
-
-    @computed get visibleColumns(): Column<T>[] {
-        return this.columns.filter(column => this.isVisible(column));
-    }
-
-    @computed get colVisProp(): IColumnVisibilityDef[] {
-        const colVisProp: IColumnVisibilityDef[] = [];
-
-        this.columns.forEach((column: Column<T>) => {
-            colVisProp.push({
-                id: column.hasOwnProperty('id') ? column.id! : column.name,
-                name: column.name,
-                visible: this.isVisible(column),
-                togglable: column.hasOwnProperty('togglable')
-                    ? column.togglable
-                    : true,
-            });
-        });
-
-        return colVisProp;
-    }
-
-    @computed get paginationStatusText(): string {
-        let firstVisibleItemDisp;
-        let lastVisibleItemDisp;
-
-        if (this.rows.length === 0) {
-            firstVisibleItemDisp = 0;
-            lastVisibleItemDisp = 0;
-        } else {
-            firstVisibleItemDisp =
-                this.itemsPerPage === PAGINATION_SHOW_ALL
-                    ? 1
-                    : this.page * this.itemsPerPage + 1;
-
-            lastVisibleItemDisp =
-                this.itemsPerPage === PAGINATION_SHOW_ALL
-                    ? this.rows.length
-                    : firstVisibleItemDisp + this.rows.length - 1;
-        }
-
-        let itemsLabel: string = this.itemsLabel;
-        if (itemsLabel.length) {
-            // we need to prepend the space here instead of within the actual return value
-            // to avoid unnecessary white-space at the end of the string
-            itemsLabel = ` ${itemsLabel}`;
-        }
-
-        return `Showing ${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${this.displayData.length}${itemsLabel}`;
-    }
-
-    @computed get tds(): JSX.Element[][] {
-        return this.visibleData.map((datum: T, rowIndex: number) => {
-            return this.visibleColumns.map((column: Column<T>) => {
-                const cellProps: any = {
-                    key: column.name,
-                };
-
-                if (column.resizable && column.truncateOnResize) {
-                    cellProps.className = 'lazyMobXTableTruncatedCell';
-                }
-
-                const result = (
-                    <td {...cellProps}>{column.render(datum, rowIndex)}</td>
-                );
-
-                if (column.resizable) {
-                    return (
-                        <React.Fragment>
-                            {result}
-                            <ColumnResizer
-                                className="columnResizer"
-                                minWidth={0}
-                            />
-                        </React.Fragment>
-                    );
-                }
-                return result;
-            });
-        });
-    }
-
-    @computed get rows(): JSX.Element[] {
-        // We separate this so that highlighting isn't such a costly operation
-        const ret = [];
-        for (let i = 0; i < this.visibleData.length; i++) {
-            const rowProps: any = {};
-            const rowIsHighlighted = this.dataStore.isHighlighted(
-                this.visibleData[i]
-            );
-            const classNames = [];
-            if (rowIsHighlighted) {
-                classNames.push('highlighted');
-            }
-            if (this.onRowClick) {
-                classNames.push('clickable');
-
-                const onRowClick = this.onRowClick; // by the time its called this might be undefined again, so need to save ref
-                rowProps.onClick = () => {
-                    onRowClick(this.visibleData[i]);
-                };
-            }
-            if (this.onRowMouseEnter) {
-                const onRowMouseEnter = this.onRowMouseEnter; // by the time its called this might be undefined again, so need to save ref
-                rowProps.onMouseEnter = () => {
-                    onRowMouseEnter!(this.visibleData[i]);
-                };
-            }
-            if (this.onRowMouseLeave) {
-                const onRowMouseLeave = this.onRowMouseLeave; // by the time its called this might be undefined again, so need to save ref
-                rowProps.onMouseLeave = () => {
-                    onRowMouseLeave!(this.visibleData[i]);
-                };
-            }
-            if (classNames.length) {
-                rowProps.className = classNames.join(' ');
-            }
-            ret.push(
-                <tr key={i} {...rowProps}>
-                    {this.tds[i]}
-                </tr>
-            );
-        }
-        return ret;
-    }
-
-    @action pageToRowIndex(index: number) {
-        this.page = Math.floor(index / this.itemsPerPage);
-    }
-
-    @action setFilterString(str: string) {
-        // we need to keep the filter string value in this store as well as in the data store,
-        // because data store gets reset each time the component receives props.
-        this.filterString = str;
-        this.dataStore.filterString = str;
-        this.page = 0;
-        this.dataStore.setFilter(
-            (
-                d: T,
-                filterString: string,
-                filterStringUpper: string,
-                filterStringLower: string
-            ) => {
-                if (!filterString) {
-                    return true; // dont filter if no input
-                }
-                let match = false;
-                for (const column of this.visibleColumns) {
-                    match =
-                        (column.filter &&
-                            column.filter(
-                                d,
-                                filterString,
-                                filterStringUpper,
-                                filterStringLower
-                            )) ||
-                        false;
-                    if (match) {
-                        break;
-                    }
-                }
-                return match;
-            }
-        );
-    }
-
-    @computed get itemsLabel() {
-        if (this._itemsLabel) {
-            // use itemsLabel for plural in case no itemsLabelPlural provided
-            if (!this._itemsLabelPlural || this.displayData.length === 1) {
-                return this._itemsLabel;
-            } else {
-                return this._itemsLabelPlural;
-            }
-        } else {
-            return '';
-        }
-    }
-
-    @action setProps(props: LazyMobXTableProps<T>) {
-        this.columns = props.columns;
-        this._itemsLabel = props.itemsLabel;
-        this._itemsLabelPlural = props.itemsLabelPlural;
-        this._columnVisibility = props.columnVisibility;
-        this.downloadDataFetcher = props.downloadDataFetcher;
-        this.onRowClick = props.onRowClick;
-        this.onRowMouseEnter = props.onRowMouseEnter;
-        this.onRowMouseLeave = props.onRowMouseLeave;
-
-        if (props.dataStore) {
-            this.dataStore = props.dataStore;
-        } else {
-            this.dataStore = new SimpleLazyMobXTableApplicationDataStore<T>(
-                props.data || []
-            );
-        }
-        if (this.dataStore.page === undefined) {
-            this.dataStore.page = 0;
-        }
-        if (this.itemsPerPage === undefined) {
-            this.itemsPerPage = props.initialItemsPerPage || 50;
-        }
-        // even if dataStore passed in, we need to initialize sort props if undefined
-        // otherwise we lose the functionality of 'initialSortColumn' and 'initialSortDirection' props
-        if (this.dataStore.sortAscending === undefined) {
-            this.dataStore.sortAscending = this.sortAscending;
-        } else {
-            // inherit the current state if defined
-            this.sortAscending = this.dataStore.sortAscending;
-        }
-
-        if (this.dataStore.sortMetric === undefined) {
-            this.dataStore.sortMetric = this.sortMetric;
-        }
-
-        // we would like to keep the previous filter if it exists
-        // this is only a problem if table is managing its own data store
-        // if not, then the filter state is managed by parent and does not need
-        // to be persisted here
-        // NOTE: this is very confusing and should be remedied by a refactor
-        if (!props.dataStore && this.filterString) {
-            this.setFilterString(this.filterString);
-        }
-    }
-
-    @action updateColumnVisibility(id: string, visible: boolean) {
-        // no previous action, need to init
-        if (this._columnVisibilityOverride === undefined) {
-            this._columnVisibilityOverride = resolveColumnVisibility(
-                this.columnVisibilityByColumnDefinition,
-                this._columnVisibility
-            );
-        }
-
-        // update visibility
-        if (this._columnVisibilityOverride[id] !== undefined) {
-            this._columnVisibilityOverride[id] = visible;
-        }
-    }
-
-    @action.bound
-    resetColumnVisibility() {
-        this._columnVisibility = undefined;
-        this._columnVisibilityOverride = undefined;
-    }
-
-    public isVisible(column: Column<T>): boolean {
-        const index = column.hasOwnProperty('id') ? column.id! : column.name;
-        return this.columnVisibility[index] || false;
-    }
-
-    constructor(lazyMobXTableProps: LazyMobXTableProps<T>) {
-        makeObservable(this);
-        this.sortColumn = lazyMobXTableProps.initialSortColumn || '';
-        this.sortAscending = lazyMobXTableProps.initialSortDirection !== 'desc'; // default ascending
-        this.headerRefs = lazyMobXTableProps.columns.map(x =>
-            React.createRef()
-        );
-        this._columnToHeaderFilterIconModal =
-            lazyMobXTableProps.columnToHeaderFilterIconModal;
-        this.setProps(lazyMobXTableProps);
-        reaction(
-            () => this.displayData.length,
-            () => {
-                this.page = this.clampPage(
-                    this.page
-                ); /* update for possibly reduced maxPage */
-            }
-        );
-    }
-}
-
 @observer
 export default class LazyMobXTable<T> extends React.Component<
     LazyMobXTableProps<T>,
@@ -850,7 +276,6 @@ export default class LazyMobXTable<T> extends React.Component<
 > {
     private store: LazyMobXTableStore<T>;
     private handlers: { [fnName: string]: (...args: any[]) => void };
-    private initialFilterTextSet = false;
     private filterInput: HTMLInputElement;
     private filterInputReaction: IReactionDisposer;
     private pageToHighlightReaction: IReactionDisposer;
@@ -944,6 +369,9 @@ export default class LazyMobXTable<T> extends React.Component<
             changeItemsPerPage: (ipp: number) => {
                 this.store.itemsPerPage = ipp;
             },
+            showMore: (ipp: number) => {
+                this.store.showMore(ipp);
+            },
             incPage: () => {
                 this.store.page += 1;
             },
@@ -952,10 +380,16 @@ export default class LazyMobXTable<T> extends React.Component<
             },
             filterInputRef: (input: HTMLInputElement) => {
                 this.filterInput = input;
-                if (input && !this.initialFilterTextSet) {
-                    input.value = this.props.initialFilterString!;
-                    this.store.setFilterString(this.props.initialFilterString!);
-                    this.initialFilterTextSet = true;
+                if (!input) {
+                    return;
+                }
+                if (this.props.dataStore?.filterString) {
+                    this.setInputValue(
+                        input,
+                        this.props.dataStore?.filterString
+                    );
+                } else if (!this.store.initialFilterTextSet) {
+                    this.setInputValue(input, this.props.initialFilterString!);
                 }
             },
         };
@@ -981,6 +415,12 @@ export default class LazyMobXTable<T> extends React.Component<
                 }
             }
         );
+    }
+
+    private setInputValue(input: HTMLInputElement, inputValue: string) {
+        input.value = inputValue;
+        this.store.setFilterString(inputValue);
+        this.store.initialFilterTextSet = true;
     }
 
     componentDidMount() {
@@ -1065,14 +505,16 @@ export default class LazyMobXTable<T> extends React.Component<
         let paginationProps: IPaginationControlsProps = {
             className: 'text-center topPagination',
             itemsPerPage: this.store.itemsPerPage,
-            totalItems: this.store.displayData.length,
+            moreItemsPerPage: this.store.moreItemsPerPage,
+            totalItems: this.store.dataStore.totalItems,
             currentPage: this.store.page,
             onChangeItemsPerPage: this.handlers.changeItemsPerPage,
+            onShowMoreClick: this.handlers.showMore,
             showItemsPerPageSelector: false,
             onPreviousPageClick: this.handlers.decPage,
             onNextPageClick: this.handlers.incPage,
-            previousPageDisabled: this.store.page === 0,
-            nextPageDisabled: this.store.page === this.store.maxPage,
+            previousPageDisabled: this.store.dataStore.isFirstPage,
+            nextPageDisabled: this.store.dataStore.isLastPage,
             textBeforeButtons: this.store.paginationStatusText,
             groupButtons: false,
             bsStyle: 'primary',

--- a/src/shared/components/lazyMobXTable/LazyMobXTableStore.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTableStore.tsx
@@ -1,0 +1,653 @@
+import { action, computed, makeObservable, observable, reaction } from 'mobx';
+import {
+    ILazyMobXTableApplicationDataStore,
+    SimpleLazyMobXTableApplicationDataStore,
+} from 'shared/lib/ILazyMobXTableApplicationDataStore';
+import * as React from 'react';
+import { ILazyMobXTableApplicationLazyDownloadDataFetcher } from 'shared/lib/ILazyMobXTableApplicationLazyDownloadDataFetcher';
+import {
+    DefaultTooltip,
+    resolveColumnVisibility,
+    resolveColumnVisibilityByColumnDefinition,
+} from 'cbioportal-frontend-commons';
+import { SortMetric } from 'shared/lib/ISortMetric';
+import $ from 'jquery';
+import ColumnResizer from 'react-column-resizer';
+import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls/ColumnVisibilityControls';
+import { SHOW_ALL_PAGE_SIZE as PAGINATION_SHOW_ALL } from 'shared/components/paginationControls/PaginationControls';
+import {
+    Column,
+    getAsList,
+    getDownloadObject,
+    LazyMobXTableProps,
+    SortDirection,
+} from 'shared/components/lazyMobXTable/LazyMobXTable';
+import { maxPage } from './utils';
+
+export class LazyMobXTableStore<T> {
+    @computed get filterString() {
+        return this.dataStore.filterString;
+    }
+
+    set filterString(filterString: string) {
+        this.dataStore.filterString = filterString;
+    }
+    @observable.ref private _itemsLabel: string | undefined = undefined;
+    @observable.ref private _itemsLabelPlural: string | undefined;
+    @observable.ref public columns: Column<T>[];
+    @observable public dataStore: ILazyMobXTableApplicationDataStore<T>;
+    @observable public headerRefs: React.RefObject<any>[];
+    @observable public downloadDataFetcher:
+        | ILazyMobXTableApplicationLazyDownloadDataFetcher<T>
+        | undefined;
+    @observable private onRowClick: ((d: T) => void) | undefined;
+    @observable private onRowMouseEnter: ((d: T) => void) | undefined;
+    @observable private onRowMouseLeave: ((d: T) => void) | undefined;
+
+    // this observable is intended to always refer to props.columnToHeaderFilterIconModal
+    @observable private _columnToHeaderFilterIconModal:
+        | ((column: Column<T>) => JSX.Element | undefined)
+        | undefined;
+    // this observable is intended to always refer to props.columnVisibility
+    // except possibly once "Reset columns" has been clicked
+    @observable private _columnVisibility:
+        | { [columnId: string]: boolean }
+        | undefined;
+    // this one keeps the state of the latest action (latest user selection)
+    @observable private _columnVisibilityOverride:
+        | { [columnId: string]: boolean }
+        | undefined;
+
+    @computed get initialFilterTextSet() {
+        return this.dataStore.initialFilterTextSet;
+    }
+
+    set initialFilterTextSet(initialFilterTextSet: boolean) {
+        this.dataStore.initialFilterTextSet = initialFilterTextSet;
+    }
+
+    @computed public get itemsPerPage() {
+        return this.dataStore.itemsPerPage;
+    }
+
+    @computed public get moreItemsPerPage() {
+        return this.dataStore.moreItemsPerPage;
+    }
+
+    @action
+    public showMore(itemsPerPage: number) {
+        this.dataStore.moreItemsPerPage = itemsPerPage;
+    }
+
+    public set itemsPerPage(i: number) {
+        this.dataStore.itemsPerPage = i;
+        this.page = this.page; // trigger clamping in page setter
+    }
+
+    @computed get firstHighlightedRowIndex() {
+        let index = -1;
+        for (let i = 0; i < this.displayData.length; i++) {
+            if (this.dataStore.isHighlighted(this.displayData[i])) {
+                index = i;
+                break;
+            }
+        }
+        return index;
+    }
+
+    @computed get displayData(): T[] {
+        return this.dataStore.tableData;
+    }
+
+    @computed get showingAllRows(): boolean {
+        return (
+            this.dataStore.totalItems <= this.itemsPerPage ||
+            this.itemsPerPage === -1
+        );
+    }
+
+    @computed public get page() {
+        return this.dataStore.page;
+    }
+
+    public set page(p: number) {
+        this.dataStore.page = p;
+    }
+
+    @computed public get sortColumn() {
+        return this.dataStore.sortColumn;
+    }
+
+    public set sortColumn(sortColumn: string | undefined) {
+        this.dataStore.sortColumn = sortColumn;
+    }
+
+    @computed public get sortAscending(): boolean {
+        return this.dataStore.sortAscending;
+    }
+
+    public set sortAscending(sortAscending: boolean) {
+        this.dataStore.sortAscending = sortAscending;
+    }
+
+    private clampPage(p: number) {
+        p = Math.max(p, 0);
+        p = Math.min(p, this.maxPage);
+        return p;
+    }
+
+    @computed get maxPage() {
+        return maxPage(this.dataStore.totalItems, this.itemsPerPage);
+    }
+
+    @computed public get columnVisibility() {
+        return resolveColumnVisibility(
+            this.columnVisibilityByColumnDefinition,
+            this._columnVisibility,
+            this._columnVisibilityOverride
+        );
+    }
+
+    @computed public get columnVisibilityByColumnDefinition() {
+        return resolveColumnVisibilityByColumnDefinition(this.columns);
+    }
+
+    @computed public get showResetColumnsButton() {
+        return (
+            JSON.stringify(this.columnVisibility) !==
+            JSON.stringify(this.columnVisibilityByColumnDefinition)
+        );
+    }
+
+    @computed public get downloadData() {
+        const tableDownloadData: string[][] = [];
+
+        // add header (including hidden columns)
+        tableDownloadData[0] = this.columns
+            .filter(c => c.download)
+            .map(c => (c.headerDownload ? c.headerDownload(c.name) : c.name));
+
+        // add rows (including hidden columns). The purpose of this part is to ensure that
+        // if any element of rowData contains a column with multiple values, rowData is written as
+        // multiple rows in tableDownloadData
+        this.dataStore.sortedDownloadedData.forEach((rowData: T) => {
+            // retrieve all the download information for each row and store it in an object,
+            // and calculate the maxColLength (max number of elements found in a column).
+            let downloadObject = getDownloadObject(this.columns, rowData);
+            // normalize the length of all columns based on the maxColLength (so that every column contains the
+            // same number of elements)
+            const rowDownloadData: string[][] = getAsList(
+                downloadObject.data,
+                downloadObject.maxColLength
+            );
+
+            //rowDownloadData is list of lists, containing all the elements per column.
+            //processedRowsDownloadData becomes the transposed of rowDownloadData.
+            let processedRowsDownloadData = rowDownloadData[0].map(function(
+                row: string,
+                i: number
+            ) {
+                return rowDownloadData.map(function(col) {
+                    return col[i];
+                });
+            });
+            //Writing the transposed list to tableDownloadData to build the final table.
+            processedRowsDownloadData.forEach(
+                (processedRowDownloadData: string[]) => {
+                    tableDownloadData.push(processedRowDownloadData);
+                }
+            );
+        });
+        return tableDownloadData;
+    }
+
+    @computed get sortColumnObject(): Column<T> | undefined {
+        return this.columns.find(
+            (col: Column<T>) => col.name === this.sortColumn
+        );
+    }
+
+    @computed get visibleData(): T[] {
+        return this.dataStore.visibleData;
+    }
+
+    private getNextSortAscending(clickedColumn: Column<T>) {
+        if (this.sortColumn === clickedColumn.name) {
+            // if current sort column is clicked column, simply toggle
+            return !this.sortAscending;
+        } else {
+            // otherwise, use columns initial sort direction, or default ascending
+            const sortDirection: SortDirection =
+                clickedColumn.defaultSortDirection || 'asc';
+            return sortDirection === 'asc';
+        }
+    }
+
+    @computed get sortMetric(): SortMetric<T> {
+        const sortColumnObject = this.sortColumnObject;
+        if (sortColumnObject && sortColumnObject.sortBy) {
+            return sortColumnObject.sortBy;
+        } else {
+            return () => 0;
+        }
+    }
+
+    @action
+    public defaultHeaderClick(column: Column<T>) {
+        this.sortAscending = this.getNextSortAscending(column);
+        this.dataStore.sortAscending = this.sortAscending;
+
+        this.sortColumn = column.name;
+        this.dataStore.sortMetric = this.sortMetric;
+        this.dataStore.sortParam = column.sortParam;
+        this.page = 0;
+    }
+
+    @computed
+    get headers(): JSX.Element[] {
+        return this.visibleColumns.map((column: Column<T>, index: number) => {
+            const headerProps: {
+                role?: 'button';
+                className?: 'sort-asc' | 'sort-des';
+                onClick?: (e: React.MouseEvent) => void;
+            } = {};
+            if (column.sortBy) {
+                headerProps.role = 'button';
+                headerProps.onClick = (e: React.MouseEvent) => {
+                    const target = e.target as HTMLElement;
+                    // Click of rc-tooltip in the header element bubbles the
+                    // on-click event, even though it is not a child of the
+                    // header cell in the DOM. The check below make sure the
+                    // click event originated from a true child in the DOM.
+                    const parent = $(target).closest('.multilineHeader');
+                    if (parent && parent.length > 0) {
+                        this.defaultHeaderClick(column);
+                    }
+                };
+            }
+
+            let sortIcon = null;
+            if (this.sortColumn === column.name) {
+                if (this.sortAscending) {
+                    headerProps.className = 'sort-asc';
+                    sortIcon = (
+                        <i
+                            className={
+                                'fa fa-sort-asc lazyMobxTableSortArrowAsc'
+                            }
+                        />
+                    );
+                } else {
+                    headerProps.className = 'sort-des';
+                    sortIcon = (
+                        <i
+                            className={
+                                'fa fa-sort-desc lazyMobxTableSortArrowDesc'
+                            }
+                        />
+                    );
+                }
+            }
+
+            let label;
+            if (column.headerRender) {
+                label = column.headerRender(column.name);
+            } else {
+                label = <span>{column.name}</span>;
+            }
+            let thContents;
+
+            if (column.tooltip) {
+                thContents = (
+                    <DefaultTooltip placement="top" overlay={column.tooltip}>
+                        {label}
+                    </DefaultTooltip>
+                );
+            } else {
+                thContents = label;
+            }
+
+            thContents = (
+                <span {...headerProps}>
+                    {thContents}
+                    {sortIcon}
+                </span>
+            );
+
+            if (
+                this._columnToHeaderFilterIconModal &&
+                this._columnToHeaderFilterIconModal(column)
+            ) {
+                const alignToJustify = {
+                    left: 'flex-start',
+                    center: 'center',
+                    right: 'flex-end',
+                };
+                thContents = (
+                    <div
+                        style={{
+                            display: 'flex',
+                            justifyContent: column.align
+                                ? alignToJustify[column.align]
+                                : 'flex-start',
+                        }}
+                    >
+                        {thContents}
+                        {this._columnToHeaderFilterIconModal(column)}
+                    </div>
+                );
+            }
+
+            let style: any = {};
+            if (column.align) {
+                style.textAlign = column.align;
+            }
+            if (column.width) {
+                style.width = column.width;
+            }
+
+            return (
+                <React.Fragment key={index}>
+                    <th
+                        ref={this.headerRefs[index]}
+                        className="multilineHeader"
+                        style={style}
+                    >
+                        {thContents}
+                    </th>
+                    {column.resizable && (
+                        <ColumnResizer
+                            className="multilineHeader columnResizer"
+                            minWidth={0}
+                        />
+                    )}
+                </React.Fragment>
+            );
+        });
+    }
+
+    @computed get visibleColumns(): Column<T>[] {
+        return this.columns.filter(column => this.isVisible(column));
+    }
+
+    @computed get colVisProp(): IColumnVisibilityDef[] {
+        const colVisProp: IColumnVisibilityDef[] = [];
+
+        this.columns.forEach((column: Column<T>) => {
+            colVisProp.push({
+                id: column.hasOwnProperty('id') ? column.id! : column.name,
+                name: column.name,
+                visible: this.isVisible(column),
+                togglable: column.hasOwnProperty('togglable')
+                    ? column.togglable
+                    : true,
+            });
+        });
+
+        return colVisProp;
+    }
+
+    @computed get paginationStatusText(): string {
+        let firstVisibleItemDisp;
+        let lastVisibleItemDisp;
+
+        if (this.rows.length === 0) {
+            firstVisibleItemDisp = 0;
+            lastVisibleItemDisp = 0;
+        } else {
+            firstVisibleItemDisp =
+                this.itemsPerPage === PAGINATION_SHOW_ALL
+                    ? 1
+                    : this.page * this.itemsPerPage + 1;
+
+            const currentPageSize =
+                this.dataStore.moreItemsPerPage || this.dataStore.itemsPerPage;
+            lastVisibleItemDisp =
+                this.itemsPerPage === PAGINATION_SHOW_ALL
+                    ? this.dataStore.totalItems
+                    : firstVisibleItemDisp + currentPageSize - 1;
+        }
+
+        let itemsLabel: string = this.itemsLabel;
+        if (itemsLabel.length) {
+            // we need to prepend the space here instead of within the actual return value
+            // to avoid unnecessary white-space at the end of the string
+            itemsLabel = ` ${itemsLabel}`;
+        }
+
+        return `Showing ${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${this.dataStore.totalItems}${itemsLabel}`;
+    }
+
+    @computed get tds(): JSX.Element[][] {
+        return this.visibleData.map((datum: T, rowIndex: number) => {
+            return this.visibleColumns.map((column: Column<T>) => {
+                const cellProps: any = {
+                    key: column.name,
+                };
+
+                if (column.resizable && column.truncateOnResize) {
+                    cellProps.className = 'lazyMobXTableTruncatedCell';
+                }
+
+                const result = (
+                    <td {...cellProps}>{column.render(datum, rowIndex)}</td>
+                );
+
+                if (column.resizable) {
+                    return (
+                        <React.Fragment>
+                            {result}
+                            <ColumnResizer
+                                className="columnResizer"
+                                minWidth={0}
+                            />
+                        </React.Fragment>
+                    );
+                }
+                return result;
+            });
+        });
+    }
+
+    @computed get rows(): JSX.Element[] {
+        // We separate this so that highlighting isn't such a costly operation
+        const ret = [];
+        for (let i = 0; i < this.visibleData.length; i++) {
+            const rowProps: any = {};
+            const rowIsHighlighted = this.dataStore.isHighlighted(
+                this.visibleData[i]
+            );
+            const classNames = [];
+            if (rowIsHighlighted) {
+                classNames.push('highlighted');
+            }
+            if (this.onRowClick) {
+                classNames.push('clickable');
+
+                const onRowClick = this.onRowClick; // by the time its called this might be undefined again, so need to save ref
+                rowProps.onClick = () => {
+                    onRowClick(this.visibleData[i]);
+                };
+            }
+            if (this.onRowMouseEnter) {
+                const onRowMouseEnter = this.onRowMouseEnter; // by the time its called this might be undefined again, so need to save ref
+                rowProps.onMouseEnter = () => {
+                    onRowMouseEnter!(this.visibleData[i]);
+                };
+            }
+            if (this.onRowMouseLeave) {
+                const onRowMouseLeave = this.onRowMouseLeave; // by the time its called this might be undefined again, so need to save ref
+                rowProps.onMouseLeave = () => {
+                    onRowMouseLeave!(this.visibleData[i]);
+                };
+            }
+            if (classNames.length) {
+                rowProps.className = classNames.join(' ');
+            }
+            ret.push(
+                <tr key={i} {...rowProps}>
+                    {this.tds[i]}
+                </tr>
+            );
+        }
+        return ret;
+    }
+
+    @action pageToRowIndex(index: number) {
+        this.page = Math.floor(index / this.itemsPerPage);
+    }
+
+    @action setFilterString(str: string) {
+        if (str === this.dataStore.filterString) {
+            return;
+        }
+        // we need to keep the filter string value in this store as well as in the data store,
+        // because data store gets reset each time the component receives props.
+        this.dataStore.filterString = str;
+        this.dataStore.page = 0;
+        this.dataStore.setFilter(
+            (
+                d: T,
+                filterString: string,
+                filterStringUpper: string,
+                filterStringLower: string
+            ) => {
+                if (!filterString) {
+                    return true; // dont filter if no input
+                }
+                let match = false;
+                for (const column of this.visibleColumns) {
+                    match =
+                        (column.filter &&
+                            column.filter(
+                                d,
+                                filterString,
+                                filterStringUpper,
+                                filterStringLower
+                            )) ||
+                        false;
+                    if (match) {
+                        break;
+                    }
+                }
+                return match;
+            }
+        );
+    }
+
+    @computed get itemsLabel() {
+        if (this._itemsLabel) {
+            // use itemsLabel for plural in case no itemsLabelPlural provided
+            if (!this._itemsLabelPlural || this.displayData.length === 1) {
+                return this._itemsLabel;
+            } else {
+                return this._itemsLabelPlural;
+            }
+        } else {
+            return '';
+        }
+    }
+
+    @action initDataStore(props: LazyMobXTableProps<T>) {
+        if (props.dataStore) {
+            this.dataStore = props.dataStore;
+        } else {
+            this.dataStore = new SimpleLazyMobXTableApplicationDataStore<T>(
+                props.data || []
+            );
+        }
+    }
+
+    @action setProps(props: LazyMobXTableProps<T>) {
+        this.columns = props.columns;
+        this._itemsLabel = props.itemsLabel;
+        this._itemsLabelPlural = props.itemsLabelPlural;
+        this._columnVisibility = props.columnVisibility;
+        this.downloadDataFetcher = props.downloadDataFetcher;
+        this.onRowClick = props.onRowClick;
+        this.onRowMouseEnter = props.onRowMouseEnter;
+        this.onRowMouseLeave = props.onRowMouseLeave;
+
+        if (this.dataStore.page === undefined) {
+            this.dataStore.page = 0;
+        }
+        if (this.itemsPerPage === undefined) {
+            this.itemsPerPage = props.initialItemsPerPage || 50;
+        }
+        // even if dataStore passed in, we need to initialize sort props if undefined
+        // otherwise we lose the functionality of 'initialSortColumn' and 'initialSortDirection' props
+        if (this.dataStore.sortAscending === undefined) {
+            this.dataStore.sortAscending = this.sortAscending;
+        } else {
+            // inherit the current state if defined
+            this.sortAscending = this.dataStore.sortAscending;
+        }
+
+        if (this.dataStore.sortMetric === undefined) {
+            this.dataStore.sortMetric = this.sortMetric;
+        }
+
+        // we would like to keep the previous filter if it exists
+        // this is only a problem if table is managing its own data store
+        // if not, then the filter state is managed by parent and does not need
+        // to be persisted here
+        // NOTE: this is very confusing and should be remedied by a refactor
+        if (!props.dataStore && this.filterString) {
+            this.setFilterString(this.filterString);
+        }
+    }
+
+    @action updateColumnVisibility(id: string, visible: boolean) {
+        // no previous action, need to init
+        if (this._columnVisibilityOverride === undefined) {
+            this._columnVisibilityOverride = resolveColumnVisibility(
+                this.columnVisibilityByColumnDefinition,
+                this._columnVisibility
+            );
+        }
+
+        // update visibility
+        if (this._columnVisibilityOverride[id] !== undefined) {
+            this._columnVisibilityOverride[id] = visible;
+        }
+    }
+
+    @action.bound
+    resetColumnVisibility() {
+        this._columnVisibility = undefined;
+        this._columnVisibilityOverride = undefined;
+    }
+
+    public isVisible(column: Column<T>): boolean {
+        const index = column.hasOwnProperty('id') ? column.id! : column.name;
+        return this.columnVisibility[index] || false;
+    }
+
+    constructor(lazyMobXTableProps: LazyMobXTableProps<T>) {
+        makeObservable(this);
+        this.initDataStore(lazyMobXTableProps);
+        if (this.sortColumn === undefined) {
+            this.sortColumn = lazyMobXTableProps.initialSortColumn || '';
+        }
+        if (this.sortAscending === undefined) {
+            this.sortAscending =
+                lazyMobXTableProps.initialSortDirection !== 'desc'; // default ascending
+        }
+        this.headerRefs = lazyMobXTableProps.columns.map(x =>
+            React.createRef()
+        );
+        this._columnToHeaderFilterIconModal =
+            lazyMobXTableProps.columnToHeaderFilterIconModal;
+        this.setProps(lazyMobXTableProps);
+
+        // TODO: reuse?
+        // reaction(
+        //     () => this.dataStore.totalItems,
+        //     () => {
+        //         this.page = this.clampPage(
+        //             this.page
+        //         ); /* update for possibly reduced maxPage */
+        //     }
+        // );
+    }
+}

--- a/src/shared/components/lazyMobXTable/TablePaginationParams.ts
+++ b/src/shared/components/lazyMobXTable/TablePaginationParams.ts
@@ -1,0 +1,9 @@
+export type PageDirection = 'ASC' | 'DESC';
+
+export interface TablePaginationParams {
+    direction: PageDirection;
+    pageNumber: number;
+    pageSize: number;
+    sortParam?: string;
+    searchTerm?: string;
+}

--- a/src/shared/components/lazyMobXTable/TablePaginationStore.tsx
+++ b/src/shared/components/lazyMobXTable/TablePaginationStore.tsx
@@ -1,0 +1,26 @@
+import MobxPromise from 'mobxpromise';
+import { TablePaginationParams } from 'shared/components/lazyMobXTable/TablePaginationParams';
+
+/**
+ * Store containing all information related to a single table page
+ * When one of the ${@link TablePaginationParams} properties change
+ * a new page will be retrieved from the backend.
+ */
+export interface TablePaginationStore<T> extends TablePaginationParams {
+    /**
+     * Defines number of items on current page
+     * without shifting page or increasing request page size
+     *
+     * Note: simply changing itemsPerPage would also
+     * shift the first item (=pageNumber * itemsPerPage)
+     */
+    moreItemsPerPage: number | undefined;
+
+    /**
+     * Result
+     */
+    totalItems: number;
+    isFirst: boolean;
+    isLast: boolean;
+    pageItems: MobxPromise<T[]>;
+}

--- a/src/shared/components/lazyMobXTable/TablePaginationStoreAdaptor.ts
+++ b/src/shared/components/lazyMobXTable/TablePaginationStoreAdaptor.ts
@@ -1,0 +1,177 @@
+import { action, computed, makeObservable, observable } from 'mobx';
+import { SortMetric } from 'shared/lib/ISortMetric';
+import {
+    DataFilterFunction,
+    getSortedData,
+    getSortedFilteredData,
+    getTableData,
+    ILazyMobXTableApplicationDataStore,
+} from 'shared/lib/ILazyMobXTableApplicationDataStore';
+import { TablePaginationStore } from 'shared/components/lazyMobXTable/TablePaginationStore';
+
+/**
+ * Wrapper around ${@link TablePaginationStore}
+ * for paginated data loading in ${@link LazyMobXTable}s
+ */
+export class TablePaginationStoreAdaptor<T>
+    implements ILazyMobXTableApplicationDataStore<T> {
+    private pageStore: TablePaginationStore<T>;
+
+    @observable protected dataFilter: DataFilterFunction<T>;
+    @observable protected dataSelector: (d: T) => boolean;
+    @observable public dataHighlighter: (d: T) => boolean;
+    @observable public downloadedData: T[];
+    @observable public sortMetric: SortMetric<T> | undefined;
+    @observable public sortColumn: string | undefined;
+
+    constructor(pageStore: TablePaginationStore<T>) {
+        this.pageStore = pageStore;
+        this.filterString = '';
+        this.dataHighlighter = () => false;
+        this.dataSelector = () => false;
+        this.dataFilter = () => true;
+        makeObservable<
+            TablePaginationStoreAdaptor<T>,
+            'dataFilter' | 'dataSelector'
+        >(this);
+    }
+
+    @computed get allData() {
+        if (!this.pageStore.pageItems.result) {
+            return [];
+        }
+        return this.pageStore.pageItems.result;
+    }
+
+    @computed get sortParam() {
+        return this.pageStore.sortParam;
+    }
+
+    set sortParam(sortParam: string | undefined) {
+        this.pageStore.sortParam = sortParam;
+    }
+
+    @computed get page() {
+        return this.pageStore.pageNumber;
+    }
+
+    set page(page: number) {
+        this.pageStore.pageNumber = page;
+    }
+
+    @computed get itemsPerPage() {
+        return this.pageStore.pageSize;
+    }
+
+    set itemsPerPage(itemsPerPage: number) {
+        this.pageStore.pageSize = itemsPerPage;
+    }
+
+    @computed get direction() {
+        return this.pageStore.direction;
+    }
+
+    set direction(newDirection) {
+        this.pageStore.direction = newDirection;
+    }
+
+    @computed get sortAscending(): boolean {
+        return this.pageStore.direction === 'ASC';
+    }
+
+    set sortAscending(isAscending: boolean) {
+        this.pageStore.direction = isAscending ? 'ASC' : 'DESC';
+    }
+
+    @computed get filterString(): string {
+        return this.pageStore.searchTerm || '';
+    }
+
+    set filterString(newFilterString: string) {
+        this.pageStore.searchTerm = newFilterString;
+    }
+
+    @computed get sortedData() {
+        return getSortedData(this.allData, this.sortMetric, this.sortAscending);
+    }
+
+    @computed get sortedFilteredData() {
+        return getSortedFilteredData(
+            this.sortedData,
+            this.filterString,
+            this.dataFilter
+        );
+    }
+
+    @computed get sortedFilteredSelectedData() {
+        return this.sortedFilteredData.filter(this.dataSelector);
+    }
+
+    @computed get tableData() {
+        return getTableData(
+            this.sortedFilteredData,
+            this.sortedFilteredSelectedData
+        );
+    }
+
+    @computed get visibleData(): T[] {
+        return this.tableData;
+    }
+
+    @computed get showingAllData() {
+        return this.tableData.length === this.allData.length;
+    }
+
+    @action public setFilter(
+        fn: (
+            d: T,
+            filterString?: string,
+            filterStringUpper?: string,
+            filterStringLower?: string
+        ) => boolean
+    ) {
+        this.dataFilter = fn;
+    }
+
+    public getFilter() {
+        return this.dataFilter;
+    }
+
+    @action public resetFilter() {
+        this.dataFilter = () => true;
+        this.filterString = '';
+    }
+
+    public isHighlighted(d: T) {
+        return this.dataHighlighter(d);
+    }
+
+    @computed get isFirstPage() {
+        return this.pageStore.isFirst;
+    }
+
+    @computed get isLastPage() {
+        return this.pageStore.isLast;
+    }
+
+    @computed get totalItems() {
+        return this.pageStore.totalItems;
+    }
+
+    @observable initialFilterTextSet: boolean;
+
+    @computed get moreItemsPerPage(): number | undefined {
+        return this.pageStore.moreItemsPerPage;
+    }
+    set moreItemsPerPage(newSize: number | undefined) {
+        this.pageStore.moreItemsPerPage = newSize;
+    }
+
+    @computed get sortedDownloadedData(): T[] {
+        return getSortedData(
+            this.downloadedData,
+            this.sortMetric,
+            this.sortAscending
+        );
+    }
+}

--- a/src/shared/components/paginationControls/PaginationControls.spec.tsx
+++ b/src/shared/components/paginationControls/PaginationControls.spec.tsx
@@ -21,6 +21,9 @@ describe('PaginationControls', () => {
                     onChangeItemsPerPage={(x: number) => {
                         itemsPerPage = x;
                     }}
+                    onShowMoreClick={(x: number) => {
+                        itemsPerPage = x;
+                    }}
                 />
             );
             let button = paginationControls.find('#showMoreButton');
@@ -88,6 +91,9 @@ describe('PaginationControls', () => {
                     onChangeItemsPerPage={(x: number) => {
                         itemsPerPage = x;
                     }}
+                    onShowMoreClick={(x: number) => {
+                        itemsPerPage = x;
+                    }}
                 />
             );
             let showMore = paginationControls.find('#showMoreButton');
@@ -110,6 +116,9 @@ describe('PaginationControls', () => {
                     itemsPerPage={3}
                     itemsPerPageOptions={[1, 2, 3, 4, 40]}
                     onChangeItemsPerPage={(x: number) => {
+                        itemsPerPage = x;
+                    }}
+                    onShowMoreClick={(x: number) => {
                         itemsPerPage = x;
                     }}
                 />

--- a/src/shared/lib/ILazyMobXTableApplicationDataStore.spec.ts
+++ b/src/shared/lib/ILazyMobXTableApplicationDataStore.spec.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import { SimpleLazyMobXTableApplicationDataStore } from './ILazyMobXTableApplicationDataStore';
+import { isLastPage } from 'pages/studyView/StudyViewUtils';
 
 describe('SimpleLazyMobXTableApplicationDataStore', () => {
     let data: number[];
@@ -130,5 +131,32 @@ describe('SimpleLazyMobXTableApplicationDataStore', () => {
             'all data, in same sorted order'
         );
         assert.equal(store.filterString.length, 0, 'filter string reset');
+    });
+});
+
+describe('isLastPage', () => {
+    it('considers 0 as first page', () => {
+        assert.isFalse(isLastPage(0, 10, 15));
+        assert.isTrue(isLastPage(1, 10, 15));
+    });
+
+    it('considers first page as last page when no items', () => {
+        assert.isTrue(isLastPage(0, 10, 5));
+    });
+
+    it('calculates last page when last page is full', () => {
+        assert.isTrue(isLastPage(0, 10, 10));
+    });
+
+    it('calculates last page when last page contains 1 item', () => {
+        assert.isFalse(isLastPage(0, 10, 11));
+        assert.isTrue(isLastPage(1, 10, 11));
+    });
+
+    it('calculates last page when "show more" has been clicked', () => {
+        assert.isTrue(isLastPage(0, 10, 11, 20));
+        assert.isTrue(isLastPage(0, 10, 20, 20));
+        assert.isFalse(isLastPage(0, 10, 21, 20));
+        assert.isTrue(isLastPage(1, 10, 21, 20));
     });
 });

--- a/src/shared/lib/ILazyMobXTableApplicationLazyDownloadDataFetcher.ts
+++ b/src/shared/lib/ILazyMobXTableApplicationLazyDownloadDataFetcher.ts
@@ -1,4 +1,4 @@
-export interface ILazyMobXTableApplicationLazyDownloadDataFetcher {
+export interface ILazyMobXTableApplicationLazyDownloadDataFetcher<T = any> {
     // fetch and cache all lazy the data (from API) required for download
-    fetchAndCacheAllLazyData: () => Promise<any[]>;
+    fetchAndCacheAllLazyData: () => Promise<T[]>;
 }


### PR DESCRIPTION
Paginate the clinical table using original (lazy mobx) table components

Requires [backend PR](https://github.com/cBioPortal/cbioportal/pull/10211/files) changes

## Problem
Current table components use a data store that fetches all data from the backend using a very large page size, and then showing a part of the fetches data on a page (like it has been paginated).
This makes the initial loading time larger than needed, and possibly requires downloading large amounts of data.

## Solution
In this poc the data store interface used by tables has been re-implemented in such a way that only the displayed page is loaded. 
The old store interface stays largely intact, so no changes to existing tables are needed (or should be needed). 

## Changes

### Frontend
The clinical table component is not passed all the data but now receives the new `PaginatedDataStore`. When the user browses to the next page, the data store fetches a new page from the backend. The data store has a new `PageStore` (`ClinicalTablePageStore`) which contains most of the pagination logic.

### Backend
Add a `total-count` header that returns the total number of items (`sampleClinicalData`) of the paginated response. To add the total, a new cached count query also needed to be added. 

## TODO
  - [x] Use pagination headers instead of spring page interface 
  - [x] Do we want to continue in this direction? Y
  - [X] Fix sorting (by subtype)
  - [X] Clean up pagination stores
  - [X] Reset to first page when sorting, filtering, etc.
  - [x] Optimize 'show more button' query: fetch only the new part and amend with already fetched data
  - [ ] Fix failing lazymobxtable unit test
  - [ ] Fix filtering by sample/patient IDs
  
