### PR TITLE
Customizable Dynamic Kaplan-Meier Plot for Survival Analysis

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -172,6 +172,7 @@ export interface IServerConfig {
     skin_comparison_view_mutation_table_columns_show_on_init: string;
     skin_patient_view_copy_number_table_columns_show_on_init: string;
     skin_patient_view_structural_variant_table_columns_show_on_init: string;
+    skin_survival_plot_clinical_event_types_show_on_init: string;
     skin_results_view_tables_default_sort_column: string;
     skin_patient_view_tables_default_sort_column: string;
     skin_patient_view_custom_sample_type_colors_json: string;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -224,6 +224,8 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
 
     skin_patient_view_structural_variant_table_columns_show_on_init: '',
 
+    skin_survival_plot_clinical_event_types_show_on_init: '',
+
     skin_results_view_tables_default_sort_column: 'Annotation',
 
     skin_patient_view_tables_default_sort_column: 'Annotation',

--- a/src/pages/groupComparison/Survival.tsx
+++ b/src/pages/groupComparison/Survival.tsx
@@ -76,7 +76,7 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
     private endEventPosition: 'FIRST' | 'LAST' = 'LAST';
 
     @observable
-    private censoredEventPosition: 'FIRST' | 'LAST' = 'FIRST';
+    private censoredEventPosition: 'FIRST' | 'LAST' = 'LAST';
 
     @observable
     private _selectedStartClinicalEventType: string | undefined = undefined;
@@ -356,6 +356,12 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
 
     @computed get selectedCensoredClinicalEventType() {
         if (this._selectedCensoredClinicalEventType !== undefined) {
+            if (this._selectedCensoredClinicalEventType === 'any') {
+                const clinicalEvents = _.values(
+                    this.props.store.clinicalEventOptions.result
+                );
+                return clinicalEvents[clinicalEvents.length - 1];
+            }
             return this.props.store.clinicalEventOptions.result[
                 this._selectedCensoredClinicalEventType
             ];
@@ -620,20 +626,30 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                                                 this
                                                     .onCensoredClinicalEventSelection
                                             }
-                                            options={_.values(
-                                                this.props.store
-                                                    .clinicalEventOptions.result
+                                            options={[
+                                                {
+                                                    label: 'any',
+                                                    value: 'any',
+                                                    attributes: [],
+                                                } as any,
+                                            ].concat(
+                                                _.values(
+                                                    this.props.store
+                                                        .clinicalEventOptions
+                                                        .result
+                                                )
                                             )}
                                             clearable={false}
                                             searchable={false}
                                         />
                                     </td>
-                                    {this._selectedCensoredClinicalEventType !==
+                                    {this.selectedCensoredClinicalEventType !==
                                         undefined &&
                                         this.props.store.clinicalEventOptions
                                             .result[
                                             this
-                                                ._selectedCensoredClinicalEventType
+                                                .selectedCensoredClinicalEventType
+                                                .value
                                         ].attributes.length > 0 && (
                                             <td
                                                 className={
@@ -661,7 +677,8 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                                                             .clinicalEventOptions
                                                             .result[
                                                             this
-                                                                ._selectedCensoredClinicalEventType
+                                                                .selectedCensoredClinicalEventType
+                                                                .value
                                                         ].attributes
                                                     }
                                                     isClearable={false}
@@ -671,34 +688,6 @@ export default class Survival extends React.Component<ISurvivalProps, {}> {
                                                 />
                                             </td>
                                         )}
-                                    <td>
-                                        <ButtonGroup>
-                                            {POSITIONS.map((option, i) => {
-                                                return (
-                                                    <Radio
-                                                        checked={
-                                                            option.value ===
-                                                            this
-                                                                .censoredEventPosition
-                                                        }
-                                                        onChange={e => {
-                                                            this.censoredEventPosition = $(
-                                                                e.target
-                                                            ).attr(
-                                                                'data-value'
-                                                            ) as any;
-                                                        }}
-                                                        inline
-                                                        data-value={
-                                                            option.value
-                                                        }
-                                                    >
-                                                        {option.label}
-                                                    </Radio>
-                                                );
-                                            })}
-                                        </ButtonGroup>
-                                    </td>
                                 </tr>
                                 <tr>
                                     <td>

--- a/src/pages/resultsView/survival/SurvivalUtil.tsx
+++ b/src/pages/resultsView/survival/SurvivalUtil.tsx
@@ -676,7 +676,10 @@ export function getSurvivalChartDataByAlteredStatus(
 }
 
 export function generateSurvivalPlotTitleFromDisplayName(displayName: string) {
-    return displayName.replace(/status|survival/gi, '');
+    return displayName
+        .replace(/status|survival/gi, '')
+        .trim()
+        .replace(/^\w/, c => c.toUpperCase());
 }
 
 export function generateSurvivalPlotYAxisLabelFromDisplayName(

--- a/src/pages/resultsView/survival/styles.module.scss
+++ b/src/pages/resultsView/survival/styles.module.scss
@@ -47,3 +47,7 @@
     background-color: white;
     margin-bottom: 3px;
 }
+
+.clickable {
+    cursor: pointer;
+}

--- a/src/pages/resultsView/survival/styles.module.scss.d.ts
+++ b/src/pages/resultsView/survival/styles.module.scss.d.ts
@@ -3,6 +3,7 @@ declare const styles: {
   readonly "SurvivalTable": string;
   readonly "Tooltip": string;
   readonly "XmaxNumberInput": string;
+  readonly "clickable": string;
   readonly "paddingLeftTruncationCheckbox": string;
 };
 export = styles;

--- a/src/shared/api/session-service/sessionServiceModels.ts
+++ b/src/shared/api/session-service/sessionServiceModels.ts
@@ -1,4 +1,8 @@
-import { ClinicalData, StudyViewFilter } from 'cbioportal-ts-api-client';
+import {
+    ClinicalData,
+    StudyViewFilter,
+    SurvivalRequest,
+} from 'cbioportal-ts-api-client';
 import { ChartType } from 'pages/studyView/StudyViewUtils';
 import { ClinicalTrackConfig } from 'shared/components/oncoprint/Oncoprint';
 import { PageSettingsIdentifier } from 'shared/userSession/PageSettingsIdentifier';
@@ -99,6 +103,12 @@ export type StudyPageSettings = {
 
 export type ResultPageSettings = {
     clinicallist?: ClinicalTrackConfig[];
+};
+
+export type ComparisonPageSettings = {
+    [sessionId: string]: {
+        [prefix: string]: Partial<SurvivalRequest>;
+    };
 };
 
 export type PageSettingsData = StudyPageSettings | ResultPageSettings;

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -2609,37 +2609,6 @@ export default abstract class ComparisonStore extends AnalysisStore
                     }
                 );
                 return _.chain(result)
-                    .map(x => {
-                        switch (x.eventType.toUpperCase()) {
-                            case 'TREATMENT': {
-                                x.attributes = x.attributes.filter(y =>
-                                    [
-                                        'TREATMENT_TYPE',
-                                        'SUBTYPE',
-                                        'AGENT',
-                                    ].includes(y.key.toUpperCase())
-                                );
-                                break;
-                            }
-                            case 'LAB_TEST': {
-                                x.attributes = x.attributes.filter(
-                                    y => 'TEST' === y.key.toUpperCase()
-                                );
-                                break;
-                            }
-                            case 'DIAGNOSIS': {
-                                x.attributes = x.attributes.filter(
-                                    y => 'SUBTYPE' === y.key.toUpperCase()
-                                );
-                                break;
-                            }
-                            default: {
-                                x.attributes = [];
-                                break;
-                            }
-                        }
-                        return x;
-                    })
                     .map(x => ({
                         label: x.eventType,
                         value: x.eventType,

--- a/src/shared/lib/comparison/ComparisonStore.ts
+++ b/src/shared/lib/comparison/ComparisonStore.ts
@@ -2609,6 +2609,16 @@ export default abstract class ComparisonStore extends AnalysisStore
                     }
                 );
                 return _.chain(result)
+                    .filter(x =>
+                        getServerConfig()
+                            .skin_survival_plot_clinical_event_types_show_on_init
+                            ? getServerConfig()
+                                  .skin_survival_plot_clinical_event_types_show_on_init.split(
+                                      ','
+                                  )
+                                  .includes(x.eventType)
+                            : true
+                    )
                     .map(x => ({
                         label: x.eventType,
                         value: x.eventType,


### PR DESCRIPTION
Address issue [Dynamic KM Plot](https://github.com/cBioPortal/cbioportal/issues/10375) and [RFC 36](https://docs.google.com/document/d/1WPY8ET9WlN9YAjDOZmHG_z2_fpEpKKmLArndok1f8bo/edit#heading=h.t10nr9te3qvu)
This frontend PR aims to have a customizable Dynamic Kaplan-Meier plot that allows users to specify start point and endpoint or censored point for survival analysis.

- Survival table and survival plot visibility
- Add start, end, censored clinical events dropdown
- Add start and end clinical attributes dropdown if available
- Save/load custom survival plots from session service
- Delete a survival plot from table
- Supports ANY event in censored event dropdown, which would choose the last event as the censored point for specific patient