### PR TITLE
Experiment with clinical data table filtering

### DIFF
--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
@@ -607,7 +607,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/ClinicalDataCollection"
+              "$ref": "#/definitions/SampleClinicalDataCollection"
             }
           }
         }
@@ -3939,24 +3939,6 @@
       },
       "title": "ClinicalDataBinFilter"
     },
-    "ClinicalDataCollection": {
-      "type": "object",
-      "properties": {
-        "patientClinicalData": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalData"
-          }
-        },
-        "sampleClinicalData": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ClinicalData"
-          }
-        }
-      },
-      "title": "ClinicalDataCollection"
-    },
     "ClinicalDataCount": {
       "type": "object",
       "properties": {
@@ -5734,6 +5716,21 @@
         }
       },
       "title": "Sample"
+    },
+    "SampleClinicalDataCollection": {
+      "type": "object",
+      "properties": {
+        "byUniqueSampleKey": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ClinicalData"
+            }
+          }
+        }
+      },
+      "title": "SampleClinicalDataCollection"
     },
     "SampleIdentifier": {
       "type": "object",

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -187,12 +187,6 @@ export type ClinicalDataBinFilter = {
         'start': number
 
 };
-export type ClinicalDataCollection = {
-    'patientClinicalData': Array < ClinicalData >
-
-        'sampleClinicalData': Array < ClinicalData >
-
-};
 export type ClinicalDataCount = {
     'count': number
 
@@ -950,6 +944,10 @@ export type Sample = {
         'uniquePatientKey': string
 
         'uniqueSampleKey': string
+
+};
+export type SampleClinicalDataCollection = {
+    'byUniqueSampleKey': {}
 
 };
 export type SampleIdentifier = {
@@ -2187,7 +2185,7 @@ export default class CBioPortalAPIInternal {
         'studyViewFilter': StudyViewFilter,
         $queryParameters ? : any,
             $domain ? : string
-    }): Promise < ClinicalDataCollection > {
+    }): Promise < SampleClinicalDataCollection > {
         return this.fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });

--- a/packages/cbioportal-ts-api-client/src/index.tsx
+++ b/packages/cbioportal-ts-api-client/src/index.tsx
@@ -13,7 +13,7 @@ export {
     BinsGeneratorConfig,
     ClinicalDataBinFilter,
     ClinicalDataBinCountFilter,
-    ClinicalDataCollection,
+    SampleClinicalDataCollection,
     ClinicalDataCount,
     ClinicalDataCountFilter,
     ClinicalDataCountItem,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -5626,6 +5626,13 @@ export class StudyViewPageStore
         },
     });
 
+    readonly clinicalAttributeDisplayNameToClinicalAttribute = remoteData({
+        await: () => [this.clinicalAttributes],
+        invoke: async () => {
+            return _.keyBy(this.clinicalAttributes.result!, 'displayName');
+        },
+    });
+
     readonly clinicalAttributeIdToDataType = remoteData({
         await: () => [this.clinicalAttributes],
         invoke: async () => {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -9791,7 +9791,7 @@ export class StudyViewPageStore
         if (this.selectedSamples.result.length === 0) {
             return Promise.resolve('');
         }
-        let sampleClinicalDataResp = await getAllClinicalDataByStudyViewFilter(
+        let sampleClinicalData = await getAllClinicalDataByStudyViewFilter(
             this.filters,
             undefined,
             undefined
@@ -9814,14 +9814,18 @@ export class StudyViewPageStore
         let dataRows = _.reduce(
             this.selectedSamples.result,
             (acc, next) => {
-                let sampleData: { [attributeId: string]: string } = {
+                const sampleData = {
                     studyId: next.studyId,
                     patientId: next.patientId,
                     sampleId: next.sampleId,
-                    ...(sampleClinicalDataResp.data[next.uniqueSampleKey] ||
-                        {}),
-                };
-
+                } as { [attributeId: string]: string };
+                const clinicalData = sampleClinicalData[next.uniqueSampleKey];
+                _.forEach(
+                    clinicalData,
+                    (attr: ClinicalData) =>
+                        (sampleData[attr['clinicalAttributeId']] =
+                            attr['value'])
+                );
                 acc.push(
                     _.map(
                         Object.keys(clinicalAttributesNameSet),

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -9798,7 +9798,7 @@ export class StudyViewPageStore
         if (this.selectedSamples.result.length === 0) {
             return Promise.resolve('');
         }
-        let sampleClinicalData = await getAllClinicalDataByStudyViewFilter(
+        let sampleClinicalDataResponse = await getAllClinicalDataByStudyViewFilter(
             this.filters,
             undefined,
             undefined
@@ -9826,7 +9826,8 @@ export class StudyViewPageStore
                     patientId: next.patientId,
                     sampleId: next.sampleId,
                 } as { [attributeId: string]: string };
-                const clinicalData = sampleClinicalData[next.uniqueSampleKey];
+                const clinicalData =
+                    sampleClinicalDataResponse.data[next.uniqueSampleKey];
                 _.forEach(
                     clinicalData,
                     (attr: ClinicalData) =>

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -55,7 +55,6 @@ import {
     isLogScaleByValues,
     isOccupied,
     makePatientToClinicalAnalysisGroup,
-    mergeClinicalDataCollection,
     needAdditionShiftForLogScaleBarChart,
     pickClinicalDataColors,
     shouldShowChart,
@@ -72,7 +71,6 @@ import {
     CancerStudy,
     ClinicalAttribute,
     ClinicalData,
-    ClinicalDataCollection,
     DataFilterValue,
     Sample,
     StudyViewFilter,
@@ -2749,86 +2747,6 @@ describe('StudyViewUtils', () => {
                     end: undefined,
                 },
             ]);
-        });
-    });
-
-    describe('mergeClinicalDataCollection', () => {
-        it('handles merge when patient key defined in sample data', () => {
-            const input = ({
-                sampleClinicalData: [
-                    {
-                        sampleId: 's1',
-                        patientId: 'p1',
-                        studyId: 'study1',
-                        uniqueSampleKey: 's1key',
-                        uniquePatientKey: 'p1key',
-                        clinicalAttributeId: 'attr1',
-                        value: 'value1',
-                    },
-                ],
-                patientClinicalData: [
-                    {
-                        sampleId: undefined,
-                        patientId: 'p1',
-                        studyId: 'study1',
-                        uniqueSampleKey: undefined,
-                        uniquePatientKey: 'p1key',
-                        clinicalAttributeId: 'attr2',
-                        value: 'value2',
-                    },
-                ],
-            } as unknown) as ClinicalDataCollection;
-            const expected = {
-                s1key: {
-                    attr1: 'value1',
-                    attr2: 'value2',
-                },
-            };
-            assert.deepEqual(
-                expected,
-                mergeClinicalDataCollection(
-                    (input as unknown) as ClinicalDataCollection
-                )
-            );
-        });
-
-        it('handles merge when patient key absent in sample data', () => {
-            const input = ({
-                sampleClinicalData: [
-                    {
-                        sampleId: 's1',
-                        patientId: 'p1',
-                        studyId: 'study1',
-                        uniqueSampleKey: 's1key',
-                        uniquePatientKey: 'p1key',
-                        clinicalAttributeId: 'attr1',
-                        value: 'value1',
-                    },
-                ],
-                patientClinicalData: [
-                    {
-                        sampleId: undefined,
-                        patientId: 'p2',
-                        studyId: 'study1',
-                        uniqueSampleKey: undefined,
-                        // note the patient key that does not line-up with the sample
-                        uniquePatientKey: 'p2key',
-                        clinicalAttributeId: 'attr2',
-                        value: 'value2',
-                    },
-                ],
-            } as unknown) as ClinicalDataCollection;
-            const expected = {
-                s1key: {
-                    attr1: 'value1',
-                },
-            };
-            assert.deepEqual(
-                expected,
-                mergeClinicalDataCollection(
-                    (input as unknown) as ClinicalDataCollection
-                )
-            );
         });
     });
 

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -3080,39 +3080,49 @@ export function updateSavedUserPreferenceChartIds(
 }
 
 export async function getAllClinicalDataByStudyViewFilter(
-    studyViewFilter: StudyViewFilter
-): Promise<{ [sampleId: string]: { [attributeId: string]: string } }> {
+    studyViewFilter: StudyViewFilter,
+    searchTerm: string | undefined = undefined,
+    sortCriteria: any,
+    pageSize: number = 500
+): Promise<{
+    totalItems: number;
+    data: { [sampleId: string]: { [attributeId: string]: string } };
+}> {
     const localClinicalDataCollection: ClinicalDataCollection = {
         sampleClinicalData: [],
         patientClinicalData: [],
     };
-    let remoteClinicalDataCollection: ClinicalDataCollection = {
-        sampleClinicalData: [],
-        patientClinicalData: [],
-    };
-    const maxPageSize = 500000;
-    let pageNumber = 0;
-    do {
-        const remoteClinicalDataCollection = await internalClient.fetchClinicalDataClinicalTableUsingPOST(
-            {
-                studyViewFilter,
-                pageSize: maxPageSize,
-                pageNumber: pageNumber,
-                searchTerm: undefined,
-                sortBy: undefined,
-                direction: 'ASC',
-            }
-        );
-        localClinicalDataCollection.sampleClinicalData = localClinicalDataCollection.sampleClinicalData.concat(
-            remoteClinicalDataCollection.sampleClinicalData
-        );
-        localClinicalDataCollection.patientClinicalData = localClinicalDataCollection.patientClinicalData.concat(
-            remoteClinicalDataCollection.patientClinicalData
-        );
-        pageNumber++;
-    } while (remoteClinicalDataCollection.sampleClinicalData.length > 0);
 
-    return mergeClinicalDataCollection(localClinicalDataCollection);
+    const [remoteClinicalDataCollection, totalItems]: [
+        ClinicalDataCollection,
+        number
+    ] = await internalClient
+        .fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo({
+            studyViewFilter,
+            pageSize,
+            pageNumber: 0,
+            searchTerm: searchTerm,
+            sortBy: sortCriteria?.field,
+            direction: sortCriteria?.direction?.toUpperCase() || 'ASC',
+        })
+        .then(response => {
+            return [
+                response.body,
+                parseInt(response.header['total-count'] || 0),
+            ];
+        });
+
+    localClinicalDataCollection.sampleClinicalData = localClinicalDataCollection.sampleClinicalData.concat(
+        remoteClinicalDataCollection.sampleClinicalData
+    );
+    localClinicalDataCollection.patientClinicalData = localClinicalDataCollection.patientClinicalData.concat(
+        remoteClinicalDataCollection.patientClinicalData
+    );
+
+    return {
+        totalItems,
+        data: mergeClinicalDataCollection(localClinicalDataCollection),
+    };
 }
 
 export function mergeClinicalDataCollection(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -3080,8 +3080,9 @@ export function updateSavedUserPreferenceChartIds(
 
 export async function getAllClinicalDataByStudyViewFilter(
     studyViewFilter: StudyViewFilter,
-    searchTerm: string | undefined = undefined,
-    sortCriteria: any,
+    searchTerm: string | undefined,
+    sortAttributeId: any,
+    sortDirection: any = 'asc',
     pageSize: number = 500
 ): Promise<{ [uniqueSampleKey: string]: ClinicalData[] }> {
     const response = await internalClient.fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo(
@@ -3090,8 +3091,8 @@ export async function getAllClinicalDataByStudyViewFilter(
             pageSize,
             pageNumber: 0,
             searchTerm: searchTerm,
-            sortBy: sortCriteria?.field,
-            direction: sortCriteria?.direction?.toUpperCase() || 'ASC',
+            sortBy: sortAttributeId,
+            direction: sortDirection?.toUpperCase(),
         }
     );
 

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -24,6 +24,7 @@ import {
     NumericGeneMolecularData,
     PatientIdentifier,
     Sample,
+    SampleClinicalDataCollection,
     SampleIdentifier,
     StructuralVariantFilterQuery,
     StudyViewFilter,
@@ -3084,19 +3085,33 @@ export async function getAllClinicalDataByStudyViewFilter(
     sortAttributeId: any,
     sortDirection: any = 'asc',
     pageSize: number = 500
-): Promise<{ [uniqueSampleKey: string]: ClinicalData[] }> {
-    const response = await internalClient.fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo(
-        {
+): Promise<{
+    totalItems: number;
+    data: { [uniqueSampleKey: string]: ClinicalData[] };
+}> {
+    const [remoteClinicalDataCollection, totalItems]: [
+        SampleClinicalDataCollection,
+        number
+    ] = await internalClient
+        .fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo({
             studyViewFilter,
             pageSize,
             pageNumber: 0,
             searchTerm: searchTerm,
             sortBy: sortAttributeId,
             direction: sortDirection?.toUpperCase(),
-        }
-    );
+        })
+        .then(response => {
+            return [
+                response.body,
+                parseInt(response.header['total-count'] || 0),
+            ];
+        });
 
-    return response.body.byUniqueSampleKey;
+    return {
+        totalItems,
+        data: remoteClinicalDataCollection.byUniqueSampleKey,
+    };
 }
 
 export function convertClinicalDataBinsToDataBins(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -7,7 +7,6 @@ import {
     ClinicalData,
     ClinicalDataBin,
     ClinicalDataBinFilter,
-    ClinicalDataCollection,
     ClinicalDataCount,
     ClinicalDataMultiStudyFilter,
     DataFilterValue,
@@ -3084,88 +3083,19 @@ export async function getAllClinicalDataByStudyViewFilter(
     searchTerm: string | undefined = undefined,
     sortCriteria: any,
     pageSize: number = 500
-): Promise<{
-    totalItems: number;
-    data: { [sampleId: string]: { [attributeId: string]: string } };
-}> {
-    const localClinicalDataCollection: ClinicalDataCollection = {
-        sampleClinicalData: [],
-        patientClinicalData: [],
-    };
-
-    const [remoteClinicalDataCollection, totalItems]: [
-        ClinicalDataCollection,
-        number
-    ] = await internalClient
-        .fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo({
+): Promise<{ [uniqueSampleKey: string]: ClinicalData[] }> {
+    const response = await internalClient.fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo(
+        {
             studyViewFilter,
             pageSize,
             pageNumber: 0,
             searchTerm: searchTerm,
             sortBy: sortCriteria?.field,
             direction: sortCriteria?.direction?.toUpperCase() || 'ASC',
-        })
-        .then(response => {
-            return [
-                response.body,
-                parseInt(response.header['total-count'] || 0),
-            ];
-        });
-
-    localClinicalDataCollection.sampleClinicalData = localClinicalDataCollection.sampleClinicalData.concat(
-        remoteClinicalDataCollection.sampleClinicalData
-    );
-    localClinicalDataCollection.patientClinicalData = localClinicalDataCollection.patientClinicalData.concat(
-        remoteClinicalDataCollection.patientClinicalData
-    );
-
-    return {
-        totalItems,
-        data: mergeClinicalDataCollection(localClinicalDataCollection),
-    };
-}
-
-export function mergeClinicalDataCollection(
-    clinicalDataCollection: ClinicalDataCollection
-): { [sampleId: string]: { [attributeId: string]: string } } {
-    const patientKeyedSampleData = _.groupBy(
-        clinicalDataCollection.sampleClinicalData,
-        d => d.uniquePatientKey
-    );
-    let patientKeyedSampleKeyedData = _.mapValues(
-        patientKeyedSampleData,
-        sampleData => _.groupBy(sampleData, d => d.uniqueSampleKey)
-    );
-    const patientKeyedPatientData = _.groupBy(
-        clinicalDataCollection.patientClinicalData,
-        d => d.uniquePatientKey
-    );
-    // Add patient level clinical data to sample clinical data.
-    patientKeyedSampleKeyedData = _.mapValues(
-        patientKeyedSampleKeyedData,
-        (sampleKeyedData, patientId) =>
-            _.mapValues(sampleKeyedData, (attrs, sampleId) =>
-                attrs.concat(patientKeyedPatientData[patientId] || [])
-            )
-    );
-    // Remove patient id levels (only keep sample id keys).
-    const sampleKeyedData = _.assign(
-        {},
-        ..._.values(patientKeyedSampleKeyedData)
-    );
-    // Put all clinical attributes in one object.
-    const sampleCollapsedAttributes = _.mapValues(
-        sampleKeyedData,
-        clinicalData => {
-            const data = _.map(clinicalData, (datum: ClinicalData) => {
-                const obj: { [attrId: string]: string } = {};
-                obj[datum.clinicalAttributeId] = datum.value;
-                return obj;
-            });
-            return _.assign({}, ...data);
         }
     );
-    return sampleCollapsedAttributes;
+
+    return response.body.byUniqueSampleKey;
 }
 
 export function convertClinicalDataBinsToDataBins(

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -440,6 +440,10 @@ export class ClinicalDataTab extends React.Component<
                                                   CLINICAL_DATA_RECORD_LIMIT
                                                 : false
                                         }
+                                        resultCountOverride={
+                                            this.getDataForClinicalDataTab
+                                                .result?.totalItems
+                                        }
                                     />
                                 </Else>
                             </If>

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -183,9 +183,11 @@ export class ClinicalDataTab extends React.Component<
                 CLINICAL_DATA_RECORD_LIMIT
             );
 
-            return sampleClinicalData;
+            return Promise.resolve(sampleClinicalData);
         },
     });
+
+    // this problem is that the visible attributes are not yet populated.
 
     readonly columns = remoteData({
         invoke: async () => {
@@ -284,6 +286,11 @@ export class ClinicalDataTab extends React.Component<
     }
 
     public render() {
+        // not that the columns which are showing in the table
+        // are dependent on visible attributes.
+        // for this reason we need to wait for visible attributes to be populated
+        // this simplest way to await this is just no avoid rendering the table when there are
+        // no visibleAttributes
         return (
             <span data-test="clinical-data-tab-content">
                 <WindowWidthBox offset={60}>
@@ -293,18 +300,13 @@ export class ClinicalDataTab extends React.Component<
                                 .isPending ||
                             this.props.store.maxSamplesForClinicalTab
                                 .isPending ||
-                            this.props.store.selectedSamples.isPending
+                            this.props.store.selectedSamples.isPending ||
+                            this.props.store.visibleAttributes.length < 1
                         }
                     >
                         <Then>
                             <LoadingIndicator
-                                isLoading={
-                                    this.props.store.clinicalAttributeProduct
-                                        .isPending ||
-                                    this.props.store.maxSamplesForClinicalTab
-                                        .isPending ||
-                                    this.props.store.selectedSamples.isPending
-                                }
+                                isLoading={true}
                                 size={'big'}
                                 center={true}
                             />
@@ -386,7 +388,8 @@ export class ClinicalDataTab extends React.Component<
                                         }
                                         showLoading={
                                             this.getDataForClinicalDataTab
-                                                .isPending
+                                                .isPending ||
+                                            this.columns.isPending
                                         }
                                         loadingComponent={
                                             <LoadingIndicator

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -59,7 +59,7 @@ async function fetchClinicalDataForStudyViewClinicalDataTab(
     sortDirection: 'asc' | 'desc' | undefined,
     recordLimit: number
 ) {
-    let sampleClinicalData = await getAllClinicalDataByStudyViewFilter(
+    let sampleClinicalDataResponse = await getAllClinicalDataByStudyViewFilter(
         filters,
         searchTerm,
         sortAttributeId,
@@ -68,7 +68,7 @@ async function fetchClinicalDataForStudyViewClinicalDataTab(
     );
 
     const aggregatedSampleClinicalData = _.mapValues(
-        sampleClinicalData,
+        sampleClinicalDataResponse.data,
         (attrs, uniqueSampleId) => {
             const sample = sampleSetByKey[uniqueSampleId];
             const sampleData = {
@@ -85,7 +85,7 @@ async function fetchClinicalDataForStudyViewClinicalDataTab(
     );
 
     return {
-        totalItems: _.keys(sampleClinicalData).length,
+        totalItems: sampleClinicalDataResponse.totalItems,
         data: _.values(aggregatedSampleClinicalData),
     };
 }

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -126,6 +126,7 @@ type LazyMobXTableProps<T> = {
     onFilterTextChange?: (filterString: string) => void;
     onSortDirectionChange?: (field: string, direction: SortDirection) => void;
     isResultLimited?: boolean;
+    resultCountOverride?: number;
     showLoading?: boolean;
     loadingComponent?: JSX.Element;
 };
@@ -293,6 +294,9 @@ export class LazyMobXTableStore<T> {
     @observable private onRowClick: ((d: T) => void) | undefined;
     @observable private onRowMouseEnter: ((d: T) => void) | undefined;
     @observable private onRowMouseLeave: ((d: T) => void) | undefined;
+
+    @observable resultCountOverride: number | undefined;
+    // now we need to use this in control if passed in. maybe call it override
 
     // this observable is intended to always refer to props.columnToHeaderFilterIconModal
     @observable private _columnToHeaderFilterIconModal:
@@ -644,7 +648,10 @@ export class LazyMobXTableStore<T> {
             itemsLabel = ` ${itemsLabel}`;
         }
 
-        return `Showing ${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${this.displayData.length}${itemsLabel}`;
+        // this allows us override the count for display purposes when we are in the
+        // result limited scenario
+        const total = this.resultCountOverride || this.displayData.length;
+        return `Showing ${firstVisibleItemDisp}-${lastVisibleItemDisp} of ${total}${itemsLabel}`;
     }
 
     @computed get tds(): JSX.Element[][] {
@@ -785,6 +792,8 @@ export class LazyMobXTableStore<T> {
         this.onRowMouseEnter = props.onRowMouseEnter;
         this.onRowMouseLeave = props.onRowMouseLeave;
         this.onSortDirectionChange = props.onSortDirectionChange;
+
+        this.resultCountOverride = props.resultCountOverride;
 
         if (props.dataStore) {
             this.dataStore = props.dataStore;
@@ -1128,10 +1137,12 @@ export default class LazyMobXTable<T> extends React.Component<
                 this.props.paginationProps
             );
         }
-        return <PaginationControls {...paginationProps} />;
-        // } else {
-        //     return null;
-        // }
+
+        return this.store.displayData.length > 0 ? (
+            <PaginationControls {...paginationProps} />
+        ) : (
+            <></>
+        );
     }
 
     private get countHeader() {

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -462,7 +462,7 @@ export class LazyMobXTableStore<T> {
             this.sortColumn = column.name;
             this.onSortDirectionChange(
                 column.name,
-                this.sortAscending ? 'desc' : 'asc'
+                this.sortAscending ? 'asc' : 'desc'
             );
         } else {
             this.sortAscending = sortAscending;

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -128,7 +128,10 @@ export interface IMutationTableProps {
     namespaceColumns?: NamespaceColumnConfig;
     data?: Mutation[][];
     dataStore?: ILazyMobXTableApplicationDataStore<Mutation[]>;
-    downloadDataFetcher?: ILazyMobXTableApplicationLazyDownloadDataFetcher;
+    downloadDataFetcher?:
+        | ILazyMobXTableApplicationLazyDownloadDataFetcher
+        | (() => Promise<any>)
+        | undefined;
     initialItemsPerPage?: number;
     itemsLabel?: string;
     itemsLabelPlural?: string;


### PR DESCRIPTION
Use new paginated endpoint for clinical data search/download tab.  This pull request adapts MobxLazyTable for use with new pagination service.  Rather than enable traditional pagination, it enables sorting and filtering with a limit on the number of records that the viewer can fetch.  

Fixes https://github.com/cBioPortal/cbioportal/issues/10479