### PR TITLE
Remove redundant makeObservable call

### DIFF
--- a/src/pages/studyView/table/GeneCell.tsx
+++ b/src/pages/studyView/table/GeneCell.tsx
@@ -32,7 +32,6 @@ export type IGeneCellProps = {
 export class GeneCell extends React.Component<IGeneCellProps, {}> {
     constructor(props: IGeneCellProps) {
         super(props);
-        makeObservable(this);
     }
 
     render() {


### PR DESCRIPTION
Fixes "Error: [MobX] No annotations were passed to makeObservable, but no decorator members have been found either” error in dev mode