### PR TITLE
Fix error logs not displaying error response

### DIFF
--- a/src/AppStore.ts
+++ b/src/AppStore.ts
@@ -24,7 +24,11 @@ export class AppStore {
 
             if (error.status && /400|500|5\d\d|403/.test(error.status)) {
                 sendSentryMessage('ERROR DIALOG SHOWN:' + error);
-                this.siteErrors.push(new SiteError(new Error(error)));
+                if (error instanceof Error) {
+                    this.siteErrors.push(new SiteError(error));
+                } else {
+                    this.siteErrors.push(new SiteError(new Error(error)));
+                }
             }
         });
     }


### PR DESCRIPTION
Under some circumstances the details of http errors were not getting printed to the error screen log.  
![image](https://github.com/cBioPortal/cbioportal-frontend/assets/186521/eb832501-af5a-4a0d-b18a-19010065b525)
