### PR TITLE
custom-selection-added

### DIFF
--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
@@ -158,7 +158,16 @@ export default class CustomCaseSelection extends React.Component<
 
     @action.bound
     onChange(newContent: string) {
-        this.validContent = newContent;
+        // Preprocess content to allow spaces, tabs, and commas as valid delimiters
+        const normalizedContent = newContent
+            .split(/[, ]+/) // Split the content by either commas or spaces
+            .map(line => line.trim()) // Remove extra spaces around each line
+            .filter(line => line.length > 0) // Remove empty lines
+            .join('\n'); // Use newline as the final delimiter
+
+        // Assign normalized content and trigger validation
+        this.validContent = normalizedContent;
+        // this.validContent = newContent;
         this.validateContent = true;
     }
 
@@ -207,11 +216,26 @@ export default class CustomCaseSelection extends React.Component<
             this.caseIdsMode === ClinicalDataTypeEnum.SAMPLE
                 ? 'sample_id'
                 : 'patient_id';
-        return `Example:\nstudy_id:${caseIdentifier}1${
+
+        // Creating example strings for each delimiter type
+        const newLineExample = `study_id:${caseIdentifier}1${
             this.props.disableGrouping ? '' : ' value1'
         }\nstudy_id:${caseIdentifier}2${
             this.props.disableGrouping ? '' : ' value2'
         }`;
+        const commaExample = `study_id:${caseIdentifier}1${
+            this.props.disableGrouping ? '' : ' value1'
+        }, study_id:${caseIdentifier}2${
+            this.props.disableGrouping ? '' : ' value2'
+        }`;
+        const spaceExample = `study_id:${caseIdentifier}1${
+            this.props.disableGrouping ? '' : ' value1'
+        } study_id:${caseIdentifier}2${
+            this.props.disableGrouping ? '' : ' value2'
+        }`;
+
+        // Combining all three cases into one string
+        return `Example with newline:\n${newLineExample}\n\nExample with comma:\n${commaExample}\n\nExample with space:\n${spaceExample}`;
     }
 
     @computed


### PR DESCRIPTION
Fix cBioPortal/cbioportal #11273

Describe changes proposed in this pull request:
- added custom selection text box to take inputs with commas, space or new line or all combined also
- also added examplary placeholder

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
![Screenshot from 2024-12-12 23-32-38](https://github.com/user-attachments/assets/091db24d-2370-48e3-ac00-3bc2add46651)
![Screenshot from 2024-12-12 23-48-43](https://github.com/user-attachments/assets/16be2746-1c58-4799-bf32-688ab72e4706)
