### PR TITLE
feat: added button to open iframe source

### DIFF
--- a/src/shared/components/iframeLoader/IFrameLoader.tsx
+++ b/src/shared/components/iframeLoader/IFrameLoader.tsx
@@ -4,6 +4,7 @@ import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
 import { observer } from 'mobx-react';
 import { makeObservable, observable } from 'mobx';
 import autobind from 'autobind-decorator';
+import FontAwesome from 'react-fontawesome';
 interface FrameLoaderProps {
     url: string;
     className?: string;
@@ -41,6 +42,13 @@ export default class IFrameLoader extends React.Component<
                     size={'big'}
                     isLoading={!this.iframeLoaded}
                 />
+                <a
+                    href={this.props.url}
+                    target="_blank"
+                    style={{ float: 'right' }}
+                >
+                    Visit <FontAwesome name="external-link" />
+                </a>
                 <iframe
                     id={this.props.iframeId || ''}
                     className={this.props.className || ''}

--- a/src/shared/components/iframeLoader/IFrameLoader.tsx
+++ b/src/shared/components/iframeLoader/IFrameLoader.tsx
@@ -45,9 +45,9 @@ export default class IFrameLoader extends React.Component<
                 <a
                     href={this.props.url}
                     target="_blank"
-                    style={{ float: 'right' }}
+                    style={{ position:"absolute", right:0, top:-25 }}
                 >
-                    Visit <FontAwesome name="external-link" />
+                    Open in new window <FontAwesome name="external-link" />
                 </a>
                 <iframe
                     id={this.props.iframeId || ''}

--- a/src/shared/components/iframeLoader/IFrameLoader.tsx
+++ b/src/shared/components/iframeLoader/IFrameLoader.tsx
@@ -36,7 +36,13 @@ export default class IFrameLoader extends React.Component<
     //NOTE: we need zindex to be higher than that of global loader
     render() {
         return (
-            <div style={{ position: 'relative', width: this.props.width }}>
+            <div
+                style={{
+                    position: 'relative',
+                    width: this.props.width,
+                    marginTop: 5,
+                }}
+            >
                 <LoadingIndicator
                     center={true}
                     size={'big'}
@@ -45,7 +51,12 @@ export default class IFrameLoader extends React.Component<
                 <a
                     href={this.props.url}
                     target="_blank"
-                    style={{ position:"absolute", right:0, top:-25 }}
+                    style={{
+                        position: 'absolute',
+                        fontSize: 12,
+                        right: 0,
+                        top: -18,
+                    }}
                 >
                     Open in new window <FontAwesome name="external-link" />
                 </a>
@@ -58,6 +69,7 @@ export default class IFrameLoader extends React.Component<
                         zIndex: 100,
                         height: this.props.height,
                         border: 'none',
+                        marginTop: 5,
                     }}
                     src={this.props.url}
                     onLoad={this.onLoad}


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10703
Describe changes proposed in this pull request:
- Added a button in the top right corner of the iframe to open the iframe source in a new tab

## Any screenshots or GIFs?
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/50466262/e2c58ae4-a381-4a54-a684-b352167e4954)


https://github.com/cBioPortal/cbioportal-frontend/assets/50466262/95e02c62-d88d-40a4-a6bd-81034509f080


## Notify reviewers
@alisman 
