### PR TITLE
:sparkles: Add PatientIdentifiers URL Parameter

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -189,13 +189,18 @@ export default class StudyViewPage extends React.Component<
                 newStudyViewFilter.sharedCustomData = params.sharedCustomData;
             }
         }
+
+        let updateStoreFromURLPromise = remoteData(() => Promise.resolve([]));
         if (!_.isEqual(newStudyViewFilter, this.store.studyViewQueryFilter)) {
-            this.store.updateStoreFromURL(newStudyViewFilter);
             this.store.studyViewQueryFilter = newStudyViewFilter;
+            updateStoreFromURLPromise = remoteData(async () => {
+                await this.store.updateStoreFromURL(newStudyViewFilter);
+                return [];
+            });
         }
 
         onMobxPromise(
-            this.store.queriedPhysicalStudyIds,
+            [this.store.queriedPhysicalStudyIds, updateStoreFromURLPromise],
             (strArr: string[]) => {
                 this.store.initializeReaction();
                 trackEvent({

--- a/src/shared/model/PatientIdentifierFilter.ts
+++ b/src/shared/model/PatientIdentifierFilter.ts
@@ -1,0 +1,8 @@
+export interface PatientIdentifierFilter {
+    patientIdentifiers: PatientIdentifier[];
+}
+
+export interface PatientIdentifier {
+    patientId: string;
+    studyId: string;
+}


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10081

The Study View Page currently has a way to construct filterJSON URL with sample IDs:

[https://cbioportal.org/study/summary?id=msk_impact_2017#filterJson={"sampleIdentifiers":[{"studyId":"msk_impact_2017","sampleId":"P-0000004-T01-IM3"}]}](https://cbioportal.org/study/summary?id=msk_impact_2017#filterJson=%7B%22sampleIdentifiers%22:%5B%7B%22studyId%22:%22msk_impact_2017%22,%22sampleId%22:%22P-0000004-T01-IM3%22%7D%5D%7D)

Update StudyViewPageStore to handle the following URL Parameter

JSON that is now supported within filterJson
`{"patientIdentifiers": [{"studyId": "test_studyId", "patientId": "test_patientid"}]}`

Ex:
[https://cbioportal.org/study/summary?id=msk_impact_2017#filterJson={"patientIdentifiers":[{"studyId":"msk_impact_2017","patientId":"P-0000004"}]}](https://cbioportal.org/study/summary?id=msk_impact_2017#filterJson=%7B%22patientIdentifiers%22:%5B%7B%22studyId%22:%22msk_impact_2017%22,%22patientId%22:%22P-0000004%22%7D%5D%7D)


