### PR TITLE
Always show the mutation aligner link for domains

### DIFF
--- a/packages/react-mutation-mapper/src/cache/MutationAlignerCache.ts
+++ b/packages/react-mutation-mapper/src/cache/MutationAlignerCache.ts
@@ -21,15 +21,24 @@ export class MutationAlignerCache extends DefaultStringQueryCache<string> {
     }
 
     public fetch(pfamAccession: string): Promise<string> {
-        return fetchMutationAlignerLink(
-            pfamAccession,
-            this.mutationAlignerUrlTemplate
-        )
-            .then(res =>
-                Promise.resolve(
-                    `http://mutationaligner.org/domains/${res.body.pfamId}`
-                )
-            )
-            .catch(e => Promise.reject(e));
+        // The code below is only to check if there is data for a specific domain
+        // Since mutation aligner is not HTTPS we need to use proxy for that
+        // We can enable this check again if we can directly query the API
+        // For now we just return the link without checking the existence of the data
+
+        // return fetchMutationAlignerLink(
+        //     pfamAccession,
+        //     this.mutationAlignerUrlTemplate
+        // )
+        //     .then(res =>
+        //         Promise.resolve(
+        //             `http://mutationaligner.org/domains/${res.body.pfamId}`
+        //         )
+        //     )
+        //     .catch(e => Promise.reject(e));
+
+        return Promise.resolve(
+            `http://mutationaligner.org/domains/${pfamAccession}`
+        );
     }
 }


### PR DESCRIPTION
This is a workaround to avoid using the proxy to check the existence of Mutation Aligner data. Instead now we always show the mutation aligner link. For domains that don't have any mutation aligner data the user will see a message in mutation aligner website after clicking the link.

![image](https://github.com/cBioPortal/cbioportal-frontend/assets/3604198/b22914d3-2b58-42a6-bd87-47433f4d0828)
