### PR TITLE
fix localdb servdist

### DIFF
--- a/end-to-end-test/local/runtime-config/serve_dist.sh
+++ b/end-to-end-test/local/runtime-config/serve_dist.sh
@@ -4,10 +4,9 @@ set -e
 set -u # unset variables throw error
 set -o pipefail # pipes fail when partial command fails
 
-(echo $CBIOPORTAL_URL | grep -q https) \
-&& ( \
-    openssl \
-        req -newkey rsa:2048 -new -nodes -x509 -days 1 -keyout key.pem -out cert.pem \
-        -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" && \
-    ./node_modules/http-server/bin/http-server -S -C cert.pem --cors dist/ -p 3000 \
-) || ./node_modules/http-server/bin/http-server --cors dist/ -p 3000
+
+openssl \
+    req -newkey rsa:2048 -new -nodes -x509 -days 1 -keyout key.pem -out cert.pem \
+    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" && \
+./node_modules/http-server/bin/http-server -S -C cert.pem --cors dist/ -p 3000 \
+


### PR DESCRIPTION
After merge of Clickhouse branch, we now always load frontend via https.  Localdb tests were breaking because of this