### PR TITLE
Fix double click on gene query icon in study view

### DIFF
--- a/src/pages/studyView/table/GeneCell.tsx
+++ b/src/pages/studyView/table/GeneCell.tsx
@@ -98,11 +98,6 @@ export class GeneCell extends React.Component<IGeneCellProps, {}> {
                                 [styles.addGeneUI]: true,
                                 [styles.selected]: geneIsSelected,
                             })}
-                            onClick={() =>
-                                this.props.onGeneSelect(
-                                    this.props.hugoGeneSymbol
-                                )
-                            }
                         >
                             <i className="fa fa-search"></i>
                         </div>


### PR DESCRIPTION
Clicking on magnifying glass icon was adding and then immediately deleting a gene from the query

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/186521/fd8d375f-3bba-42d2-8a5c-1ed03a463522)
