### PR TITLE
Extend sample type colors in patient view

### DIFF
--- a/src/pages/patientView/SampleManager.tsx
+++ b/src/pages/patientView/SampleManager.tsx
@@ -236,6 +236,31 @@ class SampleManager {
                     .DERIVED_NORMALIZED_CASE_TYPE === 'Xenograft'
             ) {
                 color = styles.sampleColorXenograft;
+            } else if (
+                this.clinicalDataLegacyCleanAndDerived[sample.id]
+                    .DERIVED_NORMALIZED_CASE_TYPE === 'Plasma'
+            ) {
+                color = styles.sampleColorPlasma;
+            } else if (
+                this.clinicalDataLegacyCleanAndDerived[sample.id]
+                    .DERIVED_NORMALIZED_CASE_TYPE === 'ctDNA'
+            ) {
+                color = styles.sampleColorCtdna;
+            } else if (
+                this.clinicalDataLegacyCleanAndDerived[sample.id]
+                    .DERIVED_NORMALIZED_CASE_TYPE === 'Urine'
+            ) {
+                color = styles.sampleColorUrine;
+            } else if (
+                this.clinicalDataLegacyCleanAndDerived[sample.id]
+                    .DERIVED_NORMALIZED_CASE_TYPE === 'Exosome'
+            ) {
+                color = styles.sampleColorExosome;
+            } else if (
+                this.clinicalDataLegacyCleanAndDerived[sample.id]
+                    .DERIVED_NORMALIZED_CASE_TYPE === 'total RNA'
+            ) {
+                color = styles.sampleColorRna;
             }
 
             this.sampleColors[sample.id] = color;

--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
@@ -132,6 +132,18 @@ function derive(clinicalData) {
                     caseTypeNormalized = 'cfDNA';
                 } else if (caseTypeLower.indexOf('prim') >= 0) {
                     caseTypeNormalized = 'Primary';
+                } else if (caseTypeLower.indexOf('ctdna') >= 0) {
+                    caseTypeNormalized = 'ctDNA';
+                } else if (caseTypeLower.indexOf('plasma') >= 0) {
+                    caseTypeNormalized = 'Plasma';
+                } else if (caseTypeLower.indexOf('urine') >= 0) {
+                    caseTypeNormalized = 'Urine';
+                } else if (caseTypeLower.indexOf('exosome') >= 0) {
+                    caseTypeNormalized = 'Exosome';
+                } else if (caseTypeLower.indexOf('total') >= 0) {
+                    caseTypeNormalized = 'total RNA';
+                } else if (caseTypeLower.indexOf('tissue') >= 0) {
+                    caseTypeNormalized = 'Tissue';
                 }
                 if (
                     caseTypeNormalized !== null &&

--- a/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
+++ b/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
@@ -5,7 +5,7 @@ $sample-color-cfdna: blue;
 $sample-color-xenograft: pink;
 $sample-color-plasma: gold;
 $sample-color-ctdna: lightblue;
-$sample-color-urine: green;
+$sample-color-urine: yellow;
 $sample-color-exosome: purple;
 $sample-color-rna: grey;
 

--- a/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
+++ b/src/pages/patientView/patientHeader/style/clinicalAttributes.scss
@@ -3,6 +3,11 @@ $sample-color-recurrence: orange;
 $sample-color-metastasis: red;
 $sample-color-cfdna: blue;
 $sample-color-xenograft: pink;
+$sample-color-plasma: gold;
+$sample-color-ctdna: lightblue;
+$sample-color-urine: green;
+$sample-color-exosome: purple;
+$sample-color-rna: grey;
 
 /* shared style and JS code variables */
 :export {
@@ -11,6 +16,11 @@ $sample-color-xenograft: pink;
     sampleColorMetastasis: $sample-color-metastasis;
     sampleColorCfdna: $sample-color-cfdna;
     sampleColorXenograft: $sample-color-xenograft;
+    sampleColorPlasma: $sample-color-plasma;
+    sampleColorCtdna: $sample-color-ctdna;
+    sampleColorUrine: $sample-color-urine;
+    sampleColorExosome: $sample-color-exosome;
+    sampleColorRna: $sample-color-rna;
 }
 
 .clinical-spans {


### PR DESCRIPTION
(Superseded by https://github.com/cBioPortal/cbioportal-frontend/pull/4704)

Extend the legend colors of sample types in the patient view. 

In addition to "cfDNA" "ctDNA" can be passed with labeling color "lighblue". The sample types "Urine", "Plasma", "Exosome", "total RNA" and "Tissue" are now also recognized, and colored with "green", "gold", "purple", "grey" and "black" respectively.

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/baa1f071-e579-49db-80c5-8b45efbf8c8a)
_Example of a patient view timeline with a sample of type ctDNA_  