### PR TITLE
Fix/10733: Updated default value of Timeline events availability chart

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -7834,10 +7834,6 @@ export class StudyViewPageStore
     @action
     initializeClinicalEventTypeCountChart(): void {
         if (this.shouldDisplayClinicalEventTypeCounts.result) {
-            this.changeChartVisibility(
-                SpecialChartsUniqueKeyEnum.CLINICAL_EVENT_TYPE_COUNTS,
-                false
-            );
             this.chartsType.set(
                 SpecialChartsUniqueKeyEnum.CLINICAL_EVENT_TYPE_COUNTS,
                 ChartTypeEnum.CLINICAL_EVENT_TYPE_COUNTS_TABLE

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -7836,7 +7836,7 @@ export class StudyViewPageStore
         if (this.shouldDisplayClinicalEventTypeCounts.result) {
             this.changeChartVisibility(
                 SpecialChartsUniqueKeyEnum.CLINICAL_EVENT_TYPE_COUNTS,
-                true
+                false
             );
             this.chartsType.set(
                 SpecialChartsUniqueKeyEnum.CLINICAL_EVENT_TYPE_COUNTS,


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10733 

- As described in the issue, modified the default value of the Timeline events availability chart and not show that table by default, and let users add whenever they want from the charts menu.


![image](https://github.com/user-attachments/assets/c8d0b6f4-aa66-4313-9bac-f03283fa8d41)
![image](https://github.com/user-attachments/assets/b4bf6b2b-7ea4-497c-b1d3-805a36e1e79b)

