### PR TITLE
Fix: previous filters deselection upon each 'Select All' click

### DIFF
--- a/src/pages/studyView/table/ClinicalTable.tsx
+++ b/src/pages/studyView/table/ClinicalTable.tsx
@@ -290,7 +290,16 @@ export default class ClinicalTable extends React.Component<
 
     @autobind
     addAll(selectedRows: ClinicalDataCountSummary[]) {
-        this.props.onUserSelection(selectedRows.map(row => row.value));
+        // To prevent the deselection of previously applied filters upon each "Select All" click,
+        // we retrieve the existing filters and concatenate them with the new ones.
+        let filters = toJS(this.props.filters);
+
+        let uniqueSelectedRows = selectedRows
+            .map(row => row.value)
+            .filter(item => !filters.includes(item));
+
+        filters = filters.concat(uniqueSelectedRows);
+        this.props.onUserSelection(filters);
     }
 
     @autobind


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10422

## Describe changes proposed in this pull request:
- This fix addresses the issue of deselecting previous filters that are not part of the search results.
### What has been done
When the user clicks 'Select All':
- Retrieve all old filters.
- Exclude already selected filters from the new ones (to avoid duplicate filter tags)
- Concatenate the old filters with the new ones.
## Any screenshots or GIFs?

### Before
![before](https://github.com/cBioPortal/cbioportal-frontend/assets/50466262/69f71a9e-2d90-4425-8304-67866de34f2c)

### After
![ezgif-6-c944135e3a](https://github.com/cBioPortal/cbioportal-frontend/assets/50466262/93de1e73-7141-4465-9d4b-67bc90affd11)

## Notify reviewers
@alisman @inodb 