### PR TITLE
Fix: data type filter set default value for checkbox

### DIFF
--- a/src/shared/components/query/DataTypeFilter.tsx
+++ b/src/shared/components/query/DataTypeFilter.tsx
@@ -122,6 +122,7 @@ export const DataTypeFilter: FunctionComponent<IDataTypeFilterProps> = props => 
                                         <input
                                             type="checkbox"
                                             style={{ marginRight: 2 }}
+                                            defaultChecked={type.checked}
                                             onClick={() => {
                                                 type.checked = !type.checked;
                                                 props.store.dataTypeFilters = createDataTypeUpdate(


### PR DESCRIPTION
Fix: Without the default value set for the checkbox of the data type filter menu, the state of the checkbox is remembered but the checkbox is not 'checked'.

Bug can be seen when a user filters on data type, select multiple studies and clicks on 'Query by Gene'. When the user clicks on 'modify' selected studies, the 'checked' checkbox is not blue. 

