### PR TITLE
Paginated download of data for Clinical Data tab in Study View

### DIFF
--- a/env/master.sh
+++ b/env/master.sh
@@ -1,2 +1,2 @@
-export CBIOPORTAL_URL="${CBIOPORTAL_URL:-https://www.cbioportal.org}"
+export CBIOPORTAL_URL="${CBIOPORTAL_URL:-https://beta.cbioportal.org}"
 export GENOME_NEXUS_URL="${GENOME_NEXUS_URL:-https://www.genomenexus.org}"

--- a/env/master.sh
+++ b/env/master.sh
@@ -1,2 +1,3 @@
 export CBIOPORTAL_URL="${CBIOPORTAL_URL:-https://beta.cbioportal.org}"
 export GENOME_NEXUS_URL="${GENOME_NEXUS_URL:-https://www.genomenexus.org}"
+export BACKEND=cbioportal:demo-fix-clinical-table-sorting

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
@@ -381,7 +381,7 @@
           },
           {
             "default": 0,
-            "description": "Page number of the result list",
+            "description": "Page number of the result list. Zero represents the first page.",
             "format": "int32",
             "in": "query",
             "minimum": 0,
@@ -5910,19 +5910,18 @@
       "type": "object"
     },
     "SampleClinicalDataCollection": {
-      "type": "object",
       "properties": {
         "byUniqueSampleKey": {
-          "type": "object",
           "additionalProperties": {
-            "type": "array",
             "items": {
               "$ref": "#/definitions/ClinicalData"
-            }
-          }
+            },
+            "type": "array"
+          },
+          "type": "object"
         }
       },
-      "title": "SampleClinicalDataCollection"
+      "type": "object"
     },
     "SampleIdentifier": {
       "properties": {

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
@@ -428,7 +428,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/ClinicalDataCollection"
+              "$ref": "#/definitions/SampleClinicalDataCollection"
             }
           }
         },
@@ -3636,23 +3636,6 @@
       },
       "type": "object"
     },
-    "ClinicalDataCollection": {
-      "properties": {
-        "patientClinicalData": {
-          "items": {
-            "$ref": "#/definitions/ClinicalData"
-          },
-          "type": "array"
-        },
-        "sampleClinicalData": {
-          "items": {
-            "$ref": "#/definitions/ClinicalData"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
     "ClinicalDataCount": {
       "properties": {
         "count": {
@@ -5925,6 +5908,21 @@
         "studyId"
       ],
       "type": "object"
+    },
+    "SampleClinicalDataCollection": {
+      "type": "object",
+      "properties": {
+        "byUniqueSampleKey": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ClinicalData"
+            }
+          }
+        }
+      },
+      "title": "SampleClinicalDataCollection"
     },
     "SampleIdentifier": {
       "properties": {

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -2239,7 +2239,7 @@ export default class CBioPortalAPIInternal {
      * @method
      * @name CBioPortalAPIInternal#fetchClinicalDataClinicalTableUsingPOST
      * @param {integer} pageSize - Page size of the result list
-     * @param {integer} pageNumber - Page number of the result list
+     * @param {integer} pageNumber - Page number of the result list. Zero represents the first page.
      * @param {string} searchTerm - Search term to filter sample rows. Samples are returned with a partial match to the search term for any sample clinical attribute.
      * @param {string} sortBy - sampleId, patientId, or the ATTR_ID to sorted by
      * @param {string} direction - Direction of the sort
@@ -2308,7 +2308,7 @@ export default class CBioPortalAPIInternal {
      * @method
      * @name CBioPortalAPIInternal#fetchClinicalDataClinicalTableUsingPOST
      * @param {integer} pageSize - Page size of the result list
-     * @param {integer} pageNumber - Page number of the result list
+     * @param {integer} pageNumber - Page number of the result list. Zero represents the first page.
      * @param {string} searchTerm - Search term to filter sample rows. Samples are returned with a partial match to the search term for any sample clinical attribute.
      * @param {string} sortBy - sampleId, patientId, or the ATTR_ID to sorted by
      * @param {string} direction - Direction of the sort

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -187,12 +187,6 @@ export type ClinicalDataBinFilter = {
         'start': number
 
 };
-export type ClinicalDataCollection = {
-    'patientClinicalData': Array < ClinicalData >
-
-        'sampleClinicalData': Array < ClinicalData >
-
-};
 export type ClinicalDataCount = {
     'count': number
 
@@ -1223,6 +1217,10 @@ export type Sample = {
         'uniquePatientKey': string
 
         'uniqueSampleKey': string
+
+};
+export type SampleClinicalDataCollection = {
+    'byUniqueSampleKey': {}
 
 };
 export type SampleIdentifier = {
@@ -2325,7 +2323,7 @@ export default class CBioPortalAPIInternal {
         'studyViewFilter' ? : StudyViewFilter,
         $queryParameters ? : any,
             $domain ? : string
-    }): Promise < ClinicalDataCollection > {
+    }): Promise < SampleClinicalDataCollection > {
         return this.fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });

--- a/packages/cbioportal-ts-api-client/src/index.tsx
+++ b/packages/cbioportal-ts-api-client/src/index.tsx
@@ -13,7 +13,7 @@ export {
     BinsGeneratorConfig,
     ClinicalDataBinFilter,
     ClinicalDataBinCountFilter,
-    ClinicalDataCollection,
+    SampleClinicalDataCollection,
     ClinicalDataCount,
     ClinicalDataCountFilter,
     ClinicalDataCountItem,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -9790,7 +9790,7 @@ export class StudyViewPageStore
         if (this.selectedSamples.result.length === 0) {
             return Promise.resolve('');
         }
-        let sampleClinicalData = await getAllClinicalDataByStudyViewFilter(
+        let sampleClinicalDataResponse = await getAllClinicalDataByStudyViewFilter(
             this.filters,
             undefined,
             undefined
@@ -9818,7 +9818,8 @@ export class StudyViewPageStore
                     patientId: next.patientId,
                     sampleId: next.sampleId,
                 } as { [attributeId: string]: string };
-                const clinicalData = sampleClinicalData[next.uniqueSampleKey];
+                const clinicalData =
+                    sampleClinicalDataResponse.data[next.uniqueSampleKey];
                 _.forEach(
                     clinicalData,
                     (attr: ClinicalData) =>

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -9783,7 +9783,7 @@ export class StudyViewPageStore
         if (this.selectedSamples.result.length === 0) {
             return Promise.resolve('');
         }
-        let sampleClinicalDataResp = await getAllClinicalDataByStudyViewFilter(
+        let sampleClinicalData = await getAllClinicalDataByStudyViewFilter(
             this.filters,
             undefined,
             undefined
@@ -9806,14 +9806,18 @@ export class StudyViewPageStore
         let dataRows = _.reduce(
             this.selectedSamples.result,
             (acc, next) => {
-                let sampleData: { [attributeId: string]: string } = {
+                const sampleData = {
                     studyId: next.studyId,
                     patientId: next.patientId,
                     sampleId: next.sampleId,
-                    ...(sampleClinicalDataResp.data[next.uniqueSampleKey] ||
-                        {}),
-                };
-
+                } as { [attributeId: string]: string };
+                const clinicalData = sampleClinicalData[next.uniqueSampleKey];
+                _.forEach(
+                    clinicalData,
+                    (attr: ClinicalData) =>
+                        (sampleData[attr['clinicalAttributeId']] =
+                            attr['value'])
+                );
                 acc.push(
                     _.map(
                         Object.keys(clinicalAttributesNameSet),

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -5865,6 +5865,13 @@ export class StudyViewPageStore
         },
     });
 
+    readonly clinicalAttributeDisplayNameToClinicalAttribute = remoteData({
+        await: () => [this.clinicalAttributes],
+        invoke: async () => {
+            return _.keyBy(this.clinicalAttributes.result!, 'displayName');
+        },
+    });
+
     readonly clinicalAttributeIdToDataType = remoteData({
         await: () => [this.clinicalAttributes],
         invoke: async () => {

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -55,7 +55,6 @@ import {
     isLogScaleByValues,
     isOccupied,
     makePatientToClinicalAnalysisGroup,
-    mergeClinicalDataCollection,
     needAdditionShiftForLogScaleBarChart,
     pickClinicalDataColors,
     shouldShowChart,
@@ -72,7 +71,6 @@ import {
     CancerStudy,
     ClinicalAttribute,
     ClinicalData,
-    ClinicalDataCollection,
     DataFilterValue,
     Sample,
     StudyViewFilter,
@@ -2752,86 +2750,6 @@ describe('StudyViewUtils', () => {
                     end: undefined,
                 },
             ]);
-        });
-    });
-
-    describe('mergeClinicalDataCollection', () => {
-        it('handles merge when patient key defined in sample data', () => {
-            const input = ({
-                sampleClinicalData: [
-                    {
-                        sampleId: 's1',
-                        patientId: 'p1',
-                        studyId: 'study1',
-                        uniqueSampleKey: 's1key',
-                        uniquePatientKey: 'p1key',
-                        clinicalAttributeId: 'attr1',
-                        value: 'value1',
-                    },
-                ],
-                patientClinicalData: [
-                    {
-                        sampleId: undefined,
-                        patientId: 'p1',
-                        studyId: 'study1',
-                        uniqueSampleKey: undefined,
-                        uniquePatientKey: 'p1key',
-                        clinicalAttributeId: 'attr2',
-                        value: 'value2',
-                    },
-                ],
-            } as unknown) as ClinicalDataCollection;
-            const expected = {
-                s1key: {
-                    attr1: 'value1',
-                    attr2: 'value2',
-                },
-            };
-            assert.deepEqual(
-                expected,
-                mergeClinicalDataCollection(
-                    (input as unknown) as ClinicalDataCollection
-                )
-            );
-        });
-
-        it('handles merge when patient key absent in sample data', () => {
-            const input = ({
-                sampleClinicalData: [
-                    {
-                        sampleId: 's1',
-                        patientId: 'p1',
-                        studyId: 'study1',
-                        uniqueSampleKey: 's1key',
-                        uniquePatientKey: 'p1key',
-                        clinicalAttributeId: 'attr1',
-                        value: 'value1',
-                    },
-                ],
-                patientClinicalData: [
-                    {
-                        sampleId: undefined,
-                        patientId: 'p2',
-                        studyId: 'study1',
-                        uniqueSampleKey: undefined,
-                        // note the patient key that does not line-up with the sample
-                        uniquePatientKey: 'p2key',
-                        clinicalAttributeId: 'attr2',
-                        value: 'value2',
-                    },
-                ],
-            } as unknown) as ClinicalDataCollection;
-            const expected = {
-                s1key: {
-                    attr1: 'value1',
-                },
-            };
-            assert.deepEqual(
-                expected,
-                mergeClinicalDataCollection(
-                    (input as unknown) as ClinicalDataCollection
-                )
-            );
         });
     });
 

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -114,6 +114,7 @@ import { MolecularAlterationType_filenameSuffix } from 'shared/lib/StoreUtils';
 import { MultiSelectionTableRow } from './table/MultiSelectionTable';
 import Survival from 'pages/groupComparison/Survival';
 import { StructVarMultiSelectionTableRow } from './table/StructuralVariantMultiSelectionTable';
+import { ClinicalEventTypeCount } from 'cbioportal-ts-api-client/dist/generated/CBioPortalAPIInternal';
 
 // Cannot use ClinicalDataTypeEnum here for the strong type. The model in the type is not strongly typed
 export enum ClinicalDataTypeEnum {

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -3158,8 +3158,9 @@ export function updateSavedUserPreferenceChartIds(
 
 export async function getAllClinicalDataByStudyViewFilter(
     studyViewFilter: StudyViewFilter,
-    searchTerm: string | undefined = undefined,
-    sortCriteria: any,
+    searchTerm: string | undefined,
+    sortAttributeId: any,
+    sortDirection: any = 'asc',
     pageSize: number = 500
 ): Promise<{ [uniqueSampleKey: string]: ClinicalData[] }> {
     const response = await internalClient.fetchClinicalDataClinicalTableUsingPOSTWithHttpInfo(
@@ -3168,8 +3169,8 @@ export async function getAllClinicalDataByStudyViewFilter(
             pageSize,
             pageNumber: 0,
             searchTerm: searchTerm,
-            sortBy: sortCriteria?.field,
-            direction: sortCriteria?.direction?.toUpperCase() || 'ASC',
+            sortBy: sortAttributeId,
+            direction: sortDirection?.toUpperCase(),
         }
     );
 

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -114,7 +114,6 @@ import { MolecularAlterationType_filenameSuffix } from 'shared/lib/StoreUtils';
 import { MultiSelectionTableRow } from './table/MultiSelectionTable';
 import Survival from 'pages/groupComparison/Survival';
 import { StructVarMultiSelectionTableRow } from './table/StructuralVariantMultiSelectionTable';
-import { ClinicalEventTypeCount } from 'cbioportal-ts-api-client/dist/generated/CBioPortalAPIInternal';
 
 // Cannot use ClinicalDataTypeEnum here for the strong type. The model in the type is not strongly typed
 export enum ClinicalDataTypeEnum {

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -440,6 +440,10 @@ export class ClinicalDataTab extends React.Component<
                                                   CLINICAL_DATA_RECORD_LIMIT
                                                 : false
                                         }
+                                        resultCountOverride={
+                                            this.getDataForClinicalDataTab
+                                                .result?.totalItems
+                                        }
                                     />
                                 </Else>
                             </If>

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -183,9 +183,11 @@ export class ClinicalDataTab extends React.Component<
                 CLINICAL_DATA_RECORD_LIMIT
             );
 
-            return sampleClinicalData;
+            return Promise.resolve(sampleClinicalData);
         },
     });
+
+    // this problem is that the visible attributes are not yet populated.
 
     readonly columns = remoteData({
         invoke: async () => {
@@ -284,6 +286,11 @@ export class ClinicalDataTab extends React.Component<
     }
 
     public render() {
+        // not that the columns which are showing in the table
+        // are dependent on visible attributes.
+        // for this reason we need to wait for visible attributes to be populated
+        // this simplest way to await this is just no avoid rendering the table when there are
+        // no visibleAttributes
         return (
             <span data-test="clinical-data-tab-content">
                 <WindowWidthBox offset={60}>
@@ -293,18 +300,13 @@ export class ClinicalDataTab extends React.Component<
                                 .isPending ||
                             this.props.store.maxSamplesForClinicalTab
                                 .isPending ||
-                            this.props.store.selectedSamples.isPending
+                            this.props.store.selectedSamples.isPending ||
+                            this.props.store.visibleAttributes.length < 1
                         }
                     >
                         <Then>
                             <LoadingIndicator
-                                isLoading={
-                                    this.props.store.clinicalAttributeProduct
-                                        .isPending ||
-                                    this.props.store.maxSamplesForClinicalTab
-                                        .isPending ||
-                                    this.props.store.selectedSamples.isPending
-                                }
+                                isLoading={true}
                                 size={'big'}
                                 center={true}
                             />
@@ -386,7 +388,8 @@ export class ClinicalDataTab extends React.Component<
                                         }
                                         showLoading={
                                             this.getDataForClinicalDataTab
-                                                .isPending
+                                                .isPending ||
+                                            this.columns.isPending
                                         }
                                         loadingComponent={
                                             <LoadingIndicator

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -59,7 +59,7 @@ async function fetchClinicalDataForStudyViewClinicalDataTab(
     sortDirection: 'asc' | 'desc' | undefined,
     recordLimit: number
 ) {
-    let sampleClinicalData = await getAllClinicalDataByStudyViewFilter(
+    let sampleClinicalDataResponse = await getAllClinicalDataByStudyViewFilter(
         filters,
         searchTerm,
         sortAttributeId,
@@ -68,7 +68,7 @@ async function fetchClinicalDataForStudyViewClinicalDataTab(
     );
 
     const aggregatedSampleClinicalData = _.mapValues(
-        sampleClinicalData,
+        sampleClinicalDataResponse.data,
         (attrs, uniqueSampleId) => {
             const sample = sampleSetByKey[uniqueSampleId];
             const sampleData = {
@@ -85,7 +85,7 @@ async function fetchClinicalDataForStudyViewClinicalDataTab(
     );
 
     return {
-        totalItems: _.keys(sampleClinicalData).length,
+        totalItems: sampleClinicalDataResponse.totalItems,
         data: _.values(aggregatedSampleClinicalData),
     };
 }

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.spec.tsx
@@ -2398,16 +2398,20 @@ describe('LazyMobXTable', () => {
     });
     describe('pagination', () => {
         it('starts with 50 items per page', () => {
-            let table = mount(<Table columns={simpleColumns} data={[]} />);
-            assert.equal(getItemsPerPage(table), 50, 'with no data');
-            table.setProps({
-                columns: simpleColumns,
-                data: data.slice(0, 100),
-            });
+            let table = mount(
+                <Table
+                    columns={simpleColumns}
+                    showLoading={false}
+                    data={data.slice(0, 100)}
+                />
+            );
             assert.equal(getItemsPerPage(table), 50, 'with data');
         });
         it('limits page accessing appropriately, depending on how many items total and how many per page, and changes page numbers correctly', () => {
-            let table = mount(<Table columns={simpleColumns} data={[]} />);
+            let table = mount(
+                <Table columns={simpleColumns} data={data.slice(0, 100)} />
+            );
+
             assert.equal(getCurrentPage(table), 0, 'starts on page 0');
             assert.isFalse(
                 clickPrevPage(table),
@@ -2510,46 +2514,40 @@ describe('LazyMobXTable', () => {
         });
 
         it('properly handles changing items per page', () => {
-            let table = mount(<Table columns={simpleColumns} data={[]} />);
-            selectItemsPerPage(table, 25);
+            let table = mount(
+                <Table columns={simpleColumns} data={data.slice(0, 100)} />
+            );
+
+            console.log('row count');
+            console.log(data.length);
+
+            selectItemsPerPage(table, 2);
             assert.equal(
                 getItemsPerPage(table),
-                25,
-                'case: no data; it successfully changes the items per page to 25'
+                2,
+                'it successfully changes the items per page to 25'
             );
+            assert.equal(getCurrentPage(table), 0, "we're on page 1");
             assert.equal(
-                getCurrentPage(table),
-                0,
-                'case: no data; still on page 0'
-            );
-            assert.equal(
-                getNumVisibleRows(table),
-                0,
-                'case: no data; no rows visible with 25/page, because no data'
+                getVisibleRows(table).length,
+                2,
+                'there are two items on the page'
             );
             selectItemsPerPage(table, -1);
             assert.equal(
                 getItemsPerPage(table),
                 -1,
-                'case: no data; it successfully changes the items per page to show all'
+                'it successfully changes the items per page to show all'
             );
-            assert.equal(
-                getCurrentPage(table),
-                0,
-                'case: no data; still on page 0'
-            );
-            assert.equal(
-                getNumVisibleRows(table),
-                0,
-                'case: no data; no rows visible with show all, because no data'
-            );
+            assert.equal(getCurrentPage(table), 0, 'still on page 1');
+            assert.equal(getNumVisibleRows(table), 5, 'shows all rows now');
 
             table.setProps({ columns: columns, data: [simpleData[0]] });
             selectItemsPerPage(table, 25);
             assert.equal(
                 getItemsPerPage(table),
                 25,
-                'case: 1 data; it successfully changes the items per page to 25'
+                'it successfully changes the items per page to 25'
             );
             assert.equal(
                 getCurrentPage(table),
@@ -2747,12 +2745,18 @@ describe('LazyMobXTable', () => {
         });
         it('shows the right text before the paging buttons', () => {
             let table = mount(<Table columns={simpleColumns} data={[]} />);
+
+            table.setProps({
+                columns: simpleColumns,
+                data: data.slice(0, 100),
+            });
+
             assert.equal(
                 getItemsPerPage(table),
                 50,
                 'confirm 50 items per page'
             );
-            assert.equal(getTextBeforeButtons(table), 'Showing 0-0 of 0');
+            assert.equal(getTextBeforeButtons(table), 'Showing 1-5 of 5');
 
             table.setProps({ columns: simpleColumns, data: [simpleData[0]] });
             assert.equal(getTextBeforeButtons(table), 'Showing 1-1 of 1');

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -462,7 +462,7 @@ export class LazyMobXTableStore<T> {
             this.sortColumn = column.name;
             this.onSortDirectionChange(
                 column.name,
-                this.sortAscending ? 'desc' : 'asc'
+                this.sortAscending ? 'asc' : 'desc'
             );
         } else {
             this.sortAscending = sortAscending;

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -81,7 +81,10 @@ type LazyMobXTableProps<T> = {
     columns: Column<T>[];
     data?: T[];
     dataStore?: ILazyMobXTableApplicationDataStore<T>;
-    downloadDataFetcher?: ILazyMobXTableApplicationLazyDownloadDataFetcher;
+    downloadDataFetcher?:
+        | ILazyMobXTableApplicationLazyDownloadDataFetcher
+        | (() => Promise<any>)
+        | undefined;
     initialSortColumn?: string;
     initialSortDirection?: SortDirection;
     initialItemsPerPage?: number;
@@ -120,6 +123,11 @@ type LazyMobXTableProps<T> = {
     ) => JSX.Element | undefined;
     deactivateColumnFilter?: (columnId: string) => void;
     customControls?: JSX.Element;
+    onFilterTextChange?: (filterString: string) => void;
+    onSortDirectionChange?: (field: string, direction: SortDirection) => void;
+    isResultLimited?: boolean;
+    showLoading?: boolean;
+    loadingComponent?: JSX.Element;
 };
 
 function compareValues<U extends number | string>(
@@ -279,6 +287,8 @@ export class LazyMobXTableStore<T> {
     @observable public headerRefs: React.RefObject<any>[];
     @observable public downloadDataFetcher:
         | ILazyMobXTableApplicationLazyDownloadDataFetcher
+        | undefined
+        | (() => Promise<any>)
         | undefined;
     @observable private onRowClick: ((d: T) => void) | undefined;
     @observable private onRowMouseEnter: ((d: T) => void) | undefined;
@@ -297,6 +307,8 @@ export class LazyMobXTableStore<T> {
     @observable private _columnVisibilityOverride:
         | { [columnId: string]: boolean }
         | undefined;
+
+    @observable private onSortDirectionChange: any;
 
     @computed public get itemsPerPage() {
         return this.dataStore.itemsPerPage;
@@ -440,12 +452,26 @@ export class LazyMobXTableStore<T> {
 
     @action
     public defaultHeaderClick(column: Column<T>) {
-        this.sortAscending = this.getNextSortAscending(column);
-        this.dataStore.sortAscending = this.sortAscending;
+        const sortAscending = this.getNextSortAscending(column);
 
-        this.sortColumn = column.name;
-        this.dataStore.sortMetric = this.sortMetric;
-        this.page = 0;
+        if (this.onSortDirectionChange) {
+            // even though are tracking sort direction in parent store
+            // we unfortunately still need keep these properties in sync
+            // a larger refactor would be necessary
+            this.sortAscending = !this.sortAscending;
+            this.sortColumn = column.name;
+            this.onSortDirectionChange(
+                column.name,
+                this.sortAscending ? 'desc' : 'asc'
+            );
+        } else {
+            this.sortAscending = sortAscending;
+            this.dataStore.sortAscending = sortAscending;
+
+            this.sortColumn = column.name;
+            this.dataStore.sortMetric = this.sortMetric;
+            this.page = 0;
+        }
     }
 
     @computed
@@ -765,6 +791,7 @@ export class LazyMobXTableStore<T> {
         this.onRowClick = props.onRowClick;
         this.onRowMouseEnter = props.onRowMouseEnter;
         this.onRowMouseLeave = props.onRowMouseLeave;
+        this.onSortDirectionChange = props.onSortDirectionChange;
 
         if (props.dataStore) {
             this.dataStore = props.dataStore;
@@ -889,23 +916,32 @@ export default class LazyMobXTable<T> extends React.Component<
             // we need to download all the lazy data before initiating the download process.
             if (this.store.downloadDataFetcher) {
                 // populate the cache instances with all available data for the lazy loaded columns
-                this.store.downloadDataFetcher
-                    .fetchAndCacheAllLazyData()
-                    .then(() => {
-                        // we don't use allData directly,
-                        // we rely on the data cached by the download data fetcher
+                if (typeof this.store.downloadDataFetcher === 'function') {
+                    this.store.downloadDataFetcher().then(data => {
                         resolve({
                             status: 'complete',
-                            text: this.getDownloadData(),
-                        });
-                    })
-                    .catch(() => {
-                        // even if loading of all lazy data fails, resolve with partial data
-                        resolve({
-                            status: 'incomplete',
-                            text: this.getDownloadData(),
+                            text: JSON.stringify(data),
                         });
                     });
+                } else {
+                    this.store.downloadDataFetcher
+                        .fetchAndCacheAllLazyData()
+                        .then(() => {
+                            // we don't use allData directly,
+                            // we rely on the data cached by the download data fetcher
+                            resolve({
+                                status: 'complete',
+                                text: this.getDownloadData(),
+                            });
+                        })
+                        .catch(() => {
+                            // even if loading of all lazy data fails, resolve with partial data
+                            resolve({
+                                status: 'incomplete',
+                                text: this.getDownloadData(),
+                            });
+                        });
+                }
             }
             // no lazy data to preload, just return the current download data
             else {
@@ -929,7 +965,9 @@ export default class LazyMobXTable<T> extends React.Component<
         this.handlers = {
             onFilterTextChange: (() => {
                 return inputBoxChangeTimeoutEvent(filterValue => {
-                    this.store.setFilterString(filterValue);
+                    props.onFilterTextChange
+                        ? props.onFilterTextChange(filterValue)
+                        : this.store.setFilterString(filterValue);
                 }, 400);
             })(),
             clearFilterText: () => {
@@ -1259,11 +1297,16 @@ export default class LazyMobXTable<T> extends React.Component<
                         : 'visible',
                 }}
             >
-                <SimpleTable
-                    headers={this.store.headers}
-                    rows={this.store.rows}
-                    className={this.props.className}
-                />
+                {(this.props.showLoading && this.props.loadingComponent) ||
+                    null}
+
+                <span style={{ opacity: this.props.showLoading ? 0.1 : 1.0 }}>
+                    <SimpleTable
+                        headers={this.store.headers}
+                        rows={this.store.rows}
+                        className={this.props.className}
+                    />
+                </span>
             </div>
         );
     }
@@ -1273,6 +1316,17 @@ export default class LazyMobXTable<T> extends React.Component<
             <div className="lazy-mobx-table" data-test="LazyMobXTable">
                 <Observer>{this.getTopToolbar}</Observer>
                 <Observer>{this.getTable}</Observer>
+                {this.props.isResultLimited &&
+                    this.store.maxPage > 0 &&
+                    this.store.page === this.store.maxPage && (
+                        <div className={'text-center alert alert-info'}>
+                            <strong>
+                                You've reached the maximum viewable records.{' '}
+                                <br />
+                                Please use filter or sort to refine result set.
+                            </strong>
+                        </div>
+                    )}
                 {!this.props.showPaginationAtTop && (
                     <Observer>{this.getBottomToolbar}</Observer>
                 )}

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -137,7 +137,10 @@ export interface IMutationTableProps {
     namespaceColumns?: NamespaceColumnConfig;
     data?: Mutation[][];
     dataStore?: ILazyMobXTableApplicationDataStore<Mutation[]>;
-    downloadDataFetcher?: ILazyMobXTableApplicationLazyDownloadDataFetcher;
+    downloadDataFetcher?:
+        | ILazyMobXTableApplicationLazyDownloadDataFetcher
+        | (() => Promise<any>)
+        | undefined;
     initialItemsPerPage?: number;
     itemsLabel?: string;
     itemsLabelPlural?: string;


### PR DESCRIPTION
:warning: This PR breaks the API. Should be merged together with the corresponding [_cbioportal_ PR](https://github.com/cbioportal/cbioportal/pull/10407)


# Background
- At present all clinical data is downloaded the the user visits the Clinical Data tab on Study View. On large studies this results in a very long wait period before the user can interact with the data table.

# Solution
- This PR will implement paginated download of clinical table. A slice of 1000 sample records is retrieved which can be paginated locally.
- Clinical Data is collected in the _SampleClinicalDataCollection_ class where the data is keyed by the _uniqueSampleKey_ (base64 encoded concatenation of sample and study identifier).
