### PR TITLE
search returns false for bad regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ cert.pem
 end
 e2e-localdb-workspace/
 junit.xml
+.nvim.lua
+.luarc.json

--- a/src/shared/lib/GenericAssayUtils/GenericAssaySelectionUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssaySelectionUtils.ts
@@ -4,13 +4,17 @@ export interface ISelectOption {
 }
 
 export function doesOptionMatchSearchText(text: string, option: ISelectOption) {
-    let result = false;
-    if (
-        !text ||
-        RegExp(text, 'i').test(option.label) ||
-        RegExp(text, 'i').test(option.value)
-    ) {
-        result = true;
+    try {
+        let result = false;
+        if (
+            !text ||
+            RegExp(text, 'i').test(option.label) ||
+            RegExp(text, 'i').test(option.value)
+        ) {
+            result = true;
+        }
+        return result;
+    } catch {
+        return false;
     }
-    return result;
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10154

Describe changes proposed in this pull request:
- doesOptionMatchSearchText was throwing an exception on a bad regex so I made it return false on an exception.

## Why no test
It's a small change, but I'm happy to add tests if you want me to.

## Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Notify reviewers
@dippindots @inodb 
