### PR TITLE
Show summary stats on homepage

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1170,6 +1170,10 @@ export class QueryStore {
         return _.sumBy(this.selectableSelectedStudies, s => s.allSampleCount);
     }
 
+    @computed get sampleCountForAllStudies() {
+        return _.sumBy(this.selectableStudies, s => s.allSampleCount);
+    }
+
     readonly sampleLists = remoteData<SampleList[]>({
         invoke: async () => {
             if (!this.isSingleNonVirtualStudySelected) {
@@ -1576,6 +1580,10 @@ export class QueryStore {
                     this.treeData.map_studyId_cancerStudy.get(id) as CancerStudy
             )
             .filter(_.identity);
+    }
+
+    @computed get selectableStudies() {
+        return Array.from(this.treeData.map_studyId_cancerStudy.values());
     }
 
     public isVirtualStudy(studyId: string): boolean {

--- a/src/shared/components/query/StudySelectorStats.tsx
+++ b/src/shared/components/query/StudySelectorStats.tsx
@@ -18,6 +18,10 @@ export const StudySelectorStats: React.FunctionComponent<{
                     let numSelectedStudies = expr(
                         () => props.store.selectableSelectedStudyIds.length
                     );
+                    let numAllStudies = expr(
+                        () => props.store.selectableStudies.length
+                    );
+
                     return (
                         <>
                             <a
@@ -27,13 +31,38 @@ export const StudySelectorStats: React.FunctionComponent<{
                                             .store.showSelectedStudiesOnly;
                                 }}
                             >
-                                <b>{numSelectedStudies}</b>{' '}
-                                {numSelectedStudies === 1 ? 'study' : 'studies'}{' '}
-                                selected (
-                                <b>
-                                    {props.store.sampleCountForSelectedStudies}
-                                </b>{' '}
-                                samples)
+                                {props.store.selectableSelectedStudies.length ==
+                                    0 && (
+                                    <div>
+                                        <b>{numAllStudies}</b> studies available
+                                        (
+                                        <b>
+                                            {
+                                                props.store
+                                                    .sampleCountForAllStudies
+                                            }
+                                        </b>{' '}
+                                        samples)
+                                    </div>
+                                )}
+
+                                {props.store.selectableSelectedStudies.length >
+                                    0 && (
+                                    <div>
+                                        <b>{numSelectedStudies}</b>{' '}
+                                        {numSelectedStudies === 1
+                                            ? 'study'
+                                            : 'studies'}{' '}
+                                        selected (
+                                        <b>
+                                            {
+                                                props.store
+                                                    .sampleCountForSelectedStudies
+                                            }
+                                        </b>{' '}
+                                        samples)
+                                    </div>
+                                )}
                             </a>
                             {props.store.selectableSelectedStudies.length >
                                 0 && (


### PR DESCRIPTION
Fix  https://github.com/cBioPortal/cbioportal/issues/10755. Add summary stats when nothing is selected:

<img width="661" alt="image" src="https://github.com/user-attachments/assets/eaa7b058-75ab-4559-bbc1-b7dcb60631e4">

Used to be:

<img width="594" alt="image" src="https://github.com/user-attachments/assets/bc05dde8-0bff-43f2-ba25-689d2eb1c80b">
