### PR TITLE
automate jitpack build and frontend version update for new releases

### DIFF
--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -43,3 +43,54 @@ jobs:
           
           echo "Failed to trigger JitPack build after $MAX_RETRIES attempts."
           exit 1
+
+      - name: Get POM File
+        run: |
+          TAG=${{ steps.get_tag.outputs.tag }}
+          JITPACK_POM_URL="https://jitpack.io/com/github/cbioportal/cbioportal-frontend/$TAG/cbioportal-frontend-$TAG.pom"
+          
+          MAX_RETRIES=10
+          RETRY_DELAY=30
+          COUNTER=0
+          
+          while [ $COUNTER -lt $MAX_RETRIES ]; do
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$JITPACK_POM_URL")
+          
+            if [ "$HTTP_STATUS" -eq 200 ]; then
+              echo "POM file successfully found."
+              exit 0
+            else
+              echo "Attempt $((COUNTER+1)) failed with status $HTTP_STATUS: POM file not found yet. Retrying in $RETRY_DELAY seconds..."
+              COUNTER=$((COUNTER+1))
+              sleep $RETRY_DELAY
+            fi
+          done
+          
+          echo "Failed to find POM file after $MAX_RETRIES attempts."
+          exit 1
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.BACKEND_REPO_TOKEN }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Set up git
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+
+      - name: Checkout cbioportal/cbioportal
+        run: |
+          git clone git@github.com:cBioPortal/cbioportal.git
+
+      - name: Update backend to use latest frontend commit
+        run: |
+          TAG=${{ steps.get_tag.outputs.tag }}
+          cd cbioportal
+          sed -i "s|<version>\(.*\)-SNAPSHOT</version>|<version>\1</version>|" pom.xml
+          sed -i "s|<frontend.version>.*</frontend.version>|<frontend.version>$TAG</frontend.version>|" pom.xml
+          git add pom.xml
+          git commit -m "Frontend $TAG"
+          git push

--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -49,7 +49,7 @@ jobs:
           TAG=${{ steps.get_tag.outputs.tag }}
           JITPACK_POM_URL="https://jitpack.io/com/github/cbioportal/cbioportal-frontend/$TAG/cbioportal-frontend-$TAG.pom"
           
-          MAX_RETRIES=10
+          MAX_RETRIES=60
           RETRY_DELAY=30
           COUNTER=0
           


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Jitpack build action now checks for pom file and waits until its built.
- Build action also updates the backend repo with the correct frontend version.

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
