### PR TITLE
Fix search issue in SV table when site1 gene is missing

### DIFF
--- a/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
+++ b/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
@@ -145,7 +145,9 @@ export default class StructuralVariantTableWrapper extends React.Component<
                     filterString: string,
                     filterStringUpper: string
                 ) => {
-                    return d[0].site1HugoSymbol.indexOf(filterStringUpper) > -1;
+                    return (
+                        d[0].site1HugoSymbol?.indexOf(filterStringUpper) > -1
+                    );
                 },
                 download: (d: StructuralVariant[]) => d[0].site1HugoSymbol,
                 sortBy: (d: StructuralVariant[]) => d[0].site1HugoSymbol,


### PR DESCRIPTION
Fixes [SV tab crashes when searching and gene1 is missing](https://github.com/cBioPortal/cbioportal/issues/10417)