### PR TITLE
Option to disable data download but still allow figure download

### DIFF
--- a/end-to-end-test/local/specs/hide-download-controls.spec.js
+++ b/end-to-end-test/local/specs/hide-download-controls.spec.js
@@ -71,7 +71,7 @@ describe('hide download controls feature', function() {
 
             before(() => {
                 openAndSetProperty(CBIOPORTAL_URL, {
-                    skin_hide_download_controls: true,
+                    skin_hide_download_controls: 'hide',
                 });
                 // browser.debug();
                 waitForStudyQueryPage();
@@ -126,7 +126,7 @@ describe('hide download controls feature', function() {
 
                 openAndSetProperty(
                     `${CBIOPORTAL_URL}/results/oncoprint?genetic_profile_ids_PROFILE_MUTATION_EXTENDED=study_es_0_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=study_es_0_gistic&cancer_study_list=study_es_0&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&profileFilter=mutations%2Cgistic&case_set_id=study_es_0_cnaseq&gene_list=CREB3L1%2520RPS11%2520PNMA1%2520MMP2%2520ZHX3%2520ERCC5%2520TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit&comparison_subtab=mrna`,
-                    { skin_hide_download_controls: true }
+                    { skin_hide_download_controls: 'hide' }
                 );
                 waitForOncoprint();
                 waitForTabs(expectedTabNames.length);
@@ -379,7 +379,7 @@ describe('hide download controls feature', function() {
             before(() => {
                 openAndSetProperty(
                     `${CBIOPORTAL_URL}/patient?studyId=study_es_0&caseId=TCGA-A1-A0SK`,
-                    { skin_hide_download_controls: true }
+                    { skin_hide_download_controls: 'hide' }
                 );
                 waitForPatientView();
                 waitForTabs(expectedTabNames.length);
@@ -461,7 +461,7 @@ describe('hide download controls feature', function() {
             before(() => {
                 openAndSetProperty(
                     `${CBIOPORTAL_URL}/study/summary?id=study_es_0`,
-                    { skin_hide_download_controls: true }
+                    { skin_hide_download_controls: 'hide' }
                 );
                 waitForStudyView();
                 waitForTabs(expectedTabNames.length);
@@ -563,7 +563,7 @@ describe('hide download controls feature', function() {
             ];
             before(() => {
                 openAndSetProperty(browser.getUrl(), {
-                    skin_hide_download_controls: false,
+                    skin_hide_download_controls: 'show',
                 });
                 openGroupComparison(
                     `${CBIOPORTAL_URL}/study/summary?id=study_es_0`,
@@ -572,7 +572,7 @@ describe('hide download controls feature', function() {
                     30000
                 );
                 openAndSetProperty(browser.getUrl(), {
-                    skin_hide_download_controls: true,
+                    skin_hide_download_controls: 'hide',
                 });
                 waitForTabs(expectedTabNames.length);
             });

--- a/packages/cbioportal-frontend-commons/src/components/appContext/AppContext.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/appContext/AppContext.tsx
@@ -1,11 +1,17 @@
 import React, { Context } from 'react';
 
+export enum DownloadControlOption {
+    SHOW_ALL = 'show',
+    HIDE_DATA = 'data',
+    HIDE_ALL = 'hide',
+}
+
 export interface IAppContext {
-    showDownloadControls: boolean;
+    showDownloadControls: DownloadControlOption;
 }
 
 export const AppContext: Context<IAppContext> = React.createContext<
     IAppContext
 >({
-    showDownloadControls: true,
+    showDownloadControls: DownloadControlOption.SHOW_ALL,
 });

--- a/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
@@ -11,7 +11,7 @@ import { saveSvg, saveSvgAsPng } from 'save-svg-as-png';
 import svgToPdfDownload from '../../lib/svgToPdfDownload';
 import { CSSProperties } from 'react';
 import { isPromiseLike } from 'cbioportal-utils';
-import { AppContext } from '../appContext/AppContext';
+import { AppContext, DownloadControlOption } from '../appContext/AppContext';
 
 type ButtonSpec = {
     key: string;
@@ -44,6 +44,7 @@ interface IDownloadControlsProps {
     style?: CSSProperties;
     className?: any;
     dataExtension?: string;
+    showDownload?: boolean;
 }
 
 function makeButton(spec: ButtonSpec) {
@@ -245,20 +246,6 @@ export default class DownloadControls extends React.Component<
                 onClick: this.downloadData,
                 disabled: !this.props.getData,
             },
-            'Summary Data': {
-                key: 'Summary Data',
-                content: (
-                    <span>
-                        Summary Data{' '}
-                        <i
-                            className="fa fa-cloud-download"
-                            aria-hidden="true"
-                        />
-                    </span>
-                ),
-                onClick: () => this.downloadData('summary'),
-                disabled: !this.props.getData,
-            },
             'Full Data': {
                 key: 'Full Data',
                 content: (
@@ -273,13 +260,37 @@ export default class DownloadControls extends React.Component<
                 onClick: () => this.downloadData('full'),
                 disabled: !this.props.getData,
             },
+            'Summary Data': {
+                key: 'Summary Data',
+                content: (
+                    <span>
+                        Summary Data{' '}
+                        <i
+                            className="fa fa-cloud-download"
+                            aria-hidden="true"
+                        />
+                    </span>
+                ),
+                onClick: () => this.downloadData('summary'),
+                disabled: !this.props.getData,
+            },
         };
     }
 
+    @computed get showDownload() {
+        return this.props.showDownload !== undefined
+            ? this.props.showDownload
+            : true;
+    }
+
     @computed get buttonSpecs() {
-        const middleButtons = (this.props.buttons || ['SVG', 'PNG', 'PDF']).map(
-            x => this.downloadControlsButtons[x]
-        );
+        const middleButtons = this.showDownload
+            ? (this.props.buttons || ['SVG', 'PNG', 'PDF']).map(
+                  x => this.downloadControlsButtons[x]
+              )
+            : (this.props.buttons || ['SVG', 'PNG', 'PDF'])
+                  .filter(x => x !== 'Data' && x !== 'Full Data')
+                  .map(x => this.downloadControlsButtons[x]);
         return (this.props.additionalLeftButtons || [])
             .concat(middleButtons)
             .concat(this.props.additionalRightButtons || []);
@@ -291,7 +302,9 @@ export default class DownloadControls extends React.Component<
     }
 
     render() {
-        if (this.context.showDownloadControls === false) {
+        if (
+            this.context.showDownloadControls === DownloadControlOption.HIDE_ALL
+        ) {
             return null;
         }
 
@@ -375,7 +388,7 @@ export default class DownloadControls extends React.Component<
                 </div>
             );
         } else if (this.props.type === 'dropdown') {
-            element = (
+            element = this.buttonSpecs.length > 0 && (
                 <ul
                     className={classnames(
                         'dropdown-menu',
@@ -387,7 +400,7 @@ export default class DownloadControls extends React.Component<
                 </ul>
             );
         } else {
-            element = (
+            element = this.buttonSpecs.length > 0 && (
                 <div
                     role="group"
                     className="btn-group chartDownloadButtons"

--- a/src/appShell/App/Container.tsx
+++ b/src/appShell/App/Container.tsx
@@ -31,6 +31,7 @@ import {
 import makeRoutes from 'routes';
 import { AppContext } from 'cbioportal-frontend-commons';
 import { IAppContext } from 'cbioportal-frontend-commons';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
 import { ErrorAlert } from 'shared/components/errorScreen/ErrorAlert';
 import { ErrorInfo } from 'react';
 import { observable } from 'mobx';
@@ -69,8 +70,8 @@ export default class Container extends React.Component<IContainerProps, {}> {
 
     get appContext(): IAppContext {
         return {
-            showDownloadControls: !getServerConfig()
-                .skin_hide_download_controls,
+            showDownloadControls: getServerConfig()
+                .skin_hide_download_controls as DownloadControlOption,
         };
     }
 

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -120,7 +120,7 @@ export interface IServerConfig {
     skin_title: string;
     skin_authorization_message: string | null;
     skin_patientview_filter_genes_profiled_all_samples: boolean;
-    skin_hide_download_controls: boolean;
+    skin_hide_download_controls: string;
     show_mdacc_heatmap: boolean;
     quick_search_enabled: boolean;
     default_cross_cancer_study_list: string; // this has a default

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -202,7 +202,7 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
     skin_home_page_unauthorized_studies_global_message:
         'The study is unauthorized. You need to request access.',
     comparison_categorical_na_values: 'NA',
-    skin_hide_download_controls: false,
+    skin_hide_download_controls: 'show',
 
     oncoprint_clinical_tracks_config_json: '',
 

--- a/src/pages/groupComparison/ClinicalDataEnrichmentsTable.tsx
+++ b/src/pages/groupComparison/ClinicalDataEnrichmentsTable.tsx
@@ -8,7 +8,10 @@ import { ClinicalDataEnrichmentStore } from './ClinicalData';
 import { ClinicalDataEnrichmentWithQ } from './GroupComparisonUtils';
 import { toConditionalPrecisionWithMinimum } from '../../shared/lib/FormatUtils';
 import { makeObservable, observable } from 'mobx';
-import { toggleColumnVisibility } from 'cbioportal-frontend-commons';
+import {
+    DownloadControlOption,
+    toggleColumnVisibility,
+} from 'cbioportal-frontend-commons';
 import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls/ColumnVisibilityControls';
 import { getServerConfig } from 'config/config';
 
@@ -194,6 +197,10 @@ export default class ClinicalDataEnrichmentsTable extends React.Component<
                 }
                 initialSortDirection="asc"
                 showColumnVisibility={true}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
                 columnVisibility={this.columnVisibility}
                 columnVisibilityProps={{
                     onColumnToggled: this.onColumnToggled,

--- a/src/pages/groupComparison/Overlap.tsx
+++ b/src/pages/groupComparison/Overlap.tsx
@@ -5,7 +5,11 @@ import { action, computed, makeObservable, observable } from 'mobx';
 import Venn from './OverlapVenn';
 import _ from 'lodash';
 import autobind from 'autobind-decorator';
-import { DownloadControls, remoteData } from 'cbioportal-frontend-commons';
+import {
+    DownloadControlOption,
+    DownloadControls,
+    remoteData,
+} from 'cbioportal-frontend-commons';
 import { MakeMobxView } from '../../shared/components/MobxView';
 import Loader from '../../shared/components/loadingIndicator/LoadingIndicator';
 import ErrorMessage from '../../shared/components/ErrorMessage';
@@ -20,6 +24,7 @@ import { getPatientIdentifiers } from '../studyView/StudyViewUtils';
 import OverlapExclusionIndicator from './OverlapExclusionIndicator';
 import OverlapUpset from './OverlapUpset';
 import ComparisonStore from '../../shared/lib/comparison/ComparisonStore';
+import { getServerConfig } from 'config/config';
 
 export interface IOverlapProps {
     store: ComparisonStore;
@@ -387,6 +392,10 @@ export default class Overlap extends React.Component<IOverlapProps, {}> {
                         dontFade={true}
                         style={{ position: 'absolute', right: 10, top: 10 }}
                         type="button"
+                        showDownload={
+                            getServerConfig().skin_hide_download_controls ===
+                            DownloadControlOption.SHOW_ALL
+                        }
                     />
                 )}
                 <div style={{ position: 'relative', display: 'inline-block' }}>

--- a/src/pages/patientView/clinicalInformation/ClinicalInformationMutationalSignatureTable.tsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationMutationalSignatureTable.tsx
@@ -10,6 +10,8 @@ import _ from 'lodash';
 import { observer } from 'mobx-react';
 import { computed, makeObservable } from 'mobx';
 import { MUTATIONAL_SIGNATURES_SIGNIFICANT_PVALUE_THRESHOLD } from 'shared/lib/GenericAssayUtils/MutationalSignaturesUtils';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface IClinicalInformationMutationalSignatureTableProps {
     data: IMutationalSignature[];
@@ -151,6 +153,10 @@ export default class ClinicalInformationMutationalSignatureTable extends React.C
                 showColumnVisibility={false}
                 initialSortColumn={this.uniqueSamples[0].id}
                 initialSortDirection="desc"
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
             />
         );
     }

--- a/src/pages/patientView/clinicalInformation/ClinicalInformationPatientTable.tsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationPatientTable.tsx
@@ -5,9 +5,10 @@ import LazyMobXTable from 'shared/components/lazyMobXTable/LazyMobXTable';
 import styles from './style/patientTable.module.scss';
 import { SHOW_ALL_PAGE_SIZE } from '../../../shared/components/paginationControls/PaginationControls';
 import { sortByClinicalAttributePriorityThenName } from '../../../shared/lib/SortUtils';
-import { isUrl } from 'cbioportal-frontend-commons';
+import { DownloadControlOption, isUrl } from 'cbioportal-frontend-commons';
 import autobind from 'autobind-decorator';
 import { formatPercentValue } from 'cbioportal-utils';
+import { getServerConfig } from 'config/config';
 
 export interface IClinicalInformationPatientTableProps {
     data: ClinicalData[];
@@ -142,7 +143,8 @@ export default class ClinicalInformationPatientTable extends React.Component<
                 initialItemsPerPage={SHOW_ALL_PAGE_SIZE}
                 showFilter={this.props.showFilter === false ? false : true}
                 showCopyDownload={
-                    this.props.showCopyDownload === false ? false : true
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
                 }
             />
         );

--- a/src/pages/patientView/clinicalInformation/ClinicalInformationSamplesTable.tsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationSamplesTable.tsx
@@ -13,7 +13,8 @@ import {
 import styles from './style/sampleTable.module.scss';
 import { SHOW_ALL_PAGE_SIZE } from '../../../shared/components/paginationControls/PaginationControls';
 import { sortByClinicalAttributePriorityThenName } from '../../../shared/lib/SortUtils';
-import { isUrl } from 'cbioportal-frontend-commons';
+import { DownloadControlOption, isUrl } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 interface IClinicalInformationSamplesTableProps {
     samples?: ClinicalDataBySampleId[];
@@ -68,6 +69,10 @@ export default class ClinicalInformationSamplesTable extends React.Component<
                 showPagination={false}
                 initialItemsPerPage={SHOW_ALL_PAGE_SIZE}
                 showColumnVisibility={false}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
             />
         );
     }

--- a/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
+++ b/src/pages/patientView/copyNumberAlterations/CopyNumberTableWrapper.tsx
@@ -33,6 +33,7 @@ import autobind from 'autobind-decorator';
 import SampleNotProfiledAlert from 'shared/components/SampleNotProfiledAlert';
 import { NamespaceColumnConfig } from 'shared/components/namespaceColumns/NamespaceColumnConfig';
 import { createNamespaceColumns } from 'shared/components/namespaceColumns/namespaceColumnsUtils';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
 
 export const TABLE_FEATURE_INSTRUCTION =
     'Click on a CNA row to zoom in on the gene in the IGV browser above';
@@ -445,6 +446,11 @@ export default class CopyNumberTableWrapper extends React.Component<
                                 onRowClick={this.props.onRowClick}
                                 onRowMouseEnter={this.props.onRowMouseEnter}
                                 onRowMouseLeave={this.props.onRowMouseLeave}
+                                showCopyDownload={
+                                    getServerConfig()
+                                        .skin_hide_download_controls ===
+                                    DownloadControlOption.SHOW_ALL
+                                }
                             />
                         </FeatureInstruction>
                     )}

--- a/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
+++ b/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
@@ -17,7 +17,7 @@ import AnnotationColumnFormatter from './column/AnnotationColumnFormatter';
 import { getServerConfig } from 'config/config';
 import { ServerConfigHelpers } from 'config/config';
 import ChromosomeColumnFormatter from 'shared/components/mutationTable/column/ChromosomeColumnFormatter';
-import { remoteData } from 'cbioportal-frontend-commons';
+import { DownloadControlOption, remoteData } from 'cbioportal-frontend-commons';
 import {
     calculateOncoKbContentPadding,
     calculateOncoKbContentWidthWithInterval,
@@ -540,6 +540,11 @@ export default class StructuralVariantTableWrapper extends React.Component<
                             itemsLabel="Structural Variants"
                             itemsLabelPlural="Structural Variants"
                             showCountHeader={true}
+                            showCopyDownload={
+                                getServerConfig()
+                                    .skin_hide_download_controls ===
+                                DownloadControlOption.SHOW_ALL
+                            }
                         />
                     )}
                 </>

--- a/src/pages/patientView/timeline/ClinicalEventsTables.tsx
+++ b/src/pages/patientView/timeline/ClinicalEventsTables.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { ClinicalEvent } from 'cbioportal-ts-api-client';
 import { groupTimelineData } from 'pages/patientView/timeline/timelineDataUtils.ts';
 import LazyMobXTable from 'shared/components/lazyMobXTable/LazyMobXTable';
 import _ from 'lodash';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 class EventsTable extends LazyMobXTable<{}> {}
 
@@ -64,7 +66,11 @@ const ClinicalEventsTables: React.FunctionComponent<{
                             showPagination={false}
                             showColumnVisibility={false}
                             showFilter={true}
-                            showCopyDownload={true}
+                            showCopyDownload={
+                                getServerConfig()
+                                    .skin_hide_download_controls ===
+                                DownloadControlOption.SHOW_ALL
+                            }
                         />
                     </>
                 );

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -27,7 +27,11 @@ import { MSKTab, MSKTabs } from '../../shared/components/MSKTabs/MSKTabs';
 import { PageLayout } from '../../shared/components/PageLayout/PageLayout';
 import autobind from 'autobind-decorator';
 import { ITabConfiguration } from '../../shared/model/ITabConfiguration';
-import { getBrowserWindow, remoteData } from 'cbioportal-frontend-commons';
+import {
+    DownloadControlOption,
+    getBrowserWindow,
+    remoteData,
+} from 'cbioportal-frontend-commons';
 import CoExpressionTab from './coExpression/CoExpressionTab';
 import Helmet from 'react-helmet';
 import {
@@ -69,7 +73,6 @@ import {
     prepareCustomTabConfigurations,
 } from 'shared/lib/customTabs/customTabHelpers';
 import { buildCBioPortalPageUrl } from 'shared/api/urls';
-import { AppContext } from 'cbioportal-frontend-commons';
 import PathWayMapperContainer from 'pages/resultsView/pathwayMapper/PathWayMapperContainer';
 
 export function initStore(
@@ -469,7 +472,10 @@ export default class ResultsViewPage extends React.Component<
             },
         ];
 
-        if (this.context.showDownloadControls === true) {
+        if (
+            getServerConfig().skin_hide_download_controls !==
+            DownloadControlOption.HIDE_ALL
+        ) {
             tabMap.push({
                 id: ResultsViewTab.DOWNLOAD,
                 getTab: () => {
@@ -798,5 +804,3 @@ export default class ResultsViewPage extends React.Component<
         }
     }
 }
-
-ResultsViewPage.contextType = AppContext;

--- a/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
+++ b/src/pages/resultsView/cancerSummary/CancerSummaryChart.tsx
@@ -29,6 +29,7 @@ import {
     DownloadControls,
     DataType,
     pluralize,
+    DownloadControlOption,
 } from 'cbioportal-frontend-commons';
 import {
     HORIZONTAL_OFFSET,
@@ -41,6 +42,7 @@ import URL from 'url';
 import { CANCER_SUMMARY_ALL_GENES } from './CancerSummaryContainer';
 import { ResultsViewURLQueryEnum } from 'pages/resultsView/ResultsViewURLWrapper';
 import ScrollWrapper from './ScrollWrapper';
+import { getServerConfig } from 'config/config';
 
 interface CancerSummaryChartProps {
     colors: Record<keyof IAlterationCountMap, string>;
@@ -889,6 +891,10 @@ export class CancerSummaryChart extends React.Component<
                     type="button"
                     buttons={['SVG', 'PNG', 'PDF', 'Data']}
                     style={{ position: 'absolute', top: 10, right: 10 }}
+                    showDownload={
+                        getServerConfig().skin_hide_download_controls !==
+                        DownloadControlOption.HIDE_ALL
+                    }
                 />
             </div>
         );

--- a/src/pages/resultsView/cnSegments/CNSegments.tsx
+++ b/src/pages/resultsView/cnSegments/CNSegments.tsx
@@ -21,8 +21,9 @@ import {
     default as ProgressIndicator,
     IProgressIndicatorItem,
 } from 'shared/components/progressIndicator/ProgressIndicator';
-import { remoteData } from 'cbioportal-frontend-commons';
+import { DownloadControlOption, remoteData } from 'cbioportal-frontend-commons';
 import CaseFilterWarning from 'shared/components/banners/CaseFilterWarning';
+import { getServerConfig } from 'config/config';
 
 @observer
 export default class CNSegments extends React.Component<
@@ -174,6 +175,10 @@ export default class CNSegments extends React.Component<
                 <CNSegmentsDownloader
                     promise={this.props.store.cnSegments}
                     filename={this.filename}
+                    showDownload={
+                        getServerConfig().skin_hide_download_controls ===
+                        DownloadControlOption.SHOW_ALL
+                    }
                 />
                 <div className={'tabMessageContainer'}>
                     <CaseFilterWarning store={this.props.store} />

--- a/src/pages/resultsView/coExpression/CoExpressionTableGenes.tsx
+++ b/src/pages/resultsView/coExpression/CoExpressionTableGenes.tsx
@@ -15,6 +15,8 @@ import { bind } from 'bind-decorator';
 import { cytobandFilter } from 'pages/resultsView/ResultsViewTableUtils';
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
 import { formatSignificanceValueWithStyle } from 'shared/lib/FormatUtils';
+import { getServerConfig } from 'config/config';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
 
 export interface ICoExpressionTableGenesProps {
     referenceGeneticEntity: Gene | Geneset;
@@ -181,6 +183,10 @@ export default class CoExpressionTableGenes extends React.Component<
                     copyDownloadProps={{
                         showCopy: false,
                     }}
+                    showCopyDownload={
+                        getServerConfig().skin_hide_download_controls !==
+                        DownloadControlOption.HIDE_ALL
+                    }
                 />
             </div>
         );

--- a/src/pages/resultsView/download/CaseAlterationTable.tsx
+++ b/src/pages/resultsView/download/CaseAlterationTable.tsx
@@ -20,6 +20,8 @@ import { Alteration } from 'shared/lib/oql/oql-parser';
 import { parsedOQLAlterationToSourceOQL } from 'shared/lib/oql/oqlfilter';
 import { insertBetween } from 'shared/lib/ArrayUtils';
 import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface ISubAlteration {
     type: string;
@@ -511,7 +513,10 @@ export default class CaseAlterationTable extends React.Component<
                 showPagination={true}
                 showColumnVisibility={true}
                 showFilter={true}
-                showCopyDownload={true}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
                 enableHorizontalScroll={true}
                 copyDownloadProps={{
                     downloadFilename: 'alterations_across_samples.tsv',

--- a/src/pages/resultsView/download/DownloadTab.tsx
+++ b/src/pages/resultsView/download/DownloadTab.tsx
@@ -58,7 +58,10 @@ import { WindowWidthBox } from '../../../shared/components/WindowWidthBox/Window
 import { DefaultTooltip, remoteData } from 'cbioportal-frontend-commons';
 import { getRemoteDataGroupStatus } from 'cbioportal-utils';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
-import { onMobxPromise } from 'cbioportal-frontend-commons';
+import {
+    DownloadControlOption,
+    onMobxPromise,
+} from 'cbioportal-frontend-commons';
 import {
     MolecularProfile,
     Sample,
@@ -77,6 +80,8 @@ import { ResultsViewTab } from '../ResultsViewPageHelpers';
 import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
 import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
 import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
+import { computed } from 'mobx';
+import { getServerConfig } from 'config/config';
 
 export interface IDownloadTabProps {
     store: ResultsViewPageStore;
@@ -622,6 +627,13 @@ export default class DownloadTab extends React.Component<
         },
     });
 
+    @computed get showDownload() {
+        return (
+            getServerConfig().skin_hide_download_controls ===
+            DownloadControlOption.SHOW_ALL
+        );
+    }
+
     public render() {
         const status = getRemoteDataGroupStatus(
             this.geneAlterationData,
@@ -685,15 +697,20 @@ export default class DownloadTab extends React.Component<
                             >
                                 <tbody>
                                     {hasValidData(this.cnaData.result!) &&
+                                        this.showDownload &&
                                         this.cnaDownloadControls()}
                                     {hasValidMutationData(
                                         this.mutationData.result!
-                                    ) && this.mutationDownloadControls()}
+                                    ) &&
+                                        this.showDownload &&
+                                        this.mutationDownloadControls()}
                                     {hasValidStructuralVariantData(
                                         this.structuralVariantData.result!
                                     ) &&
+                                        this.showDownload &&
                                         this.structuralVariantDownloadControls()}
                                     {hasValidData(this.mrnaData.result!) &&
+                                        this.showDownload &&
                                         this.mrnaExprDownloadControls(
                                             this.props.store.selectedMolecularProfiles.result!.find(
                                                 profile =>
@@ -702,6 +719,7 @@ export default class DownloadTab extends React.Component<
                                             )!.name
                                         )}
                                     {hasValidData(this.proteinData.result!) &&
+                                        this.showDownload &&
                                         this.proteinExprDownloadControls(
                                             this.props.store.selectedMolecularProfiles.result!.find(
                                                 profile =>
@@ -725,6 +743,7 @@ export default class DownloadTab extends React.Component<
                                     )}
                                     {this.props.store
                                         .doNonSelectedDownloadableMolecularProfilesExist &&
+                                        this.showDownload &&
                                         this.nonSelectedProfileDownloadRow(
                                             this.props.store
                                                 .nonSelectedDownloadableMolecularProfilesGroupByName
@@ -738,6 +757,7 @@ export default class DownloadTab extends React.Component<
                                                 .genericAssayProfilesGroupByProfileIdSuffix
                                                 .result
                                         ) &&
+                                        this.showDownload &&
                                         this.genericAssayProfileDownloadRows(
                                             this.props.store
                                                 .genericAssayProfilesGroupByProfileIdSuffix

--- a/src/pages/resultsView/download/GeneAlterationTable.tsx
+++ b/src/pages/resultsView/download/GeneAlterationTable.tsx
@@ -2,6 +2,8 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import LazyMobXTable from 'shared/components/lazyMobXTable/LazyMobXTable';
 import FrequencyBar from 'shared/components/cohort/FrequencyBar';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface IGeneAlteration {
     gene: string;
@@ -102,7 +104,10 @@ export default class GeneAlterationTable extends React.Component<
                 initialItemsPerPage={10}
                 showColumnVisibility={true}
                 showFilter={true}
-                showCopyDownload={true}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls !==
+                    DownloadControlOption.HIDE_ALL
+                }
                 copyDownloadProps={{
                     downloadFilename: 'gene_alteration_frequency.tsv',
                 }}

--- a/src/pages/resultsView/enrichments/AlterationEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/AlterationEnrichmentsTable.tsx
@@ -13,7 +13,13 @@ import { cytobandFilter } from 'pages/resultsView/ResultsViewTableUtils';
 import autobind from 'autobind-decorator';
 import { EnrichmentsTableDataStore } from 'pages/resultsView/enrichments/EnrichmentsTableDataStore';
 import { AlterationEnrichmentRow } from 'shared/model/AlterationEnrichmentRow';
-import { CNA_COLOR_AMP, CNA_COLOR_HOMDEL } from 'cbioportal-frontend-commons';
+import {
+    CNA_COLOR_AMP,
+    CNA_COLOR_HOMDEL,
+    DownloadControlOption,
+} from 'cbioportal-frontend-commons';
+
+import { getServerConfig } from 'config/config';
 
 export interface IAlterationEnrichmentTableProps {
     visibleOrderedColumnNames?: string[];
@@ -249,6 +255,10 @@ export default class AlterationEnrichmentTable extends React.Component<
                     this.props.onGeneNameClick ? this.onRowClick : undefined
                 }
                 dataStore={this.props.dataStore}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
             />
         );
     }

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsBoxPlot.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsBoxPlot.tsx
@@ -21,7 +21,11 @@ import {
 import BoxScatterPlot, {
     IBoxScatterPlotData,
 } from 'shared/components/plots/BoxScatterPlot';
-import { remoteData, DownloadControls } from 'cbioportal-frontend-commons';
+import {
+    remoteData,
+    DownloadControls,
+    DownloadControlOption,
+} from 'cbioportal-frontend-commons';
 import client from 'shared/api/cbioportalClientInstance';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
@@ -35,6 +39,7 @@ import {
     getGenericAssayPropertyOrDefault,
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { ExtendedAlteration } from 'shared/model/ExtendedAlteration';
+import { getServerConfig } from 'config/config';
 
 class EnrichmentsBoxPlotComponent extends BoxScatterPlot<
     IBoxScatterPlotPoint
@@ -370,6 +375,10 @@ export default class ExpressionEnrichmentsBoxPlot extends React.Component<
                         dontFade={true}
                         style={{ position: 'absolute', right: 10, top: 10 }}
                         type="button"
+                        showDownload={
+                            getServerConfig().skin_hide_download_controls ===
+                            DownloadControlOption.SHOW_ALL
+                        }
                     />
                     <EnrichmentsBoxPlotComponent
                         domainPadding={10}

--- a/src/pages/resultsView/enrichments/ExpressionEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/ExpressionEnrichmentsTable.tsx
@@ -14,6 +14,8 @@ import { cytobandFilter } from 'pages/resultsView/ResultsViewTableUtils';
 import autobind from 'autobind-decorator';
 import { EnrichmentsTableDataStore } from 'pages/resultsView/enrichments/EnrichmentsTableDataStore';
 import { ContinousDataPvalueTooltip } from './EnrichmentsUtil';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface IExpressionEnrichmentTableProps {
     visibleOrderedColumnNames?: string[];
@@ -184,6 +186,10 @@ export default class ExpressionEnrichmentTable extends React.Component<
                     this.props.onGeneNameClick ? this.onRowClick : undefined
                 }
                 dataStore={this.props.dataStore}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
             />
         );
     }

--- a/src/pages/resultsView/enrichments/GenericAssayEnrichmentsTable.tsx
+++ b/src/pages/resultsView/enrichments/GenericAssayEnrichmentsTable.tsx
@@ -17,6 +17,8 @@ import {
     formatGenericAssayCompactLabelByNameAndId,
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { ContinousDataPvalueTooltip } from './EnrichmentsUtil';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface IGenericAssayEnrichmentTableProps {
     genericAssayType: string;
@@ -160,6 +162,10 @@ export default class GenericAssayEnrichmentsTable extends React.Component<
                     this.props.onEntityClick ? this.onRowClick : undefined
                 }
                 dataStore={this.props.dataStore}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
             />
         );
     }

--- a/src/pages/resultsView/enrichments/MiniScatterChart.tsx
+++ b/src/pages/resultsView/enrichments/MiniScatterChart.tsx
@@ -18,9 +18,12 @@ import {
     axisLabelStyles,
     CBIOPORTAL_VICTORY_THEME,
     DownloadControls,
+    DownloadControlOption,
     getTextWidth,
     truncateWithEllipsis,
 } from 'cbioportal-frontend-commons';
+
+import { getServerConfig } from 'config/config';
 
 export interface IMiniScatterChartProps {
     data: any[];
@@ -285,6 +288,10 @@ export default class MiniScatterChart<
                             right: 10,
                             zIndex: 0,
                         }}
+                        showDownload={
+                            getServerConfig().skin_hide_download_controls ===
+                            DownloadControlOption.SHOW_ALL
+                        }
                     />
                 </div>
                 <Observer>{this.getTooltip}</Observer>

--- a/src/pages/resultsView/mutualExclusivity/MutualExclusivityTable.tsx
+++ b/src/pages/resultsView/mutualExclusivity/MutualExclusivityTable.tsx
@@ -14,6 +14,9 @@ import {
 } from './MutualExclusivityUtil';
 import styles from './styles.module.scss';
 import classNames from 'classnames';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+
+import { getServerConfig } from 'config/config';
 
 export interface IMutualExclusivityTableProps {
     columns?: MutualExclusivityTableColumnType[];
@@ -247,6 +250,10 @@ export default class MutualExclusivityTable extends React.Component<
                 initialItemsPerPage={50}
                 initialSortColumn={this.props.initialSortColumn}
                 paginationProps={{ itemsPerPageOptions: [50] }}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls !==
+                    DownloadControlOption.HIDE_ALL
+                }
             />
         );
     }

--- a/src/pages/resultsView/plots/PlotsTab.tsx
+++ b/src/pages/resultsView/plots/PlotsTab.tsx
@@ -99,7 +99,10 @@ import {
 import { getTablePlotDownloadData } from '../../../shared/components/plots/TablePlotUtils';
 import MultipleCategoryBarPlot from '../../groupComparison/MultipleCategoryBarPlot';
 import { RESERVED_CLINICAL_VALUE_COLORS } from 'shared/lib/Colors';
-import { onMobxPromise } from 'cbioportal-frontend-commons';
+import {
+    DownloadControlOption,
+    onMobxPromise,
+} from 'cbioportal-frontend-commons';
 import { showWaterfallPlot } from 'pages/resultsView/plots/PlotsTabUtils';
 import Pluralize from 'pluralize';
 import AlterationFilterWarning from '../../../shared/components/banners/AlterationFilterWarning';
@@ -4828,6 +4831,13 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
         );
     }
 
+    @computed get showDownload() {
+        return (
+            getServerConfig().skin_hide_download_controls ===
+            DownloadControlOption.SHOW_ALL
+        );
+    }
+
     @computed get plot() {
         const promises: MobxPromise<any>[] = [
             this.plotType,
@@ -5407,26 +5417,31 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
                                             <DownloadControls
                                                 getSvg={this.getSvg}
                                                 filename={this.downloadFilename}
-                                                additionalRightButtons={[
-                                                    {
-                                                        key: 'Data',
-                                                        content: (
-                                                            <span>
-                                                                Data{' '}
-                                                                <i
-                                                                    className="fa fa-cloud-download"
-                                                                    aria-hidden="true"
-                                                                />
-                                                            </span>
-                                                        ),
-                                                        onClick: this
-                                                            .downloadData,
-                                                        disabled: !this.props
-                                                            .store
-                                                            .entrezGeneIdToGene
-                                                            .isComplete,
-                                                    },
-                                                ]}
+                                                additionalRightButtons={
+                                                    this.showDownload
+                                                        ? [
+                                                              {
+                                                                  key: 'Data',
+                                                                  content: (
+                                                                      <span>
+                                                                          Data{' '}
+                                                                          <i
+                                                                              className="fa fa-cloud-download"
+                                                                              aria-hidden="true"
+                                                                          />
+                                                                      </span>
+                                                                  ),
+                                                                  onClick: this
+                                                                      .downloadData,
+                                                                  disabled: !this
+                                                                      .props
+                                                                      .store
+                                                                      .entrezGeneIdToGene
+                                                                      .isComplete,
+                                                              },
+                                                          ]
+                                                        : undefined
+                                                }
                                                 dontFade={true}
                                                 style={{
                                                     position: 'absolute',

--- a/src/pages/resultsView/survival/SurvivalChart.tsx
+++ b/src/pages/resultsView/survival/SurvivalChart.tsx
@@ -34,7 +34,11 @@ import {
 } from './SurvivalUtil';
 import { toConditionalPrecision } from 'shared/lib/NumberUtils';
 import { getPatientViewUrl } from '../../../shared/api/urls';
-import { DefaultTooltip, DownloadControls } from 'cbioportal-frontend-commons';
+import {
+    DefaultTooltip,
+    DownloadControls,
+    DownloadControlOption,
+} from 'cbioportal-frontend-commons';
 import autobind from 'autobind-decorator';
 import { AnalysisGroup, DataBin } from '../../studyView/StudyViewUtils';
 import { AbstractChart } from '../../studyView/charts/ChartContainer';
@@ -676,6 +680,10 @@ export default class SurvivalChart
                         getData={this.getData}
                         style={{ position: 'absolute', zIndex: 10, right: 10 }}
                         type="button"
+                        showDownload={
+                            getServerConfig().skin_hide_download_controls ===
+                            DownloadControlOption.SHOW_ALL
+                        }
                     />
                 )}
 

--- a/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
+++ b/src/pages/resultsView/survival/SurvivalPrefixTable.tsx
@@ -13,6 +13,7 @@ import { toConditionalPrecision } from 'shared/lib/NumberUtils';
 import { filterNumericalColumn } from 'shared/components/lazyMobXTable/utils';
 import _ from 'lodash';
 import {
+    DownloadControlOption,
     EditableSpan,
     toggleColumnVisibility,
 } from 'cbioportal-frontend-commons';
@@ -371,6 +372,10 @@ export default class SurvivalPrefixTable extends React.Component<
                     showCopy: false,
                 }}
                 filterBoxWidth={120}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls !==
+                    DownloadControlOption.HIDE_ALL
+                }
             />
         );
     }

--- a/src/pages/studyView/chartHeader/ChartHeader.tsx
+++ b/src/pages/studyView/chartHeader/ChartHeader.tsx
@@ -22,7 +22,8 @@ import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import { ISurvivalDescription } from 'pages/resultsView/survival/SurvivalDescriptionTable';
 import ComparisonVsIcon from 'shared/components/ComparisonVsIcon';
 import { getComparisonParamsForTable } from 'pages/studyView/StudyViewComparisonUtils';
-import { AppContext } from 'cbioportal-frontend-commons';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface IChartHeaderProps {
     chartMeta: ChartMeta;
@@ -272,7 +273,8 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
             this.props.chartControls &&
             this.props.downloadTypes &&
             this.props.downloadTypes.length > 0 &&
-            this.context.showDownloadControls === true
+            getServerConfig().skin_hide_download_controls !==
+                DownloadControlOption.HIDE_ALL
         );
     }
 
@@ -655,6 +657,11 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
                                     minWidth: downloadSubmenuWidth,
                                 }}
                                 dontFade={true}
+                                showDownload={
+                                    getServerConfig()
+                                        .skin_hide_download_controls ===
+                                    DownloadControlOption.SHOW_ALL
+                                }
                             />
                         )}
                     </div>
@@ -871,5 +878,3 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
         );
     }
 }
-
-ChartHeader.contextType = AppContext;

--- a/src/pages/studyView/studyPageHeader/ActionButtons.tsx
+++ b/src/pages/studyView/studyPageHeader/ActionButtons.tsx
@@ -13,7 +13,9 @@ import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import classNames from 'classnames';
 import { AppStore } from '../../../AppStore';
 import { serializeEvent } from '../../../shared/lib/tracking';
-import { AppContext } from 'cbioportal-frontend-commons';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
+
 export interface ActionButtonsProps {
     loadingComplete: boolean;
     store: StudyViewPageStore;
@@ -185,7 +187,8 @@ export default class ActionButtons extends React.Component<
                         </button>
                     </DefaultTooltip>
                 </DefaultTooltip>
-                {this.context.showDownloadControls === true && (
+                {getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL && (
                     <DefaultTooltip
                         trigger={['hover']}
                         placement={'top'}
@@ -217,5 +220,3 @@ export default class ActionButtons extends React.Component<
         );
     }
 }
-
-ActionButtons.contextType = AppContext;

--- a/src/pages/studyView/studyPageHeader/studySummary/StudySummary.tsx
+++ b/src/pages/studyView/studyPageHeader/studySummary/StudySummary.tsx
@@ -13,7 +13,8 @@ import MobxPromise from 'mobxpromise';
 import { StudyDataDownloadLink } from '../../../../shared/components/StudyDataDownloadLink/StudyDataDownloadLink';
 import { serializeEvent } from '../../../../shared/lib/tracking';
 import { mixedReferenceGenomeWarning } from 'shared/lib/referenceGenomeUtils';
-import { AppContext } from 'cbioportal-frontend-commons';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 interface IStudySummaryProps {
     studies: CancerStudy[];
@@ -119,7 +120,8 @@ export default class StudySummary extends React.Component<
     get showDownload() {
         return (
             this.props.hasRawDataForDownload &&
-            this.context.showDownloadControls === true
+            getServerConfig().skin_hide_download_controls ===
+                DownloadControlOption.SHOW_ALL
         );
     }
 
@@ -229,5 +231,3 @@ export default class StudySummary extends React.Component<
         );
     }
 }
-
-StudySummary.contextType = AppContext;

--- a/src/pages/studyView/tabs/CNSegments.tsx
+++ b/src/pages/studyView/tabs/CNSegments.tsx
@@ -20,6 +20,8 @@ import WindowStore from 'shared/components/window/WindowStore';
 
 import { StudyViewPageTabKeyEnum } from 'pages/studyView/StudyViewPageTabs';
 import { StudyViewPageStore } from '../StudyViewPageStore';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 @observer
 export default class CNSegments extends React.Component<
@@ -161,6 +163,11 @@ export default class CNSegments extends React.Component<
                         <CNSegmentsDownloader
                             promise={this.activePromise!}
                             filename={this.filename}
+                            showDownload={
+                                getServerConfig()
+                                    .skin_hide_download_controls ===
+                                DownloadControlOption.SHOW_ALL
+                            }
                         />
                     )}
                 </div>

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -16,7 +16,11 @@ import {
 } from '../StudyViewUtils';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
-import { isUrl, remoteData } from 'cbioportal-frontend-commons';
+import {
+    DownloadControlOption,
+    isUrl,
+    remoteData,
+} from 'cbioportal-frontend-commons';
 import { Else, If, Then } from 'react-if';
 import ProgressIndicator, {
     IProgressIndicatorItem,
@@ -274,7 +278,11 @@ export class ClinicalDataTab extends React.Component<
                                         <Else>
                                             <ClinicalDataTabTableComponent
                                                 initialItemsPerPage={20}
-                                                showCopyDownload={true}
+                                                showCopyDownload={
+                                                    getServerConfig()
+                                                        .skin_hide_download_controls ===
+                                                    DownloadControlOption.SHOW_ALL
+                                                }
                                                 showColumnVisibility={false}
                                                 data={
                                                     this.props.store

--- a/src/shared/components/cnSegments/CNSegmentsDownloader.tsx
+++ b/src/shared/components/cnSegments/CNSegmentsDownloader.tsx
@@ -10,13 +10,13 @@ import { generateSegmentFileContent } from 'shared/lib/IGVUtils';
 import { onMobxPromise } from 'cbioportal-frontend-commons';
 import fileDownload from 'react-file-download';
 import autobind from 'autobind-decorator';
-import { AppContext } from 'cbioportal-frontend-commons';
 
 export type CNSegmentsDownloaderProps = {
     promise: MobxPromise<CopyNumberSeg[]>;
     filename?: string;
     buttonClassName?: string;
     tooltipPlacement?: string;
+    showDownload?: boolean;
 };
 
 @observer
@@ -38,7 +38,7 @@ export default class CNSegmentsDownloader extends React.Component<
     @observable downloading = false;
 
     public render() {
-        return this.context.showDownloadControls === true ? (
+        return this.props.showDownload ? (
             <DefaultTooltip
                 overlay={
                     <span>
@@ -76,5 +76,3 @@ export default class CNSegmentsDownloader extends React.Component<
         });
     }
 }
-
-CNSegmentsDownloader.contextType = AppContext;

--- a/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadButtons.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { If } from 'react-if';
 import { Button, ButtonGroup } from 'react-bootstrap';
-import { AppContext, DefaultTooltip } from 'cbioportal-frontend-commons';
+import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import { ICopyDownloadInputsProps } from './ICopyDownloadControls';
 
 export interface ICopyDownloadButtonsProps extends ICopyDownloadInputsProps {
@@ -91,5 +91,3 @@ export class CopyDownloadButtons extends React.Component<
         );
     }
 }
-
-CopyDownloadButtons.contextType = AppContext;

--- a/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadControls.tsx
@@ -10,7 +10,6 @@ const Clipboard = require('clipboard');
 import copyDownloadStyles from './copyDownloadControls.module.scss';
 import { CopyDownloadButtons } from './CopyDownloadButtons';
 import { ICopyDownloadControlsProps } from './ICopyDownloadControls';
-import { AppContext } from 'cbioportal-frontend-commons';
 
 export interface IAsyncCopyDownloadControlsProps
     extends ICopyDownloadControlsProps {
@@ -81,7 +80,7 @@ export class CopyDownloadControls extends React.Component<
     }
 
     public render() {
-        return this.context.showDownloadControls === true ? (
+        return (
             <span>
                 <CopyDownloadButtons
                     className={this.props.className}
@@ -100,7 +99,7 @@ export class CopyDownloadControls extends React.Component<
                 {this.copyIndicatorModal()}
                 {this.downloadErrorModal()}
             </span>
-        ) : null;
+        );
     }
 
     public downloadIndicatorModal(): JSX.Element {
@@ -275,5 +274,3 @@ export class CopyDownloadControls extends React.Component<
         }, this.props.copyMessageDuration);
     }
 }
-
-CopyDownloadControls.contextType = AppContext;

--- a/src/shared/components/copyDownloadControls/CopyDownloadLinks.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadLinks.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ICopyDownloadInputsProps } from './ICopyDownloadControls';
-import { AppContext } from 'cbioportal-frontend-commons';
 import { computed } from 'mobx';
 
 export interface ICopyDownloadLinksProps extends ICopyDownloadInputsProps {
@@ -20,16 +19,11 @@ export class CopyDownloadLinks extends React.Component<
     };
 
     @computed get showDownload() {
-        return (
-            this.props.showDownload &&
-            this.context.showDownloadControls === true
-        );
+        return this.props.showDownload;
     }
 
     @computed get showCopy() {
-        return (
-            this.props.showCopy && this.context.showDownloadControls === true
-        );
+        return this.props.showCopy;
     }
 
     public render() {
@@ -69,5 +63,3 @@ export class CopyDownloadLinks extends React.Component<
         );
     }
 }
-
-CopyDownloadLinks.contextType = AppContext;

--- a/src/shared/components/copyDownloadControls/CopyDownloadQueryLinks.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadQueryLinks.tsx
@@ -7,7 +7,6 @@ import VirtualStudy, {
     IVirtualStudyProps,
 } from 'pages/studyView/virtualStudy/VirtualStudy';
 import { computed } from 'mobx';
-import { AppContext } from 'cbioportal-frontend-commons';
 
 export interface ICopyDownloadLinksProps extends ICopyDownloadInputsProps {
     copyLinkRef?: (el: HTMLAnchorElement | null) => void;
@@ -37,17 +36,12 @@ export class CopyDownloadQueryLinks extends React.Component<
 
     @computed
     get showDownload() {
-        return (
-            this.props.showDownload &&
-            this.context.showDownloadControls === true
-        );
+        return this.props.showDownload;
     }
 
     @computed
     get showCopy() {
-        return (
-            this.props.showCopy && this.context.showDownloadControls === true
-        );
+        return this.props.showCopy;
     }
 
     public render() {
@@ -138,5 +132,3 @@ export class CopyDownloadQueryLinks extends React.Component<
         );
     }
 }
-
-CopyDownloadQueryLinks.contextType = AppContext;

--- a/src/shared/components/copyDownloadControls/SimpleCopyDownloadControls.tsx
+++ b/src/shared/components/copyDownloadControls/SimpleCopyDownloadControls.tsx
@@ -6,7 +6,6 @@ import { CopyDownloadLinks } from './CopyDownloadLinks';
 import { CopyDownloadButtons } from './CopyDownloadButtons';
 import { ICopyDownloadControlsProps } from './ICopyDownloadControls';
 import { CopyDownloadQueryLinks } from './CopyDownloadQueryLinks';
-import { AppContext } from 'cbioportal-frontend-commons';
 const Clipboard = require('clipboard');
 
 export interface ISimpleCopyDownloadControlsProps
@@ -52,9 +51,6 @@ export class SimpleCopyDownloadControls extends React.Component<
     }
 
     public render() {
-        if (this.context.showDownloadControls === false) {
-            return null;
-        }
         if (this.props.controlsStyle === 'LINK') {
             return (
                 <CopyDownloadLinks
@@ -138,5 +134,3 @@ export class SimpleCopyDownloadControls extends React.Component<
         }, this.props.copyMessageDuration);
     }
 }
-
-SimpleCopyDownloadControls.contextType = AppContext;

--- a/src/shared/components/enhancedReactTable/EnhancedReactTable.tsx
+++ b/src/shared/components/enhancedReactTable/EnhancedReactTable.tsx
@@ -22,6 +22,8 @@ import {
     ColumnVisibility,
 } from './IColumnFormatter';
 import './styles.css';
+import { getServerConfig } from 'config/config';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
 
 /**
  * @author Selcuk Onur Sumer
@@ -263,7 +265,10 @@ export default class EnhancedReactTable<T> extends React.Component<
         return (
             <div className={className}>
                 <TableHeaderControls
-                    showCopyAndDownload={true}
+                    showCopyAndDownload={
+                        getServerConfig().skin_hide_download_controls ===
+                        DownloadControlOption.SHOW_ALL
+                    }
                     showHideShowColumnButton={true}
                     handleInput={this.handleFilterInput}
                     downloadDataGenerator={this.handleDownload}

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -164,6 +164,7 @@ import {
     calculateOncoKbContentWidthWithInterval,
     DEFAULT_ONCOKB_CONTENT_WIDTH,
 } from 'shared/lib/AnnotationColumnUtils';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
 import { NamespaceColumnConfig } from 'shared/components/namespaceColumns/NamespaceColumnConfig';
 
 export enum MutationTableColumnType {
@@ -1373,6 +1374,10 @@ export default class MutationTable<
                 }
                 deactivateColumnFilter={this.props.deactivateColumnFilter}
                 customControls={this.props.customControls}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
             />
         );
     }

--- a/src/shared/components/oncoprint/controls/OncoprintControls.tsx
+++ b/src/shared/components/oncoprint/controls/OncoprintControls.tsx
@@ -14,7 +14,11 @@ import {
     GenericAssayMeta,
 } from 'cbioportal-ts-api-client';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
-import { DefaultTooltip, EditableSpan } from 'cbioportal-frontend-commons';
+import {
+    DefaultTooltip,
+    DownloadControlOption,
+    EditableSpan,
+} from 'cbioportal-frontend-commons';
 import Slider from 'react-rangeslider';
 import 'react-rangeslider/lib/index.css';
 import './styles.scss';
@@ -35,11 +39,11 @@ import {
     IDriverAnnotationControlsState,
 } from 'shared/alterationFiltering/AnnotationFilteringSettings';
 import DriverAnnotationControls from 'shared/components/driverAnnotations/DriverAnnotationControls';
-import { AppContext } from 'cbioportal-frontend-commons';
 import {
     ClinicalTrackConfig,
     ClinicalTrackConfigMap,
 } from 'shared/components/oncoprint/Oncoprint';
+import { getServerConfig } from 'config/config';
 
 export interface IOncoprintControlsHandlers
     extends IDriverAnnotationControlsHandlers {
@@ -1047,7 +1051,8 @@ export default class OncoprintControls extends React.Component<
     });
 
     private DownloadMenu = observer(() => {
-        return this.context.showDownloadControls === true ? (
+        return getServerConfig().skin_hide_download_controls !==
+            DownloadControlOption.HIDE_ALL ? (
             <CustomDropdown
                 bsStyle="default"
                 title="Download"
@@ -1085,24 +1090,28 @@ export default class OncoprintControls extends React.Component<
                         'Sample'}{' '}
                     order
                 </button>
-                {!this.props.oncoprinterMode && (
-                    <button
-                        className="btn btn-sm btn-default"
-                        name={EVENT_KEY.downloadTabular}
-                        onClick={this.onButtonClick}
-                    >
-                        Tabular
-                    </button>
-                )}
-                {!this.props.oncoprinterMode && (
-                    <button
-                        className="btn btn-sm btn-default"
-                        name={EVENT_KEY.downloadOncoprinter}
-                        onClick={this.onButtonClick}
-                    >
-                        Open in Oncoprinter
-                    </button>
-                )}
+                {!this.props.oncoprinterMode &&
+                    getServerConfig().skin_hide_download_controls ===
+                        DownloadControlOption.SHOW_ALL && (
+                        <button
+                            className="btn btn-sm btn-default"
+                            name={EVENT_KEY.downloadTabular}
+                            onClick={this.onButtonClick}
+                        >
+                            Tabular
+                        </button>
+                    )}
+                {!this.props.oncoprinterMode &&
+                    getServerConfig().skin_hide_download_controls ===
+                        DownloadControlOption.SHOW_ALL && (
+                        <button
+                            className="btn btn-sm btn-default"
+                            name={EVENT_KEY.downloadOncoprinter}
+                            onClick={this.onButtonClick}
+                        >
+                            Open in Oncoprinter
+                        </button>
+                    )}
             </CustomDropdown>
         ) : null;
     });
@@ -1220,5 +1229,3 @@ export default class OncoprintControls extends React.Component<
         );
     }
 }
-
-OncoprintControls.contextType = AppContext;

--- a/src/shared/components/query/QueryAndDownloadTabs.tsx
+++ b/src/shared/components/query/QueryAndDownloadTabs.tsx
@@ -6,13 +6,15 @@ import { QueryStore } from './QueryStore';
 import { observable, action, makeObservable, computed } from 'mobx';
 import { MSKTab, MSKTabs } from '../MSKTabs/MSKTabs';
 import QuickSearch from './quickSearch/QuickSearch';
-import { getBrowserWindow } from 'cbioportal-frontend-commons';
+import {
+    DownloadControlOption,
+    getBrowserWindow,
+} from 'cbioportal-frontend-commons';
 import autobind from 'autobind-decorator';
 import { trackEvent } from 'shared/lib/tracking';
 import { If } from 'react-if';
 import { getServerConfig } from 'config/config';
 import { ModifyQueryParams } from 'pages/resultsView/ResultsViewPageStore';
-import { AppContext } from 'cbioportal-frontend-commons';
 
 const DOWNLOAD = 'download';
 const ADVANCED = 'advanced';
@@ -95,7 +97,8 @@ export default class QueryAndDownloadTabs extends React.Component<
     get hideDownloadTab() {
         return (
             !this.props.showDownloadTab ||
-            this.context.showDownloadControls === false
+            getServerConfig().skin_hide_download_controls ===
+                DownloadControlOption.HIDE_ALL
         );
     }
 
@@ -170,5 +173,3 @@ export default class QueryAndDownloadTabs extends React.Component<
         );
     }
 }
-
-QueryAndDownloadTabs.contextType = AppContext;

--- a/src/shared/components/structureViewer/StructureViewerPanel.tsx
+++ b/src/shared/components/structureViewer/StructureViewerPanel.tsx
@@ -11,7 +11,10 @@ import classnames from 'classnames';
 import { IProteinImpactTypeColors } from 'react-mutation-mapper';
 import PdbHeaderCache from 'shared/cache/PdbHeaderCache';
 import ResidueMappingCache from 'shared/cache/ResidueMappingCache';
-import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import {
+    DefaultTooltip,
+    DownloadControlOption,
+} from 'cbioportal-frontend-commons';
 import { ResidueMapping } from 'genome-nexus-ts-api-client';
 import { CacheData } from 'shared/lib/LazyMobXCache';
 import { ILazyMobXTableApplicationDataStore } from 'shared/lib/ILazyMobXTableApplicationDataStore';
@@ -35,7 +38,7 @@ import {
 import PyMolScriptGenerator from './PyMolScriptGenerator';
 
 import styles from './structureViewer.module.scss';
-import { AppContext } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface IStructureViewerPanelProps extends IProteinImpactTypeColors {
     pdbChainDataStore: ILazyMobXTableApplicationDataStore<IPdbChain>;
@@ -415,7 +418,8 @@ export default class StructureViewerPanel extends React.Component<
         return (
             <div className="row">
                 <div className="col col-sm-6">
-                    {this.context.showDownloadControls === true && (
+                    {getServerConfig().skin_hide_download_controls ===
+                        DownloadControlOption.SHOW_ALL && (
                         <ButtonGroup>
                             <DefaultTooltip
                                 overlay={<span>Download PyMol script</span>}
@@ -934,5 +938,3 @@ export default class StructureViewerPanel extends React.Component<
         return this.proteinScheme !== ProteinScheme.SPACE_FILLING;
     }
 }
-
-StructureViewerPanel.contextType = AppContext;

--- a/src/shared/components/tableHeaderControls/TableHeaderControls.tsx
+++ b/src/shared/components/tableHeaderControls/TableHeaderControls.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import {
+    DefaultTooltip,
+    DownloadControlOption,
+} from 'cbioportal-frontend-commons';
 import { Button, ButtonGroup, ButtonToolbar } from 'react-bootstrap';
 var ClipboardButton = require('react-clipboard.js');
 var Clipboard = require('clipboard');
@@ -15,7 +18,7 @@ import {
     ColumnVisibilityControls,
 } from '../columnVisibilityControls/ColumnVisibilityControls';
 import { computed } from 'mobx';
-import { AppContext } from 'cbioportal-frontend-commons';
+import { getServerConfig } from 'config/config';
 
 export interface ITableHeaderControlsProps {
     tableData?: Array<any>;
@@ -108,10 +111,7 @@ export default class TableHeaderControls extends React.Component<
 
     @computed
     get showCopyAndDownload() {
-        return (
-            this.props.showCopyAndDownload &&
-            this.context.showDownloadControls === true
-        );
+        return this.props.showCopyAndDownload;
     }
 
     public handleInput(evt: any) {
@@ -244,5 +244,3 @@ export default class TableHeaderControls extends React.Component<
         }
     };
 }
-
-TableHeaderControls.contextType = AppContext;

--- a/src/shared/lib/pathwayMapper/PathwayMapperTable.tsx
+++ b/src/shared/lib/pathwayMapper/PathwayMapperTable.tsx
@@ -6,13 +6,17 @@ import LazyMobXTable, {
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
 import { observable, makeObservable } from 'mobx';
 import { Radio } from 'react-bootstrap';
-import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import {
+    DefaultTooltip,
+    DownloadControlOption,
+} from 'cbioportal-frontend-commons';
 import {
     getSortedData,
     getSortedFilteredData,
     SimpleGetterLazyMobXTableApplicationDataStore,
 } from '../../../shared/lib/ILazyMobXTableApplicationDataStore';
 import { truncateGeneList } from './PathwayMapperHelpers';
+import { getServerConfig } from 'config/config';
 
 export interface IPathwayMapperTable {
     name: string;
@@ -217,6 +221,10 @@ export default class PathwayMapperTable extends React.Component<
                 initialSortDirection={'desc'}
                 paginationProps={{ itemsPerPageOptions: [10] }}
                 showColumnVisibility={false}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls !==
+                    DownloadControlOption.HIDE_ALL
+                }
             />
         );
     }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10180

Describe changes proposed in this pull request:
- disable data download in study view, group comparison view, result view, and patient view.
- support enum SHOW_ALL, SHOW_DATA, HIDE_ALL in frontend based on the config in backend skin.hide_download_controls
- pass showCopyDownload or showDownload as props to components to customize its behavior

Related backend PR https://github.com/cBioPortal/cbioportal/pull/10258