### PR TITLE
Improve tooltips for Altered and Unaltered group columns on comparison page #9718

### DIFF
--- a/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
+++ b/src/pages/resultsView/enrichments/EnrichmentsUtil.tsx
@@ -23,7 +23,7 @@ import styles from './styles.module.scss';
 import classNames from 'classnames';
 import { IMultipleCategoryBarPlotData } from 'pages/groupComparison/MultipleCategoryBarPlot';
 import { getTextColor } from '../../groupComparison/OverlapUtils';
-import { TruncatedText } from 'cbioportal-frontend-commons';
+import { DefaultTooltip, TruncatedText } from 'cbioportal-frontend-commons';
 import {
     ExpressionEnrichmentTableColumn,
     ExpressionEnrichmentTableColumnType,
@@ -112,6 +112,13 @@ export function formatPercentage(
     return (
         datum.alteredCount + ' (' + datum.alteredPercentage.toFixed(2) + '%)'
     );
+}
+
+export function getProfiledCount(
+    group: string,
+    data: AlterationEnrichmentRow
+): number {
+    return data.groupsSet[group].profiledCount;
 }
 
 export function getAlteredCount(
@@ -651,11 +658,27 @@ export function getAlterationEnrichmentColumns(
         columns.push({
             name: group.name,
             headerRender: PERCENTAGE_IN_headerRender,
-            render: (d: AlterationEnrichmentRow) => (
-                <span data-test={`${group.name}-CountCell`}>
-                    {formatPercentage(group.name, d)}
-                </span>
-            ),
+            render: (d: AlterationEnrichmentRow) => {
+                let overlay = (
+                    <span>
+                        {getProfiledCount(group.name, d)} samples in{' '}
+                        {group.name} are profiled for {d.hugoGeneSymbol},&nbsp;
+                        {formatPercentage(group.name, d)} of which are altered
+                        in {d.hugoGeneSymbol}
+                    </span>
+                );
+                return (
+                    <DefaultTooltip
+                        destroyTooltipOnHide={true}
+                        trigger={['hover']}
+                        overlay={overlay}
+                    >
+                        <span data-test={`${group.name}-CountCell`}>
+                            {formatPercentage(group.name, d)}
+                        </span>
+                    </DefaultTooltip>
+                );
+            },
             tooltip: (
                 <span>
                     <strong>{group.name}:</strong> {group.description}

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -916,7 +916,7 @@ export default abstract class ComparisonStore extends AnalysisStore
                                 : 'samples'
                         } in ${
                             group.name
-                        } that have an alteration in the listed gene.`,
+                        } that are profiled for, and altered in, listed gene.`,
                     };
                 })
             );


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9718

Describe changes proposed in this pull request:
- Edit the tooltip of the column headers to indicate this:
Altered group: Number (percentage) of samples in Altered group that are profiled for, and altered in, listed gene.
- As @jjgao suggested, I've added the tooltip to each data cell under Altered group and Unaltered group, saying "x samples in Altered group are profiled for [gene name], y (z%) of which are altered in [gene name]"


<img width="713" alt="Screenshot 2023-06-21 at 3 24 09 PM" src="https://github.com/cBioPortal/cbioportal-frontend/assets/23661875/72c0877e-fa8f-4ef5-97ec-becd1b35dd4c">
