### PR TITLE
Update Genome Nexus api clients to include new Mutation Assessor

### DIFF
--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
@@ -2506,6 +2506,26 @@
         }
       }
     },
+    "IntergenicConsequenceSummary": {
+      "type": "object",
+      "properties": {
+        "consequenceTerms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "impact": {
+          "type": "string"
+        },
+        "variantAllele": {
+          "type": "string"
+        },
+        "variantClassification": {
+          "type": "string"
+        }
+      }
+    },
     "IntergenicConsequences": {
       "type": "object",
       "required": [
@@ -2554,124 +2574,32 @@
     },
     "MutationAssessor": {
       "type": "object",
-      "required": [
-        "input"
-      ],
       "properties": {
-        "codonStartPosition": {
-          "type": "string",
-          "description": "Codon start position"
-        },
-        "cosmicCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of mutations in COSMIC for this protein"
-        },
-        "functionalImpact": {
-          "type": "string",
-          "description": "Functional impact"
+        "functionalImpactPrediction": {
+          "type": "string"
         },
         "functionalImpactScore": {
           "type": "number",
           "format": "double",
           "description": "Functional impact score"
         },
-        "hgvs": {
+        "hgvspShort": {
           "type": "string"
         },
-        "hugoSymbol": {
-          "type": "string",
-          "description": "Hugo gene symbol"
-        },
-        "input": {
-          "type": "string",
-          "description": "User-input variants"
-        },
-        "mappingIssue": {
-          "type": "string",
-          "description": "Mapping issue info"
-        },
-        "msaGaps": {
-          "type": "number",
-          "format": "double",
-          "description": "Portion of gaps in variant position in multiple sequence alignment"
-        },
-        "msaHeight": {
+        "mav": {
           "type": "integer",
-          "format": "int32",
-          "description": "Number of diverse sequences in multiple sequence alignment (identical or highly similar sequences filtered out)"
+          "format": "int32"
         },
-        "msaLink": {
-          "type": "string",
-          "description": "Link to multiple sequence alignment"
+        "msa": {
+          "type": "string"
         },
-        "pdbLink": {
-          "type": "string",
-          "description": "Link to 3d structure browser"
-        },
-        "referenceGenomeVariant": {
-          "type": "string",
-          "description": "Reference genome variant"
-        },
-        "referenceGenomeVariantType": {
-          "type": "string",
-          "description": "Reference genome variant type"
-        },
-        "refseqId": {
-          "type": "string",
-          "description": "Refseq protein ID"
-        },
-        "refseqPosition": {
+        "sv": {
           "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Refseq protein, can be different from the one in Uniprot"
-        },
-        "refseqResidue": {
-          "type": "string",
-          "description": "Reference residue in Refseq protein, can be different from the one in Uniprot"
-        },
-        "snpCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of SNPs in dbSNP for this protein"
+          "format": "int32"
         },
         "uniprotId": {
           "type": "string",
           "description": "Uniprot protein accession ID"
-        },
-        "uniprotPosition": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Uniprot protein, can be different from the one in Refseq"
-        },
-        "uniprotResidue": {
-          "type": "string",
-          "description": "Reference residue in Uniprot protein, can be different from the one in Refseq"
-        },
-        "variant": {
-          "type": "string",
-          "description": "Amino acid substitution"
-        },
-        "variantConservationScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant conservation score"
-        },
-        "variantSpecificityScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant specificity score"
-        }
-      }
-    },
-    "MutationAssessorAnnotation": {
-      "type": "object",
-      "properties": {
-        "annotation": {
-          "$ref": "#/definitions/MutationAssessor"
-        },
-        "license": {
-          "type": "string"
         }
       }
     },
@@ -3676,8 +3604,8 @@
           "description": "Most severe consequence"
         },
         "mutation_assessor": {
-          "description": "Mutation Assessor Annotation",
-          "$ref": "#/definitions/MutationAssessorAnnotation"
+          "description": "Mutation Assessor",
+          "$ref": "#/definitions/MutationAssessor"
         },
         "my_variant_info": {
           "description": "My Variant Info Annotation",
@@ -3757,6 +3685,12 @@
         "genomicLocation": {
           "description": "Genomic location",
           "$ref": "#/definitions/GenomicLocation"
+        },
+        "intergenicConsequenceSummaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntergenicConsequenceSummary"
+          }
         },
         "strandSign": {
           "type": "string",

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
@@ -484,6 +484,16 @@ export type IntegerRange = {
         'start': number
 
 };
+export type IntergenicConsequenceSummary = {
+    'consequenceTerms': Array < string >
+
+        'impact': string
+
+        'variantAllele': string
+
+        'variantClassification': string
+
+};
 export type IntergenicConsequences = {
     'impact': string
 
@@ -501,59 +511,19 @@ export type MainType = {
 
 };
 export type MutationAssessor = {
-    'codonStartPosition': string
-
-        'cosmicCount': number
-
-        'functionalImpact': string
+    'functionalImpactPrediction': string
 
         'functionalImpactScore': number
 
-        'hgvs': string
+        'hgvspShort': string
 
-        'hugoSymbol': string
+        'mav': number
 
-        'input': string
+        'msa': string
 
-        'mappingIssue': string
-
-        'msaGaps': number
-
-        'msaHeight': number
-
-        'msaLink': string
-
-        'pdbLink': string
-
-        'referenceGenomeVariant': string
-
-        'referenceGenomeVariantType': string
-
-        'refseqId': string
-
-        'refseqPosition': number
-
-        'refseqResidue': string
-
-        'snpCount': number
+        'sv': number
 
         'uniprotId': string
-
-        'uniprotPosition': number
-
-        'uniprotResidue': string
-
-        'variant': string
-
-        'variantConservationScore': number
-
-        'variantSpecificityScore': number
-
-};
-export type MutationAssessorAnnotation = {
-    'annotation': MutationAssessor
-
-        'license': string
 
 };
 export type MutationEffectResp = {
@@ -1008,7 +978,7 @@ export type VariantAnnotation = {
 
         'most_severe_consequence': string
 
-        'mutation_assessor': MutationAssessorAnnotation
+        'mutation_assessor': MutationAssessor
 
         'my_variant_info': MyVariantInfoAnnotation
 
@@ -1043,6 +1013,8 @@ export type VariantAnnotationSummary = {
         'canonicalTranscriptId': string
 
         'genomicLocation': GenomicLocation
+
+        'intergenicConsequenceSummaries': Array < IntergenicConsequenceSummary >
 
         'strandSign': string
 

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
@@ -469,7 +469,7 @@
           "mutation-assessor-controller"
         ],
         "summary": "Retrieves mutation assessor information for the provided list of variants",
-        "operationId": "postMutationAssessorAnnotation",
+        "operationId": "postMutationAssessor",
         "consumes": [
           "application/json"
         ],
@@ -509,7 +509,7 @@
           "mutation-assessor-controller"
         ],
         "summary": "Retrieves mutation assessor information for the provided list of variants",
-        "operationId": "fetchMutationAssessorAnnotationGET",
+        "operationId": "fetchMutationAssessorGET",
         "consumes": [
           "application/json"
         ],
@@ -1650,115 +1650,54 @@
         }
       }
     },
+    "IntergenicConsequenceSummary": {
+      "type": "object",
+      "properties": {
+        "consequenceTerms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "impact": {
+          "type": "string"
+        },
+        "variantAllele": {
+          "type": "string"
+        },
+        "variantClassification": {
+          "type": "string"
+        }
+      }
+    },
     "MutationAssessor": {
       "type": "object",
-      "required": [
-        "input"
-      ],
       "properties": {
-        "codonStartPosition": {
-          "type": "string",
-          "description": "Codon start position"
-        },
-        "cosmicCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of mutations in COSMIC for this protein"
-        },
-        "functionalImpact": {
-          "type": "string",
-          "description": "Functional impact"
+        "functionalImpactPrediction": {
+          "type": "string"
         },
         "functionalImpactScore": {
           "type": "number",
           "format": "double",
           "description": "Functional impact score"
         },
-        "hgvs": {
+        "hgvspShort": {
           "type": "string"
         },
-        "hugoSymbol": {
-          "type": "string",
-          "description": "Hugo gene symbol"
-        },
-        "input": {
-          "type": "string",
-          "description": "User-input variants"
-        },
-        "mappingIssue": {
-          "type": "string",
-          "description": "Mapping issue info"
-        },
-        "msaGaps": {
-          "type": "number",
-          "format": "double",
-          "description": "Portion of gaps in variant position in multiple sequence alignment"
-        },
-        "msaHeight": {
+        "mav": {
           "type": "integer",
-          "format": "int32",
-          "description": "Number of diverse sequences in multiple sequence alignment (identical or highly similar sequences filtered out)"
+          "format": "int32"
         },
-        "msaLink": {
-          "type": "string",
-          "description": "Link to multiple sequence alignment"
+        "msa": {
+          "type": "string"
         },
-        "pdbLink": {
-          "type": "string",
-          "description": "Link to 3d structure browser"
-        },
-        "referenceGenomeVariant": {
-          "type": "string",
-          "description": "Reference genome variant"
-        },
-        "referenceGenomeVariantType": {
-          "type": "string",
-          "description": "Reference genome variant type"
-        },
-        "refseqId": {
-          "type": "string",
-          "description": "Refseq protein ID"
-        },
-        "refseqPosition": {
+        "sv": {
           "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Refseq protein, can be different from the one in Uniprot"
-        },
-        "refseqResidue": {
-          "type": "string",
-          "description": "Reference residue in Refseq protein, can be different from the one in Uniprot"
-        },
-        "snpCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of SNPs in dbSNP for this protein"
+          "format": "int32"
         },
         "uniprotId": {
           "type": "string",
           "description": "Uniprot protein accession ID"
-        },
-        "uniprotPosition": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Uniprot protein, can be different from the one in Refseq"
-        },
-        "uniprotResidue": {
-          "type": "string",
-          "description": "Reference residue in Uniprot protein, can be different from the one in Refseq"
-        },
-        "variant": {
-          "type": "string",
-          "description": "Amino acid substitution"
-        },
-        "variantConservationScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant conservation score"
-        },
-        "variantSpecificityScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant specificity score"
         }
       }
     },
@@ -2335,6 +2274,12 @@
         "genomicLocation": {
           "description": "Genomic location",
           "$ref": "#/definitions/GenomicLocation"
+        },
+        "intergenicConsequenceSummaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntergenicConsequenceSummary"
+          }
         },
         "strandSign": {
           "type": "string",

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
@@ -303,54 +303,30 @@ export type IntegerRange = {
         'start': number
 
 };
+export type IntergenicConsequenceSummary = {
+    'consequenceTerms': Array < string >
+
+        'impact': string
+
+        'variantAllele': string
+
+        'variantClassification': string
+
+};
 export type MutationAssessor = {
-    'codonStartPosition': string
-
-        'cosmicCount': number
-
-        'functionalImpact': string
+    'functionalImpactPrediction': string
 
         'functionalImpactScore': number
 
-        'hgvs': string
+        'hgvspShort': string
 
-        'hugoSymbol': string
+        'mav': number
 
-        'input': string
+        'msa': string
 
-        'mappingIssue': string
-
-        'msaGaps': number
-
-        'msaHeight': number
-
-        'msaLink': string
-
-        'pdbLink': string
-
-        'referenceGenomeVariant': string
-
-        'referenceGenomeVariantType': string
-
-        'refseqId': string
-
-        'refseqPosition': number
-
-        'refseqResidue': string
-
-        'snpCount': number
+        'sv': number
 
         'uniprotId': string
-
-        'uniprotPosition': number
-
-        'uniprotResidue': string
-
-        'variant': string
-
-        'variantConservationScore': number
-
-        'variantSpecificityScore': number
 
 };
 export type Mutdb = {
@@ -601,6 +577,8 @@ export type VariantAnnotationSummary = {
         'canonicalTranscriptId': string
 
         'genomicLocation': GenomicLocation
+
+        'intergenicConsequenceSummaries': Array < IntergenicConsequenceSummary >
 
         'strandSign': string
 
@@ -1543,7 +1521,7 @@ export default class GenomeNexusAPIInternal {
             return response.body;
         });
     };
-    postMutationAssessorAnnotationURL(parameters: {
+    postMutationAssessorURL(parameters: {
         'variants': Array < string > ,
         $queryParameters ? : any
     }): string {
@@ -1563,10 +1541,10 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#postMutationAssessorAnnotation
+     * @name GenomeNexusAPIInternal#postMutationAssessor
      * @param {} variants - List of variants. For example ["7:g.140453136A>T","12:g.25398285C>A"]
      */
-    postMutationAssessorAnnotationWithHttpInfo(parameters: {
+    postMutationAssessorWithHttpInfo(parameters: {
         'variants': Array < string > ,
         $queryParameters ? : any,
         $domain ? : string
@@ -1607,20 +1585,20 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#postMutationAssessorAnnotation
+     * @name GenomeNexusAPIInternal#postMutationAssessor
      * @param {} variants - List of variants. For example ["7:g.140453136A>T","12:g.25398285C>A"]
      */
-    postMutationAssessorAnnotation(parameters: {
+    postMutationAssessor(parameters: {
             'variants': Array < string > ,
             $queryParameters ? : any,
             $domain ? : string
         }): Promise < Array < MutationAssessor >
         > {
-            return this.postMutationAssessorAnnotationWithHttpInfo(parameters).then(function(response: request.Response) {
+            return this.postMutationAssessorWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };
-    fetchMutationAssessorAnnotationGETURL(parameters: {
+    fetchMutationAssessorGETURL(parameters: {
         'variant': string,
         $queryParameters ? : any
     }): string {
@@ -1642,10 +1620,10 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#fetchMutationAssessorAnnotationGET
+     * @name GenomeNexusAPIInternal#fetchMutationAssessorGET
      * @param {string} variant - A variant. For example 7:g.140453136A>T
      */
-    fetchMutationAssessorAnnotationGETWithHttpInfo(parameters: {
+    fetchMutationAssessorGETWithHttpInfo(parameters: {
         'variant': string,
         $queryParameters ? : any,
         $domain ? : string
@@ -1684,15 +1662,15 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#fetchMutationAssessorAnnotationGET
+     * @name GenomeNexusAPIInternal#fetchMutationAssessorGET
      * @param {string} variant - A variant. For example 7:g.140453136A>T
      */
-    fetchMutationAssessorAnnotationGET(parameters: {
+    fetchMutationAssessorGET(parameters: {
         'variant': string,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < MutationAssessor > {
-        return this.fetchMutationAssessorAnnotationGETWithHttpInfo(parameters).then(function(response: request.Response) {
+        return this.fetchMutationAssessorGETWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });
     };


### PR DESCRIPTION
API client changes for new Mutation assessor data (v4).
We need to deploy genome nexus first, rerun this pr, and then https://github.com/cBioPortal/cbioportal-frontend/pull/5015