### PR TITLE
Disable genomic alteration filtering when no relevant molecular profiles

### DIFF
--- a/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
+++ b/src/pages/staticPages/tools/oncoprinter/Oncoprinter.tsx
@@ -143,6 +143,9 @@ export default class Oncoprinter extends React.Component<
                 // do nothing in oncoprinter mode:
                 return false;
             },
+            get isGenomicAlterationProfileSelected() {
+                return true;
+            },
         });
     }
 

--- a/src/shared/alterationFiltering/SettingsMenu.tsx
+++ b/src/shared/alterationFiltering/SettingsMenu.tsx
@@ -49,7 +49,7 @@ export default class SettingsMenu extends React.Component<
         });
         this.driverSettingsState = buildDriverAnnotationControlsState(
             props.store.driverAnnotationSettings,
-            props.store.customDriverAnnotationReport.result,
+            props.store.customDriverAnnotationReport,
             props.store.didOncoKbFailInOncoprint,
             props.store.didHotspotFailInOncoprint
         );
@@ -100,6 +100,8 @@ export default class SettingsMenu extends React.Component<
                 </div>
             );
         }
+        const noGenomicAlterations = !this.props.store.driverAnnotationSettings
+            .isGenomicAlterationProfileSelected;
         return (
             <div
                 data-test="GlobalSettingsDropdown"
@@ -140,7 +142,8 @@ export default class SettingsMenu extends React.Component<
                                         onClick={this.onInputClick}
                                         disabled={
                                             !this.driverSettingsState
-                                                .distinguishDrivers
+                                                .distinguishDrivers ||
+                                            noGenomicAlterations
                                         }
                                     />{' '}
                                     Exclude alterations (mutations, structural
@@ -159,6 +162,7 @@ export default class SettingsMenu extends React.Component<
                                                 .includeGermlineMutations
                                         }
                                         onClick={this.onInputClick}
+                                        disabled={noGenomicAlterations}
                                     />{' '}
                                     Exclude germline mutations
                                 </label>

--- a/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
+++ b/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
@@ -78,6 +78,8 @@ export default class DriverAnnotationControls extends React.Component<
     }
 
     render() {
+        const hasGenomicProfile = this.props.state
+            .isGenomicAlterationProfileSelected;
         return (
             <div>
                 <div className="checkbox">
@@ -88,6 +90,7 @@ export default class DriverAnnotationControls extends React.Component<
                             value={EVENT_KEY.distinguishDrivers}
                             checked={this.props.state.distinguishDrivers}
                             onClick={this.onInputClick}
+                            disabled={!hasGenomicProfile}
                         />
                         Putative drivers vs VUS:
                     </label>
@@ -110,7 +113,8 @@ export default class DriverAnnotationControls extends React.Component<
                                             data-test="annotateOncoKb"
                                             disabled={
                                                 this.props.state
-                                                    .annotateDriversOncoKbError
+                                                    .annotateDriversOncoKbError ||
+                                                !hasGenomicProfile
                                             }
                                         />
                                         {this.props.state
@@ -165,7 +169,8 @@ export default class DriverAnnotationControls extends React.Component<
                                                 data-test="annotateHotspots"
                                                 disabled={
                                                     this.props.state
-                                                        .annotateDriversHotspotsError
+                                                        .annotateDriversHotspotsError ||
+                                                    !hasGenomicProfile
                                                 }
                                             />
                                             {this.props.state
@@ -235,39 +240,45 @@ export default class DriverAnnotationControls extends React.Component<
                                 )}
                         </span>
                     )}
-                    {!!this.props.state
-                        .customDriverAnnotationBinaryMenuLabel && (
-                        <div className="checkbox">
-                            <label>
-                                <input
-                                    type="checkbox"
-                                    checked={
+                    {!!this.props.state.customDriverAnnotationBinaryMenuLabel &&
+                        /**
+                         * Hide when there is no genomic profile present: without any genomic alteration profiles
+                         * the driver tiers list will always be empty because it is generated on the fly
+                         * using genomic alteration data
+                         */
+                        hasGenomicProfile && (
+                            <div className="checkbox">
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        checked={
+                                            this.props.state
+                                                .annotateCustomDriverBinary
+                                        }
+                                        value={
+                                            EVENT_KEY.customDriverBinaryAnnotation
+                                        }
+                                        onClick={this.onInputClick}
+                                        data-test="annotateCustomBinary"
+                                        disabled={!hasGenomicProfile}
+                                    />{' '}
+                                    {
                                         this.props.state
-                                            .annotateCustomDriverBinary
+                                            .customDriverAnnotationBinaryMenuLabel
                                     }
-                                    value={
-                                        EVENT_KEY.customDriverBinaryAnnotation
-                                    }
-                                    onClick={this.onInputClick}
-                                    data-test="annotateCustomBinary"
-                                />{' '}
-                                {
-                                    this.props.state
-                                        .customDriverAnnotationBinaryMenuLabel
-                                }
-                                <img
-                                    src={require('../../../rootImages/driver.svg')}
-                                    alt="driver filter"
-                                    style={{
-                                        height: '15px',
-                                        width: '15px',
-                                        cursor: 'pointer',
-                                        marginLeft: '5px',
-                                    }}
-                                />
-                            </label>
-                        </div>
-                    )}
+                                    <img
+                                        src={require('../../../rootImages/driver.svg')}
+                                        alt="driver filter"
+                                        style={{
+                                            height: '15px',
+                                            width: '15px',
+                                            cursor: 'pointer',
+                                            marginLeft: '5px',
+                                        }}
+                                    />
+                                </label>
+                            </div>
+                        )}
                     {!!this.props.state
                         .customDriverAnnotationTiersMenuLabel && (
                         <span data-test="annotateCustomTiers">
@@ -313,6 +324,7 @@ export default class DriverAnnotationControls extends React.Component<
                                                     this
                                                         .onCustomDriverTierCheckboxClick
                                                 }
+                                                disabled={!hasGenomicProfile}
                                             />{' '}
                                             {tier}
                                         </label>

--- a/src/shared/components/driverAnnotations/SettingsMenu.tsx
+++ b/src/shared/components/driverAnnotations/SettingsMenu.tsx
@@ -54,7 +54,7 @@ export default class SettingsMenu extends React.Component<
         });
         this.driverSettingsState = buildDriverAnnotationControlsState(
             props.store.driverAnnotationSettings,
-            props.store.customDriverAnnotationReport.result,
+            props.store.customDriverAnnotationReport,
             props.store.didOncoKbFailInOncoprint,
             props.store.didHotspotFailInOncoprint
         );

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -611,6 +611,9 @@ export default class ResultsViewOncoprint extends React.Component<
             get isSessionServiceEnabled() {
                 return self.props.store.pageUserSession.isSessionServiceEnabled;
             },
+            get isGenomicAlterationProfileSelected() {
+                return self.props.store.isGenomicAlterationProfileSelected;
+            },
         });
 
         this.configureClinicalTracks();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -114,6 +114,14 @@ export const AlterationTypeConstants = {
     RNA_EXPRESSION: 'RNA_EXPRESSION',
 };
 
+export const genomicAlterationProfiles = [
+    AlterationTypeConstants.MUTATION_EXTENDED,
+    AlterationTypeConstants.MUTATION_UNCALLED,
+    AlterationTypeConstants.COPY_NUMBER_ALTERATION,
+    AlterationTypeConstants.STRUCTURAL_VARIANT,
+    AlterationTypeConstants.FUSION,
+];
+
 export const DataTypeConstants = {
     DISCRETE: 'DISCRETE',
     CONTINUOUS: 'CONTINUOUS',


### PR DESCRIPTION
(Replaced by https://github.com/cBioPortal/cbioportal-frontend/pull/4712)

Fix confusing filtering of the oncoprint when no genomic alteration profiles are selected.

For a more detailed explanation, see issue https://github.com/cBioPortal/cbioportal/issues/10316 .

## Changes

When all profiles with genomic alteration data are excluded:
- all genomic alteration checkboxes in the annotation menu are unchecked and deselected
- the custom tier list is hidden, because it is generated on the fly using (the excluded) genomic alteration data

This PR adds e2e tests to check the menu and oncoprint is displayed with mrna data when excluding all genomic alteration profiles. 