### PR TITLE
fixed menu stretch in long confirmation messages

### DIFF
--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -1077,7 +1077,10 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                     )}
                 </MSKTabs>
                 {this.infoMessage && !this.savingCustomData && (
-                    <SuccessBanner message={this.infoMessage} />
+                    <SuccessBanner
+                        message={this.infoMessage}
+                        containerWidth={this.getTabsWidth}
+                    />
                 )}
                 {this.savingCustomData && (
                     <div

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -1077,10 +1077,9 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                     )}
                 </MSKTabs>
                 {this.infoMessage && !this.savingCustomData && (
-                    <SuccessBanner
-                        message={this.infoMessage}
-                        containerWidth={this.getTabsWidth}
-                    />
+                    <div style={{ maxWidth: this.getTabsWidth }}>
+                        <SuccessBanner message={this.infoMessage} />
+                    </div>
                 )}
                 {this.savingCustomData && (
                     <div

--- a/src/pages/studyView/infoBanner/SuccessBanner.tsx
+++ b/src/pages/studyView/infoBanner/SuccessBanner.tsx
@@ -3,7 +3,6 @@ import { observer } from 'mobx-react';
 
 export interface ISuccessBannerProps {
     message: string;
-    containerWidth: number;
 }
 
 @observer
@@ -18,7 +17,6 @@ export default class SuccessBanner extends React.Component<
                 style={{
                     marginTop: '10px',
                     marginBottom: '0',
-                    maxWidth: this.props.containerWidth,
                 }}
             >
                 <span>

--- a/src/pages/studyView/infoBanner/SuccessBanner.tsx
+++ b/src/pages/studyView/infoBanner/SuccessBanner.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react';
 
 export interface ISuccessBannerProps {
     message: string;
+    containerWidth: number;
 }
 
 @observer
@@ -14,7 +15,11 @@ export default class SuccessBanner extends React.Component<
         return (
             <div
                 className="alert alert-success"
-                style={{ marginTop: '10px', marginBottom: '0' }}
+                style={{
+                    marginTop: '10px',
+                    marginBottom: '0',
+                    maxWidth: this.props.containerWidth,
+                }}
             >
                 <span>
                     <i className="fa fa-md fa-check" /> {this.props.message}


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10737

Describe changes proposed in this pull request:
- Fixed the Confirmation message widening the add chart menu
- Added max-width css property to `SuccessBanner` 
- Passed the `containerWidth` prop to `SuccessBanner` (similarly how it has been passed to `GeneLevelSelection`)
- Updated `ISuccessBannerProps` accordingly

Because the menu does not have an explicit width and just adjusts according to its children, setting max-width of `SuccessBanner` to 100% or inherit would not work. So, I passed the current `containerWidth` to `SuccessBanner` so that it can have a numerical limit to its width. 

> If no test is included it should explicitly be mentioned in the PR why there is no test.

It is a simple CSS fix so no extra tests are needed.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/135870090/3cf7ff0d-e0a2-45d9-82a4-d172d7e00745)

## Notify reviewers
@alisman 
