### PR TITLE
WSL setup updates - readme and gitignore for Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ e2e-localdb-workspace/
 junit.xml
 .nvim.lua
 .luarc.json
+.vs/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Note: you can check the frontend version of the live instance by checking `windo
 Make sure you have installed the node version and yarn version specified in
 [package.json](https://github.com/cBioPortal/cbioportal-frontend/blob/master/package.json).
 
-> **Tip:**  We recommend that you use [nvm:  Node Version Manager](https://github.com/nvm-sh/nvm) and [yvm:  Yarn Version Manager](https://yvm.js.org/docs/overview) to switch between versions more easily.
+> **Tip:**  We recommend that you use [nvm:  Node Version Manager](https://github.com/nvm-sh/nvm) to switch between versions more easily.
+
+> **Tip:** For yarn versions, you can use [yarn set version](https://yarnpkg.com/cli/set/version) or `npm install yarn@(version)`.
 
 > **Windows Tip:** If you are developing on Windows, we recommend that you use [Ubuntu / Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
@@ -52,6 +54,8 @@ export BRANCH_ENV=master # or rc if branching from rc
 yarn run start
 ```
 
+> **Tip:** BRANCH_ENV should be set to `master` or `rc`, and not to your local branch name.
+
 Example pages:
  - http://localhost:3000/
  - http://localhost:3000/patient?studyId=lgg_ucsf_2014&caseId=P04
@@ -70,8 +74,6 @@ GREP=example.spec.js yarn run testMain
 GREP=example.spec.js yarn run testModules
 
 ```
-
-> **Windows Tip:** There is a known solved hiccup running the tests on Ubuntu via Windows Subsystem for Linux (WSL): [#7096](https://github.com/cBioPortal/cbioportal/issues/7096)
 
 To run unit/integration tests in watch mode
 ```
@@ -139,6 +141,12 @@ or clear entire local storage
 ```
 localStorage.clear()
 ```
+You can also add a bookmarklet to quickly switch to your local frontend server. Set the URL to the following:
+
+```
+javascript:(function()%7BlocalStorage.setItem%28%60localdev%60,true%29%3Bwindow.location.reload()%3B %7D)()
+```
+
 You can also use a netlify deployed cbioportal-frontend pull request for serving the JS:
 1. Create the following bookmarklet: 
 ```
@@ -146,6 +154,8 @@ javascript:(function()%7Bvar pr %3D prompt("Please enter PR%23")%3Bif (pr %26%26
 ```
 2. Navigate to the cBioPortal installation that you want to test.
 3. Click the bookmarklet and enter your pull request number.
+
+
 
 ## Run e2e-tests
 
@@ -161,6 +171,7 @@ cd end-to-end-test
 // install deps
 yarn --ignore-engines
 
+cd ..
 ```
 
 ```
@@ -349,3 +360,23 @@ Please make sure to not introduce any dependencies from `cbioportal-frontend` wo
 ### react-mutation-mapper
 
 [react-mutation-mapper](https://www.npmjs.com/package/react-mutation-mapper/) is a separate public npm library that contains the Mutation Mapper and related components.
+
+## WSL Tips
+
+When running on a Windows environment, use [WSL: Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). You will be able to run a linux shell, which is necessary for many of the scripts used. You will also be able to use it concurrently with Windows applications.
+
+Make sure the git repo is cloned under the WSL file system (under your home directory).  If you instead clone it to the Windows file system (e.g. `/mnt/c/...` from WSL), then all of the yarn scripts will be extremely slow.
+
+Make sure your line returns are set to `lf` as opposed to the Windows default `crlf`. This may be an issue if you are interfacing with the git repo via the Windows system.
+
+```
+# from the repo folder
+git config core.autocrlf false
+```
+
+You can always point WSL to certain Windows services via the `/mnt/` pathspec.  For example, the following can go in your ~/.bashrc.
+
+```
+# if you use plink for credentials
+export GIT_SSH_COMMAND="/mnt/c/Program\ Files/PuTTY/plink.exe"
+```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Note: you can check the frontend version of the live instance by checking `windo
 Make sure you have installed the node version and yarn version specified in
 [package.json](https://github.com/cBioPortal/cbioportal-frontend/blob/master/package.json).
 
-> **Tip:**  We recommend that you use [nvm:  Node Version Manager](https://github.com/nvm-sh/nvm) to switch between versions more easily.
+> **Tip:**  For node, we recommend that you use [nvm:  Node Version Manager](https://github.com/nvm-sh/nvm) to switch between versions easily.
 
-> **Tip:** For yarn versions, you can use [yarn set version](https://yarnpkg.com/cli/set/version) or `npm install yarn@(version)`.
+> **Tip:** For yarn, you can use [yarn set version](https://yarnpkg.com/cli/set/version) or `npm install yarn@(version)`.
 
 > **Windows Tip:** If you are developing on Windows, we recommend that you use [Ubuntu / Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
@@ -54,7 +54,7 @@ export BRANCH_ENV=master # or rc if branching from rc
 yarn run start
 ```
 
-> **Tip:** BRANCH_ENV should be set to `master` or `rc`, and not to your local branch name.
+> **Tip:** BRANCH_ENV should be set to `master` or `rc`, and not to your local branch name. You can set this in your ~/.bashrc if you don't intend to change it often.
 
 Example pages:
  - http://localhost:3000/
@@ -365,18 +365,11 @@ Please make sure to not introduce any dependencies from `cbioportal-frontend` wo
 
 When running on a Windows environment, use [WSL: Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). You will be able to run a linux shell, which is necessary for many of the scripts used. You will also be able to use it concurrently with Windows applications.
 
-Make sure the git repo is cloned under the WSL file system (under your home directory).  If you instead clone it to the Windows file system (e.g. `/mnt/c/...` from WSL), then all of the yarn scripts will be extremely slow.
+Make sure the git repo is cloned under the WSL file system (under your home directory).  If you instead clone it to the Windows file system (e.g. `/mnt/c/...` from WSL), then all scripts will be extremely slow.
 
-Make sure your line returns are set to `lf` as opposed to the Windows default `crlf`. This may be an issue if you are interfacing with the git repo via the Windows system.
+If you may be working with the git repo via the Windows system, then make sure your line returns are set to `lf` as opposed to the Windows default `crlf`. 
 
 ```
 # from the repo folder
 git config core.autocrlf false
-```
-
-You can always point WSL to certain Windows services via the `/mnt/` pathspec.  For example, the following can go in your ~/.bashrc.
-
-```
-# if you use plink for credentials
-export GIT_SSH_COMMAND="/mnt/c/Program\ Files/PuTTY/plink.exe"
 ```


### PR DESCRIPTION
This is a no-code update. It updates the .gitignore and the readme.

## Changes
- .gitignore: added ".vs" folder for users using Visual Studio
- readme: updated to improve experience for new users. Added several tips for WSL users.

Details:
- added section at bottom for WSL tips
- removed older WSL Tip that seems to be no longer na issue
- replaced deprecated yvm tip with new commands
- added BRANCH_ENV tip
- added localdev bookmarklet tip
- e2e tests: added missing "cd .."

## Review
@alisman - recreated this from PR #4932 