### PR TITLE
Selection sample enhancement

### DIFF
--- a/src/pages/patientView/SampleManager.tsx
+++ b/src/pages/patientView/SampleManager.tsx
@@ -125,6 +125,17 @@ export function getSpecimenCollectionDayMap(
     return collectionDayMap;
 }
 
+export function sampleIdsForSamples(samples: Array<ClinicalDataBySampleId>) {
+    let output: { id: string; value: string }[] = [];
+    samples.forEach((sample, sampleIndex) => {
+        output.push({
+            id: sample.id,
+            value: sample.id,
+        });
+    });
+    return output;
+}
+
 export function clinicalAttributeListForSamples(
     samples: Array<ClinicalDataBySampleId>
 ) {

--- a/src/pages/patientView/timeline/VAFChartControls.tsx
+++ b/src/pages/patientView/timeline/VAFChartControls.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { observer } from 'mobx-react';
 import ReactSelect from 'react-select';
 import SampleManager, {
     clinicalAttributeListForSamples,
+    sampleIdsForSamples,
 } from '../SampleManager';
 import LabeledCheckbox from '../../../shared/components/labeledCheckbox/LabeledCheckbox';
 import VAFChartWrapperStore from './VAFChartWrapperStore';
+import _ from 'lodash';
 
 interface IVAFChartControlsProps {
     wrapperStore: VAFChartWrapperStore;
@@ -13,9 +15,65 @@ interface IVAFChartControlsProps {
 }
 
 export const GROUP_BY_NONE = 'None';
+export const SELECT_SAMPLE_ALL = {
+    label: 'All',
+    value: 'All',
+};
+export const SELECT_SAMPLE_NONE = {
+    label: 'None',
+    value: 'None',
+};
 
 const VAFChartControls: React.FunctionComponent<IVAFChartControlsProps> = observer(
     function({ wrapperStore, sampleManager }) {
+        const [
+            isInitialSelectedSamples,
+            setisInitialSelectedSamples,
+        ] = useState(true);
+
+        const selectedSamplesOptions = [
+            SELECT_SAMPLE_ALL,
+            SELECT_SAMPLE_NONE,
+            ...sampleIdsForSamples(sampleManager.samples).map(item => ({
+                label: `${item.value}`,
+                value: `${item.id}`,
+            })),
+        ];
+
+        function selectSamplesByValue() {
+            let allSelectedSamples = selectedSamplesOptions;
+            allSelectedSamples = allSelectedSamples.filter(sample => {
+                return (
+                    sample.label != SELECT_SAMPLE_ALL.label &&
+                    sample.label != SELECT_SAMPLE_NONE.label
+                );
+            });
+            if (isInitialSelectedSamples) {
+                console.log('running initial');
+                wrapperStore.setSelectedSamplesOptions(allSelectedSamples);
+                setisInitialSelectedSamples(!isInitialSelectedSamples);
+            }
+            if (wrapperStore.selectedSamplesOptions.length === 0) {
+                return {
+                    label: 'None',
+                    value: 'None',
+                };
+            }
+            if (
+                _.isEqual(
+                    wrapperStore.selectedSamplesOptions,
+                    allSelectedSamples
+                )
+            ) {
+                return {
+                    label: 'All',
+                    value: 'All',
+                };
+            }
+
+            return wrapperStore.selectedSamplesOptions;
+        }
+
         const groupByOptions = [
             {
                 label: GROUP_BY_NONE,
@@ -34,6 +92,8 @@ const VAFChartControls: React.FunctionComponent<IVAFChartControlsProps> = observ
                 opt => opt.value == wrapperStore.groupByOption
             );
 
+            console.log(`Group By Value : ${value}`);
+
             return value
                 ? {
                       label: value.label,
@@ -42,8 +102,86 @@ const VAFChartControls: React.FunctionComponent<IVAFChartControlsProps> = observ
                 : '';
         }
 
+        const SelectedSampleChecklistComponent: React.FC<any> = props => {
+            const { data, isSelected, innerRef, innerProps } = props;
+            return (
+                <div
+                    ref={innerRef}
+                    {...innerProps}
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        padding: '5px',
+                    }}
+                >
+                    <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => {}}
+                        style={{ marginRight: '10px' }}
+                    />
+                    <label>{data.label}</label>
+                </div>
+            );
+        };
+
         return (
             <div className={'VAFChartControls'} data-test={'VAFChartControls'}>
+                <label>
+                    Select Samples:&nbsp;
+                    <ReactSelect
+                        name={'select-by-sample-select'}
+                        value={selectSamplesByValue()}
+                        options={selectedSamplesOptions}
+                        onChange={(options: Array<any>) => {
+                            if (options.indexOf(SELECT_SAMPLE_ALL) !== -1) {
+                                wrapperStore.setSelectedSamplesOptions(
+                                    sampleIdsForSamples(
+                                        sampleManager.samples
+                                    ).map(item => ({
+                                        label: `${item.value}`,
+                                        value: `${item.id}`,
+                                    }))
+                                );
+                            } else if (
+                                options.indexOf(SELECT_SAMPLE_NONE) !== -1
+                            ) {
+                                wrapperStore.setSelectedSamplesOptions([]);
+                            } else {
+                                console.log(
+                                    `options before filter : ${JSON.stringify(
+                                        options
+                                    )}`
+                                );
+                                options = options.filter(
+                                    sample =>
+                                        sample.label !=
+                                            SELECT_SAMPLE_NONE.label &&
+                                        sample.label != SELECT_SAMPLE_ALL.label
+                                );
+                                console.log(
+                                    `options after filter : ${JSON.stringify(
+                                        options
+                                    )}`
+                                );
+                                wrapperStore.setSelectedSamplesOptions(options);
+                            }
+                        }}
+                        styles={{
+                            container: (styles: any) => ({
+                                ...styles,
+                                width: 250,
+                            }),
+                        }}
+                        isMulti
+                        components={{
+                            Option: SelectedSampleChecklistComponent,
+                        }}
+                        closeMenuOnSelect={false}
+                        hideSelectedOptions={false}
+                    />
+                </label>
+
                 <label>
                     Group by:&nbsp;
                     <ReactSelect

--- a/src/pages/patientView/timeline/VAFChartUtils.spec.ts
+++ b/src/pages/patientView/timeline/VAFChartUtils.spec.ts
@@ -187,6 +187,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     GROUP_BY_NONE,
+                    [],
                     {}
                 ),
                 {
@@ -228,6 +229,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     GROUP_BY_NONE,
+                    [],
                     {}
                 ),
                 {
@@ -380,6 +382,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     GROUP_BY_NONE,
+                    [],
                     {}
                 ),
                 {
@@ -515,6 +518,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     GROUP_BY_NONE,
+                    [],
                     {}
                 ),
                 {
@@ -611,6 +615,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     GROUP_BY_NONE,
+                    [],
                     {}
                 ),
                 {
@@ -736,6 +741,7 @@ describe('VAFChartUtils', () => {
                         ]
                     ),
                     GROUP_BY_NONE,
+                    [],
                     {}
                 ),
                 {
@@ -833,6 +839,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2], [3]),
                     GROUP_BY_NONE,
+                    [],
                     {}
                 ),
                 {
@@ -918,6 +925,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     'SampleType',
+                    [],
                     {
                         sample1: 'Primary',
                         sample2: 'Recurrence',
@@ -1078,6 +1086,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     'SampleCollectionSource',
+                    [],
                     {
                         sample1: 'Outside',
                         sample2: 'Inside',
@@ -1190,6 +1199,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     'SampleCollectionSource',
+                    [],
                     {
                         sample1: 'Outside',
                         sample2: 'Inside',
@@ -1276,6 +1286,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3], []),
                     'SampleCollectionSource',
+                    [],
                     {
                         sample1: 'Outside',
                         sample2: 'Inside',
@@ -1388,6 +1399,7 @@ describe('VAFChartUtils', () => {
                         ]
                     ),
                     'SampleCollectionSource',
+                    [],
                     {
                         sample1: 'Outside',
                         sample2: 'Inside',
@@ -1470,6 +1482,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2], [3]),
                     'SampleType',
+                    [],
                     {
                         sample1: 'Primary',
                         sample2: 'Recurrence',
@@ -1552,6 +1565,7 @@ describe('VAFChartUtils', () => {
                     'mutations',
                     makeCoverageInfo([1, 2, 3, 4], []),
                     'TumorPurity',
+                    [],
                     { sample2: '40', sample3: '30', sample4: '30' }
                 ),
                 {

--- a/src/pages/patientView/timeline/VAFChartUtils.ts
+++ b/src/pages/patientView/timeline/VAFChartUtils.ts
@@ -53,10 +53,32 @@ export function computeRenderData(
     mutationProfileId: string,
     coverageInformation: CoverageInformation,
     groupByOption: string,
+    selectedSamplesOption: string[],
     sampleIdToClinicalValue: { [sampleId: string]: string }
 ) {
     const grayPoints: IPoint[] = []; // points that are purely interpolated for rendering, dont have data of their own
     const lineData: IPoint[][] = [];
+    console.log(`Selected Samples : ${JSON.stringify(selectedSamplesOption)}`);
+    samples = samples.filter(sample => {
+        return _.some(selectedSamplesOption, {
+            label: sample.sampleId,
+            value: sample.sampleId,
+        });
+    });
+    mutations = mutations
+        .map(mutationArr =>
+            mutationArr.filter(mutation => {
+                return _.some(selectedSamplesOption, {
+                    label: mutation.sampleId,
+                    value: mutation.sampleId,
+                });
+            })
+        )
+        .filter(mutation => mutation.length > 0);
+    console.log(`Samples : ${JSON.stringify(samples)}`);
+    console.log(`Count of Samples : ${samples.length}`);
+    console.log(`Mutations : ${JSON.stringify(mutations)}`);
+    console.log(`Count of Mutations : ${mutations.length}`);
 
     if (groupByOption && groupByOption != GROUP_BY_NONE)
         mutations = splitMutationsBySampleGroup(

--- a/src/pages/patientView/timeline/VAFChartWrapper.tsx
+++ b/src/pages/patientView/timeline/VAFChartWrapper.tsx
@@ -183,6 +183,7 @@ export default class VAFChartWrapper extends React.Component<
             this.props.mutationProfileId,
             this.props.coverageInformation,
             this.props.wrapperStore.groupByOption!,
+            this.props.wrapperStore.selectedSamplesOptions,
             this.sampleIdToClinicalValue
         ).lineData;
     }

--- a/src/pages/patientView/timeline/VAFChartWrapperStore.tsx
+++ b/src/pages/patientView/timeline/VAFChartWrapperStore.tsx
@@ -3,6 +3,7 @@ import { getServerConfig } from 'config/config';
 
 export default class VAFChartWrapperStore {
     @observable groupByOption: string | null = null;
+    @observable selectedSamplesOptions: Array<string> = [];
 
     @observable _showSequentialMode: boolean = getServerConfig()
         .vaf_sequential_mode_default;
@@ -28,6 +29,11 @@ export default class VAFChartWrapperStore {
     @action
     setGroupByOption(value: string) {
         this.groupByOption = value;
+    }
+
+    @action
+    setSelectedSamplesOptions(value: Array<any>) {
+        this.selectedSamplesOptions = value;
     }
 
     @action


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10763 
Describe changes proposed in this pull request:
- Enhanced VAFChartControls by adding a feature to select specific samples (Some, All, or None)

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
This is a visual feature so before/after screenshots have been added to highlight the impact of the feature.
Before Screenshot:-
![Screenshot 2025-01-22 at 10 19 12 PM](https://github.com/user-attachments/assets/19619969-0397-4711-b62f-692b6de938e8)

Screenshot showing how 'All' works:-
![Screenshot 2025-01-22 at 10 19 38 PM](https://github.com/user-attachments/assets/12293b92-2f13-4b54-841c-f457fbc10257)

Screenshot showing how 'None' works:-
![Screenshot 2025-01-22 at 10 19 55 PM](https://github.com/user-attachments/assets/d82863b8-76fa-4dd6-9abb-58a96d0a998a)

Screenshot showing how selecting specific samples works:-
![Screenshot 2025-01-22 at 10 20 35 PM](https://github.com/user-attachments/assets/c84d441b-6b3a-4a07-8037-fc5fd5a960cf)

Screenshot showing compatibility with the groupBy functionality:-
![Screenshot 2025-01-22 at 10 20 57 PM](https://github.com/user-attachments/assets/d3c3472c-060a-4e9e-8d95-a64954a278b5)


## Notify reviewers