### PR TITLE
Add configuration for disabling study tag fetching (default to true)

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -181,4 +181,5 @@ export interface IServerConfig {
     vaf_sequential_mode_default: boolean; // this has a default
     vaf_log_scale_default: boolean; // this has a default
     skin_study_view_show_sv_table: boolean; // this has a default
+    enable_study_tags: boolean;
 }

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -127,6 +127,8 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
 
     session_url_length_threshold: '1500',
 
+    enable_study_tags: true,
+
     study_view: {
         tableAttrs: ['CANCER_TYPE', 'CANCER_TYPE_DETAILED'],
         priority: {

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -655,10 +655,14 @@ export class QueryStore {
     readonly cancerStudyTags = remoteData({
         await: () => [this.cancerStudies],
         invoke: async () => {
-            const studyIds = this.cancerStudies.result
-                .filter(s => s.readPermission)
-                .map(s => s.studyId);
-            return client.getTagsForMultipleStudiesUsingPOST({ studyIds });
+            if (getServerConfig().enable_study_tags) {
+                const studyIds = this.cancerStudies.result
+                    .filter(s => s.readPermission)
+                    .map(s => s.studyId);
+                return client.getTagsForMultipleStudiesUsingPOST({ studyIds });
+            } else {
+                return [];
+            }
         },
         default: [],
     });


### PR DESCRIPTION
There is a problem with Spring security (SAML mode) and the study tags endpoint.  We need to disable it on portals which don't use tags until the problem is resolved.