### PR TITLE
Fix SV pane search box: Only filter genes when present

### DIFF
--- a/src/pages/studyView/table/StructuralVariantMultiSelectionTable.tsx
+++ b/src/pages/studyView/table/StructuralVariantMultiSelectionTable.tsx
@@ -232,7 +232,7 @@ export class StructuralVariantMultiSelectionTable extends React.Component<
                     filterStringUpper: string
                 ) => {
                     return data.label1
-                        .toUpperCase()
+                        ?.toUpperCase()
                         .includes(filterStringUpper);
                 },
                 width: columnWidth,
@@ -276,7 +276,7 @@ export class StructuralVariantMultiSelectionTable extends React.Component<
                     filterStringUpper: string
                 ) => {
                     return data.label2
-                        .toUpperCase()
+                        ?.toUpperCase()
                         .includes(filterStringUpper);
                 },
                 width: columnWidth,


### PR DESCRIPTION
Fix filtering of the new sv pane when using the searchbox. The filters should only be applied on gene 1 and 2 when they are present.

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/d3827a73-14ad-4d5d-b61f-cdc1129c4d92)
_SV pane including one sv with a missing second gene, the culprit causing a 'nullpointer'_