### PR TITLE
Improve non-profiled gene panel links in oncoprint tooltip

### DIFF
--- a/src/shared/components/oncoprint/TooltipUtils.spec.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.spec.ts
@@ -1296,37 +1296,16 @@ describe('Oncoprint TooltipUtils', () => {
                 assert.equal(tooltipOutput.text().match(/panel2/g)!.length, 1);
                 assert.equal(tooltipOutput.text().match(/panel3/g)!.length, 1);
                 assert.equal(
-                    tooltipOutput.text().match(/panel1 \(1\)/g)!.length,
+                    tooltipOutput.text().match(/panel1\s*\(1\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel2 \(1\)/g)!.length,
+                    tooltipOutput.text().match(/panel2\s*\(1\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel3 \(1\)/g)!.length,
+                    tooltipOutput.text().match(/panel3\s*\(1\)/g)!.length,
                     1
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel1")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel2")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel3")')
-                        .first()
-                        .css('color'),
-                    'red'
                 );
 
                 tooltipOutput = tooltip([datum1, datum3]);
@@ -1334,37 +1313,16 @@ describe('Oncoprint TooltipUtils', () => {
                 assert.equal(tooltipOutput.text().match(/panel2/g)!.length, 1);
                 assert.equal(tooltipOutput.text().match(/panel3/g)!.length, 1);
                 assert.equal(
-                    tooltipOutput.text().match(/panel1 \(2\)/g)!.length,
+                    tooltipOutput.text().match(/panel1\s*\(2\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel2 \(2\)/g)!.length,
+                    tooltipOutput.text().match(/panel2\s*\(2\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel3 \(1\)/g)!.length,
+                    tooltipOutput.text().match(/panel3\s*\(1\)/g)!.length,
                     1
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel1")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel2")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel3")')
-                        .first()
-                        .css('color'),
-                    'red'
                 );
 
                 tooltipOutput = tooltip([datum3, datum2]);
@@ -1372,38 +1330,19 @@ describe('Oncoprint TooltipUtils', () => {
                 assert.equal(tooltipOutput.text().match(/panel2/g)!.length, 1);
                 assert.equal(tooltipOutput.text().match(/panel3/g)!.length, 1);
                 assert.equal(
-                    tooltipOutput.text().match(/panel1 \(1\)/g)!.length,
+                    tooltipOutput.text().match(/panel1\s*\(1\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel2 \(1\)/g)!.length,
+                    tooltipOutput.text().match(/panel2\s*\(1\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel3 \(2\)/g)!.length,
+                    tooltipOutput
+                        .text()
+                        .match(/panel3\s*\(gene not on panel\)\s*\(2\)/g)!
+                        .length,
                     1
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel1")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel2")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.equal(
-                    tooltipOutput
-                        .find('a:contains("panel3")')
-                        .first()
-                        .css('color'),
-                    'red',
-                    'red because Not profiled in that gene panel'
                 );
 
                 tooltipOutput = tooltip([datum3, datum1, datum2]);
@@ -1411,37 +1350,16 @@ describe('Oncoprint TooltipUtils', () => {
                 assert.equal(tooltipOutput.text().match(/panel2/g)!.length, 1);
                 assert.equal(tooltipOutput.text().match(/panel3/g)!.length, 1);
                 assert.equal(
-                    tooltipOutput.text().match(/panel1 \(2\)/g)!.length,
+                    tooltipOutput.text().match(/panel1\s*\(2\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel2 \(2\)/g)!.length,
+                    tooltipOutput.text().match(/panel2\s*\(2\)/g)!.length,
                     1
                 );
                 assert.equal(
-                    tooltipOutput.text().match(/panel3 \(1\)/g)!.length,
+                    tooltipOutput.text().match(/panel3\s*\(1\)/g)!.length,
                     1
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel1")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel2")')
-                        .first()
-                        .css('color'),
-                    'red'
-                );
-                assert.notEqual(
-                    tooltipOutput
-                        .find('a:contains("panel3")')
-                        .first()
-                        .css('color'),
-                    'red'
                 );
             });
         });

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -40,7 +40,9 @@ export function makeGenePanelPopupLink(
 ) {
     let anchor = $(
         `<span class="nobreak"><a href="#" ${
-            !profiled ? 'style="color:red;"' : ''
+            !profiled
+                ? 'style="text-decoration:line-through;" title="gene not profiled"'
+                : ''
         } oncontextmenu="return false;">${gene_panel_id}</a>${
             numSamples ? ` (${numSamples})` : ''
         }</span>`

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -39,13 +39,11 @@ export function makeGenePanelPopupLink(
     numSamples?: number
 ) {
     let anchor = $(
-        `<span class="nobreak"><a href="#" ${
-            !profiled
-                ? 'style="text-decoration:line-through;" title="gene not profiled"'
-                : ''
-        } oncontextmenu="return false;">${gene_panel_id}</a>${
-            numSamples ? ` (${numSamples})` : ''
-        }</span>`
+        `<span class="nobreak">
+            <a href="#" oncontextmenu="return false;">${gene_panel_id}</a>
+            ${!profiled ? '(gene not on panel)' : ''}
+            ${numSamples ? ` (${numSamples})` : ''}
+         </span>`
     );
     anchor.ready(() => {
         anchor.click(function() {


### PR DESCRIPTION
Currently the gene panels in an oncoprint tooltip are marked red (instead of blue) when the gene is not on the panel. 

However, just marking the gene panel with the color red is confusing for some users: what does this color mean? And why is my gene not showing up in the panel, when I click on it?

To improve the meaning of non-profiled gene panels, this PR removes the red color and adds a message that the gene is not on the gene panel.

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/83c50122-ad08-4845-bda9-543a62206124)
_New styling of gene panel without the current gene, including message_

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/5d37ec26-1882-458b-9583-f6449a521917)
_New styling when multiple patients are selected_
