### PR TITLE
:wrench: Add configurability for StudyDownloadUrl

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -168,4 +168,5 @@ export interface IServerConfig {
     oncoprint_clinical_tracks_config_json: string;
     enable_cross_study_expression: string;
     studyview_max_samples_selected: number;
+    study_download_url: string;
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -100,7 +100,7 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
     default_cross_cancer_study_list_name: 'TCGA PanCancer Atlas studies',
     skin_title: 'cBioPortal for Cancer Genomics',
 
-    skin_data_sets_header: `The portal currently contains data from the following 
+    skin_data_sets_header: `The portal currently contains data from the following
             cancer genomics studies.  The table below lists the number of available samples per data type and tumor.`,
 
     skin_example_study_queries: `tcga pancancer atlas\n
@@ -214,6 +214,8 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
     skin_patient_view_structural_variant_table_columns_show_on_init: '',
 
     studyview_max_samples_selected: 0,
+
+    study_download_url: '',
 };
 
 export default ServerConfigDefaults;

--- a/src/pages/staticPages/datasetView/DatasetPage.tsx
+++ b/src/pages/staticPages/datasetView/DatasetPage.tsx
@@ -11,7 +11,6 @@ import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicato
 import Helmet from 'react-helmet';
 import request from 'superagent';
 import { getStudyDownloadListUrl } from 'shared/api/urls';
-import { AppStore } from 'AppStore';
 
 export class DatasetPageStore {
     readonly data = remoteData({
@@ -20,9 +19,12 @@ export class DatasetPageStore {
         },
     });
 
-    readonly downloadList = remoteData(() => {
-        if (getServerConfig().app_name === 'public-portal') {
-            return request(getStudyDownloadListUrl()).then(resp => resp.body);
+    readonly downloadList = remoteData(async () => {
+        if (getServerConfig().study_download_url) {
+            const resp = await request(
+                getStudyDownloadListUrl()
+            ).catch(reason => Promise.resolve({ body: '' }));
+            return resp.body;
         } else {
             return Promise.resolve([]);
         }

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -2744,7 +2744,9 @@ export class StudyViewPageStore
     readonly hasRawDataForDownload = remoteData<boolean>({
         invoke: async () => {
             if (this.studyIds.length === 1) {
-                const response = await request(getStudyDownloadListUrl());
+                const response = await request(
+                    getStudyDownloadListUrl()
+                ).catch(err => Promise.resolve({ body: '' }));
                 return response.body.includes(this.studyIds[0]);
             } else {
                 return false;

--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -290,7 +290,11 @@ export function getDarwinUrl(sampleIds: string[], caseId: string) {
 }
 
 export function getStudyDownloadListUrl() {
-    return 'https://cbioportal-datahub.s3.amazonaws.com/study_list.json';
+    return getServerConfig().study_download_url + 'study_list.json';
+}
+
+export function getStudyDownloadUrl() {
+    return getServerConfig().study_download_url;
 }
 
 export function getMDAndersonHeatmapPatientUrl(patientId: string) {

--- a/src/shared/components/StudyDataDownloadLink/StudyDataDownloadLink.tsx
+++ b/src/shared/components/StudyDataDownloadLink/StudyDataDownloadLink.tsx
@@ -1,3 +1,4 @@
+import { getStudyDownloadUrl } from 'shared/api/urls';
 import * as React from 'react';
 import { trackEvent } from 'shared/lib/tracking';
 
@@ -10,11 +11,7 @@ export class StudyDataDownloadLink extends React.Component<
             <a
                 className="dataset-table-download-link"
                 style={{ display: 'block' }}
-                href={
-                    'https://cbioportal-datahub.s3.amazonaws.com/' +
-                    this.props.studyId +
-                    '.tar.gz'
-                }
+                href={getStudyDownloadUrl() + this.props.studyId + '.tar.gz'}
                 download
                 onClick={() =>
                     trackEvent({


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10135

Update StudyDownloadUrl to be configurable via portal properties.

## StudyDownloadUrl Design
This url needs to point to the location of downloadable studies and study_list.json.
- The downloadable studies need to have the extension .tar.gz

### Example
Url - https://cbioportal-datahub.s3.amazonaws.com/

- https://cbioportal-datahub.s3.amazonaws.com/study_list.json (List available studies within s3 bucket ex: study_id_a, study_id_b)
- https://cbioportal-datahub.s3.amazonaws.com/study_id_a.tar.gz
- https://cbioportal-datahub.s3.amazonaws.com/study_id_b.tar.gz