### PR TITLE
Use NP instead of NS for Mutations in Download tab

### DIFF
--- a/src/pages/resultsView/download/DownloadUtils.spec.ts
+++ b/src/pages/resultsView/download/DownloadUtils.spec.ts
@@ -597,7 +597,7 @@ describe('DownloadUtils', () => {
                     'WT',
                     'G598A [germline] G239C',
                 ],
-                ['skcm_tcga', 'TCGA-EE-A20C-06', 'NS', 'WT', 'WT'],
+                ['skcm_tcga', 'TCGA-EE-A20C-06', 'NP', 'WT', 'WT'],
             ];
 
             assert.deepEqual(

--- a/src/pages/resultsView/download/DownloadUtils.ts
+++ b/src/pages/resultsView/download/DownloadUtils.ts
@@ -262,7 +262,7 @@ export function generateMutationDownloadData(
               extractMutationValue,
               undefined,
               'WT',
-              'NS'
+              'NP'
           )
         : [];
 }


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/10789. Use `NP (Not profiled)` across all types of alterations (mutations was using `NS (Not Sequenced)` instead of `NP`)

- Change mutation data download format to display 'NP' instead of 'NS' for non-sequenced samples
- Update `generateMutationDownloadData` function in DownloadUtils.ts to use 'NP' as the default value for non-sequenced samples

Here is a before and after screenshot of the file. 

<img width="1296" alt="Screenshot 2024-11-28 at 11 13 43 AM" src="https://github.com/user-attachments/assets/dbf7bd21-7958-4879-8809-31f1ef7f710f">
