### PR TITLE
Fix default value bug when backend parameter is missing for oncoprint clustered option

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -168,10 +168,10 @@ export interface IServerConfig {
     skin_patient_view_structural_variant_table_columns_show_on_init: string;
     comparison_categorical_na_values: string;
     oncoprint_clinical_tracks_config_json: string;
-    oncoprint_clustered_default: boolean;
+    oncoprint_clustered_default: boolean; // this has a default
     enable_cross_study_expression: string;
     studyview_max_samples_selected: number;
     study_download_url: string;
-    vaf_sequential_mode_default: boolean;
-    vaf_log_scale_default: boolean;
+    vaf_sequential_mode_default: boolean; // this has a default
+    vaf_log_scale_default: boolean; // this has a default
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -219,6 +219,12 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
     studyview_max_samples_selected: 0,
 
     study_download_url: '',
+
+    oncoprint_clustered_default: true,
+
+    vaf_sequential_mode_default: false,
+
+    vaf_log_scale_default: false,
 };
 
 export default ServerConfigDefaults;


### PR DESCRIPTION
Fix bug introduced in https://github.com/cBioPortal/cbioportal-frontend/pull/4680

The pr changed the default setting when the backend parameter is missing for oncoprint clustered option, adding default value for those parameters.