### PR TITLE
Reduce api calls for generic assay meta in study view page

### DIFF
--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -365,7 +365,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         return (
             this.props.disableGenericAssayTabs ||
             !this.props.store.genericAssayProfiles.isComplete ||
-            !this.props.store.genericAssayEntitiesGroupedByProfileId
+            !this.props.store.genericAssayEntitiesGroupedByProfileIdSuffix
                 .isComplete ||
             (this.props.store.genericAssayProfiles.isComplete &&
                 _.isEmpty(this.props.store.genericAssayProfiles.result))
@@ -536,25 +536,17 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 // And one tab can only has one selected profile at a time
                 // selectedGenericAssayProfileIdByType been initialzed at the begining
                 // so we know we can always find a selected profile for each Generic Assay type
-                const molecularProfileIdsInType =
-                    options.find(
-                        option =>
-                            option.value ===
-                            this.selectedGenericAssayProfileIdByType.get(type)
-                    )?.profileIds || [];
+                const molecularProfileIdSuffix = this.selectedGenericAssayProfileIdByType.get(
+                    type
+                )!;
 
-                const entityMap = molecularProfileIdsInType.reduce(
-                    (acc, profileId) => {
-                        this.props.store.genericAssayEntitiesGroupedByProfileId.result![
-                            profileId
-                        ].forEach(meta => {
-                            acc[meta.stableId] = meta;
-                        });
-                        return acc;
-                    },
-                    {} as { [stableId: string]: GenericAssayMeta }
+                const entityMap = _.keyBy(
+                    this.props.store
+                        .genericAssayEntitiesGroupedByProfileIdSuffix.result![
+                        molecularProfileIdSuffix
+                    ],
+                    meta => meta.stableId
                 );
-
                 const genericAssayEntityOptions = _.map(
                     entityMap,
                     makeGenericAssayOption
@@ -1158,7 +1150,8 @@ export default class AddChartButton extends React.Component<
         return (
             this.props.store.genericAssayProfileOptionsByType.isPending ||
             this.props.store.molecularProfileOptions.isPending ||
-            this.props.store.genericAssayEntitiesGroupedByProfileId.isPending
+            this.props.store.genericAssayEntitiesGroupedByProfileIdSuffix
+                .isPending
         );
     }
 

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
@@ -18,6 +18,7 @@ import {
     GenericAssayTypeConstants,
 } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
 import * as Pluralize from 'pluralize';
+import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
 
 export const NOT_APPLICABLE_VALUE = 'NA';
 export const COMMON_GENERIC_ASSAY_PROPERTY = {
@@ -107,6 +108,38 @@ export async function fetchGenericAssayMetaByMolecularProfileIdsGroupByMolecular
         )
     );
     return genericAssayMetaGroupByMolecularProfileId;
+}
+
+export async function fetchGenericAssayMetaGroupedByMolecularProfileIdSuffix(
+    genericAssayProfiles: MolecularProfile[]
+) {
+    const genericAssayProfilesGroupedByProfileIdSuffix = _.groupBy(
+        genericAssayProfiles,
+        getSuffixOfMolecularProfile
+    );
+    const profileSuffixes = _.keys(
+        genericAssayProfilesGroupedByProfileIdSuffix
+    );
+
+    const genericAssayMetaGroupedByProfileIdSuffix: {
+        [profileIdSuffix: string]: GenericAssayMeta[];
+    } = {};
+
+    await Promise.all(
+        profileSuffixes.map(profileSuffix =>
+            fetchGenericAssayMetaByProfileIds(
+                _.map(
+                    genericAssayProfilesGroupedByProfileIdSuffix[profileSuffix],
+                    profile => profile.molecularProfileId
+                )
+            ).then(genericAssayMeta => {
+                genericAssayMetaGroupedByProfileIdSuffix[
+                    profileSuffix
+                ] = genericAssayMeta;
+            })
+        )
+    );
+    return genericAssayMetaGroupedByProfileIdSuffix;
 }
 
 export function fetchGenericAssayMetaByProfileIds(


### PR DESCRIPTION
We were unnecessarily firing generic assay meta requests for each ga entity when these could be batched (as in achieved in this PR).