### PR TITLE
Fix #11245: Add tooltip to 'Altered group' axis label for box plot statistics

### DIFF
--- a/src/pages/groupComparison/ClinicalNumericalDataVisualisation.tsx
+++ b/src/pages/groupComparison/ClinicalNumericalDataVisualisation.tsx
@@ -7,15 +7,154 @@ import BoxScatterPlot, {
 } from 'shared/components/plots/BoxScatterPlot';
 import { IBoxScatterPlotPoint } from 'shared/components/plots/PlotsTabUtils';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { computed, makeObservable } from 'mobx';
-import { DescriptiveDataTable } from './SummaryStatisticsTable';
+import { BoxModel } from 'shared/components/plots/BoxScatterPlot';
+
+import {
+    DescriptiveDataTable,
+    SummaryStatisticsTable,
+} from './SummaryStatisticsTable';
 
 export enum ClinicalNumericalVisualisationType {
     Plot = 'Plot',
     Table = 'Table',
 }
 
-export class PlotsTabBoxPlot extends BoxScatterPlot<IBoxScatterPlotPoint> {}
+export class PlotsTabBoxPlot extends BoxScatterPlot<IBoxScatterPlotPoint> {
+    render() {
+        const { data, boxPlotTooltip } = this.props;
+        console.log('Props Data:', this.props.data);
+
+        if (!data || data.length === 0) {
+            return <g />; // Return an empty <g> element if there's no data
+        }
+
+        return (
+            <g>
+                {/* Render existing chart elements */}
+                {super.render()}
+
+                {/* Dynamically render X-Axis labels with tooltips */}
+                {data.map((d, index) => (
+                    <text
+                        key={index}
+                        x={index * 100} // Adjust position dynamically
+                        y={300} // Y position for X-axis labels
+                        style={{
+                            cursor:
+                                d.label === 'Altered group'
+                                    ? 'pointer'
+                                    : 'default',
+                        }}
+                    >
+                        {d.label === 'Altered group' && boxPlotTooltip && (
+                            <title>
+                                Tooltip for {d.label}{' '}
+                                {/* Replace with dynamic tooltip content */}
+                            </title>
+                        )}
+                    </text>
+                ))}
+            </g>
+        );
+    }
+
+    transformDataForSummaryStatisticsTable(data: any[]): BoxModel[] {
+        return data.map(item => ({
+            max: item._max || item.max || 0,
+            q3: item._q3 || item.q3 || 0,
+            median: item._median || item.median || 0,
+            q1: item._q1 || item.q1 || 0,
+            min: item._min || item.min || 0,
+        }));
+    }
+
+    componentDidMount() {
+        const rawData = this.props.data || []; // Ensure rawData is an array
+        const labels = rawData.map((d: any) => d.label || 'Unknown'); // Fallback for missing labels
+
+        // Transform data using toBoxPlotData
+        const transformedData = toBoxPlotData(
+            rawData,
+            undefined, // Optional filter
+            undefined, // Optional exclude limit values
+            undefined // Optional logScale
+        );
+
+        console.log('Transformed Data for Tooltip:', transformedData);
+
+        // Select only the first entry from transformedData
+        const filteredData =
+            transformedData.length > 0 ? [transformedData[0]] : [];
+        const filteredLabels = labels.length > 0 ? [labels[0]] : []; // Match label for the first entry
+
+        console.log('Filtered Data for Tooltip:', filteredData);
+        console.log('Filtered Labels for Tooltip:', filteredLabels);
+
+        // Pass filtered data and labels to the tooltip function
+        if (filteredData.length > 0 && filteredLabels.length > 0) {
+            this.attachTooltipToAlteredGroup(filteredData, filteredLabels);
+        } else {
+            console.warn('No valid data or labels provided for tooltips.');
+        }
+    }
+
+    attachTooltipToAlteredGroup(data: BoxModel[], labels: string[]) {
+        const alteredGroupElement = Array.from(
+            document.querySelectorAll('tspan')
+        ).find(el => el.textContent === 'Altered group');
+
+        if (alteredGroupElement) {
+            let tooltipDiv = document.getElementById('tooltip-container');
+            if (!tooltipDiv) {
+                tooltipDiv = document.createElement('div');
+                tooltipDiv.id = 'tooltip-container';
+                tooltipDiv.style.position = 'absolute';
+                tooltipDiv.style.backgroundColor = 'white';
+                tooltipDiv.style.padding = '10px';
+                tooltipDiv.style.zIndex = '1000';
+                tooltipDiv.style.fontSize = '11px';
+                tooltipDiv.style.boxShadow = '0px 2px 10px rgba(0, 0, 0, 0.2)';
+                tooltipDiv.style.borderRadius = '4px';
+                tooltipDiv.style.display = 'none';
+                document.body.appendChild(tooltipDiv);
+            }
+
+            // Render SummaryStatisticsTable with transformed data
+            ReactDOM.render(
+                <div style={{ textAlign: 'left' }}>
+                    <SummaryStatisticsTable data={data} labels={labels} />
+                </div>,
+                tooltipDiv
+            );
+
+            const showTooltip = (e: MouseEvent) => {
+                if (!tooltipDiv) return;
+                const boundingRect = alteredGroupElement.getBoundingClientRect();
+                tooltipDiv.style.top = `${boundingRect.top +
+                    window.scrollY -
+                    tooltipDiv.offsetHeight -
+                    10}px`;
+                tooltipDiv.style.left = `${boundingRect.left +
+                    boundingRect.width / 2 -
+                    tooltipDiv.offsetWidth / 2}px`;
+                tooltipDiv.style.display = 'block';
+            };
+
+            const hideTooltip = () => {
+                if (!tooltipDiv) return;
+                tooltipDiv.style.display = 'none';
+            };
+
+            alteredGroupElement.addEventListener('mouseenter', showTooltip);
+            alteredGroupElement.addEventListener('mouseleave', hideTooltip);
+            (alteredGroupElement as SVGTSpanElement).style.cursor = 'default';
+        } else {
+            console.warn('Could not find "Altered group" element in the DOM.');
+        }
+    }
+}
 
 export type ClinicalNumericalDataVisualisationProps = IBoxScatterPlotProps<
     IBoxScatterPlotPoint


### PR DESCRIPTION
Fix cBioPortal/cbioportal#11245

Describe changes proposed in this pull request:
- Added a tooltip to the "Altered group" axis label to display box plot statistics.
- Tooltip content matches the statistical information shown when hovering over the box.

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
Before : 
<img width="1175" alt="Before" src="https://github.com/user-attachments/assets/04f2297f-a572-4c1a-9c67-c7059ad57fd0" />


After :
<img width="1273" alt="After" src="https://github.com/user-attachments/assets/9135c034-9306-4a79-b03e-23abfdae9365" />


## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
