### PR TITLE
Modify fetch resources from single study to multi-study

### DIFF
--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -35,14 +35,12 @@ const RECORD_LIMIT = 500;
 
 function getResourceDataOfEntireStudy(studyIds: string[]) {
     // Fetch resource data for each studyId, then return combined results
-    const allResources = _(studyIds)
-        .map(studyId =>
-            internalClient.getAllStudyResourceDataInStudyPatientSampleUsingGET({
-                studyId: studyId,
-                projection: 'DETAILED',
-            })
-        )
-        .value();
+    const allResources = studyIds.map(studyId =>
+        internalClient.getAllStudyResourceDataInStudyPatientSampleUsingGET({
+            studyId: studyId,
+            projection: 'DETAILED',
+        })
+    );
 
     return Promise.all(allResources).then(allResources =>
         _(allResources)

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -34,16 +34,21 @@ class FilesLinksTableComponent extends LazyMobXTable<{
 const RECORD_LIMIT = 500;
 
 function getResourceDataOfEntireStudy(studyIds: string[]) {
-    // Only handle the first studyId for now. Can be expanded to make a call per
-    // studyId.
-    const studyId = studyIds[0];
-    const allResources = internalClient.getAllStudyResourceDataInStudyPatientSampleUsingGET(
-        {
-            studyId: studyId,
-            projection: 'DETAILED',
-        }
+    // Fetch resource data for each studyId, then return combined results
+    const allResources = _(studyIds)
+        .map(studyId =>
+            internalClient.getAllStudyResourceDataInStudyPatientSampleUsingGET({
+                studyId: studyId,
+                projection: 'DETAILED',
+            })
+        )
+        .value();
+
+    return Promise.all(allResources).then(allResources =>
+        _(allResources)
+            .flatMap()
+            .value()
     );
-    return allResources;
 }
 
 function getResourceDataOfPatients(studyClinicalData: {


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11158. Add multiy-study result for files & resource tab on Study view. Fetch resource data for each study on the frontend and combine the results. Note: in the future we might want to improve the endpoint to handle multiple studies directly