### PR TITLE
Update function logScalePossible for generic assay negative data

### DIFF
--- a/src/shared/components/plots/PlotsTabUtils.spec.ts
+++ b/src/shared/components/plots/PlotsTabUtils.spec.ts
@@ -767,7 +767,18 @@ describe('PlotsTabUtils', () => {
     });
 
     describe('logScalePossible', () => {
-        it('should return true when data is type number', () => {
+        it('should return true when positive data is type number', () => {
+            const axisData = ({
+                datatype: 'number',
+                data: [{ value: 1 }, { value: 2 }],
+            } as any) as IAxisData;
+            const axisMenuSelection = ({
+                dataType: CLIN_ATTR_DATA_TYPE,
+                genericAssayDataType: DataTypeConstants.LIMITVALUE,
+            } as any) as AxisMenuSelection;
+            assert.isTrue(logScalePossible(axisMenuSelection, axisData));
+        });
+        it('should return false when negative data is type number', () => {
             const axisData = ({
                 datatype: 'number',
                 data: [{ value: 1 }, { value: -2 }],
@@ -776,7 +787,7 @@ describe('PlotsTabUtils', () => {
                 dataType: CLIN_ATTR_DATA_TYPE,
                 genericAssayDataType: DataTypeConstants.LIMITVALUE,
             } as any) as AxisMenuSelection;
-            assert.isTrue(logScalePossible(axisMenuSelection, axisData));
+            assert.isFalse(logScalePossible(axisMenuSelection, axisData));
         });
     });
 

--- a/src/shared/components/plots/PlotsTabUtils.tsx
+++ b/src/shared/components/plots/PlotsTabUtils.tsx
@@ -2583,11 +2583,12 @@ export function logScalePossible(
     ) {
         return true;
     } else if (
+        axisData &&
         isGenericAssaySelected(axisSelection) &&
         axisSelection.genericAssayDataType === DataTypeConstants.LIMITVALUE
     ) {
-        // Generic Assay numeric profile is log scale possible
-        return true;
+        // Check negative values in log scale
+        axisHasNegativeNumbers(axisData) ? false : true;
     } else {
         // molecular profile
         return !!(

--- a/src/shared/components/plots/PlotsTabUtils.tsx
+++ b/src/shared/components/plots/PlotsTabUtils.tsx
@@ -2588,7 +2588,7 @@ export function logScalePossible(
         axisSelection.genericAssayDataType === DataTypeConstants.LIMITVALUE
     ) {
         // Check negative values in log scale
-        axisHasNegativeNumbers(axisData) ? false : true;
+        return axisHasNegativeNumbers(axisData) ? false : true;
     } else {
         // molecular profile
         return !!(


### PR DESCRIPTION
This PR fixes the bug describe in this [issue](https://github.com/cBioPortal/cbioportal/issues/11334).

Now, when we select generic assay data with negative values, the logScalePossible does return `false` whereas before it would always return `true`. 

Before:
![image](https://github.com/user-attachments/assets/5a142284-0c9e-43cb-a03b-fe0a39974544)
Now:
![image](https://github.com/user-attachments/assets/20dba8b9-359d-457f-9239-08d30f472aba)
