### PR TITLE
Fix index page with unauthorized studies: only fetch study tags from authorized studies

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -649,7 +649,9 @@ export class QueryStore {
     readonly cancerStudyTags = remoteData({
         await: () => [this.cancerStudies],
         invoke: async () => {
-            const studyIds = this.cancerStudies.result.map(s => s.studyId);
+            const studyIds = this.cancerStudies.result
+                .filter(s => s.readPermission)
+                .map(s => s.studyId);
             return client.getTagsForMultipleStudiesUsingPOST({ studyIds });
         },
         default: [],


### PR DESCRIPTION
Fix index page error screen when a user has unauthorized studies: filter out unauthorized studies in the frontend before fetching the study tags. 

In the study list on the index page a user can also search on study tags. At the moment the tags of all studies are fetched. However, you cannot fetch the study tags of unauthorized studies, resulting in a 403 and an error screen (see https://github.com/cBioPortal/cbioportal/issues/10221) . This PR filters out unauthorized studies before fetching the study tags.

(For backend solution, see  https://github.com/cBioPortal/cbioportal/pull/10277)
