### PR TITLE
:bug: Add Missing Operations Button Txt to Clinical Event Type Table

### DIFF
--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -1095,6 +1095,11 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                             this.props.store.selectedPatientKeys
                         }
                         defaultSortBy={ClinicalEventTypeCountColumnKey.COUNT}
+                        setOperationsButtonText={
+                            this.props.store.hesitateUpdate
+                                ? 'Add Filters '
+                                : 'Select Samples '
+                        }
                     />
                 );
             }

--- a/src/pages/studyView/table/ClinicalEventTypeCountTable.tsx
+++ b/src/pages/studyView/table/ClinicalEventTypeCountTable.tsx
@@ -77,6 +77,7 @@ export interface IClinicalEventTypeCountTableProps {
         MultiSelectionTableRow
     >['extraButtons'];
     selectedPatientsKeyPromise: MobxPromise<string[]>;
+    setOperationsButtonText: string;
 }
 
 class ClinicalEventTypeCountTableComponent extends FixedHeaderTable<
@@ -478,6 +479,9 @@ export default class ClinicalEventTypeCountTable extends React.Component<
                             this.props.selectedRowsKeys.length
                         }
                         showSetOperationsButton={true}
+                        setOperationsButtonText={
+                            this.props.setOperationsButtonText
+                        }
                     />
                 )}
             </div>


### PR DESCRIPTION
Add Missing Operations Button Txt to Clinical Event Type Table

Before Fix:
![image](https://user-images.githubusercontent.com/33608920/233711624-7403c1a2-417f-4965-982d-53fe9795b043.png)

Fixed:
![image](https://user-images.githubusercontent.com/33608920/233711412-79258eae-1e36-432a-8bb9-a73a3a3efc68.png)
