### PR TITLE
Improve search of authorized and unauthorized studies

### DIFF
--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -57,6 +57,9 @@ export default class CancerStudySelector extends React.Component<
         onCheckAllFiltered: () => {
             this.logic.mainView.toggleAllFiltered();
         },
+        onCheckAuthorizedFiltered: () => {
+            this.logic.mainView.toggleAllAuthorizedAndFiltered();
+        },
         onClearFilter: () => {
             this.store.setSearchText('');
         },
@@ -193,6 +196,9 @@ export default class CancerStudySelector extends React.Component<
             shownAndSelectedStudies,
         } = this.logic.mainView.getSelectionReport();
 
+        const shownAndAuthorizedStudies = shownStudies.filter(study => {
+            return study.readPermission;
+        });
         const quickSetButtons = this.logic.mainView.quickSelectButtons(
             getServerConfig().skin_quick_select_buttons
         );
@@ -307,45 +313,104 @@ export default class CancerStudySelector extends React.Component<
                                             </div>
                                         </Then>
                                         <Else>
-                                            <label>
-                                                <input
-                                                    type="checkbox"
-                                                    data-test="selectAllStudies"
-                                                    style={{ top: -2 }}
-                                                    onClick={
-                                                        this.handlers
-                                                            .onCheckAllFiltered
-                                                    }
-                                                    checked={
-                                                        shownAndSelectedStudies.length ===
-                                                        shownStudies.length
-                                                    }
-                                                />
-                                                <strong>
-                                                    {shownAndSelectedStudies.length ===
-                                                    shownStudies.length
-                                                        ? `Deselect all listed studies ${
-                                                              shownStudies.length <
-                                                              this.store
-                                                                  .cancerStudies
-                                                                  .result.length
-                                                                  ? 'matching filter'
-                                                                  : ''
-                                                          } (${
-                                                              shownStudies.length
-                                                          })`
-                                                        : `Select all listed studies ${
-                                                              shownStudies.length <
-                                                              this.store
-                                                                  .cancerStudies
-                                                                  .result.length
-                                                                  ? 'matching filter'
-                                                                  : ''
-                                                          }  (${
-                                                              shownStudies.length
-                                                          })`}
-                                                </strong>
-                                            </label>
+                                            <If
+                                                condition={
+                                                    getServerConfig()
+                                                        .skin_home_page_show_unauthorized_studies ===
+                                                    false
+                                                }
+                                            >
+                                                <Then>
+                                                    <label>
+                                                        <input
+                                                            type="checkbox"
+                                                            data-test="selectAllStudies"
+                                                            style={{ top: -2 }}
+                                                            onClick={
+                                                                this.handlers
+                                                                    .onCheckAllFiltered
+                                                            }
+                                                            checked={
+                                                                shownAndSelectedStudies.length ===
+                                                                shownStudies.length
+                                                            }
+                                                        />
+                                                        <strong>
+                                                            {shownAndSelectedStudies.length ===
+                                                            shownStudies.length
+                                                                ? `Deselect all listed studies ${
+                                                                      shownStudies.length <
+                                                                      this.store
+                                                                          .cancerStudies
+                                                                          .result
+                                                                          .length
+                                                                          ? 'matching filter'
+                                                                          : ''
+                                                                  } (${
+                                                                      shownStudies.length
+                                                                  })`
+                                                                : `Select all listed studies ${
+                                                                      shownStudies.length <
+                                                                      this.store
+                                                                          .cancerStudies
+                                                                          .result
+                                                                          .length
+                                                                          ? 'matching filter'
+                                                                          : ''
+                                                                  }  (${
+                                                                      shownStudies.length
+                                                                  })`}
+                                                        </strong>
+                                                    </label>
+                                                </Then>
+                                                <Else>
+                                                    <label>
+                                                        <input
+                                                            type="checkbox"
+                                                            data-test="selectAuthorizedStudies"
+                                                            style={{ top: -2 }}
+                                                            onClick={
+                                                                this.handlers
+                                                                    .onCheckAuthorizedFiltered
+                                                            }
+                                                            checked={
+                                                                shownAndSelectedStudies.length ===
+                                                                    shownAndAuthorizedStudies.length &&
+                                                                shownAndAuthorizedStudies.length >
+                                                                    0
+                                                            }
+                                                        />
+                                                        <strong>
+                                                            {shownAndSelectedStudies.length ===
+                                                                shownAndAuthorizedStudies.length &&
+                                                            shownAndAuthorizedStudies.length >
+                                                                0
+                                                                ? `Deselect all authorized studies ${
+                                                                    shownStudies.length <
+                                                                      this.store
+                                                                          .cancerStudies
+                                                                          .result
+                                                                          .length
+                                                                          ? 'matching filter'
+                                                                          : ''
+                                                                  } (${
+                                                                      shownAndAuthorizedStudies.length
+                                                                  })`
+                                                                : `Select all authorized studies ${
+                                                                    shownStudies.length <
+                                                                      this.store
+                                                                          .cancerStudies
+                                                                          .result
+                                                                          .length
+                                                                          ? 'matching filter'
+                                                                          : ''
+                                                                  }  (${
+                                                                      shownAndAuthorizedStudies.length
+                                                                  })`}
+                                                        </strong>
+                                                    </label>
+                                                </Else>
+                                            </If>
                                         </Else>
                                     </If>
                                 </If>

--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -202,6 +202,10 @@ export default class CancerStudySelector extends React.Component<
         const quickSetButtons = this.logic.mainView.quickSelectButtons(
             getServerConfig().skin_quick_select_buttons
         );
+        const shownStudiesLengthstring =
+            shownStudies.length < this.store.cancerStudies.result.length
+                ? 'matching filter'
+                : '';
 
         return (
             <FlexCol
@@ -338,28 +342,8 @@ export default class CancerStudySelector extends React.Component<
                                                         <strong>
                                                             {shownAndSelectedStudies.length ===
                                                             shownStudies.length
-                                                                ? `Deselect all listed studies ${
-                                                                      shownStudies.length <
-                                                                      this.store
-                                                                          .cancerStudies
-                                                                          .result
-                                                                          .length
-                                                                          ? 'matching filter'
-                                                                          : ''
-                                                                  } (${
-                                                                      shownStudies.length
-                                                                  })`
-                                                                : `Select all listed studies ${
-                                                                      shownStudies.length <
-                                                                      this.store
-                                                                          .cancerStudies
-                                                                          .result
-                                                                          .length
-                                                                          ? 'matching filter'
-                                                                          : ''
-                                                                  }  (${
-                                                                      shownStudies.length
-                                                                  })`}
+                                                                ? `Deselect all listed studies ${shownStudiesLengthstring} (${shownStudies.length})`
+                                                                : `Select all listed studies ${shownStudiesLengthstring}  (${shownStudies.length})`}
                                                         </strong>
                                                     </label>
                                                 </Then>
@@ -385,28 +369,8 @@ export default class CancerStudySelector extends React.Component<
                                                                 shownAndAuthorizedStudies.length &&
                                                             shownAndAuthorizedStudies.length >
                                                                 0
-                                                                ? `Deselect all authorized studies ${
-                                                                    shownStudies.length <
-                                                                      this.store
-                                                                          .cancerStudies
-                                                                          .result
-                                                                          .length
-                                                                          ? 'matching filter'
-                                                                          : ''
-                                                                  } (${
-                                                                      shownAndAuthorizedStudies.length
-                                                                  })`
-                                                                : `Select all authorized studies ${
-                                                                    shownStudies.length <
-                                                                      this.store
-                                                                          .cancerStudies
-                                                                          .result
-                                                                          .length
-                                                                          ? 'matching filter'
-                                                                          : ''
-                                                                  }  (${
-                                                                      shownAndAuthorizedStudies.length
-                                                                  })`}
+                                                                ? `Deselect all authorized studies ${shownStudiesLengthstring} (${shownAndAuthorizedStudies.length})`
+                                                                : `Select all authorized studies ${shownStudiesLengthstring}  (${shownAndAuthorizedStudies.length})`}
                                                         </strong>
                                                     </label>
                                                 </Else>

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1236,7 +1236,12 @@ export class QueryStore {
         return client
             .getAllSamplesOfPatientInStudyUsingGET({ studyId, patientId })
             .then(
-                samples => ({ studyId, patientId, samples, error: undefined }),
+                samples => ({
+                    studyId,
+                    patientId,
+                    samples,
+                    error: undefined,
+                }),
                 error => ({
                     studyId,
                     patientId,
@@ -1480,11 +1485,12 @@ export class QueryStore {
     }
 
     @computed get readPermissions(): Set<string> {
-        const studies = Array.from(this.treeData.map_node_meta.keys()).filter( s => typeof((s as CancerStudy).readPermission) !== 'undefined' );
-        console.log(studies);
-        const readPermissions = studies
-            .map(n => (!!((n as CancerStudy).readPermission)).toString())
-            .filter(n => !!n);
+        const studies = Array.from(this.treeData.map_node_meta.keys()).filter(
+            s => typeof (s as CancerStudy).readPermission !== 'undefined'
+        );
+        const readPermissions = studies.map(n =>
+            (n as CancerStudy).readPermission.toString()
+        );
         return new Set(readPermissions);
     }
 

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -129,7 +129,7 @@ export class QueryStore {
 
     @computed
     get queryParser() {
-        return new QueryParser(this.referenceGenomes);
+        return new QueryParser(this.referenceGenomes, this.readPermissions);
     }
 
     initialize(urlWithInitialParams?: string) {
@@ -1477,6 +1477,15 @@ export class QueryStore {
             .map(n => (n as CancerStudy).referenceGenome)
             .filter(n => !!n);
         return new Set(referenceGenomes);
+    }
+
+    @computed get readPermissions(): Set<string> {
+        const studies = Array.from(this.treeData.map_node_meta.keys()).filter( s => typeof((s as CancerStudy).readPermission) !== 'undefined' );
+        console.log(studies);
+        const readPermissions = studies
+            .map(n => (!!((n as CancerStudy).readPermission)).toString())
+            .filter(n => !!n);
+        return new Set(readPermissions);
     }
 
     @computed get selectableSelectedStudies() {

--- a/src/shared/components/query/StudyListLogic.ts
+++ b/src/shared/components/query/StudyListLogic.ts
@@ -400,6 +400,42 @@ export class FilteredCancerTreeView {
         );
     }
 
+    @action toggleAllAuthorizedAndFiltered() {
+        const {
+            selectableSelectedStudyIds,
+            selectableSelectedStudies,
+            shownStudies,
+            shownAndSelectedStudies,
+        } = this.getSelectionReport();
+
+        let updatedSelectableSelectedStudyIds: string[] = [];
+        const shownAndAuthorizedStudies = shownStudies.filter(study => {
+            return study.readPermission;
+        });
+        if (
+            shownAndAuthorizedStudies.length === shownAndSelectedStudies.length
+        ) {
+            // deselect
+            updatedSelectableSelectedStudyIds = _.without(
+                this.store.selectableSelectedStudyIds,
+                ...shownAndAuthorizedStudies.map(
+                    (study: CancerStudy) => study.studyId
+                )
+            );
+        } else {
+            updatedSelectableSelectedStudyIds = _.union(
+                this.store.selectableSelectedStudyIds,
+                shownAndAuthorizedStudies.map(
+                    (study: CancerStudy) => study.studyId
+                )
+            );
+        }
+
+        this.store.selectableSelectedStudyIds = updatedSelectableSelectedStudyIds.filter(
+            id => !_.includes(this.store.deletedVirtualStudies, id)
+        );
+    }
+
     @action selectAllMatchingStudies(match: string | string[]) {
         const {
             selectableSelectedStudyIds,

--- a/src/shared/components/query/filteredSearch/Phrase.tsx
+++ b/src/shared/components/query/filteredSearch/Phrase.tsx
@@ -129,11 +129,9 @@ export class ListPhrase implements Phrase {
     public match(study: FullTextSearchNode): boolean {
         let anyFieldMatch = false;
         for (const fieldName of this.fields) {
-            if (!_.has(study, fieldName)) {
-                continue;
-            }
-            const fieldValue = (study as any)[fieldName];
-            if (typeof fieldValue !== 'undefined') {
+            let anyPhraseMatch = false;
+            const fieldValue = study[fieldName];
+            if (fieldValue) {
                 for (const phrase of this._phraseList) {
                     anyPhraseMatch =
                         anyPhraseMatch ||

--- a/src/shared/components/query/filteredSearch/Phrase.tsx
+++ b/src/shared/components/query/filteredSearch/Phrase.tsx
@@ -129,9 +129,11 @@ export class ListPhrase implements Phrase {
     public match(study: FullTextSearchNode): boolean {
         let anyFieldMatch = false;
         for (const fieldName of this.fields) {
-            let anyPhraseMatch = false;
-            const fieldValue = study[fieldName];
-            if (fieldValue) {
+            if (!_.has(study, fieldName)) {
+                continue;
+            }
+            const fieldValue = (study as any)[fieldName];
+            if (typeof fieldValue !== 'undefined') {
                 for (const phrase of this._phraseList) {
                     anyPhraseMatch =
                         anyPhraseMatch ||
@@ -167,7 +169,8 @@ function matchPhrase(phrase: string, fullText: string) {
 
 /**
  * Full match using lowercase
+ * Need to convert boolean to string before applying lowercase
  */
-function matchPhraseFull(phrase: string, fullText: string) {
-    return fullText.toLowerCase() === phrase.toLowerCase();
+function matchPhraseFull(phrase: string, toMatch: boolean | string | number) {
+    return _.toString(toMatch).toLowerCase() === phrase.toLowerCase();
 }

--- a/src/shared/components/query/filteredSearch/field/CheckboxFilterField.spec.ts
+++ b/src/shared/components/query/filteredSearch/field/CheckboxFilterField.spec.ts
@@ -4,6 +4,10 @@ import {
 } from 'shared/components/query/filteredSearch/field/CheckboxFilterField';
 import { CancerTreeSearchFilter } from 'shared/lib/query/textQueryUtils';
 import { ListPhrase } from 'shared/components/query/filteredSearch/Phrase';
+import {
+    toFilterFieldOption,
+    toFilterFieldValue,
+} from 'shared/components/query/filteredSearch/field/FilterFieldOption';
 
 describe('CheckboxFilterField', () => {
     describe('createQueryUpdate', () => {
@@ -12,7 +16,7 @@ describe('CheckboxFilterField', () => {
             nodeFields: ['studyId'],
             form: {
                 input: FilterCheckbox,
-                options: ['a', 'b', 'c', 'd', 'e'],
+                options: ['a', 'b', 'c', 'd', 'e'].map(toFilterFieldOption),
                 label: 'Test label',
             },
         } as CancerTreeSearchFilter;
@@ -48,7 +52,11 @@ describe('CheckboxFilterField', () => {
         it('removes all update when only And', () => {
             const checked = dummyFilter.form.options;
             const toRemove: ListPhrase[] = [];
-            const result = createQueryUpdate(toRemove, checked, dummyFilter);
+            const result = createQueryUpdate(
+                toRemove,
+                checked.map(toFilterFieldValue),
+                dummyFilter
+            );
             expect(result.toAdd?.length).toEqual(0);
         });
 

--- a/src/shared/components/query/filteredSearch/field/FilterFieldOption.ts
+++ b/src/shared/components/query/filteredSearch/field/FilterFieldOption.ts
@@ -1,0 +1,12 @@
+export type FilterFieldOption = {
+    value: string;
+    displayValue: string;
+};
+
+export function toFilterFieldOption(option: string) {
+    return { value: option, displayValue: option };
+}
+
+export function toFilterFieldValue(option: FilterFieldOption) {
+    return option.value;
+}

--- a/src/shared/components/query/filteredSearch/field/ListFormField.tsx
+++ b/src/shared/components/query/filteredSearch/field/ListFormField.tsx
@@ -5,22 +5,22 @@ import { SearchClause } from 'shared/components/query/filteredSearch/SearchClaus
 import { Phrase } from 'shared/components/query/filteredSearch/Phrase';
 import './ListFormField.scss';
 import { toQueryString } from 'shared/lib/query/textQueryUtils';
+import { FilterFieldOption } from 'shared/components/query/filteredSearch/field/FilterFieldOption';
 
 export type ListFilterField = {
     label: string;
     input: typeof FilterList;
-    options: string[];
+    options: FilterFieldOption[];
 };
 
 export const FilterList: FunctionComponent<FieldProps> = props => {
     const form = props.filter.form as ListFilterField;
     const allPhrases = toUniquePhrases(props.query);
-    const queryString = toQueryString(props.query);
     return (
         <div className="filter-list">
             <h5>{props.filter.form.label}</h5>
             {form.options.map(option => {
-                const update = props.parser.parseSearchQuery(option);
+                const update = props.parser.parseSearchQuery(option.value);
                 return (
                     <li className="dropdown-item">
                         <a
@@ -32,7 +32,7 @@ export const FilterList: FunctionComponent<FieldProps> = props => {
                                 });
                             }}
                         >
-                            {option}
+                            {option.displayValue}
                         </a>
                     </li>
                 );

--- a/src/shared/lib/query/QueryParser.spec.ts
+++ b/src/shared/lib/query/QueryParser.spec.ts
@@ -11,7 +11,7 @@ import { QueryParser } from 'shared/lib/query/QueryParser';
 import { StringPhrase } from 'shared/components/query/filteredSearch/Phrase';
 
 describe('QueryParser', () => {
-    const parser = new QueryParser(new Set<string>(),new Set<string>());
+    const parser = new QueryParser(new Set<string>(), new Set<string>());
     const referenceGenomeFields = parser.searchFilters.find(
         f => f.phrasePrefix === 'reference-genome'
     )!.nodeFields;

--- a/src/shared/lib/query/QueryParser.spec.ts
+++ b/src/shared/lib/query/QueryParser.spec.ts
@@ -11,7 +11,7 @@ import { QueryParser } from 'shared/lib/query/QueryParser';
 import { StringPhrase } from 'shared/components/query/filteredSearch/Phrase';
 
 describe('QueryParser', () => {
-    const parser = new QueryParser(new Set<string>());
+    const parser = new QueryParser(new Set<string>(),new Set<string>());
     const referenceGenomeFields = parser.searchFilters.find(
         f => f.phrasePrefix === 'reference-genome'
     )!.nodeFields;

--- a/src/shared/lib/query/QueryParser.ts
+++ b/src/shared/lib/query/QueryParser.ts
@@ -27,9 +27,6 @@ export class QueryParser {
     private readonly _searchFilters: CancerTreeSearchFilter[];
 
     constructor(referenceGenomes: Set<string>, readPermissions: Set<string>) {
-        console.log('readPermissions');
-        console.log(readPermissions);
-        console.log(readPermissions.size);
         this._searchFilters = [
             /**
              * Example queries:
@@ -65,10 +62,16 @@ export class QueryParser {
                 nodeFields: ['readPermission'],
                 form: {
                     input: FilterCheckbox,
-                    options: readPermissions.size > 1 ? [
-                        { value: 'true', displayValue: 'Authorized' },
-                        { value: 'false', displayValue: 'Unauthorized' },
-                    ]:[],
+                    options:
+                        readPermissions.size > 1
+                            ? [
+                                  { value: 'true', displayValue: 'Authorized' },
+                                  {
+                                      value: 'false',
+                                      displayValue: 'Unauthorized',
+                                  },
+                              ]
+                            : [],
                     label: 'Controlled access',
                 },
             },

--- a/src/shared/lib/query/QueryParser.ts
+++ b/src/shared/lib/query/QueryParser.ts
@@ -6,9 +6,9 @@ import {
 import {
     AndSearchClause,
     FILTER_SEPARATOR,
-    SearchClause,
     NOT_PREFIX,
     NotSearchClause,
+    SearchClause,
 } from 'shared/components/query/filteredSearch/SearchClause';
 import { FilterCheckbox } from 'shared/components/query/filteredSearch/field/CheckboxFilterField';
 import { getServerConfig, ServerConfigHelpers } from 'config/config';
@@ -18,6 +18,7 @@ import {
     ListPhrase,
     Phrase,
 } from 'shared/components/query/filteredSearch/Phrase';
+import { toFilterFieldOption } from 'shared/components/query/filteredSearch/field/FilterFieldOption';
 
 export class QueryParser {
     /**
@@ -25,7 +26,10 @@ export class QueryParser {
      */
     private readonly _searchFilters: CancerTreeSearchFilter[];
 
-    constructor(referenceGenomes: Set<string>) {
+    constructor(referenceGenomes: Set<string>, readPermissions: Set<string>) {
+        console.log('readPermissions');
+        console.log(readPermissions);
+        console.log(readPermissions.size);
         this._searchFilters = [
             /**
              * Example queries:
@@ -38,7 +42,7 @@ export class QueryParser {
                     input: FilterList,
                     options: ServerConfigHelpers.skin_example_study_queries(
                         getServerConfig()!.skin_example_study_queries || ''
-                    ),
+                    ).map(toFilterFieldOption),
                 },
             },
             /**
@@ -49,8 +53,23 @@ export class QueryParser {
                 nodeFields: ['referenceGenome'],
                 form: {
                     input: FilterCheckbox,
-                    options: [...referenceGenomes],
+                    options: [...referenceGenomes].map(toFilterFieldOption),
                     label: 'Reference genome',
+                },
+            },
+            /**
+             * Show Authorized Studies
+             */
+            {
+                phrasePrefix: 'authorized',
+                nodeFields: ['readPermission'],
+                form: {
+                    input: FilterCheckbox,
+                    options: readPermissions.size > 1 ? [
+                        { value: 'true', displayValue: 'Authorized' },
+                        { value: 'false', displayValue: 'Unauthorized' },
+                    ]:[],
+                    label: 'Controlled access',
                 },
             },
         ];

--- a/src/shared/lib/query/textQueryUtils.spec.ts
+++ b/src/shared/lib/query/textQueryUtils.spec.ts
@@ -15,7 +15,7 @@ import { QueryParser } from 'shared/lib/query/QueryParser';
 import { StringPhrase } from 'shared/components/query/filteredSearch/Phrase';
 
 describe('textQueryUtils', () => {
-    const parser = new QueryParser(new Set<string>());
+    const parser = new QueryParser(new Set<string>(), new Set<string>());
     const referenceGenomeFields = parser.searchFilters.find(
         f => f.phrasePrefix === 'reference-genome'
     )!.nodeFields;


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/9915
Improved search of authorized internal studies. Users can now filter studies based on their read permission (authorized or not authorized) in the search box. This is an optional feature that has to be enabled by settings in portal.properties. 