### PR TITLE
Update svg2pdf to fix broken Overlap charts download

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "styled-components": "^4.2.1",
     "superagent": "^3.8.3",
     "superagent-cache": "^3.0.1",
-    "svg2pdf.js": "github:cbioportal/svg2pdf.js#v1.3.3-cbio",
+    "svg2pdf.js": "github:cbioportal/svg2pdf.js#v1.3.3-cbio-patch-1",
     "svgsaver": "0.9.0",
     "swagger-client": "^3.8.22",
     "ts-loader": "4.0.0",

--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -57,7 +57,7 @@
     "save-svg-as-png": "^1.4.6",
     "seamless-immutable": "^7.0.1",
     "superagent": "^3.8.3",
-    "svg2pdf.js": "^1.3.3",
+    "svg2pdf.js": "github:cbioportal/svg2pdf.js#v1.3.3-cbio-patch-1",
     "typescript": "4.0.3",
     "url": "^0.11.0",
     "victory": "30.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23216,9 +23216,9 @@ svg-path-sdf@^1.1.3:
     parse-svg-path "^0.1.2"
     svg-path-bounds "^1.0.1"
 
-svg2pdf.js@^1.3.3, "svg2pdf.js@github:cbioportal/svg2pdf.js#v1.3.3-cbio":
+"svg2pdf.js@github:cbioportal/svg2pdf.js#v1.3.3-cbio-patch-1":
   version "1.3.3"
-  resolved "https://codeload.github.com/cbioportal/svg2pdf.js/tar.gz/37db750e7ba9e87de29a24df73c43e768837f734"
+  resolved "https://codeload.github.com/cbioportal/svg2pdf.js/tar.gz/5a935ad5432e181497bc101b1825c0adb6da6622"
   dependencies:
     jspdf-yworks "^2.0.1"
 


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/9251
Fix Overlap charts pdf download broken issue

original link: https://www.cbioportal.org/comparison?comparisonId=61c194bef8f71021ce57f32f
test link: https://deploy-preview-4601--cbioportalfrontend.netlify.app/comparison?comparisonId=61c194bef8f71021ce57f32f

<img width="957" alt="image" src="https://github.com/cBioPortal/cbioportal-frontend/assets/15748980/98d798e2-c4eb-4ca9-b782-87a498bb85c2">
