### PR TITLE
Update to remove legacy db properties

### DIFF
--- a/end-to-end-test/local/runtime-config/portal.properties
+++ b/end-to-end-test/local/runtime-config/portal.properties
@@ -7,10 +7,6 @@ spring.datasource.username=cbio_user
 spring.datasource.password=somepassword
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-db.user=cbio_user
-db.password=somepassword
-db.driver=com.mysql.jdbc.Driver
-db.connection_string=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false&allowPublicKeyRetrieval=true
 # set tomcat_resource_name when using dbconnector=jndi instead of the default
 # dbconnector=dbcp. Note that dbconnector needs to be set in CATLINA_OPTS when
 # using Tomcat (CATALINA_OPTS="-Ddbconnector=jndi"). It does not get picked up


### PR DESCRIPTION
Latest version of core throws error when legacy db properties are set
