### PR TITLE
Add property to define custom sample type colors in patient view

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -167,6 +167,7 @@ export interface IServerConfig {
     skin_comparison_view_mutation_table_columns_show_on_init: string;
     skin_patient_view_copy_number_table_columns_show_on_init: string;
     skin_patient_view_structural_variant_table_columns_show_on_init: string;
+    skin_patient_view_custom_sample_type_colors_json: string;
     comparison_categorical_na_values: string;
     oncoprint_clinical_tracks_config_json: string;
     oncoprint_clustered_default: boolean; // this has a default

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -102,6 +102,24 @@ export class ServerConfigHelpers {
         return matches ? matches.map((s: string) => s.trim()) : [];
     }
 
+    @memoize
+    static parseCustomSampleTypeColors(config: string | undefined): any {
+        const result = {
+            customSampleTypes: [] as string[],
+            customSampleTypeToColor: {} as any,
+            customSampleTypesLower: [] as string[],
+        };
+        if (!config) {
+            return result;
+        }
+        result.customSampleTypeToColor = JSON.parse(config);
+        result.customSampleTypes = _.keys(result.customSampleTypeToColor);
+        result.customSampleTypesLower = result.customSampleTypes.map(t =>
+            t.toLowerCase()
+        );
+        return result;
+    }
+
     @memoize static parseConfigFormat(
         str: string | null
     ): CategorizedConfigItems {

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -217,6 +217,8 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
 
     skin_patient_view_structural_variant_table_columns_show_on_init: '',
 
+    skin_patient_view_custom_sample_type_colors_json: '',
+
     studyview_max_samples_selected: 0,
 
     study_download_url: '',

--- a/src/pages/patientView/SampleManager.tsx
+++ b/src/pages/patientView/SampleManager.tsx
@@ -12,6 +12,7 @@ import naturalSort from 'javascript-natural-sort';
 import { ClinicalEvent, ClinicalEventData } from 'cbioportal-ts-api-client';
 import { SampleLabelHTML } from 'shared/components/sampleLabel/SampleLabel';
 import { computed, makeObservable } from 'mobx';
+import { getServerConfig, ServerConfigHelpers } from 'config/config';
 
 // sort samples based on event, clinical data and id
 // 1. based on sample collection data (timeline event)
@@ -177,6 +178,7 @@ class SampleManager {
     clinicalDataLegacyCleanAndDerived: { [s: string]: any };
     sampleColors: { [s: string]: string };
     commonClinicalDataLegacyCleanAndDerived: { [s: string]: string };
+    private customSampleTypeToColor: any;
 
     constructor(
         public samples: Array<ClinicalDataBySampleId>,
@@ -194,6 +196,9 @@ class SampleManager {
         // clinical attributes that should be displayed at patient level, since
         // they are the same in all samples
         this.commonClinicalDataLegacyCleanAndDerived = {};
+        this.customSampleTypeToColor = ServerConfigHelpers.parseCustomSampleTypeColors(
+            getServerConfig().skin_patient_view_custom_sample_type_colors_json
+        ).customSampleTypeToColor;
 
         samples.forEach((sample, i) => {
             // add legacy clinical data
@@ -209,6 +214,16 @@ class SampleManager {
             // determine color based on DERIVED_NORMALIZED_CASE_TYPE
             let color = 'black';
             if (
+                this.customSampleTypeToColor[
+                    this.clinicalDataLegacyCleanAndDerived[sample.id]
+                        .DERIVED_NORMALIZED_CASE_TYPE
+                ]
+            ) {
+                color = this.customSampleTypeToColor[
+                    this.clinicalDataLegacyCleanAndDerived[sample.id]
+                        .DERIVED_NORMALIZED_CASE_TYPE
+                ];
+            } else if (
                 this.clinicalDataLegacyCleanAndDerived[sample.id][
                     'DERIVED_NORMALIZED_CASE_TYPE'
                 ] === 'Primary'

--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
@@ -2,6 +2,7 @@ import * as $ from 'jquery';
 import _ from 'underscore';
 import * as React from 'react';
 import * as styleConsts from './clinicalAttributesStyleConsts.ts';
+import { getServerConfig, ServerConfigHelpers } from 'config/config';
 
 /**
  * Functions for dealing with clinical attributes.
@@ -95,6 +96,13 @@ function getFirstKeyFound(object, keys) {
  * @param {object} clinicalData - key/value pairs of clinical data
  */
 function derive(clinicalData) {
+    const {
+        customSampleTypes,
+        customSampleTypesLower,
+    } = ServerConfigHelpers.parseCustomSampleTypeColors(
+        getServerConfig().skin_patient_view_custom_sample_type_colors_json
+    );
+
     const derivedClinicalAttributes = $.extend({}, clinicalData);
 
     /**
@@ -116,8 +124,12 @@ function derive(clinicalData) {
 
             if (caseType !== null && typeof caseType !== 'undefined') {
                 caseTypeLower = caseType.toLowerCase();
-
-                if (caseTypeLower.indexOf('metasta') >= 0) {
+                const foundCustomIndex = customSampleTypesLower.findIndex(
+                    type => caseTypeLower.indexOf(type) >= 0
+                );
+                if (foundCustomIndex >= 0) {
+                    caseTypeNormalized = customSampleTypes[foundCustomIndex];
+                } else if (caseTypeLower.indexOf('metasta') >= 0) {
                     caseTypeNormalized = 'Metastasis';
                 } else if (caseTypeLower.indexOf('recurr') >= 0) {
                     caseTypeNormalized = 'Recurrence';


### PR DESCRIPTION
Extend the legend colors of sample types in the patient view by configuring custom sample types with a backend property. 
Depends on: https://github.com/cBioPortal/cbioportal/pull/10336.

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/baa1f071-e579-49db-80c5-8b45efbf8c8a)
_Example of a patient view timeline with a sample of type ctDNA_  

Configure custom sample types and their colors in the patient view using a new property `skin_patient_view_custom_sample_types` like:
```json
{
   "plasma": "gold",
   "ctdna": "lightblue",
   "urine": "yellow",
   "biopsy 3": "#00c040ff"
}
```
