### PR TITLE
#10762 Show gene search icon on row hover

### DIFF
--- a/src/pages/studyView/table/tables.module.scss
+++ b/src/pages/studyView/table/tables.module.scss
@@ -67,11 +67,6 @@ $study-view-table-icon-size: 10px;
         display: flex !important;
         opacity: 0.5;
     }
-    &:hover {
-        .addGeneUI {
-            @extend %addGeneUIHover;
-        }
-    }
     .addGeneUI {
         display: none;
         &.selected {
@@ -111,6 +106,12 @@ $study-view-table-icon-size: 10px;
 
 .row {
     font-size: 13px;
+
+    &:hover {
+        .addGeneUI {
+            @extend %addGeneUIHover;
+        }
+    }
 }
 
 .oddRow {


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/10762

Changes in this PR: 
- Modified hover behavior to show gene search icon when hovering over any part of the table row

https://github.com/user-attachments/assets/7f513619-841e-4dae-a4ef-1ba23c585457


## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
