### PR TITLE
Import image as source for revue logo

### DIFF
--- a/packages/react-mutation-mapper/src/component/revue/Revue.tsx
+++ b/packages/react-mutation-mapper/src/component/revue/Revue.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import { Vues as VUE } from 'genome-nexus-ts-api-client';
 import annotationStyles from '../column/annotation.module.scss';
+import revueLogo from '../../images/vue_logo.png';
 
 export const RevueTooltipContent: React.FunctionComponent<{
     vue: VUE;
@@ -59,12 +60,7 @@ export const RevueCell: React.FunctionComponent<{
                 className={`${annotationStyles['annotation-item']}`}
                 style={{ display: 'inline-flex' }}
             >
-                <img
-                    src={'../../images/vue_logo.png'}
-                    alt="reVUE logo"
-                    width={14}
-                    height={14}
-                />
+                <img src={revueLogo} alt="reVUE logo" width={14} height={14} />
             </span>
         </DefaultTooltip>
     );


### PR DESCRIPTION
<img width="182" alt="image" src="https://user-images.githubusercontent.com/16869603/235496691-2f2d41cf-c13e-43b7-ae33-f2086e9b37eb.png">
Fix reVUE icon not loading