### PR TITLE
API client update about Mutation Assessor v4 data and UI changes 

### DIFF
--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
@@ -2506,6 +2506,26 @@
         }
       }
     },
+    "IntergenicConsequenceSummary": {
+      "type": "object",
+      "properties": {
+        "consequenceTerms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "impact": {
+          "type": "string"
+        },
+        "variantAllele": {
+          "type": "string"
+        },
+        "variantClassification": {
+          "type": "string"
+        }
+      }
+    },
     "IntergenicConsequences": {
       "type": "object",
       "required": [
@@ -2554,124 +2574,32 @@
     },
     "MutationAssessor": {
       "type": "object",
-      "required": [
-        "input"
-      ],
       "properties": {
-        "codonStartPosition": {
-          "type": "string",
-          "description": "Codon start position"
-        },
-        "cosmicCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of mutations in COSMIC for this protein"
-        },
-        "functionalImpact": {
-          "type": "string",
-          "description": "Functional impact"
+        "functionalImpactPrediction": {
+          "type": "string"
         },
         "functionalImpactScore": {
           "type": "number",
           "format": "double",
           "description": "Functional impact score"
         },
-        "hgvs": {
+        "hgvspShort": {
           "type": "string"
         },
-        "hugoSymbol": {
-          "type": "string",
-          "description": "Hugo gene symbol"
-        },
-        "input": {
-          "type": "string",
-          "description": "User-input variants"
-        },
-        "mappingIssue": {
-          "type": "string",
-          "description": "Mapping issue info"
-        },
-        "msaGaps": {
-          "type": "number",
-          "format": "double",
-          "description": "Portion of gaps in variant position in multiple sequence alignment"
-        },
-        "msaHeight": {
+        "mav": {
           "type": "integer",
-          "format": "int32",
-          "description": "Number of diverse sequences in multiple sequence alignment (identical or highly similar sequences filtered out)"
+          "format": "int32"
         },
-        "msaLink": {
-          "type": "string",
-          "description": "Link to multiple sequence alignment"
+        "msa": {
+          "type": "string"
         },
-        "pdbLink": {
-          "type": "string",
-          "description": "Link to 3d structure browser"
-        },
-        "referenceGenomeVariant": {
-          "type": "string",
-          "description": "Reference genome variant"
-        },
-        "referenceGenomeVariantType": {
-          "type": "string",
-          "description": "Reference genome variant type"
-        },
-        "refseqId": {
-          "type": "string",
-          "description": "Refseq protein ID"
-        },
-        "refseqPosition": {
+        "sv": {
           "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Refseq protein, can be different from the one in Uniprot"
-        },
-        "refseqResidue": {
-          "type": "string",
-          "description": "Reference residue in Refseq protein, can be different from the one in Uniprot"
-        },
-        "snpCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of SNPs in dbSNP for this protein"
+          "format": "int32"
         },
         "uniprotId": {
           "type": "string",
           "description": "Uniprot protein accession ID"
-        },
-        "uniprotPosition": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Uniprot protein, can be different from the one in Refseq"
-        },
-        "uniprotResidue": {
-          "type": "string",
-          "description": "Reference residue in Uniprot protein, can be different from the one in Refseq"
-        },
-        "variant": {
-          "type": "string",
-          "description": "Amino acid substitution"
-        },
-        "variantConservationScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant conservation score"
-        },
-        "variantSpecificityScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant specificity score"
-        }
-      }
-    },
-    "MutationAssessorAnnotation": {
-      "type": "object",
-      "properties": {
-        "annotation": {
-          "$ref": "#/definitions/MutationAssessor"
-        },
-        "license": {
-          "type": "string"
         }
       }
     },
@@ -3676,8 +3604,8 @@
           "description": "Most severe consequence"
         },
         "mutation_assessor": {
-          "description": "Mutation Assessor Annotation",
-          "$ref": "#/definitions/MutationAssessorAnnotation"
+          "description": "Mutation Assessor",
+          "$ref": "#/definitions/MutationAssessor"
         },
         "my_variant_info": {
           "description": "My Variant Info Annotation",
@@ -3757,6 +3685,12 @@
         "genomicLocation": {
           "description": "Genomic location",
           "$ref": "#/definitions/GenomicLocation"
+        },
+        "intergenicConsequenceSummaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntergenicConsequenceSummary"
+          }
         },
         "strandSign": {
           "type": "string",

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
@@ -484,6 +484,16 @@ export type IntegerRange = {
         'start': number
 
 };
+export type IntergenicConsequenceSummary = {
+    'consequenceTerms': Array < string >
+
+        'impact': string
+
+        'variantAllele': string
+
+        'variantClassification': string
+
+};
 export type IntergenicConsequences = {
     'impact': string
 
@@ -501,59 +511,19 @@ export type MainType = {
 
 };
 export type MutationAssessor = {
-    'codonStartPosition': string
-
-        'cosmicCount': number
-
-        'functionalImpact': string
+    'functionalImpactPrediction': string
 
         'functionalImpactScore': number
 
-        'hgvs': string
+        'hgvspShort': string
 
-        'hugoSymbol': string
+        'mav': number
 
-        'input': string
+        'msa': string
 
-        'mappingIssue': string
-
-        'msaGaps': number
-
-        'msaHeight': number
-
-        'msaLink': string
-
-        'pdbLink': string
-
-        'referenceGenomeVariant': string
-
-        'referenceGenomeVariantType': string
-
-        'refseqId': string
-
-        'refseqPosition': number
-
-        'refseqResidue': string
-
-        'snpCount': number
+        'sv': number
 
         'uniprotId': string
-
-        'uniprotPosition': number
-
-        'uniprotResidue': string
-
-        'variant': string
-
-        'variantConservationScore': number
-
-        'variantSpecificityScore': number
-
-};
-export type MutationAssessorAnnotation = {
-    'annotation': MutationAssessor
-
-        'license': string
 
 };
 export type MutationEffectResp = {
@@ -1008,7 +978,7 @@ export type VariantAnnotation = {
 
         'most_severe_consequence': string
 
-        'mutation_assessor': MutationAssessorAnnotation
+        'mutation_assessor': MutationAssessor
 
         'my_variant_info': MyVariantInfoAnnotation
 
@@ -1043,6 +1013,8 @@ export type VariantAnnotationSummary = {
         'canonicalTranscriptId': string
 
         'genomicLocation': GenomicLocation
+
+        'intergenicConsequenceSummaries': Array < IntergenicConsequenceSummary >
 
         'strandSign': string
 

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal-docs.json
@@ -469,7 +469,7 @@
           "mutation-assessor-controller"
         ],
         "summary": "Retrieves mutation assessor information for the provided list of variants",
-        "operationId": "postMutationAssessorAnnotation",
+        "operationId": "postMutationAssessor",
         "consumes": [
           "application/json"
         ],
@@ -509,7 +509,7 @@
           "mutation-assessor-controller"
         ],
         "summary": "Retrieves mutation assessor information for the provided list of variants",
-        "operationId": "fetchMutationAssessorAnnotationGET",
+        "operationId": "fetchMutationAssessorGET",
         "consumes": [
           "application/json"
         ],
@@ -1650,115 +1650,54 @@
         }
       }
     },
+    "IntergenicConsequenceSummary": {
+      "type": "object",
+      "properties": {
+        "consequenceTerms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "impact": {
+          "type": "string"
+        },
+        "variantAllele": {
+          "type": "string"
+        },
+        "variantClassification": {
+          "type": "string"
+        }
+      }
+    },
     "MutationAssessor": {
       "type": "object",
-      "required": [
-        "input"
-      ],
       "properties": {
-        "codonStartPosition": {
-          "type": "string",
-          "description": "Codon start position"
-        },
-        "cosmicCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of mutations in COSMIC for this protein"
-        },
-        "functionalImpact": {
-          "type": "string",
-          "description": "Functional impact"
+        "functionalImpactPrediction": {
+          "type": "string"
         },
         "functionalImpactScore": {
           "type": "number",
           "format": "double",
           "description": "Functional impact score"
         },
-        "hgvs": {
+        "hgvspShort": {
           "type": "string"
         },
-        "hugoSymbol": {
-          "type": "string",
-          "description": "Hugo gene symbol"
-        },
-        "input": {
-          "type": "string",
-          "description": "User-input variants"
-        },
-        "mappingIssue": {
-          "type": "string",
-          "description": "Mapping issue info"
-        },
-        "msaGaps": {
-          "type": "number",
-          "format": "double",
-          "description": "Portion of gaps in variant position in multiple sequence alignment"
-        },
-        "msaHeight": {
+        "mav": {
           "type": "integer",
-          "format": "int32",
-          "description": "Number of diverse sequences in multiple sequence alignment (identical or highly similar sequences filtered out)"
+          "format": "int32"
         },
-        "msaLink": {
-          "type": "string",
-          "description": "Link to multiple sequence alignment"
+        "msa": {
+          "type": "string"
         },
-        "pdbLink": {
-          "type": "string",
-          "description": "Link to 3d structure browser"
-        },
-        "referenceGenomeVariant": {
-          "type": "string",
-          "description": "Reference genome variant"
-        },
-        "referenceGenomeVariantType": {
-          "type": "string",
-          "description": "Reference genome variant type"
-        },
-        "refseqId": {
-          "type": "string",
-          "description": "Refseq protein ID"
-        },
-        "refseqPosition": {
+        "sv": {
           "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Refseq protein, can be different from the one in Uniprot"
-        },
-        "refseqResidue": {
-          "type": "string",
-          "description": "Reference residue in Refseq protein, can be different from the one in Uniprot"
-        },
-        "snpCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of SNPs in dbSNP for this protein"
+          "format": "int32"
         },
         "uniprotId": {
           "type": "string",
           "description": "Uniprot protein accession ID"
-        },
-        "uniprotPosition": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Variant position in Uniprot protein, can be different from the one in Refseq"
-        },
-        "uniprotResidue": {
-          "type": "string",
-          "description": "Reference residue in Uniprot protein, can be different from the one in Refseq"
-        },
-        "variant": {
-          "type": "string",
-          "description": "Amino acid substitution"
-        },
-        "variantConservationScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant conservation score"
-        },
-        "variantSpecificityScore": {
-          "type": "number",
-          "format": "double",
-          "description": "Variant specificity score"
         }
       }
     },
@@ -2335,6 +2274,12 @@
         "genomicLocation": {
           "description": "Genomic location",
           "$ref": "#/definitions/GenomicLocation"
+        },
+        "intergenicConsequenceSummaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntergenicConsequenceSummary"
+          }
         },
         "strandSign": {
           "type": "string",

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPIInternal.ts
@@ -303,54 +303,30 @@ export type IntegerRange = {
         'start': number
 
 };
+export type IntergenicConsequenceSummary = {
+    'consequenceTerms': Array < string >
+
+        'impact': string
+
+        'variantAllele': string
+
+        'variantClassification': string
+
+};
 export type MutationAssessor = {
-    'codonStartPosition': string
-
-        'cosmicCount': number
-
-        'functionalImpact': string
+    'functionalImpactPrediction': string
 
         'functionalImpactScore': number
 
-        'hgvs': string
+        'hgvspShort': string
 
-        'hugoSymbol': string
+        'mav': number
 
-        'input': string
+        'msa': string
 
-        'mappingIssue': string
-
-        'msaGaps': number
-
-        'msaHeight': number
-
-        'msaLink': string
-
-        'pdbLink': string
-
-        'referenceGenomeVariant': string
-
-        'referenceGenomeVariantType': string
-
-        'refseqId': string
-
-        'refseqPosition': number
-
-        'refseqResidue': string
-
-        'snpCount': number
+        'sv': number
 
         'uniprotId': string
-
-        'uniprotPosition': number
-
-        'uniprotResidue': string
-
-        'variant': string
-
-        'variantConservationScore': number
-
-        'variantSpecificityScore': number
 
 };
 export type Mutdb = {
@@ -601,6 +577,8 @@ export type VariantAnnotationSummary = {
         'canonicalTranscriptId': string
 
         'genomicLocation': GenomicLocation
+
+        'intergenicConsequenceSummaries': Array < IntergenicConsequenceSummary >
 
         'strandSign': string
 
@@ -1543,7 +1521,7 @@ export default class GenomeNexusAPIInternal {
             return response.body;
         });
     };
-    postMutationAssessorAnnotationURL(parameters: {
+    postMutationAssessorURL(parameters: {
         'variants': Array < string > ,
         $queryParameters ? : any
     }): string {
@@ -1563,10 +1541,10 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#postMutationAssessorAnnotation
+     * @name GenomeNexusAPIInternal#postMutationAssessor
      * @param {} variants - List of variants. For example ["7:g.140453136A>T","12:g.25398285C>A"]
      */
-    postMutationAssessorAnnotationWithHttpInfo(parameters: {
+    postMutationAssessorWithHttpInfo(parameters: {
         'variants': Array < string > ,
         $queryParameters ? : any,
         $domain ? : string
@@ -1607,20 +1585,20 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#postMutationAssessorAnnotation
+     * @name GenomeNexusAPIInternal#postMutationAssessor
      * @param {} variants - List of variants. For example ["7:g.140453136A>T","12:g.25398285C>A"]
      */
-    postMutationAssessorAnnotation(parameters: {
+    postMutationAssessor(parameters: {
             'variants': Array < string > ,
             $queryParameters ? : any,
             $domain ? : string
         }): Promise < Array < MutationAssessor >
         > {
-            return this.postMutationAssessorAnnotationWithHttpInfo(parameters).then(function(response: request.Response) {
+            return this.postMutationAssessorWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };
-    fetchMutationAssessorAnnotationGETURL(parameters: {
+    fetchMutationAssessorGETURL(parameters: {
         'variant': string,
         $queryParameters ? : any
     }): string {
@@ -1642,10 +1620,10 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#fetchMutationAssessorAnnotationGET
+     * @name GenomeNexusAPIInternal#fetchMutationAssessorGET
      * @param {string} variant - A variant. For example 7:g.140453136A>T
      */
-    fetchMutationAssessorAnnotationGETWithHttpInfo(parameters: {
+    fetchMutationAssessorGETWithHttpInfo(parameters: {
         'variant': string,
         $queryParameters ? : any,
         $domain ? : string
@@ -1684,15 +1662,15 @@ export default class GenomeNexusAPIInternal {
     /**
      * Retrieves mutation assessor information for the provided list of variants
      * @method
-     * @name GenomeNexusAPIInternal#fetchMutationAssessorAnnotationGET
+     * @name GenomeNexusAPIInternal#fetchMutationAssessorGET
      * @param {string} variant - A variant. For example 7:g.140453136A>T
      */
-    fetchMutationAssessorAnnotationGET(parameters: {
+    fetchMutationAssessorGET(parameters: {
         'variant': string,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < MutationAssessor > {
-        return this.fetchMutationAssessorAnnotationGETWithHttpInfo(parameters).then(function(response: request.Response) {
+        return this.fetchMutationAssessorGETWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });
     };

--- a/packages/react-variant-view/src/component/functionalPrediction/FunctionalPrediction.tsx
+++ b/packages/react-variant-view/src/component/functionalPrediction/FunctionalPrediction.tsx
@@ -31,9 +31,7 @@ class FunctionalPrediction extends React.Component<IFunctionalPredictionProps> {
         genomeNexusData: VariantAnnotation | undefined
     ): IFunctionalImpactData {
         const mutationAssessor =
-            genomeNexusData &&
-            genomeNexusData.mutation_assessor &&
-            genomeNexusData.mutation_assessor.annotation;
+            genomeNexusData && genomeNexusData.mutation_assessor;
         const siftScore =
             genomeNexusData &&
             genomeNexusData.transcript_consequences &&

--- a/packages/react-variant-view/src/component/functionalPrediction/FunctionalPrediction.tsx
+++ b/packages/react-variant-view/src/component/functionalPrediction/FunctionalPrediction.tsx
@@ -30,8 +30,7 @@ class FunctionalPrediction extends React.Component<IFunctionalPredictionProps> {
     public getData(
         genomeNexusData: VariantAnnotation | undefined
     ): IFunctionalImpactData {
-        const mutationAssessor =
-            genomeNexusData && genomeNexusData.mutation_assessor;
+        const mutationAssessor = genomeNexusData?.mutation_assessor;
         const siftScore =
             genomeNexusData &&
             genomeNexusData.transcript_consequences &&

--- a/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
+++ b/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
@@ -27,25 +27,20 @@ export default class MutationAssessor extends React.Component<
     IMutationAssessorProps,
     {}
 > {
-    private static MUTATION_ASSESSOR_URL: string =
-        'http://mutationassessor.org/r3/';
+    // Change to new url when available
+    // New url will need to be added in tooltip, discrption, "Please refer to the score range here." and "Go to Mutation Assessor"
+    // private static MUTATION_ASSESSOR_URL: string = 'http://mutationassessor.org/r3/';
 
     private static mutationAssessorText() {
         return (
             <div style={{ width: 450, height: 110 }}>
-                <a
-                    href={MutationAssessor.MUTATION_ASSESSOR_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    Mutation Assessor
-                </a>{' '}
-                predicts the functional impact of amino-acid substitutions in
-                proteins, such as mutations discovered in cancer or missense
-                polymorphisms. The functional impact is assessed based on
-                evolutionary conservation of the affected amino acid in protein
-                homologs. The method has been validated on a large set (60k) of
-                disease associated (OMIM) and polymorphic variants.
+                Mutation Assessor predicts the functional impact of amino-acid
+                substitutions in proteins, such as mutations discovered in
+                cancer or missense polymorphisms. The functional impact is
+                assessed based on evolutionary conservation of the affected
+                amino acid in protein homologs. The method has been validated on
+                a large set of disease associated and polymorphic variants
+                (ClinVar).
             </div>
         );
     }
@@ -143,24 +138,6 @@ export default class MutationAssessor extends React.Component<
         );
     }
 
-    // This is mostly to make the legacy MA links work
-    private static maLink(link: string | undefined) {
-        let url = null;
-
-        // ignore invalid links ("", "NA", "Not Available")
-        if (link) {
-            // getma.org is the legacy link, need to replace it with the actual value
-            url = link.replace('getma.org', 'mutationassessor.org/r3');
-
-            // prepend "http://" if needed
-            if (url.indexOf('http://') !== 0) {
-                url = `http://${url}`;
-            }
-        }
-
-        return url;
-    }
-
     constructor(props: IMutationAssessorProps) {
         super(props);
 
@@ -179,11 +156,11 @@ export default class MutationAssessor extends React.Component<
 
         if (
             this.props.mutationAssessor &&
-            this.props.mutationAssessor.functionalImpact != null &&
-            this.props.mutationAssessor.functionalImpact !== ''
+            this.props.mutationAssessor.functionalImpactPrediction != null &&
+            this.props.mutationAssessor.functionalImpactPrediction !== ''
         ) {
             const maData = this.props.mutationAssessor;
-            maContent = <span>{maData.functionalImpact}</span>;
+            maContent = <span>{maData.functionalImpactPrediction}</span>;
         } else {
             maContent = <span>N/A</span>;
         }
@@ -191,26 +168,12 @@ export default class MutationAssessor extends React.Component<
         return (
             <div className={featureTableStyle['feature-table-layout']}>
                 <div className={featureTableStyle['data-source']}>
-                    {this.mutationAssessorTooltip(
-                        <a
-                            href={MutationAssessor.MUTATION_ASSESSOR_URL}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            {dataSource}
-                        </a>
-                    )}
+                    {this.mutationAssessorTooltip(<>{dataSource}</>)}
                 </div>
                 <div>
                     {this.mutationAssessorTooltip(
                         <span className={featureTableStyle['data-with-link']}>
-                            <a
-                                href={MutationAssessor.MUTATION_ASSESSOR_URL}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                {maContent}
-                            </a>
+                            {maContent}
                         </span>
                     )}
                 </div>
@@ -221,12 +184,7 @@ export default class MutationAssessor extends React.Component<
     private mutationAssessorData() {
         if (this.props.mutationAssessor) {
             const maData = this.props.mutationAssessor;
-            const xVarLink = MutationAssessor.maLink(
-                `http://mutationassessor.org/r3/?cm=var&p=${maData.uniprotId}&var=${maData.variant}`
-            );
-            const msaLink = MutationAssessor.maLink(maData.msaLink);
-            const pdbLink = MutationAssessor.maLink(maData.pdbLink);
-            const impact = maData.functionalImpact ? (
+            const impact = maData.functionalImpactPrediction ? (
                 <div>
                     <table className={tooltipStyles['ma-tooltip-table']}>
                         {(maData.functionalImpactScore ||
@@ -245,86 +203,12 @@ export default class MutationAssessor extends React.Component<
                             </tbody>
                         )}
                     </table>
-                    <span>
-                        Please refer to the score range{' '}
-                        <a
-                            href="http://mutationassessor.org/r3/"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            here
-                        </a>
-                        .
-                    </span>
                 </div>
             ) : null;
-
-            const xVar =
-                xVarLink &&
-                maData.uniprotId.length !== 0 &&
-                maData.variant.length !== 0 ? (
-                    <div className={tooltipStyles['mutation-assessor-link']}>
-                        <a
-                            href={xVarLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            <img
-                                height="15"
-                                width="19"
-                                src={mutationAssessorLogo}
-                                className={
-                                    tooltipStyles['mutation-assessor-main-img']
-                                }
-                                alt="Mutation Assessor"
-                            />
-                            Go to Mutation Assessor
-                        </a>
-                    </div>
-                ) : null;
-
-            const msa =
-                msaLink && maData.msaLink.length !== 0 ? (
-                    <div className={tooltipStyles['mutation-assessor-link']}>
-                        <a
-                            href={msaLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            <span
-                                className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-msa-icon']}`}
-                            >
-                                msa
-                            </span>
-                            Multiple Sequence Alignment
-                        </a>
-                    </div>
-                ) : null;
-
-            const pdb =
-                pdbLink && maData.pdbLink.length !== 0 ? (
-                    <div className={tooltipStyles['mutation-assessor-link']}>
-                        <a
-                            href={pdbLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            <span
-                                className={`${tooltipStyles['ma-icon']} ${tooltipStyles['ma-3d-icon']}`}
-                            >
-                                3D
-                            </span>
-                            Mutation Assessor 3D View
-                        </a>
-                    </div>
-                ) : null;
 
             return (
                 <div>
                     {impact}
-                    {msa}
-                    {pdb}
-                    {xVar}
                     <br />
                 </div>
             );

--- a/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
+++ b/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
@@ -27,20 +27,32 @@ export default class MutationAssessor extends React.Component<
     IMutationAssessorProps,
     {}
 > {
-    // Change to new url when available
+    // TODO Change to new url when manuscript is available
     // New url will need to be added in tooltip, discrption, "Please refer to the score range here." and "Go to Mutation Assessor"
     // private static MUTATION_ASSESSOR_URL: string = 'http://mutationassessor.org/r3/';
 
     private static mutationAssessorText() {
         return (
-            <div style={{ width: 450, height: 110 }}>
+            <div style={{ width: 450, height: 130 }}>
                 Mutation Assessor predicts the functional impact of amino-acid
                 substitutions in proteins, such as mutations discovered in
                 cancer or missense polymorphisms. The functional impact is
                 assessed based on evolutionary conservation of the affected
                 amino acid in protein homologs. The method has been validated on
-                a large set of disease associated and polymorphic variants
-                (ClinVar).
+                a large set of disease associated and polymorphic variants (
+                <a href="https://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">
+                    ClinVar
+                </a>
+                ).
+                <br />
+                <b>
+                    Mutation Assessor V4 data is now available in the portal!
+                </b>{' '}
+                New manuscript is in progress. Click{` `}
+                <a href="http://mutationassessor.org/r3/" target="_blank">
+                    here
+                </a>
+                {` `} to see information about V3 data.
             </div>
         );
     }
@@ -146,14 +158,6 @@ export default class MutationAssessor extends React.Component<
 
     public render() {
         let maContent: JSX.Element = <span />;
-        const dataSource = (
-            <>
-                Mutation Assessor&nbsp;
-                <i className="fas fa-external-link-alt" />
-                {!this.props.isCanonicalTranscriptSelected && <span> *</span>}
-            </>
-        );
-
         if (
             this.props.mutationAssessor &&
             this.props.mutationAssessor.functionalImpactPrediction != null &&
@@ -168,7 +172,15 @@ export default class MutationAssessor extends React.Component<
         return (
             <div className={featureTableStyle['feature-table-layout']}>
                 <div className={featureTableStyle['data-source']}>
-                    {this.mutationAssessorTooltip(<>{dataSource}</>)}
+                    {this.mutationAssessorTooltip(
+                        <>
+                            Mutation Assessor&nbsp;
+                            <i className="fas fa-external-link-alt" />
+                            {!this.props.isCanonicalTranscriptSelected && (
+                                <span> *</span>
+                            )}
+                        </>
+                    )}
                 </div>
                 <div>
                     {this.mutationAssessorTooltip(

--- a/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
+++ b/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
@@ -19,7 +19,8 @@ export default class MutationAssessor extends React.Component<
     IMutationAssessorProps,
     {}
 > {
-    static MUTATION_ASSESSOR_URL: string = 'http://mutationassessor.org/r3/';
+    // Replace to new url when publication available
+    // static MUTATION_ASSESSOR_URL: string = 'http://mutationassessor.org/r3/';
 
     constructor(props: IMutationAssessorProps) {
         super(props);
@@ -31,7 +32,7 @@ export default class MutationAssessor extends React.Component<
         mutationAssessorData: MutationAssessorData | undefined
     ): string {
         if (mutationAssessorData) {
-            return `impact: ${mutationAssessorData.functionalImpact}, score: ${mutationAssessorData.functionalImpactScore}`;
+            return `impact: ${mutationAssessorData.functionalImpactPrediction}, score: ${mutationAssessorData.functionalImpactScore}`;
         } else {
             return 'NA';
         }
@@ -44,7 +45,7 @@ export default class MutationAssessor extends React.Component<
 
         if (
             this.props.mutationAssessor &&
-            this.props.mutationAssessor.functionalImpact !== null
+            this.props.mutationAssessor.functionalImpactPrediction !== null
         ) {
             const maData = this.props.mutationAssessor;
             maContent = (
@@ -52,7 +53,7 @@ export default class MutationAssessor extends React.Component<
                     className={classNames(
                         annotationStyles['annotation-item-text'],
                         (mutationAssessorColumn as any)[
-                            `ma-${maData.functionalImpact}`
+                            `ma-${maData.functionalImpactPrediction}`
                         ]
                     )}
                 >
@@ -80,15 +81,14 @@ export default class MutationAssessor extends React.Component<
     private tooltipContent() {
         if (this.props.mutationAssessor) {
             const maData = this.props.mutationAssessor;
-            const impact = maData.functionalImpact ? (
+            const impact = maData.functionalImpactPrediction ? (
                 <div>
                     <table className={tooltipStyles['ma-tooltip-table']}>
                         <tr>
                             <td>Source</td>
                             <td>
-                                <a href="http://mutationassessor.org/r3">
-                                    MutationAssessor
-                                </a>
+                                {/* Add link when pubilcation is available */}
+                                MutationAssessor
                             </td>
                         </tr>
                         <tr>
@@ -97,11 +97,11 @@ export default class MutationAssessor extends React.Component<
                                 <span
                                     className={
                                         (mutationAssessorColumn as any)[
-                                            `ma-${maData.functionalImpact}`
+                                            `ma-${maData.functionalImpactPrediction}`
                                         ]
                                     }
                                 >
-                                    {maData.functionalImpact}
+                                    {maData.functionalImpactPrediction}
                                 </span>
                             </td>
                         </tr>

--- a/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
+++ b/src/shared/components/annotation/genomeNexus/MutationAssessor.tsx
@@ -19,7 +19,7 @@ export default class MutationAssessor extends React.Component<
     IMutationAssessorProps,
     {}
 > {
-    // Replace to new url when publication available
+    // TODO Replace to new url when manuscript is available
     // static MUTATION_ASSESSOR_URL: string = 'http://mutationassessor.org/r3/';
 
     constructor(props: IMutationAssessorProps) {
@@ -87,8 +87,8 @@ export default class MutationAssessor extends React.Component<
                         <tr>
                             <td>Source</td>
                             <td>
-                                {/* Add link when pubilcation is available */}
-                                MutationAssessor
+                                {/* TODO Add link when manuscript is available */}
+                                Mutation Assessor
                             </td>
                         </tr>
                         <tr>

--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -306,18 +306,13 @@ class FunctionalImpactColumnTooltip extends React.Component<
     public static mutationAssessorText() {
         return (
             <div style={{ width: 450, height: 100 }}>
-                <a
-                    href={MutationAssessor.MUTATION_ASSESSOR_URL}
-                    target="_blank"
-                >
-                    Mutation Assessor
-                </a>{' '}
-                predicts the functional impact of amino-acid substitutions in
-                proteins, such as mutations discovered in cancer or missense
-                polymorphisms. The functional impact is assessed based on
-                evolutionary conservation of the affected amino acid in protein
-                homologs. The method has been validated on a large set (60k) of
-                disease associated (OMIM) and polymorphic variants.
+                Mutation Assessor predicts the functional impact of amino-acid
+                substitutions in proteins, such as mutations discovered in
+                cancer or missense polymorphisms. The functional impact is
+                assessed based on evolutionary conservation of the affected
+                amino acid in protein homologs. The method has been validated on
+                a large set of disease associated and polymorphic variants
+                (ClinVar).
             </div>
         );
     }
@@ -531,13 +526,7 @@ export default class FunctionalImpactColumnFormatter {
     public static getMutationAssessorData(
         mutationAssessorDataCache: VariantAnnotation | null
     ): MutationAssessorData | undefined {
-        if (!mutationAssessorDataCache) {
-            return undefined;
-        } else {
-            return mutationAssessorDataCache.mutation_assessor
-                ? mutationAssessorDataCache.mutation_assessor.annotation
-                : undefined;
-        }
+        return mutationAssessorDataCache?.mutation_assessor;
     }
 
     public static renderFunction(

--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -305,14 +305,26 @@ class FunctionalImpactColumnTooltip extends React.Component<
 
     public static mutationAssessorText() {
         return (
-            <div style={{ width: 450, height: 100 }}>
+            <div style={{ width: 450, height: 130 }}>
                 Mutation Assessor predicts the functional impact of amino-acid
                 substitutions in proteins, such as mutations discovered in
                 cancer or missense polymorphisms. The functional impact is
                 assessed based on evolutionary conservation of the affected
                 amino acid in protein homologs. The method has been validated on
-                a large set of disease associated and polymorphic variants
-                (ClinVar).
+                a large set of disease associated and polymorphic variants (
+                <a href="https://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">
+                    ClinVar
+                </a>
+                ).
+                <br />
+                <b>
+                    Mutation Assessor V4 data is now available in the portal!
+                </b>{' '}
+                New manuscript is in progress. Click{` `}
+                <a href="http://mutationassessor.org/r3/" target="_blank">
+                    here
+                </a>
+                {` `} to see information about V3 data.
             </div>
         );
     }


### PR DESCRIPTION
Part of: https://github.com/genome-nexus/genome-nexus/issues/753
There are some API model changes about Mutation Assessor v4 in genome nexus. This pr changes data display and tooltip text to work with new data
**Header tooltip:**
![image](https://github.com/user-attachments/assets/47ea869a-01c9-420b-8bbf-caa87e31dc30)
**Data and tooltip:**
![image](https://github.com/user-attachments/assets/26290356-8d3f-4279-8e0d-634d39f29988)

Test link (need to add Functional Impact in column dropdown): https://deploy-preview-5015.cancerrevue.org/results/mutations?cancer_study_list=msk_impact_2017&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cstructural_variants%2Ccna&case_set_id=msk_impact_2017_cnaseq&gene_list=BRAF&geneset_list=%20&tab_index=tab_visualize&Action=Submit