### PR TITLE
add retry logic for 404 errors

### DIFF
--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -17,14 +17,29 @@ jobs:
 
       - name: Get release tag
         id: get_tag
-        run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Trigger JitPack Build
         run: |
           TAG=${{ steps.get_tag.outputs.tag }}
           JITPACK_BUILD_URL="https://jitpack.io/com/github/cbioportal/cbioportal-frontend/$TAG/build.log"
-          echo "Triggering JitPack build for $TAG"
-          curl -I $JITPACK_BUILD_URL
-
-      - name: Notify success
-        run: echo "JitPack build triggered successfully."
+          
+          MAX_RETRIES=10
+          RETRY_DELAY=30
+          COUNTER=0
+          
+          while [ $COUNTER -lt $MAX_RETRIES ]; do
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$JITPACK_BUILD_URL")
+          
+            if [ "$HTTP_STATUS" -eq 200 ]; then
+              echo "Build triggered successfully for version ${TAG}."
+              exit 0
+            else
+              echo "Attempt $((COUNTER+1)) failed with status $HTTP_STATUS: Tag not found yet. Retrying in $RETRY_DELAY seconds..."
+              ((COUNTER++))
+              sleep $RETRY_DELAY
+            fi
+          done
+          
+          echo "Failed to trigger JitPack build after $MAX_RETRIES attempts."
+          exit 1


### PR DESCRIPTION
Fix cBioPortal/cbioportal# (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Modified github action "Trigger JitPack Build". Now, the action keeps retriggering the jitpack build every 30 seconds for a maximum of 5 minutes, until the jitpack url returns a success code of 200.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
