### PR TITLE
Fix hidden non-genomic data when excluding VUS in oncoprint

### DIFF
--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -1792,9 +1792,9 @@ export class ResultsViewPageStore extends AnalysisStore
     readonly nonOqlFilteredAlterations = remoteData<ExtendedAlteration[]>({
         await: () => [
             this.filteredAndAnnotatedMutations,
-            this.filteredAndAnnotatedNonGenomicData,
             this.filteredAndAnnotatedCnaData,
             this.filteredAndAnnotatedStructuralVariants,
+            this.filteredAndAnnotatedNonGenomicData,
             this.selectedMolecularProfiles,
             this.entrezGeneIdToGene,
         ],
@@ -1805,9 +1805,9 @@ export class ResultsViewPageStore extends AnalysisStore
             const entrezGeneIdToGene = this.entrezGeneIdToGene.result!;
             let result = [
                 ...this.filteredAndAnnotatedMutations.result!,
-                ...this.filteredAndAnnotatedNonGenomicData.result!,
                 ...this.filteredAndAnnotatedCnaData.result!,
                 ...this.filteredAndAnnotatedStructuralVariants.result!,
+                ...this.filteredAndAnnotatedNonGenomicData.result!,
             ];
             return Promise.resolve(
                 result.map(d => {
@@ -1932,9 +1932,9 @@ export class ResultsViewPageStore extends AnalysisStore
                         [
                             ...this.filteredAndAnnotatedMutations.result!,
                             ...this.filteredAndAnnotatedCnaData.result!,
-                            ...this.filteredAndAnnotatedNonGenomicData.result!,
                             ...this.filteredAndAnnotatedStructuralVariants
                                 .result!,
+                            ...this.filteredAndAnnotatedNonGenomicData.result!,
                         ],
                         new AccessorsForOqlFilter(
                             this.selectedMolecularProfiles.result!
@@ -1997,9 +1997,9 @@ export class ResultsViewPageStore extends AnalysisStore
     >({
         await: () => [
             this.filteredAndAnnotatedMutations,
-            this.filteredAndAnnotatedNonGenomicData,
             this.filteredAndAnnotatedCnaData,
             this.filteredAndAnnotatedStructuralVariants,
+            this.filteredAndAnnotatedNonGenomicData,
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
             this.samples,
@@ -2008,9 +2008,9 @@ export class ResultsViewPageStore extends AnalysisStore
         invoke: () => {
             const data = [
                 ...this.filteredAndAnnotatedMutations.result!,
-                ...this.filteredAndAnnotatedNonGenomicData.result!,
                 ...this.filteredAndAnnotatedCnaData.result!,
                 ...this.filteredAndAnnotatedStructuralVariants.result!,
+                ...this.filteredAndAnnotatedNonGenomicData.result!,
             ];
             const accessorsInstance = new AccessorsForOqlFilter(
                 this.selectedMolecularProfiles.result!
@@ -2104,9 +2104,9 @@ export class ResultsViewPageStore extends AnalysisStore
     >({
         await: () => [
             this.filteredAndAnnotatedMutations,
-            this.filteredAndAnnotatedNonGenomicData,
             this.filteredAndAnnotatedCnaData,
             this.filteredAndAnnotatedStructuralVariants,
+            this.filteredAndAnnotatedNonGenomicData,
             this.selectedMolecularProfiles,
             this.defaultOQLQuery,
             this.samples,
@@ -2122,9 +2122,9 @@ export class ResultsViewPageStore extends AnalysisStore
                     this.oqlText,
                     [
                         ...this.filteredAndAnnotatedMutations.result!,
-                        ...this.filteredAndAnnotatedNonGenomicData.result!,
                         ...this.filteredAndAnnotatedCnaData.result!,
                         ...this.filteredAndAnnotatedStructuralVariants.result!,
+                        ...this.filteredAndAnnotatedNonGenomicData.result!,
                     ],
                     new AccessorsForOqlFilter(
                         this.selectedMolecularProfiles.result!

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -5059,13 +5059,9 @@ export class ResultsViewPageStore extends AnalysisStore
             this.filteredSampleKeyToSample,
         ],
         invoke: () => {
-            let data = this._filteredAndAnnotatedMolecularDataReport.result!
-                .data;
-            if (this.driverAnnotationSettings.includeVUS) {
-                data = data.concat(
-                    this._filteredAndAnnotatedMolecularDataReport.result!.vus
-                );
-            }
+            const data = this._filteredAndAnnotatedMolecularDataReport.result!.data.concat(
+                this._filteredAndAnnotatedMolecularDataReport.result!.vus
+            );
             const filteredSampleKeyToSample = this.filteredSampleKeyToSample
                 .result!;
             return Promise.resolve(

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -1775,7 +1775,8 @@ export default class ResultsViewOncoprint extends React.Component<
         ret.push({
             label: getAnnotatingProgressMessage(usingOncokb, usingHotspot),
             promises: [
-                this.props.store.filteredAndAnnotatedMolecularData,
+                this.props.store.filteredAndAnnotatedNonGenomicData,
+                this.props.store.filteredAndAnnotatedCnaData,
                 this.props.store.filteredAndAnnotatedMutations,
                 this.props.store.filteredAndAnnotatedStructuralVariants,
             ],


### PR DESCRIPTION
Fix 'exclude VUS' filter in oncoprint. 

Replaces this [PR](https://github.com/cBioPortal/cbioportal-frontend/pull/4693), related to this [issue](https://github.com/cBioPortal/cbioportal/issues/10316).

When selecting 'exclude alterations of unknown significance', non-genomic mRNA and proteomic data are currently filtered out. We have driver information for Mutations, CNA and SVs, but not for mRNA and proteomic data, so we figured it would be better not to filter those out. If one wants to exclude those, one could deselect the mRNA/proteomic profile instead. This PR introduces that change.

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/9158fc13-5c31-4c3f-8064-c55f0b471d3a)
_Exclude VUS filter in annotation menu_

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/c190f735-81fd-4da8-95b1-70e2f10660d0)
_Before selecting the exclude VUS filter_

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3323006/b3812da6-ecf0-4931-b40f-1ca23c7ffbbc)
_With this fix, and after selecting the exclude VUS filter, mRNA data is now still shown_
