### PR TITLE
Render custom tooltip in oncoprint using custom js function

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -42,6 +42,7 @@ export interface IServerConfig {
     oncoprint_custom_driver_annotation_binary_menu_label: string | null; // default:
     disabled_tabs: string | null;
     custom_tabs: any[];
+    custom_js_urls: string; // comma delimited string
     oncoprint_custom_driver_annotation_binary_default: boolean;
     oncoprint_custom_driver_annotation_tiers_default: boolean;
     oncoprint_oncokb_default: boolean;

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -40,7 +40,12 @@ import {
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import { AlterationTypeConstants } from 'shared/constants';
 import ifNotDefined from '../../lib/ifNotDefined';
-import { makeGeneticTrackTooltip } from 'shared/components/oncoprint/makeGeneticTrackTooltip';
+import {
+    DataUnderMouse,
+    makeGeneticTrackTooltip,
+} from 'shared/components/oncoprint/makeGeneticTrackTooltip';
+import $ from 'jquery';
+import getCustomJsFunctions from 'shared/getCustomJsFunctions';
 
 // This file implements functions that call imperative OncoprintJS library
 //  methods in order to keep the oncoprint in a state consistent with the
@@ -1096,6 +1101,19 @@ function transitionGeneticTrack(
         return;
     } else if (nextSpec && !prevSpec) {
         // Add track
+        const createCustomOncoprintTooltip = getCustomJsFunctions()
+            .createCustomOncoprintTooltip;
+        let tooltipFn;
+        if (createCustomOncoprintTooltip) {
+            tooltipFn = (dataUnderMouse: DataUnderMouse) =>
+                createCustomOncoprintTooltip(nextProps, dataUnderMouse);
+        } else {
+            tooltipFn = makeGeneticTrackTooltip(
+                nextProps.caseLinkOutInTooltips,
+                getMolecularProfileMap,
+                nextProps.alterationTypesInQuery
+            );
+        }
         const geneticTrackParams: UserTrackSpec<any> = {
             rule_set_params: getGeneticTrackRuleSetParams(
                 nextProps.distinguishMutationType,
@@ -1113,11 +1131,7 @@ function transitionGeneticTrack(
             description: nextSpec.oql,
             data_id_key: 'uid',
             data: nextSpec.data,
-            tooltipFn: makeGeneticTrackTooltip(
-                nextProps.caseLinkOutInTooltips,
-                getMolecularProfileMap,
-                nextProps.alterationTypesInQuery
-            ),
+            tooltipFn,
             track_info: nextSpec.info,
             $track_info_tooltip_elt: nextSpec.infoTooltip
                 ? $('<div>' + nextSpec.infoTooltip + '</div>')

--- a/src/shared/getCustomJsFunctions.ts
+++ b/src/shared/getCustomJsFunctions.ts
@@ -1,0 +1,22 @@
+import { getBrowserWindow } from 'cbioportal-frontend-commons';
+import { IOncoprintProps } from 'shared/components/oncoprint/Oncoprint';
+import { DataUnderMouse } from 'shared/components/oncoprint/makeGeneticTrackTooltip';
+
+export type CustomJsFunctions = {
+    createCustomOncoprintTooltip?: (
+        oncoprintProps: IOncoprintProps,
+        dataUnderMouse: DataUnderMouse
+    ) => string;
+};
+
+export default function getCustomJsFunctions(): CustomJsFunctions {
+    if (!getBrowserWindow().customJsFunctions) {
+        getBrowserWindow().customJsFunctions = {};
+    }
+    return getBrowserWindow().customJsFunctions;
+}
+
+// expose functions to dynamically loaded js:
+const win = window as any;
+win.getBrowserWindow = getBrowserWindow;
+win.getCustomJsFunctions = getCustomJsFunctions;


### PR DESCRIPTION
Create a custom tooltip in oncoprint by configuring a custom js function, that will be loaded when the webapp is initialized and is called when available when rendering the oncoprint.

_Work in progress_

Proof of concept for RFC 70.

## Testing locally
Locally this funcionality could be tested by mounting a file `createCustomOncoprintTooltipHtml.js` at `/cbioportal-webapp/js/custom/` in your cbioportal container, with the following dummy content rendering a tooltip printing the custom namespace columns json:
```js
/**
 * Custom javascript function that allows a user
 * to convert oncoprintProps and dataUnderMouse into a jquery object or plain string
 * that will be rendered by oncoprint as a tooltip
 *
 * (For parameter types, see: getCustomJsFunctions.ts)
 */
getCustomJsFunctions().createCustomOncoprintTooltip = (oncoprintProps, dataUnderMouse) => {
    const $tooltip = $('<div class="oncoprint__tooltip"></div>');
    for (const selected of dataUnderMouse) {
        const id = selected.sample ? selected.sample : selected.patient;
        $tooltip.append($(`<h6>Custom Namespace Columns for ${id}</h6>`));
        const namespaceColumns = selected.data.map(d => d.namespaceColumns);
        $tooltip.append($(`<pre>${JSON.stringify(namespaceColumns, null, 2)}</pre>`))
    }
    return $tooltip;
}
```
You can configure custom js files by configuring them in the `rawConfiguration.frontendConfigOverride` field. Add a file `frontendConfig.json` to the classpath:
```json
{
    "custom_js_urls": "https://localhost/js/custom/createCustomOncoprintTooltip.js,/nonExistingCustomFunction.js"
}
```
... And start cbio using this flag: `-Dfrontend.config=classpath://frontendConfig.json`