### PR TITLE
Check undefined annotation_summary when fetching revue

### DIFF
--- a/packages/react-mutation-mapper/src/component/column/Annotation.tsx
+++ b/packages/react-mutation-mapper/src/component/column/Annotation.tsx
@@ -230,7 +230,7 @@ export function getAnnotationData(
                     ? getVariantAnnotation(
                           mutation,
                           indexedVariantAnnotations.result
-                      )?.annotation_summary.vues
+                      )?.annotation_summary?.vues
                     : undefined,
         };
 


### PR DESCRIPTION
please see the below error log: 
{"type":"ErrorBoundary","log":"TypeError: Cannot read properties of undefined (reading 'vues')","url":"https://genie.cbioportal.org/results/mutations?cancer_study_list=genie_public&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cstructural_variants%2Ccna&case_set_id=genie_public_all&gene_list=BCOR&geneset_list=%20&tab_index=tab_visualize&Action=Submit&mutations_transcript_id=ENST00000378444"} 
 