### PR TITLE
🔨Refactor code: retrieve ndex tooltip information dynamically

### DIFF
--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -65,6 +65,13 @@ const TooltipContent: React.FC = observer(() => {
         tooltipContent: null as DatabaseItem[] | null,
         tooltipData: makeRemoteData(),
     }));
+    const formatUrl = (url: string) => {
+        if (url.startsWith('http://') || url.startsWith('https://')) {
+            return url;
+        } else {
+            return 'http://' + url;
+        }
+    };
 
     return (
         <div style={{ maxWidth: 400 }}>
@@ -83,7 +90,7 @@ const TooltipContent: React.FC = observer(() => {
                                     <li key={index}>
                                         {item.numberOfNetworks} from{' '}
                                         <a
-                                            href={`https://${item.url}`}
+                                            href={formatUrl(item.url)}
                                             target="_blank"
                                         >
                                             {item.name}

--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -9,7 +9,7 @@ import { ResultsViewPageStore } from 'pages/resultsView/ResultsViewPageStore';
 import ResultsViewURLWrapper from 'pages/resultsView/ResultsViewURLWrapper';
 import { AppStore } from 'AppStore';
 import { useLocalObservable } from 'mobx-react-lite';
-import { runInAction, autorun } from 'mobx';
+import { runInAction } from 'mobx';
 import request from 'superagent';
 import { remoteData } from 'cbioportal-frontend-commons';
 
@@ -39,11 +39,6 @@ function makeRemoteData() {
                 .get(
                     'https://iquery-cbio-dev.ucsd.edu/integratedsearch/v1/source'
                 )
-                .query({
-                    param1: 'value1',
-                    param2: 'value2',
-                    param3: 'value3',
-                })
                 .set('Accept', 'application/json')
                 .timeout(60000)
                 .redirects(0);
@@ -68,7 +63,6 @@ function makeRemoteData() {
 const TooltipContent: React.FC = observer(() => {
     const store = useLocalObservable(() => ({
         tooltipContent: null as DatabaseItem[] | null,
-        isFetchingTooltip: false,
         tooltipData: makeRemoteData(),
     }));
 
@@ -89,7 +83,7 @@ const TooltipContent: React.FC = observer(() => {
                                     <li key={index}>
                                         {item.numberOfNetworks} from{' '}
                                         <a
-                                            href={`https://www.${item.url}`}
+                                            href={`https://${item.url}`}
                                             target="_blank"
                                         >
                                             {item.name}
@@ -171,79 +165,6 @@ const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerPro
                             urlWrapper={resultsViewPageStore.urlWrapper}
                         />
                     </MSKTab>
-                    {/*<MSKTab
-                        key={ResultsViewPathwaysSubTab.NDEX}
-                        id={ResultsViewPathwaysSubTab.NDEX}
-                        linkText={ResultsViewPathwaysSubTab.NDEX}
-                        linkTooltip={
-                            <div style={{ maxWidth: 400 }}>
-                                <a
-                                    href="https://www.ndexbio.org/"
-                                    target="_blank"
-                                >
-                                    NDEx
-                                </a>{' '}
-                                shows 1,352 pathways:
-                                <ul>
-                                    <li>
-                                        207 from{' '}
-                                        <a
-                                            href="https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/NCI_PID/index.html"
-                                            target="_blank"
-                                        >
-                                            NCI-PID
-                                        </a>
-                                    </li>
-                                    <li>
-                                        83 from{' '}
-                                        <a
-                                            href="https://signor.uniroma2.it/"
-                                            target="_blank"
-                                        >
-                                            Signor
-                                        </a>
-                                    </li>
-                                    <li>
-                                        675 from{' '}
-                                        <a
-                                            href="https://www.wikipathways.org/"
-                                            target="_blank"
-                                        >
-                                            WikiPathways
-                                        </a>
-                                        <li>
-                                            11 from{' '}
-                                            <a
-                                                href="http://cptac.wikipathways.org/"
-                                                target="_blank"
-                                            >
-                                                CPTAC
-                                            </a>
-                                        </li>
-                                        <li>
-                                            30 from{' '}
-                                            <a
-                                                href="http://cptac.wikipathways.org/"
-                                                target="_blank"
-                                            >
-                                                CCMI
-                                            </a>
-                                        </li>
-                                    </li>
-                                </ul>
-                            </div>
-                        }
-                        hide={
-                            !getServerConfig().show_ndex ||
-                            !resultsViewPageStore.remoteNdexUrl.isComplete ||
-                            !resultsViewPageStore.remoteNdexUrl.result
-                        }
-                    >
-                        <IFrameLoader
-                            height={800}
-                            url={`${resultsViewPageStore.remoteNdexUrl.result}`}
-                        />
-                    </MSKTab>*/}
                     <MSKTab
                         key={ResultsViewPathwaysSubTab.NDEX}
                         id={ResultsViewPathwaysSubTab.NDEX}

--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -12,6 +12,7 @@ import { useLocalObservable } from 'mobx-react-lite';
 import { runInAction } from 'mobx';
 import request from 'superagent';
 import { remoteData } from 'cbioportal-frontend-commons';
+import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 
 interface IPathwayMapperContainerProps {
     resultsViewPageStore: ResultsViewPageStore;
@@ -54,10 +55,19 @@ function makeRemoteData() {
                     url: result.url,
                 })
             );
+
             return extractedData;
         },
         default: [],
     });
+}
+
+function formatUrl(url: string) {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+        return url;
+    } else {
+        return 'http://' + url;
+    }
 }
 
 const TooltipContent: React.FC = observer(() => {
@@ -65,13 +75,6 @@ const TooltipContent: React.FC = observer(() => {
         tooltipContent: null as DatabaseItem[] | null,
         tooltipData: makeRemoteData(),
     }));
-    const formatUrl = (url: string) => {
-        if (url.startsWith('http://') || url.startsWith('https://')) {
-            return url;
-        } else {
-            return 'http://' + url;
-        }
-    };
 
     return (
         <div style={{ maxWidth: 400 }}>
@@ -80,7 +83,14 @@ const TooltipContent: React.FC = observer(() => {
             </a>{' '}
             shows 1,352 pathways:
             {store.tooltipData.isPending ? (
-                <div>Loading tooltip content...</div>
+                <div>
+                    <LoadingIndicator
+                        isLoading={true}
+                        size={'small'}
+                        inline={true}
+                    />{' '}
+                    Loading networks
+                </div>
             ) : (
                 <div>
                     {store.tooltipData.result && (
@@ -101,7 +111,9 @@ const TooltipContent: React.FC = observer(() => {
                         </ul>
                     )}
                     {store.tooltipData.isError && (
-                        <div>Error: Failed to load tooltip content.</div>
+                        <div className={'text-warning'}>
+                            Error: Failed to load tooltip content.
+                        </div>
                     )}
                 </div>
             )}


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10595 (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Using this [endpoint](https://iquery-cbio-dev.ucsd.edu/integratedsearch/v1/source) to populate the **Ndex Cancer Pathways** tooltip rather than hardcoding it as it is now
- Not finding the exact match for hardcoded URLs in endpoint, currently all URLs point to "#" (can be adjusted after discussion)

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

Before:
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/71656941/0da7d6f5-4ce4-4394-8e96-ed1de4e270b2)
 
 After:
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/71656941/d331c812-96b1-4c77-a62b-0790eff56344)


## Notify reviewers
@inodb 
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
