### PR TITLE
[RFC77] Filter buttons on the landing page study search menu

### DIFF
--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -27,7 +27,11 @@ import QuickSelectButtons from './QuickSelectButtons';
 import { StudySelectorStats } from 'shared/components/query/StudySelectorStats';
 import WindowStore from 'shared/components/window/WindowStore';
 import { StudySearch } from 'shared/components/query/StudySearch';
-
+import { DataTypeFilter } from 'shared/components/query/DataTypeFilter';
+import {
+    getSampleCountsPerFilter,
+    getStudyCountPerFilter,
+} from 'shared/components/query/filteredSearch/StudySearchControls';
 const MIN_LIST_HEIGHT = 200;
 
 export interface ICancerStudySelectorProps {
@@ -36,6 +40,49 @@ export interface ICancerStudySelectorProps {
     forkedMode: boolean;
     aboveStudyListBlurb?: JSX.Element;
 }
+
+const StudyFilterOptionsFormatted = [
+    {
+        id: 'sequencedSampleCount',
+        name: 'Mutations',
+        checked: false,
+    },
+    {
+        id: 'cnaSampleCount',
+        name: 'CNA',
+        checked: false,
+    },
+    {
+        id: 'mrnaRnaSeqV2SampleCount',
+        name: 'RNA-Seq',
+        checked: false,
+    },
+    {
+        id: 'mrnaMicroarraySampleCount',
+        name: 'RNA (microarray)',
+        checked: false,
+    },
+    {
+        id: 'miRnaSampleCount',
+        name: 'miRNA',
+        checked: false,
+    },
+    {
+        id: 'rppaSampleCount',
+        name: 'RPPA',
+        checked: false,
+    },
+    {
+        id: 'massSpectrometrySampleCount',
+        name: 'Protein Mass-Spectrometry',
+        checked: false,
+    },
+    {
+        id: 'treatmentCount',
+        name: 'Treatment',
+        checked: false,
+    },
+];
 
 @observer
 export default class CancerStudySelector extends React.Component<
@@ -158,6 +205,40 @@ export default class CancerStudySelector extends React.Component<
         }
     }
 
+    @computed get showSamplesPerFilterType() {
+        const shownStudies = this.logic.mainView.getSelectionReport()
+            .shownStudies;
+        const studyForCalculation =
+            shownStudies.length < this.store.cancerStudies.result.length
+                ? shownStudies
+                : this.store.cancerStudies.result;
+        const filterAttributes = StudyFilterOptionsFormatted.filter(
+            item => item.name
+        );
+        const sampleCountsPerFilter = getSampleCountsPerFilter(
+            StudyFilterOptionsFormatted,
+            studyForCalculation
+        );
+        return sampleCountsPerFilter;
+    }
+
+    @computed get showStudiesPerFilterType() {
+        const shownStudies = this.logic.mainView.getSelectionReport()
+            .shownStudies;
+        const studyForCalculation =
+            shownStudies.length < this.store.cancerStudies.result.length
+                ? shownStudies
+                : this.store.cancerStudies.result;
+        const filterAttributes = StudyFilterOptionsFormatted.filter(
+            item => item.name
+        );
+        const studyCount = getStudyCountPerFilter(
+            StudyFilterOptionsFormatted,
+            studyForCalculation
+        );
+        return studyCount;
+    }
+
     private windowSizeDisposer: IReactionDisposer;
 
     componentDidMount(): void {
@@ -193,6 +274,7 @@ export default class CancerStudySelector extends React.Component<
             shownAndSelectedStudies,
         } = this.logic.mainView.getSelectionReport();
 
+        // TO DO shownStudies can be filtered based on the DataTypeFIlter
         const quickSetButtons = this.logic.mainView.quickSelectButtons(
             getServerConfig().skin_quick_select_buttons
         );
@@ -237,22 +319,50 @@ export default class CancerStudySelector extends React.Component<
                             let searchTimeout: number | null = null;
 
                             return (
-                                <div
-                                    data-tour="cancer-study-search-box"
-                                    style={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                    }}
-                                >
-                                    {this.store.queryParser && (
-                                        <StudySearch
-                                            parser={this.store.queryParser}
-                                            query={this.store.searchClauses}
-                                            onSearch={query =>
-                                                (this.store.searchClauses = query)
+                                <div>
+                                    <div
+                                        data-tour="data-type-filter"
+                                        data-test="data-type-filter-test"
+                                        style={{
+                                            display: 'inline-block',
+                                            alignItems: 'center',
+                                        }}
+                                    >
+                                        <DataTypeFilter
+                                            dataFilter={
+                                                this.store.dataTypeFilters
+                                            }
+                                            isChecked={false}
+                                            buttonText={'Data type'}
+                                            dataFilterActive={
+                                                StudyFilterOptionsFormatted
+                                            }
+                                            store={this.store}
+                                            samplePerFilter={
+                                                this.showSamplesPerFilterType
+                                            }
+                                            studyPerFilter={
+                                                this.showStudiesPerFilterType
                                             }
                                         />
-                                    )}
+                                    </div>
+                                    <div
+                                        data-tour="cancer-study-search-box"
+                                        style={{
+                                            display: 'inline-block',
+                                            alignItems: 'center',
+                                        }}
+                                    >
+                                        {this.store.queryParser && (
+                                            <StudySearch
+                                                parser={this.store.queryParser}
+                                                query={this.store.searchClauses}
+                                                onSearch={query =>
+                                                    (this.store.searchClauses = query)
+                                                }
+                                            />
+                                        )}
+                                    </div>
                                 </div>
                             );
                         }}

--- a/src/shared/components/query/DataTypeFilter.spec.ts
+++ b/src/shared/components/query/DataTypeFilter.spec.ts
@@ -1,0 +1,263 @@
+import { CancerStudy } from 'cbioportal-ts-api-client';
+import {
+    getSampleCountsPerFilter,
+    getStudyCountPerFilter,
+} from 'shared/components/query/filteredSearch/StudySearchControls';
+
+describe('DataTypeFilter', () => {
+    it('Calculate the number of samples with a specific data type', () => {
+        const studies: CancerStudy[] = [
+            {
+                allSampleCount: 1500,
+                cancerType: {
+                    cancerTypeId: 'biliary_tract',
+                    dedicatedColor: 'Green',
+                    name: 'Biliary Tract',
+                    parent: 'tissue',
+                    shortName: 'BILIARY_TRACT',
+                },
+                cancerTypeId: 'test1',
+                citation: 'No citation',
+                cnaSampleCount: 250,
+                completeSampleCount: 1500,
+                description: 'Test 1 study for data filter',
+                groups: '',
+                importDate: '',
+                massSpectrometrySampleCount: 15,
+                methylationHm27SampleCount: 49,
+                miRnaSampleCount: 650,
+                mrnaMicroarraySampleCount: 750,
+                mrnaRnaSeqSampleCount: 1500,
+                mrnaRnaSeqV2SampleCount: 0,
+                name: 'Test study 1',
+                pmid: '',
+                publicStudy: false,
+                readPermission: true,
+                referenceGenome: 'hg19',
+                rppaSampleCount: 0,
+                sequencedSampleCount: 240,
+                status: 1,
+                studyId: 'teststudy1',
+                treatmentCount: 45,
+            },
+            {
+                allSampleCount: 1500,
+                cancerType: {
+                    cancerTypeId: 'biliary_tract',
+                    dedicatedColor: 'Green',
+                    name: 'Biliary Tract',
+                    parent: 'tissue',
+                    shortName: 'BILIARY_TRACT',
+                },
+                cancerTypeId: 'test2',
+                citation: 'No citation',
+                cnaSampleCount: 160,
+                completeSampleCount: 1500,
+                description: 'Test 2 study for data filter',
+                groups: '',
+                importDate: '',
+                massSpectrometrySampleCount: 160,
+                methylationHm27SampleCount: 150,
+                miRnaSampleCount: 67,
+                mrnaMicroarraySampleCount: 750,
+                mrnaRnaSeqSampleCount: 1500,
+                mrnaRnaSeqV2SampleCount: 0,
+                name: 'Test study 2',
+                pmid: '',
+                publicStudy: false,
+                readPermission: true,
+                referenceGenome: 'hg19',
+                rppaSampleCount: 10,
+                sequencedSampleCount: 100,
+                status: 1,
+                studyId: 'teststudy2',
+                treatmentCount: 45,
+            },
+        ];
+
+        const filter = [
+            {
+                id: 'cnaSampleCount',
+                name: 'CNA',
+                checked: false,
+            },
+            {
+                id: 'treatmentCount',
+                name: 'Treatment',
+                checked: false,
+            },
+        ];
+        const testResultCNA = getSampleCountsPerFilter(filter, studies);
+        expect(testResultCNA).toStrictEqual([410, 90]);
+    });
+    it('Calculate the number of studies with a specific data type', () => {
+        const studies: CancerStudy[] = [
+            {
+                allSampleCount: 1500,
+                cancerType: {
+                    cancerTypeId: 'biliary_tract',
+                    dedicatedColor: 'Green',
+                    name: 'Biliary Tract',
+                    parent: 'tissue',
+                    shortName: 'BILIARY_TRACT',
+                },
+                cancerTypeId: 'test1',
+                citation: 'No citation',
+                cnaSampleCount: 250,
+                completeSampleCount: 1500,
+                description: 'Test 1 study for data filter',
+                groups: '',
+                importDate: '',
+                massSpectrometrySampleCount: 15,
+                methylationHm27SampleCount: 49,
+                miRnaSampleCount: 650,
+                mrnaMicroarraySampleCount: 750,
+                mrnaRnaSeqSampleCount: 1500,
+                mrnaRnaSeqV2SampleCount: 0,
+                name: 'Test study 1',
+                pmid: '',
+                publicStudy: false,
+                readPermission: true,
+                referenceGenome: 'hg19',
+                rppaSampleCount: 0,
+                sequencedSampleCount: 240,
+                status: 1,
+                studyId: 'teststudy1',
+                treatmentCount: 45,
+            },
+            {
+                allSampleCount: 1500,
+                cancerType: {
+                    cancerTypeId: 'biliary_tract',
+                    dedicatedColor: 'Green',
+                    name: 'Biliary Tract',
+                    parent: 'tissue',
+                    shortName: 'BILIARY_TRACT',
+                },
+                cancerTypeId: 'test2',
+                citation: 'No citation',
+                cnaSampleCount: 160,
+                completeSampleCount: 1500,
+                description: 'Test 2 study for data filter',
+                groups: '',
+                importDate: '',
+                massSpectrometrySampleCount: 160,
+                methylationHm27SampleCount: 150,
+                miRnaSampleCount: 67,
+                mrnaMicroarraySampleCount: 750,
+                mrnaRnaSeqSampleCount: 1500,
+                mrnaRnaSeqV2SampleCount: 0,
+                name: 'Test study 2',
+                pmid: '',
+                publicStudy: false,
+                readPermission: true,
+                referenceGenome: 'hg19',
+                rppaSampleCount: 10,
+                sequencedSampleCount: 100,
+                status: 1,
+                studyId: 'teststudy2',
+                treatmentCount: 45,
+            },
+        ];
+
+        const filter = [
+            {
+                id: 'cnaSampleCount',
+                name: 'CNA',
+                checked: false,
+            },
+            {
+                id: 'treatmentCount',
+                name: 'Treatment',
+                checked: false,
+            },
+        ];
+        const testResultStudyCount = getStudyCountPerFilter(filter, studies);
+        expect(testResultStudyCount).toStrictEqual([2, 2]);
+    });
+    it('Calculate the number of studies with a specific data type not measured', () => {
+        const studies: CancerStudy[] = [
+            {
+                allSampleCount: 1500,
+                cancerType: {
+                    cancerTypeId: 'biliary_tract',
+                    dedicatedColor: 'Green',
+                    name: 'Biliary Tract',
+                    parent: 'tissue',
+                    shortName: 'BILIARY_TRACT',
+                },
+                cancerTypeId: 'test1',
+                citation: 'No citation',
+                cnaSampleCount: 250,
+                completeSampleCount: 1500,
+                description: 'Test 1 study for data filter',
+                groups: '',
+                importDate: '',
+                massSpectrometrySampleCount: 15,
+                methylationHm27SampleCount: 49,
+                miRnaSampleCount: 650,
+                mrnaMicroarraySampleCount: 750,
+                mrnaRnaSeqSampleCount: 1500,
+                mrnaRnaSeqV2SampleCount: 0,
+                name: 'Test study 1',
+                pmid: '',
+                publicStudy: false,
+                readPermission: true,
+                referenceGenome: 'hg19',
+                rppaSampleCount: 0,
+                sequencedSampleCount: 240,
+                status: 1,
+                studyId: 'teststudy1',
+                treatmentCount: 45,
+            },
+            {
+                allSampleCount: 1500,
+                cancerType: {
+                    cancerTypeId: 'biliary_tract',
+                    dedicatedColor: 'Green',
+                    name: 'Biliary Tract',
+                    parent: 'tissue',
+                    shortName: 'BILIARY_TRACT',
+                },
+                cancerTypeId: 'test2',
+                citation: 'No citation',
+                cnaSampleCount: 0,
+                completeSampleCount: 1500,
+                description: 'Test 2 study for data filter',
+                groups: '',
+                importDate: '',
+                massSpectrometrySampleCount: 160,
+                methylationHm27SampleCount: 150,
+                miRnaSampleCount: 67,
+                mrnaMicroarraySampleCount: 750,
+                mrnaRnaSeqSampleCount: 1500,
+                mrnaRnaSeqV2SampleCount: 0,
+                name: 'Test study 2',
+                pmid: '',
+                publicStudy: false,
+                readPermission: true,
+                referenceGenome: 'hg19',
+                rppaSampleCount: 10,
+                sequencedSampleCount: 100,
+                status: 1,
+                studyId: 'teststudy2',
+                treatmentCount: 45,
+            },
+        ];
+
+        const filter = [
+            {
+                id: 'cnaSampleCount',
+                name: 'CNA',
+                checked: false,
+            },
+            {
+                id: 'treatmentCount',
+                name: 'Treatment',
+                checked: false,
+            },
+        ];
+        const testResultStudyCount = getStudyCountPerFilter(filter, studies);
+        expect(testResultStudyCount).toStrictEqual([1, 2]);
+    });
+});

--- a/src/shared/components/query/DataTypeFilter.tsx
+++ b/src/shared/components/query/DataTypeFilter.tsx
@@ -70,9 +70,9 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                             width: 350,
                         }}
                     >
-                        <h5 style={{ paddingTop: 8 }}>
+                        <label style={{ paddingTop: 8 }}>
                             Filter to studies with selected data types
-                        </h5>
+                        </label>
                         <label
                             style={{
                                 color: '#3786C2',

--- a/src/shared/components/query/DataTypeFilter.tsx
+++ b/src/shared/components/query/DataTypeFilter.tsx
@@ -78,7 +78,7 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                                 color: '#3786C2',
                                 paddingTop: 5,
                                 float: 'left',
-                                width: '65%',
+                                width: 220,
                             }}
                         >
                             Data type
@@ -86,11 +86,11 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                         <label
                             style={{
                                 paddingTop: 6,
-                                paddingRight: 10,
+                                paddingRight: 15,
                                 color: '#999',
                                 textAlign: 'right',
                                 float: 'left',
-                                width: '15%',
+                                width: 55,
                                 display: 'inline-block',
                             }}
                         >
@@ -100,9 +100,10 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                             style={{
                                 paddingTop: 6,
                                 color: '#999',
+                                marginRight: 2,
                                 textAlign: 'right',
                                 float: 'left',
-                                width: '15%',
+                                width: 55,
                                 display: 'inline-block',
                             }}
                         >
@@ -115,7 +116,7 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                                         style={{
                                             paddingTop: 5,
                                             float: 'left',
-                                            width: '65%',
+                                            width: 220,
                                         }}
                                     >
                                         <input
@@ -140,7 +141,7 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                                             paddingRight: 10,
                                             textAlign: 'right',
                                             float: 'left',
-                                            width: '15%',
+                                            width: 55,
                                             display: 'inline-block',
                                         }}
                                     >
@@ -150,7 +151,7 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                                         style={{
                                             paddingTop: 5,
                                             float: 'left',
-                                            width: '15%',
+                                            width: 55,
                                             color: '#999',
                                             marginRight: 2,
                                             textAlign: 'right',

--- a/src/shared/components/query/DataTypeFilter.tsx
+++ b/src/shared/components/query/DataTypeFilter.tsx
@@ -1,0 +1,180 @@
+import * as React from 'react';
+import { FunctionComponent } from 'react';
+import { Dropdown } from 'react-bootstrap';
+import { DropdownToggleProps } from 'react-bootstrap/lib/DropdownToggle';
+
+import { DropdownMenuProps } from 'react-bootstrap/lib/DropdownMenu';
+import { QueryStore } from 'shared/components/query/QueryStore';
+
+export interface IFilterDef {
+    id: string;
+    name: string;
+    checked: boolean;
+}
+
+export type IDataTypeFilterProps = {
+    dataFilter: string[];
+    isChecked: boolean;
+    buttonText: string | JSX.Element;
+    dataFilterActive?: IFilterDef[];
+    store: QueryStore;
+    samplePerFilter: number[];
+    studyPerFilter: number[];
+};
+
+export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => {
+    return (
+        <div data-test="dropdown-data-type-filter" style={{ paddingRight: 5 }}>
+            <div className="input-group input-group-sm input-group-toggle">
+                <Dropdown id="dropdown-study-data-filter">
+                    <Dropdown.Toggle
+                        {...({
+                            rootCloseEvent: 'click',
+                        } as DropdownToggleProps)}
+                        className="btn-sm"
+                        style={{
+                            minWidth: 118,
+                            maxWidth: 118,
+                            textAlign: 'right',
+                            float: 'right',
+                            paddingRight: 5,
+                        }}
+                    >
+                        <span
+                            style={{
+                                float: 'left',
+                                paddingLeft: 0,
+                                marginLeft: 0,
+                            }}
+                        >
+                            {props.buttonText}
+                        </span>
+                        {props.store.dataTypeFilters!.length > 0 && (
+                            <span
+                                className="oncoprintDropdownCount"
+                                style={{ marginLeft: 5 }}
+                            >
+                                {props.store.dataTypeFilters!.length} /{' '}
+                                {props.dataFilterActive!.length}
+                            </span>
+                        )}
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu
+                        {...({ bsRole: 'menu' } as DropdownMenuProps)}
+                        style={{
+                            paddingLeft: 10,
+                            overflow: 'auto',
+                            maxHeight: 300,
+                            whiteSpace: 'nowrap',
+                            paddingRight: 1,
+                            width: 350,
+                        }}
+                    >
+                        <h5 style={{ paddingTop: 8 }}>
+                            Filter to studies with selected data types
+                        </h5>
+                        <label
+                            style={{
+                                color: '#3786C2',
+                                paddingTop: 5,
+                                float: 'left',
+                                width: '65%',
+                            }}
+                        >
+                            Data type
+                        </label>
+                        <label
+                            style={{
+                                paddingTop: 6,
+                                paddingRight: 10,
+                                marginRight: 3,
+                                color: '#999',
+                                textAlign: 'right',
+                                float: 'left',
+                                width: '15%',
+                                display: 'inline-block',
+                            }}
+                        >
+                            Studies
+                        </label>
+                        <label
+                            style={{
+                                paddingTop: 6,
+                                color: '#999',
+                                textAlign: 'right',
+                                float: 'left',
+                                width: '15%',
+                                display: 'inline-block',
+                            }}
+                        >
+                            Samples
+                        </label>
+                        {props.dataFilterActive!.map((type, i) => {
+                            return (
+                                <div style={{ display: 'inline' }}>
+                                    <label
+                                        style={{
+                                            paddingTop: 5,
+                                            float: 'left',
+                                            width: '65%',
+                                        }}
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            style={{ marginRight: 2 }}
+                                            onClick={() => {
+                                                type.checked = !type.checked;
+                                                props.store.dataTypeFilters = createDataTypeUpdate(
+                                                    props.dataFilterActive!
+                                                );
+                                            }}
+                                        />
+                                        {}
+                                        <span style={{ paddingLeft: 5 }}>
+                                            {type.name}
+                                        </span>
+                                    </label>
+                                    <label
+                                        style={{
+                                            paddingTop: 5,
+                                            color: '#999',
+                                            paddingRight: 10,
+                                            marginRight: 3,
+                                            textAlign: 'right',
+                                            float: 'left',
+                                            width: '15%',
+                                            display: 'inline-block',
+                                        }}
+                                    >
+                                        {props.studyPerFilter![i]}
+                                    </label>
+                                    <label
+                                        style={{
+                                            paddingTop: 5,
+                                            float: 'left',
+                                            width: '15%',
+                                            color: '#999',
+                                            marginRight: 2,
+                                            textAlign: 'right',
+                                            display: 'inline-block',
+                                        }}
+                                    >
+                                        {props.samplePerFilter![i]}
+                                    </label>
+                                </div>
+                            );
+                        })}
+                    </Dropdown.Menu>
+                </Dropdown>
+            </div>
+        </div>
+    );
+};
+
+export function createDataTypeUpdate(allFilters: IFilterDef[]): string[] {
+    const toAdd: string[] = [];
+    allFilters.map((subDataFilter: IFilterDef) =>
+        subDataFilter.checked ? toAdd.push(subDataFilter.id) : ''
+    );
+    return toAdd;
+}

--- a/src/shared/components/query/DataTypeFilter.tsx
+++ b/src/shared/components/query/DataTypeFilter.tsx
@@ -71,7 +71,7 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                         }}
                     >
                         <label style={{ paddingTop: 8 }}>
-                            Filter to studies with selected data types
+                            Filter studies with selected data types
                         </label>
                         <label
                             style={{

--- a/src/shared/components/query/DataTypeFilter.tsx
+++ b/src/shared/components/query/DataTypeFilter.tsx
@@ -87,7 +87,6 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                             style={{
                                 paddingTop: 6,
                                 paddingRight: 10,
-                                marginRight: 3,
                                 color: '#999',
                                 textAlign: 'right',
                                 float: 'left',
@@ -139,7 +138,6 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                                             paddingTop: 5,
                                             color: '#999',
                                             paddingRight: 10,
-                                            marginRight: 3,
                                             textAlign: 'right',
                                             float: 'left',
                                             width: '15%',

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -291,8 +291,14 @@ export class QueryStore {
 
     @observable.ref searchClauses: SearchClause[] = [];
 
+    @observable.ref dataTypeFilters: string[] = [];
+
     @computed get searchText(): string {
         return toQueryString(this.searchClauses);
+    }
+
+    @computed get filterType(): string[] {
+        return this.dataTypeFilters;
     }
 
     @observable private _allSelectedStudyIds: ObservableMap<
@@ -632,7 +638,7 @@ export class QueryStore {
     );
 
     readonly cancerStudies = remoteData(
-        client.getAllStudiesUsingGET({ projection: 'SUMMARY' }),
+        client.getAllStudiesUsingGET({ projection: 'DETAILED' }),
         []
     );
 
@@ -2222,6 +2228,10 @@ export class QueryStore {
     @action setSearchText(searchText: string) {
         this.clearSelectedCancerType();
         this.searchClauses = this.queryParser.parseSearchQuery(searchText);
+    }
+
+    @action setFilterType(filter: string) {
+        this.dataTypeFilters.push(filter);
     }
 
     @action clearSelectedCancerType() {

--- a/src/shared/components/query/StudyListLogic.ts
+++ b/src/shared/components/query/StudyListLogic.ts
@@ -15,7 +15,6 @@ import { cached } from 'mobxpromise';
 import { ServerConfigHelpers } from '../../../config/config';
 import memoize from 'memoize-weak-decorator';
 import { SearchResult } from 'shared/components/query/filteredSearch/SearchClause';
-
 export const PAN_CAN_SIGNATURE = 'pan_can_atlas';
 
 export default class StudyListLogic {
@@ -45,7 +44,6 @@ export default class StudyListLogic {
     @cached @computed get map_node_filterBySearchText() {
         // first compute individual node match results
         let map_node_searchResult = new Map<CancerTreeNode, SearchResult>();
-
         for (const [
             study,
             meta,
@@ -59,11 +57,9 @@ export default class StudyListLogic {
                 )
             );
         }
-
         let map_node_filter = new Map<CancerTreeNode, boolean>();
         for (let [node, meta] of this.store.treeData.map_node_meta.entries()) {
             if (map_node_filter.has(node)) continue;
-
             let filter = false;
             for (let item of [
                 node,
@@ -89,6 +85,51 @@ export default class StudyListLogic {
                         map_node_filter.set(cancerType, true);
         }
         return map_node_filter;
+    }
+
+    @cached @computed get map_node_filtered_by_datatype() {
+        // Create a map with all the studies and set all to true (no filter applied)
+        let map_node_filter = new Map<CancerTreeNode, boolean>();
+        for (let node of this.store.treeData.map_node_meta.keys()) {
+            map_node_filter.set(node, true);
+        }
+        let map_node_dataTypeResult = new Map<CancerTreeNode, boolean>();
+        for (let [node, meta] of this.store.treeData.map_node_meta.entries()) {
+            if (this.store.dataTypeFilters.length == 0) {
+                map_node_dataTypeResult.set(node, true);
+            } else {
+                let nodeStudy = this.store.cancerStudies.result.filter(
+                    study => study.name === node.name
+                );
+                let filterValue: boolean[] = [];
+                const keys = Object.keys(node) as (keyof typeof node)[];
+                const filterToApply = this.store.dataTypeFilters;
+                for (const filter in filterToApply) {
+                    for (const x in keys) {
+                        if (keys[x] === filterToApply[filter]) {
+                            Object.values(node)[x]! > 0
+                                ? filterValue.push(true)
+                                : filterValue.push(false);
+                        }
+                    }
+                }
+                const filterBoolean =
+                    filterValue.length == 0
+                        ? false
+                        : filterValue.every(v => v === true);
+                map_node_dataTypeResult.set(node, filterBoolean);
+
+                // include ancestors of matching studies
+                if (filterBoolean && !meta.isCancerType)
+                    for (let cancerTypes of [
+                        meta.ancestors,
+                        meta.priorityCategories,
+                    ])
+                        for (let cancerType of cancerTypes)
+                            map_node_dataTypeResult.set(cancerType, true);
+            }
+        }
+        return map_node_dataTypeResult;
     }
 
     @cached @computed get map_node_filterBySelectedCancerTypes() {
@@ -144,6 +185,7 @@ export default class StudyListLogic {
             this.map_node_filterByDepth,
             this.map_node_filterBySearchText,
             this.map_node_filterBySelectedCancerTypes,
+            this.map_node_filtered_by_datatype,
         ]);
     }
 
@@ -151,6 +193,7 @@ export default class StudyListLogic {
         return new FilteredCancerTreeView(this.store, [
             this.map_node_filterByDepth,
             this.map_node_filterBySearchText,
+            this.map_node_filtered_by_datatype,
         ]);
     }
 
@@ -183,7 +226,8 @@ export default class StudyListLogic {
     isHighlighted(node: CancerTreeNode): boolean {
         return (
             !!this.store.searchText &&
-            !!this.map_node_filterBySearchText.get(node)
+            !!this.map_node_filterBySearchText.get(node) &&
+            !!this.map_node_filtered_by_datatype.get(node)
         );
     }
 }
@@ -353,7 +397,8 @@ export class FilteredCancerTreeView {
     @computed get isFiltered() {
         return (
             this.store.selectedCancerTypeIds.length > 0 ||
-            this.store.searchText.length > 0
+            this.store.searchText.length > 0 ||
+            this.store.dataTypeFilters.length > 0
         );
     }
 

--- a/src/shared/components/query/filteredSearch/Phrase.tsx
+++ b/src/shared/components/query/filteredSearch/Phrase.tsx
@@ -1,4 +1,3 @@
-import { CancerTreeNode } from 'shared/components/query/CancerStudyTreeData';
 import {
     FullTextSearchFields,
     FullTextSearchNode,
@@ -8,7 +7,6 @@ import {
     FILTER_SEPARATOR,
     FILTER_VALUE_SEPARATOR,
 } from 'shared/components/query/filteredSearch/SearchClause';
-import { CancerStudy } from 'cbioportal-ts-api-client';
 
 /**
  * Phrase and associated fields

--- a/src/shared/components/query/filteredSearch/StudySearchControls.tsx
+++ b/src/shared/components/query/filteredSearch/StudySearchControls.tsx
@@ -7,6 +7,7 @@ import {
 } from 'shared/components/query/filteredSearch/SearchClause';
 import { QueryParser } from 'shared/lib/query/QueryParser';
 import { FilterFormField } from 'shared/components/query/filteredSearch/field/FilterFormField';
+import { CancerStudy } from 'cbioportal-ts-api-client';
 
 export type FilteredSearchDropdownFormProps = {
     query: SearchClause[];
@@ -58,4 +59,51 @@ export const StudySearchControls: FunctionComponent<FilteredSearchDropdownFormPr
  */
 function showFilter(filter: CancerTreeSearchFilter): boolean {
     return filter.form.options.length >= 2;
+}
+
+export function getSampleCountsPerFilter(
+    studyFilters: { checked: boolean; id: string; name: string }[],
+    studies: CancerStudy[]
+): number[] {
+    const countArray: number[] = studyFilters
+        .map(item => item.id)
+        .map(filter => {
+            const countPerFilter: number[] = [];
+            studies.map(study => {
+                const keys = Object.keys(study) as (keyof typeof study)[];
+                for (const keyIndex in keys) {
+                    if (keys[keyIndex] == filter) {
+                        countPerFilter.push(
+                            Object.values(study)[keyIndex] as number
+                        );
+                    }
+                }
+            });
+            return countPerFilter.reduce((a, b) => a + b, 0);
+        });
+    return countArray;
+}
+
+export function getStudyCountPerFilter(
+    studyFilters: { checked: boolean; id: string; name: string }[],
+    studies: CancerStudy[]
+): number[] {
+    const countArray: number[] = studyFilters
+        .map(item => item.id)
+        .map(filter => {
+            let countPerFilter: number = 0;
+            studies.map(study => {
+                const keys = Object.keys(study) as (keyof typeof study)[];
+                for (const keyIndex in keys) {
+                    if (
+                        keys[keyIndex] == filter &&
+                        Object.values(study)[keyIndex] > 0
+                    ) {
+                        countPerFilter += 1;
+                    }
+                }
+            });
+            return countPerFilter;
+        });
+    return countArray;
 }

--- a/src/shared/components/query/filteredSearch/field/CheckboxFilterField.tsx
+++ b/src/shared/components/query/filteredSearch/field/CheckboxFilterField.tsx
@@ -22,14 +22,12 @@ export type CheckboxFilterField = {
 
 export const FilterCheckbox: FunctionComponent<FieldProps> = props => {
     const options = props.filter.form.options;
-
     if (options.length < 2) {
         return null;
     }
 
     const prefix = props.filter.phrasePrefix || '';
     let checkedOptions: string[] = [];
-
     const relevantClauses: SearchClause[] = [];
     const toRemove: ListPhrase[] = [];
     props.query.forEach(clause => {
@@ -41,14 +39,12 @@ export const FilterCheckbox: FunctionComponent<FieldProps> = props => {
             toRemove.push(phraseToRemove as ListPhrase);
         }
     });
-
     for (const option of options) {
         const isChecked = isOptionChecked(option, relevantClauses);
         if (isChecked) {
             checkedOptions.push(option);
         }
     }
-
     return (
         <div className="filter-checkbox">
             <h5>{props.filter.form.label}</h5>
@@ -97,7 +93,6 @@ export const FilterCheckbox: FunctionComponent<FieldProps> = props => {
             </div>
         </div>
     );
-
     function updatePhrases(option: string, checked?: boolean) {
         if (checked) {
             checkedOptions.push(option);
@@ -146,7 +141,6 @@ export function createQueryUpdate(
 ): QueryUpdate {
     let toAdd: SearchClause[];
     const toRemove = phrasesToRemove;
-
     const options = filter.form.options;
     const prefix = filter.phrasePrefix || '';
     const fields = filter.nodeFields;
@@ -154,13 +148,13 @@ export function createQueryUpdate(
     const onlyAnd = optionsToAdd.length === options.length;
     const onlyNot = !optionsToAdd.length;
     const moreAnd = optionsToAdd.length > options.length / 2;
-
     if (onlyAnd) {
         toAdd = [];
     } else if (onlyNot || moreAnd) {
         const phrase = options
             .filter(o => !optionsToAdd.includes(o))
             .join(FILTER_VALUE_SEPARATOR);
+
         toAdd = [new NotSearchClause(createListPhrase(prefix, phrase, fields))];
     } else {
         const phrase = optionsToAdd.join(FILTER_VALUE_SEPARATOR);

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -104,10 +104,8 @@ export default class StudyList extends QueryStoreComponent<
         let childStudyIds = this.logic.cancerTypeListView
             .getDescendantCancerStudies(cancerType)
             .map(study => study.studyId);
-
         let heading: JSX.Element | undefined;
         let indentArrow: JSX.Element | undefined;
-
         if (cancerType != this.rootCancerType) {
             let liClassName = classNames(
                 styles.CancerType,


### PR DESCRIPTION
Currently, users can only filter their data sets by reference genome but not by available data types. Users have to be either familiar with the data types in a study or click on a study to check whether the data types of interest are available.

This PR introduces an extension to the study search menu by introducing filters related to the available data types in each study. The data type filter will be an AND filter, which is different from the current reference genome filter (OR filter).

Therefore, the filter icon from the patient view page has been reused (with a label that mentions the AND filter).
![Screenshot_DataTypeFile](https://github.com/cBioPortal/cbioportal-frontend/assets/33220871/d6d98af7-65e6-4fdb-a67f-e2c25257a311)

The following tests have been added for the AND filter behavior to `Phrase.spec.tsx`:
- Should return a match when field has measured samples
- Should return no match when field has no measured samples and match in phraselist
- Should return match when two field have measured samples
- Should return no match when field has measured samples and one field having no samples
