### PR TITLE
:wrench: Update keycloak image to quay.io

### DIFF
--- a/end-to-end-test/local/docker_compose/keycloak.yml
+++ b/end-to-end-test/local/docker_compose/keycloak.yml
@@ -15,7 +15,7 @@ services:
     networks:
     - cbio-net
     container_name: keycloak
-    image: jboss/keycloak:11.0.3
+    image: quay.io/keycloak/keycloak:11.0.3
     restart: unless-stopped
     depends_on:
     - kcdb


### PR DESCRIPTION
For some reason jboss/keycloak:11.0.3 does not exists anymore.... updated to quay.io