### PR TITLE
Refactor to allow pie and table charts to download both full and summ…

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
@@ -154,6 +154,16 @@ export default class DownloadControls extends React.Component<
         );
     }
 
+    private buildFileName(dataType?: string) {
+        return (
+            `${this.props.filename}${
+                typeof dataType === 'string' ? `.${dataType}` : ''
+            }` +
+            `.` +
+            `${this.props.dataExtension ? this.props.dataExtension : 'txt'}`
+        );
+    }
+
     @autobind
     private downloadData(dataType?: DataType) {
         if (this.props.getData) {
@@ -162,15 +172,7 @@ export default class DownloadControls extends React.Component<
                 if (isPromiseLike<string | null>(result)) {
                     result.then(data => {
                         if (data) {
-                            fileDownload(
-                                data,
-                                `${this.props.filename}.` +
-                                    `${
-                                        this.props.dataExtension
-                                            ? this.props.dataExtension
-                                            : 'txt'
-                                    }`
-                            );
+                            fileDownload(data, this.buildFileName(dataType));
                         }
                     });
                 } else {

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -240,7 +240,7 @@ export class StudySummaryTab extends React.Component<
                 }
                 props.onChangeChartType = this.handlers.onChangeChartType;
                 props.getData = (dataType?: DataType) =>
-                    this.store.getPieChartDataDownload(chartMeta, dataType);
+                    this.store.getChartDownloadableData(chartMeta, dataType);
                 props.downloadTypes = [
                     'Summary Data',
                     'Full Data',
@@ -374,9 +374,9 @@ export class StudySummaryTab extends React.Component<
                     props.onResetSelection = this.handlers.onValueSelection;
                 }
                 props.onChangeChartType = this.handlers.onChangeChartType;
-                props.getData = () =>
-                    this.store.getChartDownloadableData(chartMeta);
-                props.downloadTypes = ['Data'];
+                props.getData = dataType =>
+                    this.store.getChartDownloadableData(chartMeta, dataType);
+                props.downloadTypes = ['Summary Data', 'Full Data'];
                 break;
             }
             case ChartTypeEnum.MUTATED_GENES_TABLE: {


### PR DESCRIPTION
Product team noticed that we only allow Summary and Full download options on pie charts.  This generalizes the behavior.  Only question is are there some times of table chart which should not offer summary?  