### PR TITLE
Remove StudyID Requirement for Single Study in Custom Selection.

### DIFF
--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
@@ -81,7 +81,7 @@ export default class CustomCaseSelection extends React.Component<
     get sampleSet(): { [id: string]: Sample } {
         return _.keyBy(
             this.props.selectedSamples,
-            s => `${s.studyId}:${s.sampleId}`
+            s => (this.isSingleStudy ? s.sampleId : `${s.studyId}:${s.sampleId}`)
         );
     }
 


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/10445

Changes:
Introduced a ternary operator to decide whether to include the ```studyId:``` prefix based on the ```isSingleStudy``` property. If it is a single study, only ```s.sampleId``` is used; otherwise, the original format with ```studyId:``` prefix is maintained.


