### PR TITLE
Timeline: links if event popover should open in new window when signaled

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TimelineTrack.tsx
@@ -472,21 +472,39 @@ export const EventTooltipContent: React.FunctionComponent<{
         <div>
             <table className={'table table-condensed'}>
                 <tbody>
-                    {_.map(attributes, (att: any) => {
+                    {_.map(attributes, (attr: any) => {
                         return (
                             <tr>
-                                <td>{att.key.replace(/_/g, ' ')}</td>
+                                <td>{attr.key.replace(/_/g, ' ')}</td>
                                 <td>
                                     <ReactMarkdown
                                         allowedElements={['p', 'a']}
                                         linkTarget={'_blank'}
                                         components={{
-                                            a: ({ node, ...props }) => (
-                                                <OurPopup {...props} />
-                                            ),
+                                            a: ({ node, ...props }) => {
+                                                if (
+                                                    /:blank$/.test(props.href!)
+                                                ) {
+                                                    return (
+                                                        <a
+                                                            href={props.href?.replace(
+                                                                /:blank$/,
+                                                                ''
+                                                            )}
+                                                            target={'_blank'}
+                                                        >
+                                                            {props.children}
+                                                        </a>
+                                                    );
+                                                } else {
+                                                    return (
+                                                        <OurPopup {...props} />
+                                                    );
+                                                }
+                                            },
                                         }}
                                     >
-                                        {att.value}
+                                        {attr.value}
                                     </ReactMarkdown>
                                 </td>
                             </tr>


### PR DESCRIPTION
By default, links show up in iframes.  Some external websites do not allow themselves to be opened in iframes, so we must provide a way to open in new window.  This behavior is turned on in the markdown with the ":blank" directive in the link text:

```
[PRSSMM:blank](https://www.hello.com)
```

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/186521/75e46fc4-48dd-4f7d-91ac-9c6545690513)
