### PR TITLE
Fix for endless loop preventing gene update using modify query interface (after direct load of results of view)

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "mobx-react-lite": "3.0.1",
     "mobx-react-router": "4.1.0",
     "mobx-utils": "6.0.1",
-    "mobxpromise": "github:cbioportal/mobxpromise#303db72588860bff0a6862a4f07a4e8a3578c94f",
+    "mobxpromise": "github:cbioportal/mobxpromise#c3429672eb39be54e54ce14a8636e8d843729db3",
     "numeral": "^2.0.6",
     "object-sizeof": "^1.2.0",
     "oncokb-frontend-commons": "^0.0.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16637,6 +16637,18 @@ mobx@^6.0.0:
   dependencies:
     mobx "^6.0.0"
 
+"mobxpromise@github:cbioportal/mobxpromise#b6cf1d86a72644b2521463c4db428408dbcb35b1":
+  version "2.0.1"
+  resolved "https://codeload.github.com/cbioportal/mobxpromise/tar.gz/b6cf1d86a72644b2521463c4db428408dbcb35b1"
+  dependencies:
+    mobx "^6.0.0"
+
+"mobxpromise@github:cbioportal/mobxpromise#c3429672eb39be54e54ce14a8636e8d843729db3":
+  version "2.0.1"
+  resolved "https://codeload.github.com/cbioportal/mobxpromise/tar.gz/c3429672eb39be54e54ce14a8636e8d843729db3"
+  dependencies:
+    mobx "^6.0.0"
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
If you try to change genes using modify query, the interface will not allow you to change genes (if results view has been loaded directly (not from homepage).
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/186521/595b7936-c989-4752-82a8-e067d55185b2)
