### PR TITLE
On Study View handle larger number of resource files

### DIFF
--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal-docs.json
@@ -2831,6 +2831,103 @@
         "operationId": "getAllStudyResourceDataInStudyUsingGET"
       }
     },
+    "/api/studies/{studyId}/resource-data-all": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Study ID e.g. acc_tcga",
+            "in": "path",
+            "name": "studyId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Resource ID",
+            "in": "query",
+            "name": "resourceId",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "default": "SUMMARY",
+            "description": "Level of detail of the response",
+            "enum": [
+              "ID",
+              "SUMMARY",
+              "DETAILED",
+              "META"
+            ],
+            "in": "query",
+            "name": "projection",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "default": 10000000,
+            "description": "Page size of the result list",
+            "format": "int32",
+            "in": "query",
+            "maximum": 10000000,
+            "minimum": 1,
+            "name": "pageSize",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "default": 0,
+            "description": "Page number of the result list",
+            "format": "int32",
+            "in": "query",
+            "minimum": 0,
+            "name": "pageNumber",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "Name of the property that the result list is sorted by",
+            "enum": [
+              "ResourceId",
+              "url"
+            ],
+            "in": "query",
+            "name": "sortBy",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "default": "ASC",
+            "description": "Direction of the sort",
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "items": {
+                "$ref": "#/definitions/ResourceData"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "tags": [
+          "Resource Data"
+        ],
+        "description": "Get all resource data for for all patients and all samples within a study",
+        "operationId": "getAllStudyResourceDataInStudyPatientSampleUsingGET"
+      }
+    },
     "/api/studies/{studyId}/resource-definitions": {
       "get": {
         "produces": [

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -6746,6 +6746,159 @@ export default class CBioPortalAPIInternal {
                 return response.body;
             });
         };
+    getAllStudyResourceDataInStudyPatientSampleUsingGETURL(parameters: {
+        'studyId': string,
+        'resourceId' ? : string,
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        'pageSize' ? : number,
+        'pageNumber' ? : number,
+        'sortBy' ? : "ResourceId" | "url",
+        'direction' ? : "ASC" | "DESC",
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/api/studies/{studyId}/resource-data-all';
+
+        path = path.replace('{studyId}', parameters['studyId'] + '');
+        if (parameters['resourceId'] !== undefined) {
+            queryParameters['resourceId'] = parameters['resourceId'];
+        }
+
+        if (parameters['projection'] !== undefined) {
+            queryParameters['projection'] = parameters['projection'];
+        }
+
+        if (parameters['pageSize'] !== undefined) {
+            queryParameters['pageSize'] = parameters['pageSize'];
+        }
+
+        if (parameters['pageNumber'] !== undefined) {
+            queryParameters['pageNumber'] = parameters['pageNumber'];
+        }
+
+        if (parameters['sortBy'] !== undefined) {
+            queryParameters['sortBy'] = parameters['sortBy'];
+        }
+
+        if (parameters['direction'] !== undefined) {
+            queryParameters['direction'] = parameters['direction'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Get all resource data for for all patients and all samples within a study
+     * @method
+     * @name CBioPortalAPIInternal#getAllStudyResourceDataInStudyPatientSampleUsingGET
+     * @param {string} studyId - Study ID e.g. acc_tcga
+     * @param {string} resourceId - Resource ID
+     * @param {string} projection - Level of detail of the response
+     * @param {integer} pageSize - Page size of the result list
+     * @param {integer} pageNumber - Page number of the result list
+     * @param {string} sortBy - Name of the property that the result list is sorted by
+     * @param {string} direction - Direction of the sort
+     */
+    getAllStudyResourceDataInStudyPatientSampleUsingGETWithHttpInfo(parameters: {
+        'studyId': string,
+        'resourceId' ? : string,
+        'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+        'pageSize' ? : number,
+        'pageNumber' ? : number,
+        'sortBy' ? : "ResourceId" | "url",
+        'direction' ? : "ASC" | "DESC",
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/api/studies/{studyId}/resource-data-all';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+
+            path = path.replace('{studyId}', parameters['studyId'] + '');
+
+            if (parameters['studyId'] === undefined) {
+                reject(new Error('Missing required  parameter: studyId'));
+                return;
+            }
+
+            if (parameters['resourceId'] !== undefined) {
+                queryParameters['resourceId'] = parameters['resourceId'];
+            }
+
+            if (parameters['projection'] !== undefined) {
+                queryParameters['projection'] = parameters['projection'];
+            }
+
+            if (parameters['pageSize'] !== undefined) {
+                queryParameters['pageSize'] = parameters['pageSize'];
+            }
+
+            if (parameters['pageNumber'] !== undefined) {
+                queryParameters['pageNumber'] = parameters['pageNumber'];
+            }
+
+            if (parameters['sortBy'] !== undefined) {
+                queryParameters['sortBy'] = parameters['sortBy'];
+            }
+
+            if (parameters['direction'] !== undefined) {
+                queryParameters['direction'] = parameters['direction'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Get all resource data for for all patients and all samples within a study
+     * @method
+     * @name CBioPortalAPIInternal#getAllStudyResourceDataInStudyPatientSampleUsingGET
+     * @param {string} studyId - Study ID e.g. acc_tcga
+     * @param {string} resourceId - Resource ID
+     * @param {string} projection - Level of detail of the response
+     * @param {integer} pageSize - Page size of the result list
+     * @param {integer} pageNumber - Page number of the result list
+     * @param {string} sortBy - Name of the property that the result list is sorted by
+     * @param {string} direction - Direction of the sort
+     */
+    getAllStudyResourceDataInStudyPatientSampleUsingGET(parameters: {
+            'studyId': string,
+            'resourceId' ? : string,
+            'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",
+            'pageSize' ? : number,
+            'pageNumber' ? : number,
+            'sortBy' ? : "ResourceId" | "url",
+            'direction' ? : "ASC" | "DESC",
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < ResourceData >
+        > {
+            return this.getAllStudyResourceDataInStudyPatientSampleUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
     getAllResourceDefinitionsInStudyUsingGETURL(parameters: {
         'studyId': string,
         'projection' ? : "ID" | "SUMMARY" | "DETAILED" | "META",

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI-docs.json
@@ -1606,6 +1606,15 @@
         },
         "ncitCode": {
           "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "uuid": {
+          "type": "string"
         }
       }
     },

--- a/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
+++ b/packages/genome-nexus-ts-api-client/src/generated/GenomeNexusAPI.ts
@@ -192,6 +192,10 @@ export type Drug = {
 
         'ncitCode': string
 
+        'synonyms': Array < string >
+
+        'uuid': string
+
 };
 export type EnsemblFilter = {
     'geneIds': Array < string >

--- a/packages/oncokb-ts-api-client/src/generated/OncoKbAPI-docs.json
+++ b/packages/oncokb-ts-api-client/src/generated/OncoKbAPI-docs.json
@@ -112,7 +112,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -157,7 +157,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -218,7 +218,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -263,7 +263,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -324,7 +324,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -369,7 +369,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -480,7 +480,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -525,7 +525,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -633,7 +633,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -678,7 +678,7 @@
           "400": {
             "description": "Error, error message will be given.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -1173,6 +1173,27 @@
           "format": "int32"
         },
         "hugoSymbol": {
+          "type": "string"
+        }
+      }
+    },
+    "ApiHttpError": {
+      "type": "object",
+      "properties": {
+        "detail": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
           "type": "string"
         }
       }

--- a/packages/oncokb-ts-api-client/src/generated/OncoKbAPI.ts
+++ b/packages/oncokb-ts-api-client/src/generated/OncoKbAPI.ts
@@ -79,6 +79,18 @@ export type QueryGene = {
         'hugoSymbol': string
 
 };
+export type ApiHttpError = {
+    'detail': string
+
+        'message': string
+
+        'path': string
+
+        'status': number
+
+        'title': string
+
+};
 export type CancerGene = {
     'entrezGeneId': number
 

--- a/src/appShell/App/usageAgreements/StudyAgreement.tsx
+++ b/src/appShell/App/usageAgreements/StudyAgreement.tsx
@@ -71,7 +71,7 @@ export const StudyAgreement: React.FunctionComponent<{}> = function({}) {
                         href="https://mskcc.sharepoint.com/sites/pub-ResearchDG/SitePages/Home.aspx?ga=1"
                         target="_blank"
                     >
-                        MSK-IMPACT Research Data Governance publication
+                        MSK-IMPACT Memorial Hospital Research Data Governance publication
                         guidelines
                     </a>
                     .

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -138,30 +138,36 @@ async function fetchFilesLinksData(
 
     const resourcesForPatientsAndSamples = resourcesForEntireStudy
         .filter(
-            resource =>
+            (resource: ResourceData) =>
                 selectedSamplesList.includes(resource.sampleId) ||
                 selectedPatientsList.includes(resource.patientId)
         )
-        .reduce((idMap: { [key: string]: ResourceData[] }, resource) => {
-            const { resourceType } = resource.resourceDefinition;
-            const { patientId, sampleId } = resource;
+        .reduce(
+            (
+                idMap: { [key: string]: ResourceData[] },
+                resource: ResourceData
+            ) => {
+                const { resourceType } = resource.resourceDefinition;
+                const { patientId, sampleId } = resource;
 
-            if (resourceType == 'PATIENT') {
-                if (idMap.hasOwnProperty(patientId)) {
-                    idMap[patientId].push(resource);
-                } else {
-                    idMap[patientId] = [resource];
+                if (resourceType == 'PATIENT') {
+                    if (idMap.hasOwnProperty(patientId)) {
+                        idMap[patientId].push(resource);
+                    } else {
+                        idMap[patientId] = [resource];
+                    }
+                } else if (resourceType == 'SAMPLE') {
+                    if (idMap.hasOwnProperty(sampleId)) {
+                        idMap[sampleId].push(resource);
+                    } else {
+                        idMap[sampleId] = [resource];
+                    }
                 }
-            } else if (resourceType == 'SAMPLE') {
-                if (idMap.hasOwnProperty(sampleId)) {
-                    idMap[sampleId].push(resource);
-                } else {
-                    idMap[sampleId] = [resource];
-                }
-            }
 
-            return idMap;
-        }, {});
+                return idMap;
+            },
+            {}
+        );
 
     // we create objects with the necessary properties for each resource
     // calculate the total number of resources per patient.

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -146,7 +146,7 @@ async function fetchFilesLinksData(
         .filter(resource =>
             selectedIds.has(resource.sampleId || resource.patientId)
         )
-        .groupBy('patientId')
+        .groupBy(r => r.patientId)
         .value();
 
     // we create objects with the necessary properties for each resource

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -14,7 +14,6 @@ import {
     getSampleViewUrlWithPathname,
     getPatientViewUrlWithPathname,
 } from 'shared/api/urls';
-import { getAllClinicalDataByStudyViewFilter } from '../StudyViewUtils';
 import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import { isUrl, remoteData } from 'cbioportal-frontend-commons';
 import { makeObservable, observable, computed } from 'mobx';
@@ -116,23 +115,14 @@ async function fetchFilesLinksData(
     sortDirection: 'asc' | 'desc' | undefined,
     recordLimit: number
 ) {
-    const studyClinicalDataResponse = await getAllClinicalDataByStudyViewFilter(
-        filters,
-        searchTerm,
-        sortAttributeId,
-        sortDirection,
-        recordLimit,
-        0
-    );
-
     const selectedStudyIds = [
         ...new Set(selectedSamples.map(item => item.studyId)),
     ];
 
     // sampleIds (+patientIds) for the selectedSamples
     const selectedIds = new Map([
-        ...new Map(selectedSamples.map(item => [item.sampleId, item.studyId])),
-        ...new Map(selectedSamples.map(item => [item.patientId, item.studyId])),
+        ...selectedSamples.map(item => [item.sampleId, item.studyId] as const),
+        ...selectedSamples.map(item => [item.patientId, item.studyId] as const),
     ]);
 
     // Fetch resources for entire study


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/11004 (associated backend PR is merged, see https://github.com/cBioPortal/cbioportal/pull/11051). This PR modifies the FilesAndLinks table on the Study View to use the new resource-data-all endpoint, which reduces the number of API requests and enables showing thousands of resource files without performance degradation