### PR TITLE
#11285 Fixed issue of server config properties not getting rendered correctly

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -96,6 +96,20 @@ function applyDefaultConfigurationValues(serverConfig: any) {
             }
         }
     });
+
+    // This pass handles boolean values that aren't in ServerConfigDefaults
+    // Without this, these boolean properties will be rendered as string
+    Object.keys(serverConfig).forEach(key => {
+        if (typeof serverConfig[key] === 'string') {
+            const lowerVal = serverConfig[key].toLowerCase();
+            if (lowerVal === 'true' || lowerVal === 'false') {
+                serverConfig[key] = lowerVal === 'true';
+            }
+            console.warn(
+                `Warning: Boolean value for key "${key}" encountered, but it's missing from ServerConfigDefaults.`
+            );
+        }
+    });
 }
 
 export class ServerConfigHelpers {


### PR DESCRIPTION
Describe changes proposed in this pull request:

### Problem: 

The server config API returns all values as strings, including boolean values (like 'true' or 'false'). Our current code only converts those strings to actual boolean values if they exist in our `ServerConfigDefaults` file. This caused a few boolean values like `skin_show_donate_button` to be rendered as string: `true`. 

### Solution:

Added a second pass after applying defaults that looks at all config values from the API and converts any 'true'/'false' strings to proper boolean values.

<img width="1728" alt="Screenshot 2024-12-19 at 10 30 50 AM" src="https://github.com/user-attachments/assets/825b04b3-4556-43f9-a222-6e35edf2ad0e" />


## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
