### PR TITLE
Fix Mutations Lollipop Tool Tip Info to await promise before retrieving patient counts

### DIFF
--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -334,14 +334,20 @@ export default class Mutations extends React.Component<
         count: number,
         mutations: Mutation[],
         axisMode: AxisScale
-    ): JSX.Element {
-        return (
-            <LollipopTooltipCountInfo
-                count={count}
-                mutations={mutations}
-                axisMode={axisMode}
-                patientCount={this.props.store.filteredPatients.result!.length}
-            />
-        );
+    ) {
+        if (this.props.store.filteredPatients.isComplete) {
+            return (
+                <LollipopTooltipCountInfo
+                    count={count}
+                    mutations={mutations}
+                    axisMode={axisMode}
+                    patientCount={
+                        this.props.store.filteredPatients.result.length
+                    }
+                />
+            );
+        } else {
+            return <></>;
+        }
     }
 }


### PR DESCRIPTION

Mutation tab failed when attempting to grab filteredPatients promise before data was available.
