### PR TITLE
#10191 Feat: Auto ordering of groups on comparision tab done

### DIFF
--- a/src/pages/groupComparison/groupSelector/GroupSelector.tsx
+++ b/src/pages/groupComparison/groupSelector/GroupSelector.tsx
@@ -206,6 +206,15 @@ export default class GroupSelector extends React.Component<
                         index={buttons.length}
                     />
                 );
+                // Logic To Put Primary First
+                let buttons_: any[] = [];
+                buttons_[0] = buttons[1];
+                buttons_[1] = buttons[0];
+                // console.log("chk",  buttons[0].props.group, buttons[1].props.group, buttons_[0].props.group, buttons_[1].props.group)
+                buttons_[0].props.group.ordinal = 'A';
+                buttons_[1].props.group.ordinal = 'B';
+                // buttons_[0].props.group.nameWithOrdinal = buttons[1].props.group.nameWithOrdinal;
+                // buttons_[1].props.group.nameWithOrdinal = buttons[0].props.group.nameWithOrdinal;
                 return (
                     <div
                         data-tour="single-study-group-comparison-groups"


### PR DESCRIPTION
Fix cBioPortal/cbioportal [#10191
](https://github.com/cBioPortal/cbioportal/issues/10191)
Describe changes proposed in this pull request:
1. Auto-ordering of groups on the comparison tab.
2. Primary placed before Metastasis on the very first render of the component.
