### PR TITLE
Remove entity stable ID from generic assay name

### DIFF
--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
@@ -17,7 +17,7 @@ import { ISelectOption } from 'shared/lib/GenericAssayUtils/GenericAssaySelectio
 
 describe('GenericAssayCommonUtils', () => {
     describe('makeGenericAssayOption()', () => {
-        it('Includes entity_stable_id and description when present and unique', () => {
+        it('Includes description and hides stableId when present and unique', () => {
             const genericAssayEntity: GenericAssayMeta = {
                 stableId: 'id_1',
                 entityType: 'GENERIC_ASSAY',
@@ -29,7 +29,7 @@ describe('GenericAssayCommonUtils', () => {
 
             const expect = {
                 value: 'id_1',
-                label: 'name_1 (id_1): desc_1',
+                label: 'name_1: desc_1',
             };
             assert.deepEqual(
                 makeGenericAssayOption(genericAssayEntity),
@@ -49,7 +49,7 @@ describe('GenericAssayCommonUtils', () => {
 
             const expect = {
                 value: 'id_1',
-                label: 'name_1 (id_1)',
+                label: 'name_1',
             };
             assert.deepEqual(
                 makeGenericAssayOption(genericAssayEntity),
@@ -77,7 +77,7 @@ describe('GenericAssayCommonUtils', () => {
             );
         });
 
-        it('Hides name and description when same as entity_stable_id', () => {
+        it('Hides stableId and description when same as name', () => {
             const genericAssayEntity: GenericAssayMeta = {
                 stableId: 'id_1',
                 entityType: 'GENERIC_ASSAY',
@@ -116,7 +116,7 @@ describe('GenericAssayCommonUtils', () => {
             );
         });
 
-        it('Shows entity_stable_id and name when description is missing in properties', () => {
+        it('Shows name and hides stableId when description is missing in properties', () => {
             const genericAssayEntity: GenericAssayMeta = {
                 stableId: 'id_1',
                 entityType: 'GENERIC_ASSAY',
@@ -127,7 +127,7 @@ describe('GenericAssayCommonUtils', () => {
 
             const expect = {
                 value: 'id_1',
-                label: 'name_1 (id_1)',
+                label: 'name_1',
             };
             assert.deepEqual(
                 makeGenericAssayOption(genericAssayEntity),
@@ -166,7 +166,7 @@ describe('GenericAssayCommonUtils', () => {
 
             const expect = {
                 value: 'id_1',
-                label: 'name_1 (id_1): desc_1',
+                label: 'name_1: desc_1',
                 plotAxisLabel: 'name_1',
             };
             assert.deepEqual(
@@ -187,8 +187,8 @@ describe('GenericAssayCommonUtils', () => {
 
             const expect = {
                 value: 'id_1',
-                label: 'name_1 (id_1): desc_1',
-                plotAxisLabel: 'name_1 (id_1)',
+                label: 'name_1: desc_1',
+                plotAxisLabel: 'name_1',
             };
             assert.deepEqual(
                 makeGenericAssayPlotsTabOption(genericAssayEntity, true),
@@ -295,7 +295,7 @@ describe('GenericAssayCommonUtils', () => {
     });
 
     describe('formatGenericAssayCompactLabelByNameAndId()', () => {
-        it('Hides name when same as stableId', () => {
+        it('Hides stableId when same as name', () => {
             const stableId = 'STABLE_ID';
             const name = stableId;
             assert.equal(
@@ -303,12 +303,12 @@ describe('GenericAssayCommonUtils', () => {
                 stableId
             );
         });
-        it('shows name and stableId when they are unique', () => {
+        it('Only shows name when name and stableId are unique', () => {
             const stableId = 'STABLE_ID';
             const name = 'NAME';
             assert.equal(
                 formatGenericAssayCompactLabelByNameAndId(stableId, name),
-                `${name} (${stableId})`
+                `${name}`
             );
         });
     });

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
@@ -236,14 +236,12 @@ export function formatGenericAssayCommonLabel(meta: GenericAssayMeta) {
     const uniqueDesc = description !== meta.stableId && description !== name;
     // set stableId as default label
     let label = meta.stableId;
-    if (!uniqueName && !uniqueDesc) {
-        label = meta.stableId;
-    } else if (!uniqueName) {
+    if (uniqueName && uniqueDesc) {
+        label = `${name}: ${description}`;
+    } else if (uniqueName) {
+        label = name;
+    } else if (uniqueDesc) {
         label = `${meta.stableId}: ${description}`;
-    } else if (!uniqueDesc) {
-        label = `${name} (${meta.stableId})`;
-    } else {
-        label = `${name} (${meta.stableId}): ${description}`;
     }
     return label;
 }
@@ -255,7 +253,7 @@ export function formatGenericAssayCompactLabelByNameAndId(
     const uniqueName = name !== stableId;
     let label = stableId;
     if (uniqueName) {
-        label = `${name} (${stableId})`;
+        label = name;
     }
     return label;
 }


### PR DESCRIPTION
Follow up to https://github.com/cBioPortal/cbioportal-core/pull/7

As the ENTITY_STABLE_IDs for Generic Assays are now more strictly validated, we propose to simply hide the stable ID if the `NAME` property is given, instead of showing `NAME (ENTITY_STABLE_ID)`.

Describe changes proposed in this pull request:
- a
- b

## Checks
- [] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
