### PR TITLE
On Study View sort structural variant table by sample count

### DIFF
--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -803,7 +803,9 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                                         MultiSelectionTableColumnKey.FREQ,
                                 },
                             ]}
-                            defaultSortBy={MultiSelectionTableColumnKey.FREQ}
+                            defaultSortBy={
+                                MultiSelectionTableColumnKey.NUMBER_STRUCTURAL_VARIANTS
+                            }
                             setOperationsButtonText={
                                 this.props.store.hesitateUpdate
                                     ? 'Add Filters '


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11208. This is a quick fix to handle partner gene frequencies >100%. It sorts SVs by sample count by default (practically hiding partner genes with low sample counts and potentially high alteration frequencies). It will be fixed more properly at a later stage (prolly with introduction of RFC80)
![image](https://github.com/user-attachments/assets/0dd30a0f-b773-40fb-be21-e6d73341816b)
