### PR TITLE
When bookmark url is too long, prompt user to create a virtual study instead

### DIFF
--- a/packages/cbioportal-frontend-commons/src/components/defaultTooltip/DefaultTooltip.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/defaultTooltip/DefaultTooltip.tsx
@@ -56,9 +56,6 @@ export default class DefaultTooltip extends React.Component<
     render() {
         let { disabled, visible, onPopupAlign, ...restProps } = this.props;
         let tooltipProps: TooltipProps = restProps;
-        if (disabled) {
-            visible = false;
-        }
         if (typeof visible !== 'undefined') {
             tooltipProps.visible = visible;
         }

--- a/src/pages/resultsView/bookmark/BookmarkModal.tsx
+++ b/src/pages/resultsView/bookmark/BookmarkModal.tsx
@@ -14,6 +14,7 @@ interface IBookmarkModalProps {
     title: string;
     description?: string;
 }
+
 @observer
 export class BookmarkModal extends React.Component<IBookmarkModalProps, {}> {
     @observable urlData: ShareUrls | undefined = undefined;
@@ -78,7 +79,6 @@ export class BookmarkModal extends React.Component<IBookmarkModalProps, {}> {
     public container: HTMLDivElement;
 
     render() {
-        //NOTE: internal div id necessary for
         return (
             <Modal show={true} onHide={this.props.onHide}>
                 <Modal.Header closeButton>
@@ -91,66 +91,71 @@ export class BookmarkModal extends React.Component<IBookmarkModalProps, {}> {
                         style={{ top: 32 }}
                         isLoading={!this.urlData}
                     />
-                    <div
-                        className={classNames({ hidden: !this.urlData })}
-                        ref={(el: HTMLDivElement) => (this.container = el)}
-                    >
-                        <form>
-                            <div className="form-group">
-                                <p>{this.props.description}</p>
-                                <div className="input-group">
-                                    <input
-                                        type="text"
-                                        className="form-control"
-                                        data-test="bookmark-url"
-                                        value={
-                                            this.urlData
-                                                ? this.urlData.fullUrl
-                                                : ''
-                                        }
-                                    />
-                                    <div className="input-group-addon">
-                                        <a
-                                            ref={(el: HTMLAnchorElement) =>
-                                                (this.sessionButton = el)
-                                            }
-                                            onClick={this.showThumb}
-                                        >
-                                            <i className="fa fa-clipboard"></i>
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                            {this.urlData && this.urlData.bitlyUrl && (
+
+                    {
+                        <div
+                            className={classNames({ hidden: !this.urlData })}
+                            ref={(el: HTMLDivElement) => (this.container = el)}
+                        >
+                            <form>
                                 <div className="form-group">
-                                    <label htmlFor="exampleInputAmount">
-                                        Shortened URL
-                                    </label>
+                                    <p>{this.props.description}</p>
                                     <div className="input-group">
                                         <input
                                             type="text"
                                             className="form-control"
+                                            data-test="bookmark-url"
                                             value={
                                                 this.urlData
-                                                    ? this.urlData.bitlyUrl
+                                                    ? this.urlData.fullUrl
                                                     : ''
                                             }
                                         />
                                         <div className="input-group-addon">
                                             <a
-                                                onClick={this.showThumb}
                                                 ref={(el: HTMLAnchorElement) =>
-                                                    (this.bitlyButton = el)
+                                                    (this.sessionButton = el)
                                                 }
+                                                onClick={this.showThumb}
                                             >
                                                 <i className="fa fa-clipboard"></i>
                                             </a>
                                         </div>
                                     </div>
                                 </div>
-                            )}
-                        </form>
-                    </div>
+                                {this.urlData && this.urlData.bitlyUrl && (
+                                    <div className="form-group">
+                                        <label htmlFor="exampleInputAmount">
+                                            Shortened URL
+                                        </label>
+                                        <div className="input-group">
+                                            <input
+                                                type="text"
+                                                className="form-control"
+                                                value={
+                                                    this.urlData
+                                                        ? this.urlData.bitlyUrl
+                                                        : ''
+                                                }
+                                            />
+                                            <div className="input-group-addon">
+                                                <a
+                                                    onClick={this.showThumb}
+                                                    ref={(
+                                                        el: HTMLAnchorElement
+                                                    ) =>
+                                                        (this.bitlyButton = el)
+                                                    }
+                                                >
+                                                    <i className="fa fa-clipboard"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                )}
+                            </form>
+                        </div>
+                    }
                 </Modal.Body>
             </Modal>
         );

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -77,11 +77,14 @@ import {
     buildCustomTabs,
     prepareCustomTabConfigurations,
 } from 'shared/lib/customTabs/customTabHelpers';
+import { VirtualStudyModal } from 'pages/studyView/virtualStudy/VirtualStudyModal';
 
 export interface IStudyViewPageProps {
     routing: any;
     appStore: AppStore;
 }
+
+export const MAX_URL_LENGTH = 300000;
 
 @observer
 export class StudyResultsSummary extends React.Component<
@@ -292,6 +295,14 @@ export default class StudyViewPage extends React.Component<
     toggleShareLinkModal() {
         this.shareLinkModal = !this.shareLinkModal;
         this.sharedGroups = [];
+    }
+
+    @observable showVirtualStudyModal = false;
+
+    @action.bound
+    toggleVirtualStudyModal() {
+        debugger;
+        this.showVirtualStudyModal = !this.showVirtualStudyModal;
     }
 
     @action.bound
@@ -554,19 +565,45 @@ export default class StudyViewPage extends React.Component<
         return buildCustomTabs(this.customTabsConfigs);
     }
 
+    @computed get bookmarkModal() {
+        // urls have a length limit after which browser will fail to read them
+        // when the url WITH FILTERS exceed this length, the only option is to make a virtual
+        // study with filtered cohort
+        // this will NOT show any fitlers, but it's the best we can do right now
+        if (this.studyViewFullUrlWithFilter.length > MAX_URL_LENGTH) {
+            return (
+                <VirtualStudyModal
+                    appStore={this.props.appStore}
+                    pageStore={this.store}
+                    message={
+                        <div className={'alert alert-warning'}>
+                            The url is too long to share. Please consider making
+                            a virtual study containing the selected samples.
+                        </div>
+                    }
+                    onHide={this.toggleBookmarkModal}
+                />
+            );
+        } else {
+            return (
+                <BookmarkModal
+                    onHide={this.toggleBookmarkModal}
+                    title={'Bookmark this filter'}
+                    urlPromise={this.getBookmarkUrl()}
+                />
+            );
+        }
+    }
+
     content() {
         return (
             <div className="studyView">
-                {this.showBookmarkModal && (
-                    <BookmarkModal
-                        onHide={this.toggleBookmarkModal}
-                        title={'Bookmark this filter'}
-                        urlPromise={this.getBookmarkUrl()}
-                    />
-                )}
+                {this.showBookmarkModal && this.bookmarkModal}
+
                 {this.shareLinkModal && (
                     <BookmarkModal
                         onHide={this.toggleShareLinkModal}
+                        //onRequestVirtualStudy={this.togg}
                         title={
                             this.sharedGroups.length > 1
                                 ? `Share ${this.sharedGroups.length} Groups`

--- a/src/pages/studyView/studyPageHeader/ActionButtons.tsx
+++ b/src/pages/studyView/studyPageHeader/ActionButtons.tsx
@@ -5,7 +5,7 @@ import { action, computed, makeObservable, observable } from 'mobx';
 import styles from '../styles.module.scss';
 import autobind from 'autobind-decorator';
 import { getPatientViewUrl } from 'shared/api/urls';
-import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import { DefaultTooltip, getBrowserWindow } from 'cbioportal-frontend-commons';
 import VirtualStudy from 'pages/studyView/virtualStudy/VirtualStudy';
 import fileDownload from 'react-file-download';
 import { Else, If, Then } from 'react-if';
@@ -15,6 +15,8 @@ import { AppStore } from '../../../AppStore';
 import { serializeEvent } from '../../../shared/lib/tracking';
 import { DownloadControlOption } from 'cbioportal-frontend-commons';
 import { getServerConfig } from 'config/config';
+import { Modal } from 'react-bootstrap';
+import { VirtualStudyModal } from 'pages/studyView/virtualStudy/VirtualStudyModal';
 
 export interface ActionButtonsProps {
     loadingComplete: boolean;
@@ -22,6 +24,7 @@ export interface ActionButtonsProps {
     appStore: AppStore;
 }
 
+// this is for list of patients
 export const MAX_URL_LENGTH = 4500;
 
 @observer
@@ -31,10 +34,12 @@ export default class ActionButtons extends React.Component<
 > {
     constructor(props: ActionButtonsProps) {
         super(props);
+
         makeObservable(this);
     }
     @observable downloadingData = false;
     @observable showDownloadErrorMessage = false;
+    @observable showVirtualStudiesDialog = false;
 
     @autobind
     private initiateDownload() {
@@ -53,6 +58,11 @@ export default class ActionButtons extends React.Component<
                 this.downloadingData = false;
                 this.showDownloadErrorMessage = true;
             });
+    }
+
+    @autobind
+    private toggleVirtualStudiesDialog() {
+        this.showVirtualStudiesDialog = !this.showVirtualStudiesDialog;
     }
 
     @autobind
@@ -111,38 +121,46 @@ export default class ActionButtons extends React.Component<
         return 'Download clinical data for the selected cases';
     }
 
-    @computed
-    get virtualStudy(): JSX.Element | null {
-        return (
-            <VirtualStudy
-                user={this.props.appStore.userName}
-                name={
-                    this.props.store.isSingleVirtualStudyPageWithoutFilter
-                        ? this.props.store.filteredVirtualStudies.result[0].data
-                              .name
-                        : undefined
-                }
-                description={
-                    this.props.store.isSingleVirtualStudyPageWithoutFilter
-                        ? this.props.store.filteredVirtualStudies.result[0].data
-                              .description
-                        : undefined
-                }
-                studyWithSamples={this.props.store.studyWithSamples.result}
-                selectedSamples={this.props.store.selectedSamples.result}
-                filter={this.props.store.userSelections}
-                attributesMetaSet={this.props.store.chartMetaSet}
-                molecularProfileNameSet={
-                    this.props.store.molecularProfileNameSet.result || {}
-                }
-                caseListNameSet={this.props.store.caseListNameSet.result || {}}
-            />
-        );
-    }
+    // @computed
+    // get virtualStudy(): JSX.Element | null {
+    //     return (
+    //         <VirtualStudy
+    //             user={this.props.appStore.userName}
+    //             name={
+    //                 this.props.store.isSingleVirtualStudyPageWithoutFilter
+    //                     ? this.props.store.filteredVirtualStudies.result[0].data
+    //                           .name
+    //                     : undefined
+    //             }
+    //             description={
+    //                 this.props.store.isSingleVirtualStudyPageWithoutFilter
+    //                     ? this.props.store.filteredVirtualStudies.result[0].data
+    //                           .description
+    //                     : undefined
+    //             }
+    //             studyWithSamples={this.props.store.studyWithSamples.result}
+    //             selectedSamples={this.props.store.selectedSamples.result}
+    //             filter={this.props.store.userSelections}
+    //             attributesMetaSet={this.props.store.chartMetaSet}
+    //             molecularProfileNameSet={
+    //                 this.props.store.molecularProfileNameSet.result || {}
+    //             }
+    //             caseListNameSet={this.props.store.caseListNameSet.result || {}}
+    //         />
+    //     );
+    // }
 
     render() {
         return (
             <div className={classNames(styles.actionButtons, 'btn-group')}>
+                {this.showVirtualStudiesDialog && (
+                    <VirtualStudyModal
+                        appStore={this.props.appStore}
+                        pageStore={this.props.store}
+                        onHide={this.toggleVirtualStudiesDialog}
+                    ></VirtualStudyModal>
+                )}
+
                 <DefaultTooltip
                     trigger={['hover']}
                     placement={'top'}
@@ -164,32 +182,26 @@ export default class ActionButtons extends React.Component<
                 </DefaultTooltip>
 
                 <DefaultTooltip
-                    trigger={['click']}
-                    destroyTooltipOnHide={true}
-                    overlay={this.virtualStudy}
-                    placement="bottom"
+                    placement={'top'}
+                    trigger={['hover']}
+                    overlay={<span>{this.virtualStudyButtonTooltip}</span>}
                 >
-                    <DefaultTooltip
-                        placement={'top'}
-                        trigger={['hover']}
-                        overlay={<span>{this.virtualStudyButtonTooltip}</span>}
+                    <button
+                        data-tour="action-button-bookmark"
+                        className="btn btn-default btn-sm"
+                        onClick={this.toggleVirtualStudiesDialog}
+                        disabled={
+                            this.props.store.filteredVirtualStudies.isPending ||
+                            this.props.store.selectedSamples.isPending ||
+                            this.props.store.molecularProfileNameSet
+                                .isPending ||
+                            this.props.store.caseListNameSet.isPending
+                        }
                     >
-                        <button
-                            data-tour="action-button-bookmark"
-                            className="btn btn-default btn-sm"
-                            disabled={
-                                this.props.store.filteredVirtualStudies
-                                    .isPending ||
-                                this.props.store.selectedSamples.isPending ||
-                                this.props.store.molecularProfileNameSet
-                                    .isPending ||
-                                this.props.store.caseListNameSet.isPending
-                            }
-                        >
-                            <i className="fa fa-bookmark"></i>
-                        </button>
-                    </DefaultTooltip>
+                        <i className="fa fa-bookmark"></i>
+                    </button>
                 </DefaultTooltip>
+
                 {getServerConfig().skin_hide_download_controls ===
                     DownloadControlOption.SHOW_ALL && (
                     <DefaultTooltip

--- a/src/pages/studyView/virtualStudy/VirtualStudy.tsx
+++ b/src/pages/studyView/virtualStudy/VirtualStudy.tsx
@@ -18,6 +18,7 @@ import {
 } from 'pages/studyView/StudyViewUtils';
 import autobind from 'autobind-decorator';
 import { serializeEvent } from '../../../shared/lib/tracking';
+import FontAwesome from 'react-fontawesome';
 
 const Clipboard = require('clipboard');
 
@@ -192,6 +193,9 @@ export default class VirtualStudy extends React.Component<
     private copyLinkRef(el: HTMLAnchorElement | null) {
         if (el) {
             new Clipboard(el, {
+                container: document.getElementsByClassName(
+                    styles.virtualStudy
+                )[0],
                 text: () => this.virtualStudyUrl,
             });
         }
@@ -263,9 +267,11 @@ export default class VirtualStudy extends React.Component<
                                                 : undefined
                                         )}
                                     >
-                                        <div className="input-group">
+                                        <div className="form-group">
+                                            <label>Title:</label>
                                             <input
                                                 type="text"
+                                                id={'sniglet'}
                                                 className="form-control"
                                                 value={this.name}
                                                 placeholder={
@@ -277,181 +283,204 @@ export default class VirtualStudy extends React.Component<
                                                         event.currentTarget.value)
                                                 }
                                             />
-                                            <div className="input-group-btn">
-                                                {this.showSaveButton && (
-                                                    <button
-                                                        data-tour="virtual-study-summary-save-btn"
-                                                        className={classnames(
-                                                            'btn btn-default',
-                                                            styles.saveButton
-                                                        )}
-                                                        data-event={serializeEvent(
-                                                            {
-                                                                category:
-                                                                    'studyPage',
-                                                                action:
-                                                                    'saveVirtualStudy',
-                                                            }
-                                                        )}
-                                                        type="button"
-                                                        disabled={
-                                                            this.buttonsDisabled
-                                                        }
-                                                        onClick={event => {
-                                                            this.saving = true;
-                                                        }}
-                                                    >
-                                                        {this.saving ? (
-                                                            <i
-                                                                className="fa fa-spinner fa-spin"
-                                                                aria-hidden="true"
-                                                            ></i>
-                                                        ) : (
-                                                            'Save'
-                                                        )}
-                                                    </button>
-                                                )}
+                                        </div>
+                                        <div className={'form-group'}>
+                                            <label>Description:</label>
+                                            <textarea
+                                                className="form-control"
+                                                rows={5}
+                                                placeholder="Virtual study description (Optional)"
+                                                value={this.description}
+                                                onChange={event =>
+                                                    (this.description =
+                                                        event.currentTarget.value)
+                                                }
+                                            />
+                                        </div>
+
+                                        <div>
+                                            {this.showSaveButton && (
                                                 <button
-                                                    data-tour="virtual-study-summary-share-btn"
+                                                    data-tour="virtual-study-summary-save-btn"
                                                     className={classnames(
                                                         'btn btn-default',
                                                         styles.saveButton
                                                     )}
+                                                    data-event={serializeEvent({
+                                                        category: 'studyPage',
+                                                        action:
+                                                            'saveVirtualStudy',
+                                                    })}
                                                     type="button"
                                                     disabled={
                                                         this.buttonsDisabled
                                                     }
-                                                    data-event={serializeEvent({
-                                                        category: 'studyPage',
-                                                        action:
-                                                            'shareVirtualStudy',
-                                                    })}
                                                     onClick={event => {
-                                                        this.sharing = true;
+                                                        this.saving = true;
                                                     }}
                                                 >
-                                                    {this.sharing ? (
+                                                    {this.saving ? (
                                                         <i
                                                             className="fa fa-spinner fa-spin"
                                                             aria-hidden="true"
                                                         ></i>
                                                     ) : (
-                                                        'Share'
+                                                        'Save'
                                                     )}
                                                 </button>
-                                            </div>
+                                            )}
+                                            <button
+                                                data-tour="virtual-study-summary-share-btn"
+                                                className={classnames(
+                                                    'btn btn-default',
+                                                    styles.saveButton
+                                                )}
+                                                type="button"
+                                                disabled={this.buttonsDisabled}
+                                                data-event={serializeEvent({
+                                                    category: 'studyPage',
+                                                    action: 'shareVirtualStudy',
+                                                })}
+                                                onClick={event => {
+                                                    this.sharing = true;
+                                                }}
+                                            >
+                                                {this.sharing ? (
+                                                    <i
+                                                        className="fa fa-spinner fa-spin"
+                                                        aria-hidden="true"
+                                                    ></i>
+                                                ) : (
+                                                    'Create'
+                                                )}
+                                            </button>
                                         </div>
-                                        <textarea
-                                            className="form-control"
-                                            rows={10}
-                                            placeholder="Virtual study description (Optional)"
-                                            value={this.description}
-                                            onChange={event =>
-                                                (this.description =
-                                                    event.currentTarget.value)
-                                            }
-                                        />
                                     </div>
-                                    <span
-                                        style={{
-                                            display: 'block',
-                                            fontWeight: 'bold',
-                                        }}
-                                    >
-                                        This virtual study was derived from:
-                                    </span>
-                                    <div className={styles.studiesSummaryInfo}>
-                                        {this.props.studyWithSamples.map(
-                                            study => (
-                                                <StudySummaryRecord
-                                                    {...study}
-                                                />
-                                            )
-                                        )}
-                                    </div>
+                                    {/*<span*/}
+                                    {/*    style={{*/}
+                                    {/*        display: 'block',*/}
+                                    {/*        fontWeight: 'bold',*/}
+                                    {/*    }}*/}
+                                    {/*>*/}
+                                    {/*    This virtual study was derived from:*/}
+                                    {/*</span>*/}
+                                    {/*<div className={styles.studiesSummaryInfo}>*/}
+                                    {/*    {this.props.studyWithSamples.map(*/}
+                                    {/*        study => (*/}
+                                    {/*            <StudySummaryRecord*/}
+                                    {/*                {...study}*/}
+                                    {/*            />*/}
+                                    {/*        )*/}
+                                    {/*    )}*/}
+                                    {/*</div>*/}
                                 </div>
                             </Then>
                             <Else>
-                                <div className={classnames(styles.result)}>
-                                    <div className={styles.name}>
-                                        <a
-                                            target="_blank"
-                                            href={`${this.virtualStudyUrl}`}
-                                            style={{ width: '220px' }}
+                                <div>
+                                    <p className={'text-success'}>
+                                        Success! Copy the following link to view
+                                        virtual study.
+                                    </p>
+
+                                    <div className="form-group">
+                                        <label
+                                            className="sr-only"
+                                            htmlFor="exampleInputAmount"
                                         >
-                                            {this.virtualStudyUrl}
-                                        </a>
-                                    </div>
-                                    <div
-                                        className={classnames(
-                                            'btn-group btn-group-xs',
-                                            styles.controls
-                                        )}
-                                    >
-                                        <DefaultTooltip
-                                            overlay={
-                                                <If condition={this.copied}>
-                                                    <Then>
-                                                        <span className="alert-success">
-                                                            Copied!
-                                                        </span>
-                                                    </Then>
-                                                    <Else>
-                                                        <span>Copy</span>
-                                                    </Else>
-                                                </If>
-                                            }
-                                            placement="top"
-                                            onVisibleChange={
-                                                this.onTooltipVisibleChange
-                                            }
-                                        >
-                                            <span
-                                                className="btn btn-default"
-                                                ref={this.copyLinkRef}
-                                                onClick={this.onCopyClick}
-                                            >
-                                                Copy
-                                            </span>
-                                        </DefaultTooltip>
-                                        <span
-                                            className="btn btn-default"
-                                            onClick={event =>
-                                                window.open(
-                                                    this.virtualStudyUrl,
-                                                    '_blank'
-                                                )
-                                            }
-                                        >
-                                            View
-                                        </span>
-                                        {this.saving && (
-                                            <span
-                                                data-tour="virtual-study-summary-query-btn"
-                                                className="btn btn-default"
-                                                onClick={event => {
-                                                    if (
-                                                        this.virtualStudy.result
-                                                    ) {
-                                                        window.open(
-                                                            buildCBioPortalPageUrl(
-                                                                'results',
-                                                                {
-                                                                    cancer_study_id: this
-                                                                        .virtualStudy
-                                                                        .result
-                                                                        .id,
+                                            Amount (in dollars)
+                                        </label>
+                                        <div className="input-group">
+                                            <input
+                                                type="text"
+                                                className="form-control"
+                                                value={this.virtualStudyUrl}
+                                                style={{ width: 400 }}
+                                            />
+                                            <div className="input-group-addon">
+                                                <a
+                                                    ref={this.copyLinkRef}
+                                                    onClick={this.onCopyClick}
+                                                >
+                                                    {this.copied ? (
+                                                        <FontAwesome
+                                                            name={'thumbs-up'}
+                                                        />
+                                                    ) : (
+                                                        <DefaultTooltip
+                                                            placement={'top'}
+                                                            overlay={
+                                                                'Copy to clipboard'
+                                                            }
+                                                        >
+                                                            <FontAwesome
+                                                                name={
+                                                                    'clipboard'
                                                                 }
-                                                            ),
-                                                            '_blank'
-                                                        );
+                                                            />
+                                                        </DefaultTooltip>
+                                                    )}
+                                                </a>
+                                            </div>
+                                            <div className="input-group-addon">
+                                                <DefaultTooltip
+                                                    placement={'top'}
+                                                    overlay={
+                                                        'Open virtual study in a new tab'
                                                     }
-                                                }}
-                                            >
-                                                Query
-                                            </span>
-                                        )}
+                                                >
+                                                    <a
+                                                        onClick={event =>
+                                                            window.open(
+                                                                this
+                                                                    .virtualStudyUrl,
+                                                                '_blank'
+                                                            )
+                                                        }
+                                                    >
+                                                        <FontAwesome
+                                                            name={
+                                                                'external-link'
+                                                            }
+                                                        />
+                                                    </a>
+                                                </DefaultTooltip>
+                                            </div>
+                                        </div>
                                     </div>
+
+                                    {/*<div*/}
+                                    {/*    className={classnames(*/}
+                                    {/*        'btn-group btn-group-xs',*/}
+                                    {/*        styles.controls*/}
+                                    {/*    )}*/}
+                                    {/*>*/}
+                                    {/*    {this.saving && (*/}
+                                    {/*        <span*/}
+                                    {/*            data-tour="virtual-study-summary-query-btn"*/}
+                                    {/*            className="btn btn-default"*/}
+                                    {/*            onClick={event => {*/}
+                                    {/*                if (*/}
+                                    {/*                    this.virtualStudy.result*/}
+                                    {/*                ) {*/}
+                                    {/*                    window.open(*/}
+                                    {/*                        buildCBioPortalPageUrl(*/}
+                                    {/*                            'results',*/}
+                                    {/*                            {*/}
+                                    {/*                                cancer_study_id: this*/}
+                                    {/*                                    .virtualStudy*/}
+                                    {/*                                    .result*/}
+                                    {/*                                    .id,*/}
+                                    {/*                            }*/}
+                                    {/*                        ),*/}
+                                    {/*                        '_blank'*/}
+                                    {/*                    );*/}
+                                    {/*                }*/}
+                                    {/*            }}*/}
+                                    {/*        >*/}
+                                    {/*            Query*/}
+                                    {/*        </span>*/}
+                                    {/*    )}*/}
+                                    {/*</div>*/}
                                 </div>
                             </Else>
                         </If>

--- a/src/pages/studyView/virtualStudy/VirtualStudyModal.tsx
+++ b/src/pages/studyView/virtualStudy/VirtualStudyModal.tsx
@@ -1,0 +1,54 @@
+import { Modal } from 'react-bootstrap';
+import * as React from 'react';
+import VirtualStudy from 'pages/studyView/virtualStudy/VirtualStudy';
+import { AppStore } from 'AppStore';
+import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
+import { JsxElement } from 'typescript';
+
+export interface IVirtualStudyModalProps {
+    appStore: AppStore;
+    pageStore: StudyViewPageStore;
+    message?: JSX.Element | string;
+    onHide: () => void;
+}
+
+export const VirtualStudyModal: React.FunctionComponent<IVirtualStudyModalProps> = function({
+    appStore,
+    pageStore,
+    message,
+    onHide,
+}) {
+    return (
+        <Modal onHide={onHide} show={true}>
+            <Modal.Header closeButton>
+                <Modal.Title>Create a Virtual Study</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                {message || null}
+                <VirtualStudy
+                    user={appStore.userName}
+                    name={
+                        pageStore.isSingleVirtualStudyPageWithoutFilter
+                            ? pageStore.filteredVirtualStudies.result[0].data
+                                  .name
+                            : undefined
+                    }
+                    description={
+                        pageStore.isSingleVirtualStudyPageWithoutFilter
+                            ? pageStore.filteredVirtualStudies.result[0].data
+                                  .description
+                            : undefined
+                    }
+                    studyWithSamples={pageStore.studyWithSamples.result}
+                    selectedSamples={pageStore.selectedSamples.result}
+                    filter={pageStore.userSelections}
+                    attributesMetaSet={pageStore.chartMetaSet}
+                    molecularProfileNameSet={
+                        pageStore.molecularProfileNameSet.result || {}
+                    }
+                    caseListNameSet={pageStore.caseListNameSet.result || {}}
+                />
+            </Modal.Body>
+        </Modal>
+    );
+};

--- a/src/shared/lib/extraHeader.ts
+++ b/src/shared/lib/extraHeader.ts
@@ -11,7 +11,13 @@ export function setCurrentURLHeader() {
 
     XMLHttpRequest.prototype.send = function() {
         if (this._url && /www\.cbioportal\.org\/api/.test(this._url)) {
-            this.setRequestHeader('X-CURRENT-URL', window.location.href);
+            this.setRequestHeader(
+                'X-CURRENT-URL',
+                window.location.href.substr(
+                    0,
+                    window.location.href.indexOf('#')
+                )
+            );
         }
         old_send.apply(this, arguments);
     };


### PR DESCRIPTION
When a study view is filtered to a custom sample, the bookmark url can grow to hundreds of thousands of characters in length.  Too big for url shortener which commonly allow only 1000 chars.  When we detect a url of excessive length, we prompt use to make a virtual study composed of the currently filtered cohort.

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/186521/cea7294e-2115-4c27-beb8-4b33f95bb0b9)

The ultimate solution would be to memoize the filter url in a backend session similar to what we do for results view.  This is a stop gap solution.

Fixes https://github.com/cBioPortal/cbioportal/issues/10486
