### PR TITLE
[RFC 76] Redesign oncoprint annotation menu

### DIFF
--- a/end-to-end-test/local/runtime-config/portal.properties
+++ b/end-to-end-test/local/runtime-config/portal.properties
@@ -263,10 +263,10 @@ ucsc.build=hg19
 oncoprint.defaultview=patient
 
 # OncoPrint driver mutation annotations
- oncoprint.custom_driver_annotation.binary.menu_label=Custom driver annotation
- oncoprint.custom_driver_annotation.tiers.menu_label=Custom driver tiers
- oncoprint.custom_driver_annotation.binary.default=true
- oncoprint.custom_driver_annotation.tiers.default=true
+oncoprint.custom_driver_annotation.binary.menu_label=Custom driver annotations
+oncoprint.custom_driver_annotation.tiers.menu_label=Driver tiers
+oncoprint.custom_driver_annotation.binary.default=true
+oncoprint.custom_driver_annotation.tiers.default=true
 oncoprint.oncokb.default=true
 oncoprint.hotspots.default=true
 # oncoprint.hide_vus.default=true

--- a/end-to-end-test/local/specs/custom-driver-annotations-in-result-view.spec.js
+++ b/end-to-end-test/local/specs/custom-driver-annotations-in-result-view.spec.js
@@ -74,25 +74,6 @@ describe('custom driver annotations feature in result view', function() {
             waitForOncoprint();
             assert(!$('div.alert-info').isExisting());
         });
-
-        it('(de-)selects custom driver checkboxes with main annotation select option', () => {
-            $('input[data-test=ColorByDriver]').click();
-            waitForOncoprint();
-
-            $('input[data-test=annotateCustomBinary]').waitForExist();
-            var topCheckBox = $('input[data-test=annotateCustomBinary]');
-            var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$(
-                'input'
-            );
-            assert(!topCheckBox.isSelected());
-            assert(!tiersCheckboxes[0].isSelected());
-            assert(!tiersCheckboxes[1].isSelected());
-
-            $('input[data-test=ColorByDriver]').click();
-            assert(topCheckBox.isSelected());
-            assert(tiersCheckboxes[0].isSelected());
-            assert(tiersCheckboxes[1].isSelected());
-        });
     });
 
     describe('oncoprint tab - discrete CNA', () => {
@@ -157,23 +138,6 @@ describe('custom driver annotations feature in result view', function() {
                 $('div.alert-info*=16 copy number alterations').isExisting()
             );
         });
-
-        it('(de-)selects custom driver checkboxes with main annotation select option', () => {
-            $('input[data-test=ColorByDriver]').click();
-            waitForOncoprint();
-            var topCheckBox = $('input[data-test=annotateCustomBinary]');
-            var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$(
-                'input'
-            );
-            assert(!topCheckBox.isSelected());
-            assert(!tiersCheckboxes[0].isSelected());
-            assert(!tiersCheckboxes[1].isSelected());
-
-            $('input[data-test=ColorByDriver]').click();
-            assert(topCheckBox.isSelected());
-            assert(tiersCheckboxes[0].isSelected());
-            assert(tiersCheckboxes[1].isSelected());
-        });
     });
 
     describe('oncoprint tab - structural variants', () => {
@@ -212,21 +176,6 @@ describe('custom driver annotations feature in result view', function() {
                 .click();
             waitForOncoprint();
             assert($('div.alert-info*=2 structural variants').isExisting());
-        });
-
-        it('(de-)selects custom driver checkboxes with main annotation select option', () => {
-            $('input[data-test=ColorByDriver]').click();
-            waitForOncoprint();
-            var topCheckBox = $('input[data-test=annotateCustomBinary]');
-            var tiersCheckboxes = $('span[data-test=annotateCustomTiers]').$$(
-                'input'
-            );
-            assert(!topCheckBox.isSelected());
-            assert(!tiersCheckboxes[0].isSelected());
-
-            $('input[data-test=ColorByDriver]').click();
-            assert(topCheckBox.isSelected());
-            assert(tiersCheckboxes[0].isSelected());
         });
     });
 });

--- a/end-to-end-test/remote/specs/core/oncoprinter.screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/oncoprinter.screenshot.spec.js
@@ -266,24 +266,7 @@ describe('oncoprinter screenshot tests', function() {
         var res = checkOncoprintElement();
         assertScreenShotMatch(res);
     });
-    it('oncoprinter example data, dont color by driver vs VUS', function() {
-        goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}/oncoprinter`);
-        $('.oncoprinterGeneticExampleData').waitForExist();
-        $('.oncoprinterClinicalExampleData').waitForExist();
-        $('.oncoprinterHeatmapExampleData').waitForExist();
-        $('.oncoprinterGeneticExampleData').click();
-        $('.oncoprinterClinicalExampleData').click();
-        $('.oncoprinterHeatmapExampleData').click();
-        $('.oncoprinterSubmit').click();
-        waitForOncoprint(TIMEOUT);
-        setOncoprintMutationsMenuOpen(true);
-        $('input[data-test="ColorByDriver"]').click();
-        waitForOncoprint(TIMEOUT);
-        setOncoprintMutationsMenuOpen(false); // get it out of the way for screenshot
 
-        var res = checkOncoprintElement();
-        assertScreenShotMatch(res);
-    });
     it('oncoprinter example data, hide VUS', function() {
         goToUrlAndSetLocalStorage(`${CBIOPORTAL_URL}/oncoprinter`);
         $('.oncoprinterGeneticExampleData').waitForExist();

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -28,8 +28,8 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
         'https://mygene.info/v3/gene/<%= entrezGeneId %>?fields=uniprot',
 
     oncoprint_custom_driver_annotation_binary_menu_label:
-        'Custom driver annotation',
-    oncoprint_custom_driver_annotation_tiers_menu_label: 'Custom driver tiers',
+        'Custom driver annotations',
+    oncoprint_custom_driver_annotation_tiers_menu_label: 'Driver tiers',
     oncoprint_custom_driver_annotation_binary_default: true,
     oncoprint_custom_driver_annotation_tiers_default: true,
     oncoprint_oncokb_default: true,

--- a/src/shared/alterationFiltering/AnnotationFilteringSettings.ts
+++ b/src/shared/alterationFiltering/AnnotationFilteringSettings.ts
@@ -108,7 +108,7 @@ export function buildDriverAnnotationSettings(
             this._includeDriver = val;
         },
         get includeVUS() {
-            return this._includeVUS;
+            return this._includeVUS || !this.driversAnnotated;
         },
         set includeVUS(val: boolean) {
             this._includeVUS = val;
@@ -124,7 +124,7 @@ export function buildDriverAnnotationSettings(
                 this.oncoKb ||
                 this.hotspots ||
                 this.customBinary ||
-                _.some(this.driverTiers.entries(), entry => entry[1]);
+                _.some([...this.driverTiers.entries()], entry => entry[1]);
             return anySelected;
         },
 

--- a/src/shared/alterationFiltering/SettingsMenu.tsx
+++ b/src/shared/alterationFiltering/SettingsMenu.tsx
@@ -12,6 +12,7 @@ import {
     buildDriverAnnotationControlsHandlers,
 } from './AnnotationFilteringSettings';
 import styles from 'shared/components/driverAnnotations/styles.module.scss';
+import InfoIcon from 'shared/components/InfoIcon';
 
 enum EVENT_KEY {
     hidePutativePassengers = '0',
@@ -110,22 +111,20 @@ export default class SettingsMenu extends React.Component<
                 style={{ padding: 5 }}
             >
                 {this.props.annotationTitleComponent}
-                <div style={{ marginLeft: 10 }}>
-                    <DriverAnnotationControls
-                        state={this.driverSettingsState}
-                        handlers={this.driverSettingsHandlers}
-                        showOnckbAnnotationControls={
-                            this.props.showOnckbAnnotationControls
-                        }
-                    />
-                </div>
+                <DriverAnnotationControls
+                    state={this.driverSettingsState}
+                    handlers={this.driverSettingsHandlers}
+                    showOnckbAnnotationControls={
+                        this.props.showOnckbAnnotationControls
+                    }
+                />
                 {this.props.showFilterControls && (
                     <>
                         <hr />
                         <h5 style={{ marginTop: 'auto', marginBottom: 'auto' }}>
                             Filter Data
                         </h5>
-                        <div style={{ marginLeft: 10 }}>
+                        <div>
                             <div className="checkbox">
                                 <label>
                                     <input
@@ -143,9 +142,20 @@ export default class SettingsMenu extends React.Component<
                                                 .distinguishDrivers
                                         }
                                     />{' '}
-                                    Exclude alterations (mutations, structural
-                                    variants and copy number) of unknown
-                                    significance
+                                    Show only drivers
+                                    <InfoIcon
+                                        style={{ color: 'grey' }}
+                                        divStyle={{
+                                            display: 'inline-block',
+                                            marginLeft: 6,
+                                        }}
+                                        tooltip={
+                                            <>
+                                                Exclude VUS: Drivers are defined
+                                                through the options above
+                                            </>
+                                        }
+                                    />
                                 </label>
                             </div>
                             <div className="checkbox">
@@ -160,11 +170,21 @@ export default class SettingsMenu extends React.Component<
                                         }
                                         onClick={this.onInputClick}
                                     />{' '}
-                                    Exclude germline mutations
+                                    Show only somatic
+                                    <InfoIcon
+                                        style={{ color: 'grey' }}
+                                        divStyle={{
+                                            display: 'inline-block',
+                                            marginLeft: 6,
+                                        }}
+                                        tooltip={
+                                            <>Exclude germline mutations</>
+                                        }
+                                    />
                                 </label>
                             </div>
                             {this.props.showExcludeUnprofiledSamplesControl && (
-                                <div>
+                                <>
                                     <div className="checkbox">
                                         <label>
                                             <input
@@ -180,10 +200,28 @@ export default class SettingsMenu extends React.Component<
                                                 }
                                                 onClick={this.onInputClick}
                                             />{' '}
-                                            Exclude unprofiled samples
+                                            Show only profiled
+                                            <InfoIcon
+                                                style={{ color: 'grey' }}
+                                                divStyle={{
+                                                    display: 'inline-block',
+                                                    marginLeft: 6,
+                                                }}
+                                                tooltip={
+                                                    <>
+                                                        Exclude unprofiled
+                                                        samples
+                                                    </>
+                                                }
+                                            />
                                         </label>
                                     </div>
-                                    <div style={{ marginLeft: 10 }}>
+                                    <div
+                                        style={{
+                                            marginLeft: 10,
+                                            marginTop: -5,
+                                        }}
+                                    >
                                         <div className="radio">
                                             <label>
                                                 <input
@@ -198,9 +236,8 @@ export default class SettingsMenu extends React.Component<
                                                     }
                                                     onClick={this.onInputClick}
                                                 />
-                                                Exclude samples that are
-                                                unprofiled in any queried gene
-                                                or profile
+                                                Profiled in <strong>all</strong>{' '}
+                                                queried genes/profiles
                                             </label>
                                             <label>
                                                 <input
@@ -215,13 +252,12 @@ export default class SettingsMenu extends React.Component<
                                                     }
                                                     onClick={this.onInputClick}
                                                 />
-                                                Exclude samples that are
-                                                unprofiled in every queried gene
-                                                and profile.
+                                                Profiled in <strong>any</strong>{' '}
+                                                queried genes/profiles
                                             </label>
                                         </div>
                                     </div>
-                                </div>
+                                </>
                             )}
                         </div>
                     </>

--- a/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
+++ b/src/shared/components/driverAnnotations/DriverAnnotationControls.tsx
@@ -6,12 +6,10 @@ import {
     IDriverAnnotationControlsState,
     IDriverAnnotationControlsHandlers,
 } from '../../alterationFiltering/AnnotationFilteringSettings';
-import {
-    EditableSpan,
-    DefaultTooltip,
-    getNCBIlink,
-} from 'cbioportal-frontend-commons';
+import { DefaultTooltip, getNCBIlink } from 'cbioportal-frontend-commons';
 import 'rc-tooltip/assets/bootstrap_white.css';
+import styles from './styles.module.scss';
+import InfoIcon from 'shared/components/InfoIcon';
 
 enum EVENT_KEY {
     distinguishDrivers = '0',
@@ -79,61 +77,54 @@ export default class DriverAnnotationControls extends React.Component<
 
     render() {
         return (
-            <div>
-                <div className="checkbox">
-                    <label>
-                        <input
-                            data-test="ColorByDriver"
-                            type="checkbox"
-                            value={EVENT_KEY.distinguishDrivers}
-                            checked={this.props.state.distinguishDrivers}
-                            onClick={this.onInputClick}
+            <>
+                <div>
+                    <p className={styles.headerSubsection}>
+                        Driver annotations:
+                        <InfoIcon
+                            style={{ color: 'grey' }}
+                            divStyle={{
+                                display: 'inline-block',
+                                marginLeft: 6,
+                            }}
+                            tooltip={<>Annotate drivers from these sources</>}
                         />
-                        Putative drivers vs VUS:
-                    </label>
-                </div>
-                <div style={{ marginLeft: '20px' }}>
-                    {this.props.showOnckbAnnotationControls && (
-                        <span>
-                            {!this.props.state
-                                .annotateDriversOncoKbDisabled && (
-                                <div className="checkbox">
-                                    <label>
-                                        <input
-                                            type="checkbox"
-                                            value={EVENT_KEY.annotateOncoKb}
-                                            checked={
-                                                this.props.state
-                                                    .annotateDriversOncoKb
-                                            }
-                                            onClick={this.onInputClick}
-                                            data-test="annotateOncoKb"
-                                            disabled={
-                                                this.props.state
-                                                    .annotateDriversOncoKbError
-                                            }
-                                        />
-                                        {this.props.state
-                                            .annotateDriversOncoKbError && (
-                                            <ErrorIcon
-                                                style={{ marginRight: 4 }}
-                                                tooltip={
-                                                    <span>
-                                                        Error loading OncoKb
-                                                        data. Please refresh the
-                                                        page or try again later.
-                                                    </span>
+                    </p>
+                    <div style={{ marginLeft: '20px' }}>
+                        {this.props.showOnckbAnnotationControls && (
+                            <>
+                                {!this.props.state
+                                    .annotateDriversOncoKbDisabled && (
+                                    <div className="checkbox">
+                                        <label>
+                                            <input
+                                                type="checkbox"
+                                                value={EVENT_KEY.annotateOncoKb}
+                                                checked={
+                                                    this.props.state
+                                                        .annotateDriversOncoKb
+                                                }
+                                                onClick={this.onInputClick}
+                                                data-test="annotateOncoKb"
+                                                disabled={
+                                                    this.props.state
+                                                        .annotateDriversOncoKbError
                                                 }
                                             />
-                                        )}
-                                        <DefaultTooltip
-                                            overlay={
-                                                <span>
-                                                    Oncogenicity from OncoKB™
-                                                </span>
-                                            }
-                                            placement="top"
-                                        >
+                                            {this.props.state
+                                                .annotateDriversOncoKbError && (
+                                                <ErrorIcon
+                                                    style={{ marginRight: 4 }}
+                                                    tooltip={
+                                                        <span>
+                                                            Error loading OncoKb
+                                                            data. Please refresh
+                                                            the page or try
+                                                            again later.
+                                                        </span>
+                                                    }
+                                                />
+                                            )}
                                             <img
                                                 src={require('oncokb-styles/dist/images/logo/oncokb.svg')}
                                                 style={{
@@ -142,187 +133,218 @@ export default class DriverAnnotationControls extends React.Component<
                                                     marginRight: '5px',
                                                 }}
                                             />
-                                        </DefaultTooltip>
-                                        driver annotation
-                                    </label>
-                                </div>
-                            )}
-                            {this.props.handlers.onSelectAnnotateHotspots &&
-                                !this.props.state
-                                    .annotateDriversHotspotsDisabled && (
-                                    <div className="checkbox">
-                                        <label>
-                                            <input
-                                                type="checkbox"
-                                                value={
-                                                    EVENT_KEY.annotateHotspots
-                                                }
-                                                checked={
-                                                    this.props.state
-                                                        .annotateDriversHotspots
-                                                }
-                                                onClick={this.onInputClick}
-                                                data-test="annotateHotspots"
-                                                disabled={
-                                                    this.props.state
-                                                        .annotateDriversHotspotsError
+                                            <InfoIcon
+                                                style={{ color: 'grey' }}
+                                                divStyle={{
+                                                    display: 'inline-block',
+                                                    marginLeft: 6,
+                                                }}
+                                                tooltip={
+                                                    <>
+                                                        Oncogenicity from
+                                                        OncoKB™
+                                                    </>
                                                 }
                                             />
-                                            {this.props.state
-                                                .annotateDriversHotspotsError && (
-                                                <ErrorIcon
-                                                    style={{ marginRight: 4 }}
-                                                    tooltip={
-                                                        <span>
-                                                            Error loading
-                                                            Hotspots data.
-                                                            Please refresh the
-                                                            page or try again
-                                                            later.
-                                                        </span>
-                                                    }
-                                                />
-                                            )}
-                                            Hotspots
-                                            <DefaultTooltip
-                                                overlay={
-                                                    <div
-                                                        style={{
-                                                            maxWidth: '400px',
-                                                        }}
-                                                    >
-                                                        Identified as a
-                                                        recurrent hotspot
-                                                        (statistically
-                                                        significant) in a
-                                                        population-scale cohort
-                                                        of tumor samples of
-                                                        various cancer types
-                                                        using methodology based
-                                                        in part on{' '}
-                                                        <a
-                                                            href={getNCBIlink(
-                                                                '/pubmed/26619011'
-                                                            )}
-                                                            target="_blank"
-                                                        >
-                                                            Chang et al., Nat
-                                                            Biotechnol, 2016.
-                                                        </a>
-                                                        Explore all mutations at{' '}
-                                                        <a
-                                                            href="https://www.cancerhotspots.org"
-                                                            target="_blank"
-                                                        >
-                                                            https://cancerhotspots.org
-                                                        </a>
-                                                    </div>
-                                                }
-                                                placement="top"
-                                            >
-                                                <img
-                                                    src={require('../../../rootImages/cancer-hotspots.svg')}
-                                                    style={{
-                                                        height: '15px',
-                                                        width: '15px',
-                                                        cursor: 'pointer',
-                                                        marginLeft: '5px',
-                                                    }}
-                                                />
-                                            </DefaultTooltip>
                                         </label>
                                     </div>
                                 )}
-                        </span>
-                    )}
-                    {!!this.props.state
-                        .customDriverAnnotationBinaryMenuLabel && (
-                        <div className="checkbox">
-                            <label>
-                                <input
-                                    type="checkbox"
-                                    checked={
-                                        this.props.state
-                                            .annotateCustomDriverBinary
-                                    }
-                                    value={
-                                        EVENT_KEY.customDriverBinaryAnnotation
-                                    }
-                                    onClick={this.onInputClick}
-                                    data-test="annotateCustomBinary"
-                                />{' '}
-                                {
-                                    this.props.state
-                                        .customDriverAnnotationBinaryMenuLabel
-                                }
-                                <img
-                                    src={require('../../../rootImages/driver.svg')}
-                                    alt="driver filter"
-                                    style={{
-                                        height: '15px',
-                                        width: '15px',
-                                        cursor: 'pointer',
-                                        marginLeft: '5px',
-                                    }}
-                                />
-                            </label>
-                        </div>
-                    )}
-                    {!!this.props.state
-                        .customDriverAnnotationTiersMenuLabel && (
-                        <span data-test="annotateCustomTiers">
-                            <span className="caret" />
-                            &nbsp;&nbsp;
-                            <span>
-                                {
-                                    this.props.state
-                                        .customDriverAnnotationTiersMenuLabel
-                                }
-                            </span>
-                            &nbsp;
-                            <img
-                                src={require('../../../rootImages/driver_tiers.png')}
-                                alt="driver tiers filter"
-                                style={{
-                                    height: '15px',
-                                    width: '15px',
-                                    cursor: 'pointer',
-                                    marginLeft: '5px',
-                                }}
-                            />
-                            <div style={{ marginLeft: '30px' }}>
-                                {(
-                                    this.props.state
-                                        .customDriverAnnotationTiers || []
-                                ).map(tier => (
-                                    <div className="checkbox">
-                                        <label>
-                                            <input
-                                                type="checkbox"
-                                                value={tier}
-                                                checked={
-                                                    !!(
+                                {this.props.handlers.onSelectAnnotateHotspots &&
+                                    !this.props.state
+                                        .annotateDriversHotspotsDisabled && (
+                                        <div className="checkbox">
+                                            <label>
+                                                <input
+                                                    type="checkbox"
+                                                    value={
+                                                        EVENT_KEY.annotateHotspots
+                                                    }
+                                                    checked={
                                                         this.props.state
-                                                            .selectedCustomDriverAnnotationTiers &&
-                                                        this.props.state.selectedCustomDriverAnnotationTiers.get(
-                                                            tier
-                                                        )
-                                                    )
-                                                }
-                                                onClick={
-                                                    this
-                                                        .onCustomDriverTierCheckboxClick
-                                                }
-                                            />{' '}
-                                            {tier}
-                                        </label>
-                                    </div>
-                                ))}
+                                                            .annotateDriversHotspots
+                                                    }
+                                                    onClick={this.onInputClick}
+                                                    data-test="annotateHotspots"
+                                                    disabled={
+                                                        this.props.state
+                                                            .annotateDriversHotspotsError
+                                                    }
+                                                />
+                                                {this.props.state
+                                                    .annotateDriversHotspotsError && (
+                                                    <ErrorIcon
+                                                        style={{
+                                                            marginRight: 4,
+                                                        }}
+                                                        tooltip={
+                                                            <span>
+                                                                Error loading
+                                                                Hotspots data.
+                                                                Please refresh
+                                                                the page or try
+                                                                again later.
+                                                            </span>
+                                                        }
+                                                    />
+                                                )}
+                                                Hotspots
+                                                <DefaultTooltip
+                                                    overlay={
+                                                        <div
+                                                            style={{
+                                                                maxWidth:
+                                                                    '400px',
+                                                            }}
+                                                        >
+                                                            Identified as a
+                                                            recurrent hotspot
+                                                            (statistically
+                                                            significant) in a
+                                                            population-scale
+                                                            cohort of tumor
+                                                            samples of various
+                                                            cancer types using
+                                                            methodology based in
+                                                            part on{' '}
+                                                            <a
+                                                                href={getNCBIlink(
+                                                                    '/pubmed/26619011'
+                                                                )}
+                                                                target="_blank"
+                                                            >
+                                                                Chang et al.,
+                                                                Nat Biotechnol,
+                                                                2016.
+                                                            </a>
+                                                            Explore all
+                                                            mutations at{' '}
+                                                            <a
+                                                                href="https://www.cancerhotspots.org"
+                                                                target="_blank"
+                                                            >
+                                                                https://cancerhotspots.org
+                                                            </a>
+                                                        </div>
+                                                    }
+                                                    placement="top"
+                                                >
+                                                    <img
+                                                        src={require('../../../rootImages/cancer-hotspots.svg')}
+                                                        style={{
+                                                            height: '15px',
+                                                            width: '15px',
+                                                            cursor: 'pointer',
+                                                            marginLeft: '5px',
+                                                        }}
+                                                    />
+                                                </DefaultTooltip>
+                                            </label>
+                                        </div>
+                                    )}
+                            </>
+                        )}
+                        {!!this.props.state
+                            .customDriverAnnotationBinaryMenuLabel && (
+                            <div className="checkbox">
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        checked={
+                                            this.props.state
+                                                .annotateCustomDriverBinary
+                                        }
+                                        value={
+                                            EVENT_KEY.customDriverBinaryAnnotation
+                                        }
+                                        onClick={this.onInputClick}
+                                        data-test="annotateCustomBinary"
+                                    />{' '}
+                                    {
+                                        this.props.state
+                                            .customDriverAnnotationBinaryMenuLabel
+                                    }
+                                    <img
+                                        src={require('../../../rootImages/driver.svg')}
+                                        alt="driver filter"
+                                        style={{
+                                            height: '15px',
+                                            width: '15px',
+                                            cursor: 'pointer',
+                                            marginLeft: '5px',
+                                        }}
+                                    />
+                                    <InfoIcon
+                                        style={{ color: 'grey' }}
+                                        divStyle={{
+                                            display: 'inline-block',
+                                            marginLeft: 6,
+                                        }}
+                                        tooltip={
+                                            <>
+                                                Use driver annotations from
+                                                source data
+                                            </>
+                                        }
+                                    />
+                                </label>
                             </div>
-                        </span>
-                    )}
+                        )}
+                    </div>
                 </div>
-            </div>
+                {!!this.props.state.customDriverAnnotationTiersMenuLabel && (
+                    <span data-test="annotateCustomTiers">
+                        <p className={styles.headerSubsection}>
+                            {
+                                this.props.state
+                                    .customDriverAnnotationTiersMenuLabel
+                            }
+                            :
+                            <InfoIcon
+                                style={{ color: 'grey' }}
+                                divStyle={{
+                                    display: 'inline-block',
+                                    marginLeft: 6,
+                                }}
+                                tooltip={
+                                    <>
+                                        Consider these annotation tiers as
+                                        driver
+                                    </>
+                                }
+                            />
+                        </p>
+                        <div style={{ marginLeft: '20px' }}>
+                            {(
+                                this.props.state.customDriverAnnotationTiers ||
+                                []
+                            ).map(tier => (
+                                <div className="checkbox">
+                                    <label>
+                                        <input
+                                            type="checkbox"
+                                            value={tier}
+                                            checked={
+                                                !!(
+                                                    this.props.state
+                                                        .selectedCustomDriverAnnotationTiers &&
+                                                    this.props.state.selectedCustomDriverAnnotationTiers.get(
+                                                        tier
+                                                    )
+                                                )
+                                            }
+                                            onClick={
+                                                this
+                                                    .onCustomDriverTierCheckboxClick
+                                            }
+                                        />{' '}
+                                        {tier}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                    </span>
+                )}
+            </>
         );
     }
 }

--- a/src/shared/components/driverAnnotations/SettingsMenuButton.tsx
+++ b/src/shared/components/driverAnnotations/SettingsMenuButton.tsx
@@ -67,8 +67,10 @@ export default class SettingsMenuButton extends React.Component<
                         style={{ color: 'rgb(54, 134, 194)' }}
                         tooltip={
                             <span>
-                                Putative driver vs VUS setings apply to every
-                                tab except{' '}
+                                This section defines which sources are
+                                considered to annotate driver variants in your
+                                data. Putative driver vs VUS setings apply to
+                                every tab except{' '}
                                 <BoldedSpanList
                                     words={['Co-expression', 'CN Segments']}
                                 />

--- a/src/shared/components/driverAnnotations/styles.module.scss
+++ b/src/shared/components/driverAnnotations/styles.module.scss
@@ -34,3 +34,9 @@
         margin-top: 15px;
     }
 }
+
+p.headerSubsection {
+    font-size: 1.2em;
+    margin-top: 15px;
+    line-height: 7px;
+}

--- a/src/shared/components/driverAnnotations/styles.module.scss.d.ts
+++ b/src/shared/components/driverAnnotations/styles.module.scss.d.ts
@@ -4,6 +4,7 @@ declare const styles: {
   readonly "fa-info-circle": string;
   readonly "globalSettingsDropdown": string;
   readonly "headerSection": string;
+  readonly "headerSubsection": string;
 };
 export = styles;
 


### PR DESCRIPTION
Redesign the oncoprint annotation menu as described in [RFC 76](https://docs.google.com/document/d/1e-UrHJyUsseV_7z9sOIZ6Bd_IJfCe8HD4KryYERaGgM/edit).

## Changes
- Remove the top 'Putative Drivers vs VUS' toggle
- Move custom driver annotations to its own section
- Reword filters to clarify meaning
- Add info tooltips to add some additional information to the checkboxes
- For automatic disabling of the 'exclude VUS' filter, the custom driver tiers now also need to be disabled
 
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/77146de2-7434-4551-8bd4-e8b0ce199c90)
_Screenshot of restyled menu_