### PR TITLE
Add VEP link in reVUE tooltip

### DIFF
--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
@@ -3809,6 +3809,12 @@
         "comment": {
           "type": "string"
         },
+        "confirmed": {
+          "type": "boolean"
+        },
+        "context": {
+          "type": "string"
+        },
         "defaultEffect": {
           "type": "string"
         },
@@ -3821,17 +3827,17 @@
         "hugoGeneSymbol": {
           "type": "string"
         },
-        "pubmedIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32"
-          }
+        "pubmedId": {
+          "type": "integer",
+          "format": "int32"
         },
         "referenceText": {
           "type": "string"
         },
         "revisedProteinEffect": {
+          "type": "string"
+        },
+        "revisedVariantClassification": {
           "type": "string"
         },
         "transcriptId": {
@@ -3840,7 +3846,10 @@
         "variant": {
           "type": "string"
         },
-        "variantClassification": {
+        "vepPredictedProteinEffect": {
+          "type": "string"
+        },
+        "vepPredictedVariantClassification": {
           "type": "string"
         }
       }

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
@@ -1064,6 +1064,10 @@ export type Version = {
 export type Vues = {
     'comment': string
 
+        'confirmed': boolean
+
+        'context': string
+
         'defaultEffect': string
 
         'genomicLocation': string
@@ -1072,17 +1076,21 @@ export type Vues = {
 
         'hugoGeneSymbol': string
 
-        'pubmedIds': Array < number >
+        'pubmedId': number
 
         'referenceText': string
 
         'revisedProteinEffect': string
 
+        'revisedVariantClassification': string
+
         'transcriptId': string
 
         'variant': string
 
-        'variantClassification': string
+        'vepPredictedProteinEffect': string
+
+        'vepPredictedVariantClassification': string
 
 };
 

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
@@ -2376,6 +2376,12 @@
         "comment": {
           "type": "string"
         },
+        "confirmed": {
+          "type": "boolean"
+        },
+        "context": {
+          "type": "string"
+        },
         "defaultEffect": {
           "type": "string"
         },
@@ -2388,17 +2394,17 @@
         "hugoGeneSymbol": {
           "type": "string"
         },
-        "pubmedIds": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int32"
-          }
+        "pubmedId": {
+          "type": "integer",
+          "format": "int32"
         },
         "referenceText": {
           "type": "string"
         },
         "revisedProteinEffect": {
+          "type": "string"
+        },
+        "revisedVariantClassification": {
           "type": "string"
         },
         "transcriptId": {
@@ -2407,7 +2413,10 @@
         "variant": {
           "type": "string"
         },
-        "variantClassification": {
+        "vepPredictedProteinEffect": {
+          "type": "string"
+        },
+        "vepPredictedVariantClassification": {
           "type": "string"
         }
       }

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
@@ -618,6 +618,10 @@ export type Vcf = {
 export type Vues = {
     'comment': string
 
+        'confirmed': boolean
+
+        'context': string
+
         'defaultEffect': string
 
         'genomicLocation': string
@@ -626,17 +630,21 @@ export type Vues = {
 
         'hugoGeneSymbol': string
 
-        'pubmedIds': Array < number >
+        'pubmedId': number
 
         'referenceText': string
 
         'revisedProteinEffect': string
 
+        'revisedVariantClassification': string
+
         'transcriptId': string
 
         'variant': string
 
-        'variantClassification': string
+        'vepPredictedProteinEffect': string
+
+        'vepPredictedVariantClassification': string
 
 };
 

--- a/packages/react-mutation-mapper/src/component/revue/Revue.tsx
+++ b/packages/react-mutation-mapper/src/component/revue/Revue.tsx
@@ -19,7 +19,8 @@ export const RevueTooltipContent: React.FunctionComponent<{
             </a>
             <ul>
                 <li>
-                    Predicted Effect: <strong>{props.vue.defaultEffect}</strong>
+                    Predicted Effect*:{' '}
+                    <strong>{props.vue.defaultEffect}</strong>
                 </li>
                 <li>
                     Experimentally Validated Effect:{' '}
@@ -38,6 +39,14 @@ export const RevueTooltipContent: React.FunctionComponent<{
                     rel="noopener noreferrer"
                 >
                     reVUE <i className="fa fa-external-link" />
+                </a>
+                {', '}
+                <a
+                    href="https://useast.ensembl.org/info/docs/tools/vep/index.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    *VEP <i className="fa fa-external-link" />
                 </a>
             </div>
         </div>

--- a/packages/react-mutation-mapper/src/component/revue/Revue.tsx
+++ b/packages/react-mutation-mapper/src/component/revue/Revue.tsx
@@ -8,48 +8,45 @@ export const RevueTooltipContent: React.FunctionComponent<{
     vue: VUE;
 }> = props => {
     return (
-        <div>
-            {props.vue.comment}{' '}
-            <a
-                href={`https://pubmed.ncbi.nlm.nih.gov/${props.vue.pubmedIds[0]}/`}
-                rel="noopener noreferrer"
-                target="_blank"
-            >
-                ({props.vue.referenceText})
-            </a>
-            <ul>
-                <li>
-                    Predicted Effect*:{' '}
-                    <strong>{props.vue.defaultEffect}</strong>
-                </li>
-                <li>
-                    Experimentally Validated Effect:{' '}
-                    <strong>{props.vue.variantClassification}</strong>
-                </li>
-                <li>
-                    Revised Protein Effect:{' '}
-                    <strong>{props.vue.revisedProteinEffect}</strong>
-                </li>
-            </ul>
-            <div>
-                Source:{' '}
-                <a
-                    href="https://cancerrevue.org"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    reVUE <i className="fa fa-external-link" />
-                </a>
-                {', '}
-                <a
-                    href="https://useast.ensembl.org/info/docs/tools/vep/index.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    *VEP <i className="fa fa-external-link" />
-                </a>
-            </div>
-        </div>
+        <ul>
+            <li>
+                Predicted Effect by{` `}
+                {
+                    <a
+                        href="https://useast.ensembl.org/info/docs/tools/vep/index.html"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        VEP
+                    </a>
+                }
+                : <strong>{props.vue.defaultEffect}</strong>
+            </li>
+            <li>
+                Revised Protein Effect by{` `}
+                {
+                    <a
+                        href="https://cancerrevue.org"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        reVUE
+                    </a>
+                }
+                {` (`}
+                {
+                    <a
+                        href={`https://pubmed.ncbi.nlm.nih.gov/${props.vue.pubmedId}/`}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        {props.vue.referenceText}
+                    </a>
+                }
+                {`): `}
+                <strong>{props.vue.revisedProteinEffect}</strong>
+            </li>
+        </ul>
     );
 };
 

--- a/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
@@ -98,7 +98,7 @@ export default class AnnotationColumnFormatter {
             annotationDownloadContent.push(
                 `reVUE: ${
                     annotationData.vue
-                        ? `${annotationData.vue.comment},PubmedId:${annotationData.vue.pubmedIds[0]},PredictedEffect:${annotationData.vue.defaultEffect},ExperimentallyValidatedEffect:${annotationData.vue.variantClassification},RevisedProteinEffect:${annotationData.vue.revisedProteinEffect}`
+                        ? `${annotationData.vue.comment},PubmedId:${annotationData.vue.pubmedId},PredictedEffect:${annotationData.vue.defaultEffect},ExperimentallyValidatedEffect:${annotationData.vue.revisedVariantClassification},RevisedProteinEffect:${annotationData.vue.revisedProteinEffect}`
                         : 'no'
                 }`
             );


### PR DESCRIPTION
- Update genome nexus api with the latest revue data model
- Update revue tooltip content
<img width="415" alt="image" src="https://github.com/cBioPortal/cbioportal-frontend/assets/16869603/8b60661a-2301-480d-a10e-d7ea41f4eeda">
