### PR TITLE
Fix incorrect oncokb data and cancer type label used in mutations table

### DIFF
--- a/src/pages/groupComparison/GroupComparisonMutationMapper.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationMapper.tsx
@@ -59,6 +59,9 @@ interface IGroupComparisonMutationMapperProps extends IMutationMapperProps {
     uniqueSampleKeyToTumorType: {
         [uniqueSampleKey: string]: string;
     };
+    uniqueSampleKeyToCancerType: {
+        [uniqueSampleKey: string]: string;
+    };
 }
 
 @observer
@@ -95,6 +98,9 @@ export default class GroupComparisonMutationMapper extends MutationMapper<
                 uniqueSampleKeyToTumorType={
                     this.props.uniqueSampleKeyToTumorType
                 }
+                uniqueSampleKeyToCancerType={
+                    this.props.uniqueSampleKeyToCancerType
+                }
                 oncoKbCancerGenes={this.props.store.oncoKbCancerGenes}
                 pubMedCache={this.props.pubMedCache}
                 genomeNexusCache={this.props.genomeNexusCache}
@@ -112,6 +118,9 @@ export default class GroupComparisonMutationMapper extends MutationMapper<
                     this.props.store.indexedMyVariantInfoAnnotations
                 }
                 oncoKbData={this.props.store.oncoKbData}
+                oncoKbDataForCancerType={
+                    this.props.store.oncoKbDataForCancerType
+                }
                 oncoKbDataForUnknownPrimary={
                     this.props.store.oncoKbDataForUnknownPrimary
                 }

--- a/src/pages/groupComparison/GroupComparisonMutationMapperWrapper.tsx
+++ b/src/pages/groupComparison/GroupComparisonMutationMapperWrapper.tsx
@@ -54,6 +54,8 @@ export default class GroupComparisonMutationMapperWrapper extends React.Componen
                 filterMutationsBySelectedTranscript: true,
                 uniqueSampleKeyToTumorType: this.props.store
                     .uniqueSampleKeyToTumorType.result,
+                uniqueSampleKeyToCancerType: this.props.store
+                    .uniqueSampleKeyToCancerType.result,
             }
         );
         return store;
@@ -226,6 +228,10 @@ export default class GroupComparisonMutationMapperWrapper extends React.Componen
                             }
                             uniqueSampleKeyToTumorType={
                                 this.props.store.uniqueSampleKeyToTumorType
+                                    .result!
+                            }
+                            uniqueSampleKeyToCancerType={
+                                this.props.store.uniqueSampleKeyToCancerType
                                     .result!
                             }
                         />

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -86,6 +86,7 @@ import { getDefaultExpectedAltCopiesColumnDefinition } from 'shared/components/m
 export interface IMutationTableProps {
     studyIdToStudy?: { [studyId: string]: CancerStudy };
     uniqueSampleKeyToTumorType?: { [uniqueSampleKey: string]: string };
+    uniqueSampleKeyToCancerType?: { [uniqueSampleKey: string]: string };
     molecularProfileIdToMolecularProfile?: {
         [molecularProfileId: string]: MolecularProfile;
     };
@@ -114,6 +115,7 @@ export interface IMutationTableProps {
     >;
     cosmicData?: ICosmicData;
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
+    oncoKbDataForCancerType?: RemoteData<IOncoKbData | Error | undefined>;
     oncoKbDataForUnknownPrimary?: RemoteData<IOncoKbData | Error | undefined>;
     usingPublicOncoKbInstance: boolean;
     mergeOncoKbIcons?: boolean;
@@ -333,6 +335,28 @@ export default class MutationTable<
         // first, try to get it from uniqueSampleKeyToTumorType map
         if (this.props.uniqueSampleKeyToTumorType) {
             return this.props.uniqueSampleKeyToTumorType[
+                mutation.uniqueSampleKey
+            ];
+        }
+
+        // second, try the study cancer type
+        if (this.props.studyIdToStudy) {
+            const studyMetaData = this.props.studyIdToStudy[mutation.studyId];
+
+            if (studyMetaData.cancerTypeId !== 'mixed') {
+                return studyMetaData.cancerType.name;
+            }
+        }
+
+        // return Unknown, this should not happen...
+        return 'Unknown';
+    }
+
+    @autobind
+    protected resolveCancerType(mutation: Mutation) {
+        // first, try to get it from uniqueSampleKeyToCancerType map
+        if (this.props.uniqueSampleKeyToCancerType) {
+            return this.props.uniqueSampleKeyToCancerType[
                 mutation.uniqueSampleKey
             ];
         }

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1152,21 +1152,6 @@ export function generateUniqueSampleKeyToTumorTypeMap(
                 }
             );
         }
-
-        // // first priority is CANCER_TYPE_DETAILED in clinical data
-        // _.each(clinicalDataForSamples.result, (clinicalData: ClinicalData) => {
-        //     if (clinicalData.clinicalAttributeId === 'CANCER_TYPE_DETAILED') {
-        //         map[clinicalData.uniqueSampleKey] = clinicalData.value;
-        //     }
-        // });
-
-        // // second priority is CANCER_TYPE in clinical data
-        // _.each(clinicalDataForSamples.result, (clinicalData: ClinicalData) => {
-        //     // update map with CANCER_TYPE value only if it is not already updated
-        //     if (clinicalData.clinicalAttributeId === "CANCER_TYPE" && map[clinicalData.uniqueSampleKey] === undefined) {
-        //         map[clinicalData.uniqueSampleKey] = clinicalData.value;
-        //     }
-        // });
     }
 
     // last resort: fall back to the study cancer type

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -1122,17 +1122,43 @@ export function findMrnaRankMolecularProfileId(
 export function generateUniqueSampleKeyToTumorTypeMap(
     clinicalDataForSamples: MobxPromise<ClinicalData[]>,
     studies?: MobxPromise<CancerStudy[]>,
-    samples?: MobxPromise<Sample[]>
+    samples?: MobxPromise<Sample[]>,
+    useCancerTypeAttribute?: boolean
 ): { [sampleId: string]: string } {
     const map: { [sampleId: string]: string } = {};
 
     if (clinicalDataForSamples.result) {
-        // first priority is CANCER_TYPE_DETAILED in clinical data
-        _.each(clinicalDataForSamples.result, (clinicalData: ClinicalData) => {
-            if (clinicalData.clinicalAttributeId === 'CANCER_TYPE_DETAILED') {
-                map[clinicalData.uniqueSampleKey] = clinicalData.value;
-            }
-        });
+        // if useCancerTypeAttribute is true, use CANCER_TYPE in clinical data
+        // else, use CANCER_TYPE_DETAILED in clinical data
+        if (useCancerTypeAttribute) {
+            _.each(
+                clinicalDataForSamples.result,
+                (clinicalData: ClinicalData) => {
+                    if (clinicalData.clinicalAttributeId === 'CANCER_TYPE') {
+                        map[clinicalData.uniqueSampleKey] = clinicalData.value;
+                    }
+                }
+            );
+        } else {
+            _.each(
+                clinicalDataForSamples.result,
+                (clinicalData: ClinicalData) => {
+                    if (
+                        clinicalData.clinicalAttributeId ===
+                        'CANCER_TYPE_DETAILED'
+                    ) {
+                        map[clinicalData.uniqueSampleKey] = clinicalData.value;
+                    }
+                }
+            );
+        }
+
+        // // first priority is CANCER_TYPE_DETAILED in clinical data
+        // _.each(clinicalDataForSamples.result, (clinicalData: ClinicalData) => {
+        //     if (clinicalData.clinicalAttributeId === 'CANCER_TYPE_DETAILED') {
+        //         map[clinicalData.uniqueSampleKey] = clinicalData.value;
+        //     }
+        // });
 
         // // second priority is CANCER_TYPE in clinical data
         // _.each(clinicalDataForSamples.result, (clinicalData: ClinicalData) => {

--- a/src/shared/lib/comparison/AnalysisStore.ts
+++ b/src/shared/lib/comparison/AnalysisStore.ts
@@ -344,6 +344,26 @@ export default abstract class AnalysisStore {
         },
     });
 
+    readonly uniqueSampleKeyToCancerType = remoteData<{
+        [uniqueSampleKey: string]: string;
+    }>({
+        await: () => [
+            this.clinicalDataForSamples,
+            this.studiesForSamplesWithoutCancerTypeClinicalData,
+            this.samplesWithoutCancerTypeClinicalData,
+        ],
+        invoke: () => {
+            return Promise.resolve(
+                generateUniqueSampleKeyToTumorTypeMap(
+                    this.clinicalDataForSamples,
+                    this.studiesForSamplesWithoutCancerTypeClinicalData,
+                    this.samplesWithoutCancerTypeClinicalData,
+                    true
+                )
+            );
+        },
+    });
+
     readonly clinicalDataForSamples = remoteData<ClinicalData[]>(
         {
             await: () => [this.studies, this.samples],


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/10421

Currently, when `CANCER_TYPE_DETAILED` is the same for all mutations of a row in the table, it uses this to fetch the oncoKb data; otherwise, it uses "Cancer of Unknown Primary".

This fixes it so that if there are multiple `CANCER_TYPE_DETAILED` for mutations of a row, it checks if `CANCER_TYPE` is the same and if so, uses that to fetch the oncoKb data. If there are multiple `CANCER_TYPE` as well, then it uses "Cancer of Unknown Primary".
