### PR TITLE
Hide empty resource tab on patient view

### DIFF
--- a/src/pages/patientView/PatientViewPageTabs.tsx
+++ b/src/pages/patientView/PatientViewPageTabs.tsx
@@ -552,25 +552,26 @@ export function tabs(
             )}
         </MSKTab>
     );
-
-    tabs.push(
-        <MSKTab
-            key={4}
-            id={PatientViewPageTabs.FilesAndLinks}
-            linkText={RESOURCES_TAB_NAME}
-            hide={!pageComponent.shouldShowResources}
-        >
-            <div>
-                <ResourcesTab
-                    store={pageComponent.patientViewPageStore}
-                    sampleManager={
-                        pageComponent.patientViewPageStore.sampleManager.result!
-                    }
-                    openResource={pageComponent.openResource}
-                />
-            </div>
-        </MSKTab>
-    );
+    if (pageComponent.shouldShowResources)
+        tabs.push(
+            <MSKTab
+                key={4}
+                id={PatientViewPageTabs.FilesAndLinks}
+                linkText={RESOURCES_TAB_NAME}
+                hide={!pageComponent.shouldShowResources}
+            >
+                <div>
+                    <ResourcesTab
+                        store={pageComponent.patientViewPageStore}
+                        sampleManager={
+                            pageComponent.patientViewPageStore.sampleManager
+                                .result!
+                        }
+                        openResource={pageComponent.openResource}
+                    />
+                </div>
+            </MSKTab>
+        );
 
     tabs.push(
         <MSKTab


### PR DESCRIPTION
Fixing the bug: in the patient view, when selecting the 'Files and Links' tab and navigating through patients, an empty tab was shown for those without data (see [link](https://www.cbioportal.org/patient/filesAndLinks?studyId=msk_spectrum_tme_2022&caseId=P-0048670)). This fix ensures that the 'Files & Links' tab will disappear. 
