### PR TITLE
Add truncation of timeline label

### DIFF
--- a/packages/cbioportal-clinical-timeline/src/TrackHeader.tsx
+++ b/packages/cbioportal-clinical-timeline/src/TrackHeader.tsx
@@ -4,12 +4,9 @@ import { TICK_AXIS_HEIGHT } from './TickAxis';
 import { CustomTrackSpecification } from './CustomTrack';
 import { TimelineStore } from './TimelineStore';
 import { useObserver } from 'mobx-react-lite';
-import { TruncatedText } from 'cbioportal-frontend-commons';
+import { EllipsisTextTooltip } from 'cbioportal-frontend-commons';
 import { isTrackVisible } from './lib/helpers';
-import LineChartAxis, {
-    LINE_CHART_AXIS_SVG_WIDTH,
-    LINE_CHART_AXIS_TICK_WIDTH,
-} from './LineChartAxis';
+import LineChartAxis, { LINE_CHART_AXIS_SVG_WIDTH } from './LineChartAxis';
 import ReactDOM from 'react-dom';
 
 interface ITrackHeaderProps {
@@ -50,7 +47,7 @@ const TrackHeader: React.FunctionComponent<ITrackHeaderProps> = function({
                 onMouseLeave={handleTrackHover}
             >
                 <span>
-                    <TruncatedText text={getTrackLabel(track)} maxLength={20} />
+                    <EllipsisTextTooltip text={getTrackLabel(track)} />
                 </span>
                 {isLineChartTrack && (
                     <div

--- a/packages/cbioportal-clinical-timeline/src/timeline.scss
+++ b/packages/cbioportal-clinical-timeline/src/timeline.scss
@@ -87,8 +87,11 @@ $tl-fontsize: 12px;
         > div {
             white-space: nowrap;
             border-bottom: 1px dashed #eee;
-            padding-right: 10px;
+            padding-right: 18px;
             padding-top: 2px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 100%; // Modify to test the ellipsis and tooltip
         }
     }
 }

--- a/packages/cbioportal-clinical-timeline/src/timeline.scss
+++ b/packages/cbioportal-clinical-timeline/src/timeline.scss
@@ -79,19 +79,20 @@ $tl-fontsize: 12px;
 }
 
 .tl-timeline-leftbar {
+    max-width: 150px;
     .tl-timeline-tracklabels {
         overflow: hidden;
         display: flex;
         flex-direction: column;
-        font-size: $tl-fontsize;
+        font-size: 12.5px; // The first tooltip does not show up if the font-size is too small (<12px)
         > div {
             white-space: nowrap;
             border-bottom: 1px dashed #eee;
-            padding-right: 18px;
+            padding-right: 15px;
             padding-top: 2px;
             overflow: hidden;
             text-overflow: ellipsis;
-            max-width: 100%; // Modify to test the ellipsis and tooltip
+            //max-width: 100%;
         }
     }
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10448. Add truncation to timeline labels. Also add padding between end of label and arrow.

Describe changes proposed in this pull request:
- Change type of balise for TrackHeader label that display Timeline let bar and modify css accordingly
- Add some padding to end of label
- Remove unused import

With added padding
<img width="273" alt="timeline-leftbar-padding" src="https://github.com/user-attachments/assets/4f9b6d8d-1e5a-4c94-8db9-55893e634ae2">

Demo of tooltip. Notes, I could not find other example so I "forced" ellipse by limiting timeline left bar size.
<img width="273" alt="timeline-leftbar-tootips" src="https://github.com/user-attachments/assets/5d5e1631-4488-48c2-8cf6-444c7279afe0">

