### PR TITLE
Mutation tab: Handle missing functional impact data from GN gracefully

### DIFF
--- a/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/FunctionalImpactColumnFormatter.tsx
@@ -393,7 +393,7 @@ export default class FunctionalImpactColumnFormatter {
         }
 
         const transcript = selectedTranscriptId
-            ? cacheData.data.transcript_consequences.find(
+            ? cacheData?.data?.transcript_consequences?.find(
                   tc => tc.transcript_id === selectedTranscriptId
               )
             : undefined;


### PR DESCRIPTION
The following VEP error needs to be handled gracefully:
![image](https://github.com/user-attachments/assets/fec63021-9d42-489f-9ded-5b4cb21cb9d2)
