### PR TITLE
Genie portal timeline: tweak track ordering for assessment tracks

### DIFF
--- a/src/pages/patientView/timeline/timeline_helpers.tsx
+++ b/src/pages/patientView/timeline/timeline_helpers.tsx
@@ -143,7 +143,9 @@ export function configureGenieTimeline(baseConfig: ITimelineConfig) {
         'Lab_test',
         'Status',
         'IMAGING',
+        'MEDONC',
         'Med Onc Assessment',
+        'Pathology',
     ];
 
     const legend: TimelineLegendItem[] = [


### PR DESCRIPTION
After fix the two assessment tracks are paired:
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/186521/2fedeed6-3611-49a8-a215-2d4da4eb3424)
