### PR TITLE
Add defaults for mutation heatmap and line chart checkboxes

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -168,7 +168,10 @@ export interface IServerConfig {
     skin_patient_view_structural_variant_table_columns_show_on_init: string;
     comparison_categorical_na_values: string;
     oncoprint_clinical_tracks_config_json: string;
+    oncoprint_clustered_default: boolean;
     enable_cross_study_expression: string;
     studyview_max_samples_selected: number;
     study_download_url: string;
+    vaf_sequential_mode_default: boolean;
+    vaf_log_scale_default: boolean;
 }

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
@@ -44,6 +44,7 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import ReactDOM from 'react-dom';
 import PatientViewUrlWrapper from '../../PatientViewUrlWrapper';
 import { getVariantAlleleFrequency } from 'shared/lib/MutationUtils';
+import { getServerConfig } from 'config/config';
 
 export interface IMutationOncoprintProps {
     store: PatientViewPageStore;
@@ -84,11 +85,15 @@ export default class MutationOncoprint extends React.Component<
         });
     }
 
-    private get clustered() {
+    private get clustered(): boolean {
         const urlValue = this.props.urlWrapper.query.genomicEvolutionSettings
             .clusterHeatmap;
-        return !urlValue || urlValue === 'true'; // default true
+        if (urlValue) {
+            return urlValue === 'true';
+        }
+        return getServerConfig().oncoprint_clustered_default;
     }
+
     private set clustered(o: boolean) {
         this.props.urlWrapper.updateURL(currentParams => {
             currentParams.genomicEvolutionSettings.clusterHeatmap = o.toString();

--- a/src/pages/patientView/timeline/VAFChartWrapperStore.tsx
+++ b/src/pages/patientView/timeline/VAFChartWrapperStore.tsx
@@ -1,9 +1,12 @@
 import { action, computed, observable, makeObservable } from 'mobx';
+import { getServerConfig } from 'config/config';
 
 export default class VAFChartWrapperStore {
     @observable groupByOption: string | null = null;
 
-    @observable _showSequentialMode: boolean | undefined = undefined;
+    @observable _showSequentialMode: boolean = getServerConfig()
+        .vaf_sequential_mode_default;
+
     @computed
     get showSequentialMode() {
         return this.isOnlySequentialModePossible || this._showSequentialMode;
@@ -11,7 +14,8 @@ export default class VAFChartWrapperStore {
 
     @observable onlyShowSelectedInVAFChart: boolean | undefined = undefined;
 
-    @observable vafChartLogScale: boolean | undefined = undefined;
+    @observable vafChartLogScale: boolean = getServerConfig()
+        .vaf_log_scale_default;
 
     @observable vafChartYAxisToDataRange: boolean | undefined = undefined;
 


### PR DESCRIPTION
Allow configured defaults for the mutation heatmap and line chart checkboxes in the genomic evolution tab of the patient view:

- Linechart log scale: `vaf.log_scale.default` (figure 1)
- Linechart sequentical mode: `vaf.sequential_mode.default`  (figure 1)
- Mutation oncoprint heatmap clustering: `oncoprint.clustered.default`  (figure 2)

See also the backend PR https://github.com/cBioPortal/cbioportal/pull/10309

---

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/48d725ce-a029-4649-87e7-c91a918d339a)
_Figure 1) Linechart log scale and sequentical mode checkbox_

---

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/81224cb0-54d9-4d37-8d17-fad6d6e1d904)
_Figure 2) Mutation oncoprint heatmap clustering checkbox_
