### PR TITLE
Fix SVG download (prevent embedding of css)

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "sass": "^1.32.4",
     "sass-loader": "10.1.1",
     "sass-resources-loader": "^1.3.1",
-    "save-svg-as-png": "^1.4.6",
+    "save-svg-as-png": "^1.4.17",
     "script-loader": "^0.7.0",
     "seamless-immutable": "^7.0.1",
     "seedrandom": "^2.4.3",

--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -54,7 +54,7 @@
     "react-file-download": "^0.3.2",
     "react-overlays": "0.7.4",
     "react-select": "^3.0.4",
-    "save-svg-as-png": "^1.4.6",
+    "save-svg-as-png": "^1.4.17",
     "seamless-immutable": "^7.0.1",
     "superagent": "^3.8.3",
     "svg2pdf.js": "github:cbioportal/svg2pdf.js#v1.3.3-cbio-patch-1",

--- a/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
@@ -105,7 +105,7 @@ export default class DownloadControls extends React.Component<
 
     @autobind
     private download(
-        saveMethod: (svg: SVGElement, fileName: string) => void,
+        saveMethod: (svg: SVGElement, fileName: string, options?: any) => void,
         fileExtension: string
     ) {
         if (this.props.getSvg) {
@@ -116,14 +116,16 @@ export default class DownloadControls extends React.Component<
                         if (svg) {
                             saveMethod(
                                 svg,
-                                `${this.props.filename}.${fileExtension}`
+                                `${this.props.filename}.${fileExtension}`,
+                                { excludeCss: true }
                             );
                         }
                     });
                 } else {
                     saveMethod(
                         result,
-                        `${this.props.filename}.${fileExtension}`
+                        `${this.props.filename}.${fileExtension}`,
+                        { excludeCss: true }
                     );
                 }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21700,10 +21700,10 @@ sass@^1.32.4:
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
 
-save-svg-as-png@^1.4.6:
-  version "1.4.11"
-  resolved "https://registry.yarnpkg.com/save-svg-as-png/-/save-svg-as-png-1.4.11.tgz#b6a8d8c1d616716f0f1eb5fe303ca20badb75eea"
-  integrity sha512-NyMPYqdkyP6xX8pYh9rUJq/RmoZL6dlLrDeu9wmiziE9B3Kc1/c7TNCVZRMZa3snUz8M8K28eOSqzoOMKI79wA==
+save-svg-as-png@^1.4.17:
+  version "1.4.17"
+  resolved "https://registry.yarnpkg.com/save-svg-as-png/-/save-svg-as-png-1.4.17.tgz#294442002772a24f1db1bf8a2aaf7df4ab0cdc55"
+  integrity sha512-7QDaqJsVhdFPwviCxkgHiGm9omeaMBe1VKbHySWU6oFB2LtnGCcYS13eVoslUgq6VZC6Tjq/HddBd1K6p2PGpA==
 
 sax@>=0.6.0, sax@^1.1.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"


### PR DESCRIPTION
Our SVG exports were embedding extraneous CSS in SVG CDATA.  This was breaking latest version of Illustrator on import.  We needed to upgrade the SVG export library, which gives option to ignore css.