### PR TITLE
Fix Sift and Polyphen blank in NRAS

### DIFF
--- a/packages/react-variant-view/src/component/functionalPrediction/FunctionalPrediction.tsx
+++ b/packages/react-variant-view/src/component/functionalPrediction/FunctionalPrediction.tsx
@@ -28,25 +28,21 @@ interface IFunctionalImpactData {
 @observer
 class FunctionalPrediction extends React.Component<IFunctionalPredictionProps> {
     public getData(
-        genomeNexusData: VariantAnnotation | undefined
+        genomeNexusData: VariantAnnotation | undefined,
+        selectedTranscriptId?: string
     ): IFunctionalImpactData {
         const mutationAssessor = genomeNexusData?.mutation_assessor;
-        const siftScore =
-            genomeNexusData &&
-            genomeNexusData.transcript_consequences &&
-            genomeNexusData.transcript_consequences[0].sift_score;
-        const siftPrediction =
-            genomeNexusData &&
-            genomeNexusData.transcript_consequences &&
-            genomeNexusData.transcript_consequences[0].sift_prediction;
-        const polyPhenScore =
-            genomeNexusData &&
-            genomeNexusData.transcript_consequences &&
-            genomeNexusData.transcript_consequences[0].polyphen_score;
-        const polyPhenPrediction =
-            genomeNexusData &&
-            genomeNexusData.transcript_consequences &&
-            genomeNexusData.transcript_consequences[0].polyphen_prediction;
+        const transcriptConsequence =
+            genomeNexusData && selectedTranscriptId
+                ? genomeNexusData.transcript_consequences.find(
+                      tc => tc.transcript_id === selectedTranscriptId
+                  )
+                : undefined;
+
+        const siftScore = transcriptConsequence?.sift_score;
+        const siftPrediction = transcriptConsequence?.sift_prediction;
+        const polyPhenScore = transcriptConsequence?.polyphen_score;
+        const polyPhenPrediction = transcriptConsequence?.polyphen_prediction;
 
         return {
             mutationAssessor,

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -906,7 +906,8 @@ export default class MutationTable<
                     return FunctionalImpactColumnFormatter.renderFunction(
                         d,
                         this.props.genomeNexusCache,
-                        this.props.genomeNexusMutationAssessorCache
+                        this.props.genomeNexusMutationAssessorCache,
+                        this.props.selectedTranscriptId
                     );
                 } else {
                     return <span></span>;
@@ -917,7 +918,8 @@ export default class MutationTable<
                     d,
                     this.props.genomeNexusCache as GenomeNexusCache,
                     this.props
-                        .genomeNexusMutationAssessorCache as GenomeNexusMutationAssessorCache
+                        .genomeNexusMutationAssessorCache as GenomeNexusMutationAssessorCache,
+                    this.props.selectedTranscriptId
                 ),
             headerRender: FunctionalImpactColumnFormatter.headerRender,
             visible: false,


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/11150
Get Sift and Polyphen data from the selected/active transcript, instead of always getting from the first transcript.
Testing: add `Functional Impact` column in mutation table ([link](https://deploy-preview-5039.cancerrevue.org/results/mutations?cancer_study_list=coadread_tcga_pub&cancer_study_id=coadread_tcga_pub&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=coadread_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=coadread_tcga_pub_gistic&Z_SCORE_THRESHOLD=2.0&case_set_id=coadread_tcga_pub_nonhypermut&gene_list=KRAS%20NRAS%20BRAF&gene_set_choice=user-defined-list&mutations_gene=NRAS))

Before:
![image](https://github.com/user-attachments/assets/f2f59a69-e64e-45ac-92fd-4d1c73936740)

After:
![image](https://github.com/user-attachments/assets/f8844e77-8ab0-4441-9fbc-44618dc33a9d)
