### PR TITLE
Remove demo-rfc72 reference from local e2e test

### DIFF
--- a/end-to-end-test/local/docker_compose/setup.sh
+++ b/end-to-end-test/local/docker_compose/setup.sh
@@ -11,9 +11,6 @@ mkdir -p $E2E_WORKSPACE/keycloak
 cd $E2E_WORKSPACE
 git clone https://github.com/cBioPortal/cbioportal-docker-compose.git
 cd cbioportal-docker-compose
-#TODO: temporarily use docker compose for demo-rfc72
-# https://github.com/cBioPortal/cbioportal-docker-compose/pull/23
-git checkout demo-rfc72
 
 # update keycloak config with permissions for test studies
 config_json="$(cat $TEST_HOME/docker_compose/keycloak/keycloak-config.json)"


### PR DESCRIPTION
Since we merged the changes for v6, now it's time to remove outdated branch references in the localdb test. demo-rfc72 will be deleted