### PR TITLE
Add Mutation Assessor V4 available date on tooltip

### DIFF
--- a/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
+++ b/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
@@ -47,7 +47,7 @@ export default class MutationAssessor extends React.Component<
                 <br />
                 <b>
                     Mutation Assessor V4 data is available in the portal since
-                    Oct. 8, 2024!
+                    Oct. 8, 2024.
                 </b>{' '}
                 New manuscript is in progress. Click{` `}
                 <a href="http://mutationassessor.org/r3/" target="_blank">

--- a/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
+++ b/packages/react-variant-view/src/component/functionalPrediction/MutationAssessor.tsx
@@ -46,7 +46,8 @@ export default class MutationAssessor extends React.Component<
                 ).
                 <br />
                 <b>
-                    Mutation Assessor V4 data is now available in the portal!
+                    Mutation Assessor V4 data is available in the portal since
+                    Oct. 8, 2024!
                 </b>{' '}
                 New manuscript is in progress. Click{` `}
                 <a href="http://mutationassessor.org/r3/" target="_blank">

--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -318,7 +318,8 @@ class FunctionalImpactColumnTooltip extends React.Component<
                 ).
                 <br />
                 <b>
-                    Mutation Assessor V4 data is now available in the portal!
+                    Mutation Assessor V4 data is available in the portal since
+                    Oct. 8, 2024!
                 </b>{' '}
                 New manuscript is in progress. Click{` `}
                 <a href="http://mutationassessor.org/r3/" target="_blank">

--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -319,7 +319,7 @@ class FunctionalImpactColumnTooltip extends React.Component<
                 <br />
                 <b>
                     Mutation Assessor V4 data is available in the portal since
-                    Oct. 8, 2024!
+                    Oct. 8, 2024.
                 </b>{' '}
                 New manuscript is in progress. Click{` `}
                 <a href="http://mutationassessor.org/r3/" target="_blank">


### PR DESCRIPTION
Add date on tooltip
![image](https://github.com/user-attachments/assets/43037c36-0cbd-4425-af97-d8519767573f)
