### PR TITLE
Fix infinite loop in QueryStore

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -124,6 +124,26 @@ export class QueryStore {
 
         makeObservable(this);
 
+        /**
+         * Reset selectedSampleListId when sampleLists and sampleListInSelectedStudies have finished
+         */
+        reaction(
+            () => [this.sampleLists, this.sampleListInSelectedStudies],
+            () => {
+                if (
+                    !this.sampleLists.isComplete ||
+                    !this.sampleListInSelectedStudies.isComplete
+                ) {
+                    return;
+                }
+                if (
+                    !this.initiallySelected.sampleListId ||
+                    this.studiesHaveChangedSinceInitialization
+                ) {
+                    this._selectedSampleListId = undefined;
+                }
+            }
+        );
         this.initialize(urlWithInitialParams);
     }
 
@@ -1004,14 +1024,6 @@ export class QueryStore {
             );
         },
         default: [],
-        onResult: () => {
-            if (
-                !this.initiallySelected.sampleListId ||
-                this.studiesHaveChangedSinceInitialization
-            ) {
-                this._selectedSampleListId = undefined;
-            }
-        },
     });
 
     readonly validProfileIdSetForSelectedStudies = remoteData({
@@ -1088,14 +1100,6 @@ export class QueryStore {
             return _.sortBy(sampleLists, sampleList => sampleList.name);
         },
         default: [],
-        onResult: () => {
-            if (
-                !this.initiallySelected.sampleListId ||
-                this.studiesHaveChangedSinceInitialization
-            ) {
-                this._selectedSampleListId = undefined;
-            }
-        },
     });
 
     readonly mutSigForSingleStudy = remoteData({


### PR DESCRIPTION
When a user views a virtual study without any mutations, the result view page will fire an infinite number of backend requests to `/api/session/virtual_study`. 
This is caused by an infinite loop in the `QueryStore` that keeps recalculating `sampleLists` when selecting a virtual study.

(This PR also adds some documentation on the `localdev` property that is needed to debug the frontend using https.)

## Reproduce bug
The bug can be reproduced by:
- importing a study without mutations;
- using cbioportal with https
- selecting the virtual study on the index page by clicking the checkbox next to it (not the 'pie chart' link to the study);
- click 'explore selected studies' on the index page

## Fix
The (duplicated) `onResult` part of `sampleList` and `sampleListInSelectedStudies` trigger the infinite loop. By moving this logic to a reaction the bug is fixed.