### PR TITLE
Update Genome Nexus API model and reVUE reference to fit new model

### DIFF
--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
@@ -1594,15 +1594,6 @@
         },
         "ncitCode": {
           "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "uuid": {
-          "type": "string"
         }
       }
     },

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
@@ -1594,6 +1594,15 @@
         },
         "ncitCode": {
           "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "uuid": {
+          "type": "string"
         }
       }
     },
@@ -3800,6 +3809,18 @@
         }
       }
     },
+    "VueReference": {
+      "type": "object",
+      "properties": {
+        "pubmedId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "referenceText": {
+          "type": "string"
+        }
+      }
+    },
     "Vues": {
       "type": "object",
       "properties": {
@@ -3824,17 +3845,22 @@
         "hugoGeneSymbol": {
           "type": "string"
         },
-        "pubmedId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "referenceText": {
+        "mutationOrigin": {
           "type": "string"
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VueReference"
+          }
         },
         "revisedProteinEffect": {
           "type": "string"
         },
         "revisedVariantClassification": {
+          "type": "string"
+        },
+        "revisedVariantClassificationStandard": {
           "type": "string"
         },
         "transcriptId": {

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
@@ -186,10 +186,6 @@ export type Drug = {
 
         'ncitCode': string
 
-        'synonyms': Array < string >
-
-        'uuid': string
-
 };
 export type EnsemblFilter = {
     'geneIds': Array < string >

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
@@ -186,6 +186,10 @@ export type Drug = {
 
         'ncitCode': string
 
+        'synonyms': Array < string >
+
+        'uuid': string
+
 };
 export type EnsemblFilter = {
     'geneIds': Array < string >
@@ -1061,6 +1065,12 @@ export type Version = {
         'version': string
 
 };
+export type VueReference = {
+    'pubmedId': number
+
+        'referenceText': string
+
+};
 export type Vues = {
     'comment': string
 
@@ -1076,13 +1086,15 @@ export type Vues = {
 
         'hugoGeneSymbol': string
 
-        'pubmedId': number
+        'mutationOrigin': string
 
-        'referenceText': string
+        'references': Array < VueReference >
 
         'revisedProteinEffect': string
 
         'revisedVariantClassification': string
+
+        'revisedVariantClassificationStandard': string
 
         'transcriptId': string
 

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
@@ -2370,6 +2370,18 @@
         }
       }
     },
+    "VueReference": {
+      "type": "object",
+      "properties": {
+        "pubmedId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "referenceText": {
+          "type": "string"
+        }
+      }
+    },
     "Vues": {
       "type": "object",
       "properties": {
@@ -2394,17 +2406,22 @@
         "hugoGeneSymbol": {
           "type": "string"
         },
-        "pubmedId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "referenceText": {
+        "mutationOrigin": {
           "type": "string"
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VueReference"
+          }
         },
         "revisedProteinEffect": {
           "type": "string"
         },
         "revisedVariantClassification": {
+          "type": "string"
+        },
+        "revisedVariantClassificationStandard": {
           "type": "string"
         },
         "transcriptId": {

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
@@ -615,6 +615,12 @@ export type Vcf = {
         'ref': string
 
 };
+export type VueReference = {
+    'pubmedId': number
+
+        'referenceText': string
+
+};
 export type Vues = {
     'comment': string
 
@@ -630,13 +636,15 @@ export type Vues = {
 
         'hugoGeneSymbol': string
 
-        'pubmedId': number
+        'mutationOrigin': string
 
-        'referenceText': string
+        'references': Array < VueReference >
 
         'revisedProteinEffect': string
 
         'revisedVariantClassification': string
+
+        'revisedVariantClassificationStandard': string
 
         'transcriptId': string
 

--- a/packages/react-mutation-mapper/src/component/revue/Revue.tsx
+++ b/packages/react-mutation-mapper/src/component/revue/Revue.tsx
@@ -35,7 +35,7 @@ export const RevueTooltipContent: React.FunctionComponent<{
                 }
                 {` (`}
                 {props.vue.references.map((reference, index) => (
-                    <div key={index}>
+                    <span key={index}>
                         <a
                             href={`https://pubmed.ncbi.nlm.nih.gov/${reference.pubmedId}/`}
                             rel="noopener noreferrer"
@@ -44,7 +44,7 @@ export const RevueTooltipContent: React.FunctionComponent<{
                             {reference.referenceText}
                         </a>
                         {index !== props.vue.references.length - 1 ? ';' : ''}
-                    </div>
+                    </span>
                 ))}
                 {`): `}
                 <strong>{props.vue.revisedProteinEffect}</strong>

--- a/packages/react-mutation-mapper/src/component/revue/Revue.tsx
+++ b/packages/react-mutation-mapper/src/component/revue/Revue.tsx
@@ -43,7 +43,7 @@ export const RevueTooltipContent: React.FunctionComponent<{
                         >
                             {reference.referenceText}
                         </a>
-                        {index !== props.vue.references.length - 1 ? ';' : ''}
+                        {index < props.vue.references.length - 1 && ';'}
                     </span>
                 ))}
                 {`): `}

--- a/packages/react-mutation-mapper/src/component/revue/Revue.tsx
+++ b/packages/react-mutation-mapper/src/component/revue/Revue.tsx
@@ -34,15 +34,18 @@ export const RevueTooltipContent: React.FunctionComponent<{
                     </a>
                 }
                 {` (`}
-                {
-                    <a
-                        href={`https://pubmed.ncbi.nlm.nih.gov/${props.vue.pubmedId}/`}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        {props.vue.referenceText}
-                    </a>
-                }
+                {props.vue.references.map((reference, index) => (
+                    <div key={index}>
+                        <a
+                            href={`https://pubmed.ncbi.nlm.nih.gov/${reference.pubmedId}/`}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            {reference.referenceText}
+                        </a>
+                        {index !== props.vue.references.length - 1 ? ';' : ''}
+                    </div>
+                ))}
                 {`): `}
                 <strong>{props.vue.revisedProteinEffect}</strong>
             </li>

--- a/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
@@ -98,7 +98,17 @@ export default class AnnotationColumnFormatter {
             annotationDownloadContent.push(
                 `reVUE: ${
                     annotationData.vue
-                        ? `${annotationData.vue.comment},PubmedId:${annotationData.vue.pubmedId},PredictedEffect:${annotationData.vue.defaultEffect},ExperimentallyValidatedEffect:${annotationData.vue.revisedVariantClassification},RevisedProteinEffect:${annotationData.vue.revisedProteinEffect}`
+                        ? `${
+                              annotationData.vue.comment
+                          },PubmedId:${annotationData.vue.references
+                              .map(reference => reference.pubmedId)
+                              .join(';')},PredictedEffect:${
+                              annotationData.vue.defaultEffect
+                          },ExperimentallyValidatedEffect:${
+                              annotationData.vue.revisedVariantClassification
+                          },RevisedProteinEffect:${
+                              annotationData.vue.revisedProteinEffect
+                          }`
                         : 'no'
                 }`
             );

--- a/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/AnnotationColumnFormatter.tsx
@@ -105,7 +105,8 @@ export default class AnnotationColumnFormatter {
                               .join(';')},PredictedEffect:${
                               annotationData.vue.defaultEffect
                           },ExperimentallyValidatedEffect:${
-                              annotationData.vue.revisedVariantClassification
+                              annotationData.vue
+                                  .revisedVariantClassificationStandard
                           },RevisedProteinEffect:${
                               annotationData.vue.revisedProteinEffect
                           }`


### PR DESCRIPTION
Update genome nexus API model and make some changes to the code to fit new model

EGFR (p.A763_Y764insFQEA) revue is available:
https://www.cbioportal.org/results/mutations?cancer_study_list=msk_met_2021&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cstructural_variants%2Ccna&case_set_id=msk_met_2021_cnaseq&gene_list=EGFR&geneset_list=%20&tab_index=tab_visualize&Action=Submit
<img width="675" alt="image" src="https://github.com/cBioPortal/cbioportal-frontend/assets/16869603/bdb4b59c-98e8-4073-9234-0ad8cec3aae8">
