### PR TITLE
Change file and links name to resource displayName

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -721,7 +721,13 @@ export default class StudyViewPage extends React.Component<
                                         id={
                                             StudyViewPageTabKeyEnum.FILES_AND_LINKS
                                         }
-                                        linkText={RESOURCES_TAB_NAME}
+                                        linkText={
+                                            this.store.resourceDefinitions
+                                                .result?.length == 1
+                                                ? this.store.resourceDefinitions
+                                                      .result[0].displayName
+                                                : RESOURCES_TAB_NAME
+                                        }
                                         hide={!this.shouldShowResources}
                                     >
                                         <div>


### PR DESCRIPTION
Adds a condition to the link text where if all resources are of the same type, then rename the Files & Links tab to the resourceDefinition displayName
