### PR TITLE
Show all survival attributes and remove duplicates in study clinical data tab

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -674,7 +674,7 @@ export class StudyViewPageStore
         this.reactionDisposers.push(
             reaction(
                 () => [
-                    this.visibleAttributes,
+                    this.visibleAttributesForSummary,
                     this.columns,
                     _.fromPairs(this.chartsDimension.toJSON()),
                     _.fromPairs(this.chartsType.toJSON()),
@@ -2436,7 +2436,7 @@ export class StudyViewPageStore
     @action.bound
     private updateLayout(): void {
         this.currentGridLayout = calculateLayout(
-            this.visibleAttributes,
+            this.visibleAttributesForSummary,
             this.columns,
             _.fromPairs(this.chartsDimension.toJSON()),
             this.currentGridLayout,
@@ -6837,6 +6837,7 @@ export class StudyViewPageStore
         if (this.isSavingUserPreferencePossible) {
             chartSettingsMap = getChartSettingsMap(
                 this.visibleAttributes,
+                this.visibleAttributesForSummary,
                 this.columns,
                 _.fromPairs(this.chartsDimension.toJSON()),
                 _.fromPairs(this.chartsType.toJSON()),
@@ -7043,8 +7044,19 @@ export class StudyViewPageStore
             },
             [] as ChartMeta[]
         );
+        const visibleAttributesForSummary = _.reduce(
+            this._defaultVisibleChartIds,
+            (acc, chartUniqueKey) => {
+                if (this.chartMetaSetForSummary[chartUniqueKey]) {
+                    acc.push(this.chartMetaSetForSummary[chartUniqueKey]);
+                }
+                return acc;
+            },
+            [] as ChartMeta[]
+        );
         return getChartSettingsMap(
             visibleAttributes,
+            visibleAttributesForSummary,
             this.columns,
             _.fromPairs(this._defaultChartsDimension.toJSON()),
             _.fromPairs(this._defaultChartsType.toJSON()),

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -182,7 +182,7 @@ import {
     getCustomChartDownloadData,
     generateColorMapKey,
     MutationCategorization,
-    getChartMetaSetForClinicalAttributes,
+    getChartMetaSet,
     getVisibleAttributes,
 } from './StudyViewUtils';
 import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
@@ -6583,7 +6583,7 @@ export class StudyViewPageStore
     @computed get chartMetaSetForSummary(): {
         [id: string]: ChartMeta;
     } {
-        let chartMetaSet = getChartMetaSetForClinicalAttributes(
+        let chartMetaSet = getChartMetaSet(
             this._customCharts,
             this.molecularProfiles.result,
             this._geneSpecificCharts,
@@ -6611,7 +6611,7 @@ export class StudyViewPageStore
     @computed get chartMetaSetForClinicalData(): {
         [id: string]: ChartMeta;
     } {
-        let chartMetaSet = getChartMetaSetForClinicalAttributes(
+        let chartMetaSet = getChartMetaSet(
             this._customCharts,
             this.molecularProfiles.result,
             this._geneSpecificCharts,
@@ -6637,7 +6637,7 @@ export class StudyViewPageStore
     // all chart meta information
     @computed
     get chartMetaSet(): { [id: string]: ChartMeta } {
-        let chartMetaSet = getChartMetaSetForClinicalAttributes(
+        let chartMetaSet = getChartMetaSet(
             this._customCharts,
             this.molecularProfiles.result,
             this._geneSpecificCharts,
@@ -7036,23 +7036,23 @@ export class StudyViewPageStore
     } {
         const visibleAttributes = _.reduce(
             this._defaultVisibleChartIds,
-            (acc, chartUniqueKey) => {
+            (acc: ChartMeta[], chartUniqueKey) => {
                 if (this.chartMetaSet[chartUniqueKey]) {
                     acc.push(this.chartMetaSet[chartUniqueKey]);
                 }
                 return acc;
             },
-            [] as ChartMeta[]
+            []
         );
         const visibleAttributesForSummary = _.reduce(
             this._defaultVisibleChartIds,
-            (acc, chartUniqueKey) => {
+            (acc: ChartMeta[], chartUniqueKey) => {
                 if (this.chartMetaSetForSummary[chartUniqueKey]) {
                     acc.push(this.chartMetaSetForSummary[chartUniqueKey]);
                 }
                 return acc;
             },
-            [] as ChartMeta[]
+            []
         );
         return getChartSettingsMap(
             visibleAttributes,

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -2807,6 +2807,7 @@ export function isSpecialChart(chartMeta: ChartMeta) {
 
 export function getChartSettingsMap(
     visibleAttributes: ChartMeta[],
+    visibleAttributesForSummary: ChartMeta[],
     columns: number,
     chartDimensionSet: { [uniqueId: string]: ChartDimension },
     chartTypeSet: { [uniqueId: string]: ChartType },
@@ -2824,7 +2825,7 @@ export function getChartSettingsMap(
 ) {
     if (!gridLayout) {
         gridLayout = calculateLayout(
-            visibleAttributes,
+            visibleAttributesForSummary,
             columns,
             chartDimensionSet,
             []
@@ -2895,9 +2896,19 @@ export function getChartSettingsMap(
         }
         chartSettingsMap[id] = chartSetting;
     });
+    // attributes disabled on the summary tab (used in Clinical Data tab but not Summary tab like most survival attributes)
+    const disabledAttributes = _.differenceWith(
+        visibleAttributes,
+        visibleAttributesForSummary,
+        _.isEqual
+    );
     // add layout for each chart
     gridLayout.forEach(layout => {
-        if (layout.i && chartSettingsMap[layout.i]) {
+        if (
+            layout.i &&
+            chartSettingsMap[layout.i] &&
+            !disabledAttributes.find(a => a.uniqueKey === layout.i)
+        ) {
             chartSettingsMap[layout.i].layout = {
                 x: layout.x,
                 y: layout.y,
@@ -4579,6 +4590,7 @@ export async function getMutationTypesDownloadData(
         });
         return data.join('\n');
     } else return '';
+}
 
 export function getChartMetaSetForClinicalAttributes(
     customCharts: ObservableMap<string, ChartMeta>,

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -114,6 +114,7 @@ import { MolecularAlterationType_filenameSuffix } from 'shared/lib/StoreUtils';
 import { MultiSelectionTableRow } from './table/MultiSelectionTable';
 import Survival from 'pages/groupComparison/Survival';
 import { StructVarMultiSelectionTableRow } from './table/StructuralVariantMultiSelectionTable';
+import { ObservableMap } from 'mobx';
 
 // Cannot use ClinicalDataTypeEnum here for the strong type. The model in the type is not strongly typed
 export enum ClinicalDataTypeEnum {
@@ -2417,14 +2418,17 @@ export function getOptionsByChartMetaDataType(
     chartsMeta: ChartMeta[],
     selectedAttrs: string[],
     allChartTypes: { [id: string]: ChartType },
-    isSharedCustomData?: (chartId: string) => boolean
+    isSharedCustomData?: (chartId: string) => boolean,
+    chartMetaSetForCurrentTab?: { [id: string]: ChartMeta }
 ): ChartOption[] {
     return _.map(chartsMeta, chartMeta => {
         const chartOption: ChartOption = {
             label: chartMeta.displayName,
             key: chartMeta.uniqueKey,
             chartType: allChartTypes[chartMeta.uniqueKey],
-            disabled: false,
+            disabled: chartMetaSetForCurrentTab
+                ? !chartMetaSetForCurrentTab[chartMeta.uniqueKey] // if not chartMeta for current tab, disable option
+                : false,
             selected: selectedAttrs.includes(chartMeta.uniqueKey),
             freq: 100,
         };
@@ -4575,4 +4579,289 @@ export async function getMutationTypesDownloadData(
         });
         return data.join('\n');
     } else return '';
+
+export function getChartMetaSetForClinicalAttributes(
+    customCharts: ObservableMap<string, ChartMeta>,
+    molecularProfiles: MolecularProfile[],
+    geneSpecificCharts: ObservableMap<string, ChartMeta>,
+    genericAssayCharts: ObservableMap<string, ChartMeta>,
+    XvsYCharts: ObservableMap<string, ChartMeta>,
+    clinicalAttributes: ClinicalAttribute[],
+    survivalPlots: SurvivalType[],
+    mutationProfiles: MolecularProfile[],
+    structuralVariantProfiles: MolecularProfile[],
+    isStructVarTableFeatureEnabled: boolean,
+    cnaProfiles: MolecularProfile[],
+    shouldDisplayClinicalEventTypeCounts?: boolean,
+    shouldDisplaySampleTreatments?: boolean,
+    shouldDisplayPatientTreatments?: boolean,
+    shouldDisplaySampleTreatmentGroups?: boolean,
+    shouldDisplayPatientTreatmentGroups?: boolean,
+    shouldDisplaySampleTreatmentTarget?: boolean,
+    shouldDisplayPatientTreatmentTarget?: boolean
+) {
+    const customChartMetaSet = _.fromPairs(customCharts.toJSON());
+    // if no molecular profiles, genomic profiles sample count chart will be empty so remove it from set
+    if (_.isEmpty(molecularProfiles)) {
+        delete customChartMetaSet[
+            SpecialChartsUniqueKeyEnum.GENOMIC_PROFILES_SAMPLE_COUNT
+        ];
+    }
+    const geneSpecificChartMetaSet = _.fromPairs(geneSpecificCharts.toJSON());
+    const genericAssayChartMetaSet = _.fromPairs(genericAssayCharts.toJSON());
+    const XvsYChartMetaSet = _.fromPairs(XvsYCharts.toJSON());
+
+    // Add meta information for clinical attributes
+    // Convert to a Set for easy access and to update attribute meta information (would be useful while adding new features)
+    const clinicalAttributeChartMetaSet = _.reduce(
+        clinicalAttributes,
+        (acc: { [id: string]: ChartMeta }, attribute) => {
+            const uniqueKey = getUniqueKey(attribute);
+            const priority = getPriorityByClinicalAttribute(attribute);
+            if (priority > -1) {
+                acc[uniqueKey] = {
+                    displayName: attribute.displayName,
+                    uniqueKey: uniqueKey,
+                    dataType: getChartMetaDataType(uniqueKey),
+                    patientAttribute: attribute.patientAttribute,
+                    description: attribute.description,
+                    priority: priority,
+                    renderWhenDataChange: false,
+                    clinicalAttribute: attribute,
+                };
+            }
+            return acc;
+        },
+        {}
+    );
+
+    const survivalPlotChartMetaSet = _.reduce(
+        survivalPlots,
+        (acc: { [id: string]: ChartMeta }, survivalPlot) => {
+            acc[survivalPlot.id] = {
+                uniqueKey: survivalPlot.id,
+                dataType: getChartMetaDataType(survivalPlot.id),
+                patientAttribute: true,
+                displayName: survivalPlot.title,
+                clinicalAttribute: survivalPlot.survivalStatusAttribute,
+                // use survival status attribute's priority as KM plot's priority for non-reserved plots
+                priority:
+                    STUDY_VIEW_CONFIG.priority[survivalPlot.id] ||
+                    getPriorityByClinicalAttribute(
+                        survivalPlot.survivalStatusAttribute
+                    ),
+                renderWhenDataChange: false,
+                description: '',
+            };
+            return acc;
+        },
+        {}
+    );
+
+    const chartMetaSet = {
+        ...customChartMetaSet,
+        ...geneSpecificChartMetaSet,
+        ...genericAssayChartMetaSet,
+        ...XvsYChartMetaSet,
+        ...clinicalAttributeChartMetaSet,
+        ...survivalPlotChartMetaSet,
+    };
+
+    if (shouldDisplayClinicalEventTypeCounts) {
+        chartMetaSet['CLINICAL_EVENT_TYPE_COUNTS'] = {
+            uniqueKey: 'CLINICAL_EVENT_TYPE_COUNTS',
+            dataType: ChartMetaDataTypeEnum.CLINICAL,
+            patientAttribute: false,
+            displayName: 'Timeline Events Availability',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.CLINICAL_EVENT_TYPE_COUNTS_TABLE
+            ),
+            renderWhenDataChange: false,
+            description:
+                'Distinct Counts of Patients with Clinical Event Types',
+        };
+    }
+    if (shouldDisplaySampleTreatments) {
+        chartMetaSet['SAMPLE_TREATMENTS'] = {
+            uniqueKey: 'SAMPLE_TREATMENTS',
+            dataType: ChartMetaDataTypeEnum.CLINICAL,
+            patientAttribute: true,
+            displayName: 'Treatment per Sample (pre/post)',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.SAMPLE_TREATMENTS_TABLE
+            ),
+            renderWhenDataChange: true,
+            description:
+                'List of treatments and the corresponding number of samples acquired before treatment or after/on treatment',
+        };
+    }
+
+    if (shouldDisplayPatientTreatments) {
+        chartMetaSet['PATIENT_TREATMENTS'] = {
+            uniqueKey: 'PATIENT_TREATMENTS',
+            dataType: ChartMetaDataTypeEnum.CLINICAL,
+            patientAttribute: true,
+            displayName: 'Treatment per Patient',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.PATIENT_TREATMENTS_TABLE
+            ),
+            renderWhenDataChange: true,
+            description:
+                'List of treatments and the corresponding number of patients treated',
+        };
+    }
+
+    if (shouldDisplaySampleTreatmentGroups) {
+        chartMetaSet['SAMPLE_TREATMENT_GROUPS'] = {
+            uniqueKey: 'SAMPLE_TREATMENT_GROUPS',
+            dataType: ChartMetaDataTypeEnum.CLINICAL,
+            patientAttribute: true,
+            displayName: 'Treatment Category per Sample (pre/post)',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.SAMPLE_TREATMENT_GROUPS_TABLE
+            ),
+            renderWhenDataChange: true,
+            description:
+                'List of treatments groups and the corresponding number of samples acquired before treatment or after/on treatment',
+        };
+    }
+
+    if (shouldDisplayPatientTreatmentGroups) {
+        chartMetaSet['PATIENT_TREATMENT_GROUPS'] = {
+            uniqueKey: 'PATIENT_TREATMENT_GROUPS',
+            dataType: ChartMetaDataTypeEnum.CLINICAL,
+            patientAttribute: true,
+            displayName: 'Treatment Category per Patient',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.PATIENT_TREATMENT_GROUPS_TABLE
+            ),
+            renderWhenDataChange: true,
+            description:
+                'List of treatment groups and the corresponding number of patients treated',
+        };
+    }
+
+    if (shouldDisplaySampleTreatmentTarget) {
+        chartMetaSet['SAMPLE_TREATMENT_TARGET'] = {
+            uniqueKey: 'SAMPLE_TREATMENT_TARGET',
+            dataType: ChartMetaDataTypeEnum.CLINICAL,
+            patientAttribute: true,
+            displayName: 'Treatment Target per Sample (pre/post)',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.SAMPLE_TREATMENT_TARGET_TABLE
+            ),
+            renderWhenDataChange: true,
+            description:
+                'List of treatments targets and the corresponding number of samples acquired before treatment or after/on treatment',
+        };
+    }
+
+    if (shouldDisplayPatientTreatmentTarget) {
+        chartMetaSet['PATIENT_TREATMENT_TARGET'] = {
+            uniqueKey: 'PATIENT_TREATMENT_TARGET',
+            dataType: ChartMetaDataTypeEnum.CLINICAL,
+            patientAttribute: true,
+            displayName: 'Treatment Target per Patient',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.PATIENT_TREATMENT_TARGET_TABLE
+            ),
+            renderWhenDataChange: true,
+            description:
+                'List of treatment targets and the corresponding number of patients treated',
+        };
+    }
+
+    if (!_.isEmpty(mutationProfiles)) {
+        const uniqueKey = getUniqueKeyFromMolecularProfileIds(
+            mutationProfiles.map(
+                mutationProfile => mutationProfile.molecularProfileId
+            )
+        );
+        chartMetaSet[uniqueKey] = {
+            uniqueKey: uniqueKey,
+            dataType: ChartMetaDataTypeEnum.GENOMIC,
+            patientAttribute: false,
+            displayName: 'Mutated Genes',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.MUTATED_GENES_TABLE
+            ),
+            renderWhenDataChange: false,
+            description: '',
+        };
+    }
+
+    if (!_.isEmpty(structuralVariantProfiles)) {
+        const uniqueKey = getUniqueKeyFromMolecularProfileIds(
+            structuralVariantProfiles.map(p => p.molecularProfileId),
+            ChartTypeEnum.STRUCTURAL_VARIANT_GENES_TABLE
+        );
+        chartMetaSet[uniqueKey] = {
+            uniqueKey,
+            dataType: ChartMetaDataTypeEnum.GENOMIC,
+            patientAttribute: false,
+            displayName: 'Structural Variant Genes',
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.STRUCTURAL_VARIANT_GENES_TABLE
+            ),
+            renderWhenDataChange: true,
+            description: '',
+        };
+        if (isStructVarTableFeatureEnabled) {
+            const structVarGenesUniqueKey = getUniqueKeyFromMolecularProfileIds(
+                structuralVariantProfiles.map(p => p.molecularProfileId),
+                ChartTypeEnum.STRUCTURAL_VARIANTS_TABLE
+            );
+            chartMetaSet[structVarGenesUniqueKey] = {
+                uniqueKey: structVarGenesUniqueKey,
+                dataType: ChartMetaDataTypeEnum.GENOMIC,
+                patientAttribute: false,
+                displayName: 'Structural Variants',
+                priority: getDefaultPriorityByUniqueKey(
+                    ChartTypeEnum.STRUCTURAL_VARIANTS_TABLE
+                ),
+                renderWhenDataChange: true,
+                description: '',
+            };
+        }
+    }
+
+    if (!_.isEmpty(cnaProfiles)) {
+        const uniqueKey = getUniqueKeyFromMolecularProfileIds(
+            cnaProfiles.map(
+                mutationProfile => mutationProfile.molecularProfileId
+            )
+        );
+        chartMetaSet[uniqueKey] = {
+            uniqueKey,
+            dataType: ChartMetaDataTypeEnum.GENOMIC,
+            patientAttribute: false,
+            displayName: 'CNA Genes',
+            renderWhenDataChange: false,
+            priority: getDefaultPriorityByUniqueKey(
+                ChartTypeEnum.CNA_GENES_TABLE
+            ),
+            description: '',
+        };
+    }
+
+    return chartMetaSet;
+}
+
+export function getVisibleAttributes(
+    chartVisibility: ObservableMap<string, boolean>,
+    chartMetaSet: {
+        [id: string]: ChartMeta;
+    }
+) {
+    return _.reduce(
+        Array.from(chartVisibility.entries() || []),
+        (acc: ChartMeta[], [chartUniqueKey, visible]) => {
+            if (visible && chartMetaSet[chartUniqueKey]) {
+                let chartMeta = chartMetaSet[chartUniqueKey];
+                acc.push(chartMeta);
+            }
+            return acc;
+        },
+        []
+    );
 }

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -4592,7 +4592,7 @@ export async function getMutationTypesDownloadData(
     } else return '';
 }
 
-export function getChartMetaSetForClinicalAttributes(
+export function getChartMetaSet(
     customCharts: ObservableMap<string, ChartMeta>,
     molecularProfiles: MolecularProfile[],
     geneSpecificCharts: ObservableMap<string, ChartMeta>,

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -28,6 +28,7 @@ import {
     ChartDataCountSet,
     getOptionsByChartMetaDataType,
     getGenomicChartUniqueKey,
+    ChartMeta,
 } from '../StudyViewUtils';
 import { MSKTab, MSKTabs } from '../../../shared/components/MSKTabs/MSKTabs';
 import { ChartTypeEnum, ChartTypeNameEnum } from '../StudyViewConfig';
@@ -299,13 +300,26 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         });
     }
 
+    // provide chartMetaSet for current tab to disable appropriate options
+    // if summary tab, disable survival attributes
+    // if clinical data tab, disable survival plot attributes
     @computed
     get clinicalDataOptions(): ChartOption[] {
+        let chartMetaSetForCurrentTab: { [id: string]: ChartMeta };
+        if (this.props.currentTab === StudyViewPageTabKeyEnum.SUMMARY) {
+            chartMetaSetForCurrentTab = this.props.store.chartMetaSetForSummary;
+        } else {
+            chartMetaSetForCurrentTab = this.props.store
+                .chartMetaSetForClinicalData;
+        }
+
         return getOptionsByChartMetaDataType(
             this.groupedChartMetaByDataType[ChartMetaDataTypeEnum.CLINICAL] ||
                 [],
             this.selectedAttrs,
-            _.fromPairs(this.props.store.chartsType.toJSON())
+            _.fromPairs(this.props.store.chartsType.toJSON()),
+            undefined,
+            chartMetaSetForCurrentTab
         );
     }
 

--- a/src/pages/studyView/addChartButton/addChartByType/AddChartByType.tsx
+++ b/src/pages/studyView/addChartButton/addChartByType/AddChartByType.tsx
@@ -68,7 +68,7 @@ export default class AddChartByType extends React.Component<
                     acc.push({
                         label: next.label,
                         key: next.key,
-                        disabled: disabled,
+                        disabled: next.disabled || disabled,
                         selected: next.selected,
                         isSharedChart: next.isSharedChart,
                         freq: disabled

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -239,7 +239,9 @@ export class ClinicalDataTab extends React.Component<
                 });
             }
             return _.reduce(
-                this.props.store.visibleAttributes.sort(chartMetaComparator),
+                this.props.store.visibleAttributesForClinicalDataTab.sort(
+                    chartMetaComparator
+                ),
                 (
                     acc: Column<{ [id: string]: string }>[],
                     chartMeta: ChartMeta,

--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -228,7 +228,7 @@ export class ClinicalDataTab extends React.Component<
 
             if (
                 _.find(
-                    this.props.store.visibleAttributes,
+                    this.props.store.visibleAttributesForClinicalData,
                     chartMeta =>
                         chartMeta.uniqueKey ===
                         SpecialChartsUniqueKeyEnum.CANCER_STUDIES
@@ -239,7 +239,7 @@ export class ClinicalDataTab extends React.Component<
                 });
             }
             return _.reduce(
-                this.props.store.visibleAttributesForClinicalDataTab.sort(
+                this.props.store.visibleAttributesForClinicalData.sort(
                     chartMetaComparator
                 ),
                 (

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -1097,7 +1097,7 @@ export class StudySummaryTab extends React.Component<
                                         }
                                         onResizeStop={this.onResize}
                                     >
-                                        {this.store.visibleAttributes.map(
+                                        {this.store.visibleAttributesForSummary.map(
                                             this.renderAttributeChart
                                         )}
                                     </ReactGridLayout>


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/10696

Continue to hide survival attributes (besides `OS_STATUS`) in Summary tab.