### PR TITLE
Add instructions for running browser in insecure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,40 @@ To build all packages the main project depends on (must be done prior to start o
 yarn run buildModules
 ```
 
+### Running the Application with a Self-Signed Certificate
+
+When running the application locally, you might encounter issues with SSL due to the self-signed certificate being used. Most browsers will block access to `localhost` when an untrusted certificate is detected. To bypass this and allow local development, you can start your browser in "insecure mode."
+
+#### For Google Chrome:
+1. Close all instances of Chrome.
+2. Open a terminal or command prompt.
+3. Run the following command:
+
+   - **Windows:**
+     ```bash
+     chrome.exe --ignore-certificate-errors --disable-web-security
+     ```
+
+   - **macOS:**
+     ```bash
+     open -na "Google Chrome" --args --ignore-certificate-errors --disable-web-security
+     ```
+
+   - **Linux:**
+     ```bash
+     google-chrome --ignore-certificate-errors --disable-web-security
+     ```
+
+#### For Mozilla Firefox:
+1. Open Firefox.
+2. Type `about:config` in the address bar and press Enter.
+3. Search for `security.tls.version.min` and set it to `1`.
+4. Search for `security.tls.version.fallback-limit` and set it to `1`.
+5. Confirm any warnings, and restart Firefox.
+
+> **Note:** Running the browser in insecure mode should only be used for local development purposes.
+> **Warning:** Running your browser in insecure mode can expose you to security risks. Do this only for local development purposes and revert any changes made when done.
+
 To start the dev server with hot reload enabled
 ```
 # set the environment variables you want based on what branch you're branching


### PR DESCRIPTION
### Description of Changes

This pull request adds a section in the README file explaining how to run the browser in insecure mode to allow opening `localhost` with a self-signed certificate.

This information is valuable for developers who may encounter SSL certificate issues when running the application locally. Instructions are provided for both Google Chrome and Mozilla Firefox, along with appropriate disclaimers to highlight that this method is for development purposes only.

### Fixes

N/A (No specific issue is being fixed by this PR)

### Changes Proposed in This Pull Request:

- Added instructions for running the browser in insecure mode for local development in the README file.
- Included steps for Google Chrome on Windows, macOS, and Linux.
- Included steps for Mozilla Firefox.
- Added a disclaimer for using insecure mode only in development.

### Checks

- [x] The commit log is comprehensible and follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/).
- [x] No additional tests are required for this documentation change.

### Screenshots or GIFs

N/A (This PR only includes changes to the documentation)

### Notify Reviewers

N/A (Documentation update only)
