### PR TITLE
Do not let clickhouse points at secondary subdomain of beta

### DIFF
--- a/src/shared/api/cbioportalInternalClientInstance.ts
+++ b/src/shared/api/cbioportalInternalClientInstance.ts
@@ -29,11 +29,7 @@ function proxyColumnStore(client: any, endpoint: string) {
     const old = client[method];
 
     client[method] = function(params: any) {
-        const host =
-            getBrowserWindow().location.hostname ===
-            'genie-public-beta.cbioportal.org'
-                ? 'genie-public-beta1.cbioportal.org'
-                : getLoadConfig().baseUrl;
+        const host = getLoadConfig().baseUrl;
 
         const oldRequest = this.request;
 


### PR DESCRIPTION
new endpoint will try to use `genie-public-beta1.cbioportal.org` to send requests and this is causing authentication issue, this pr removes the support for this domain