### PR TITLE
Expand tooltip target for boxplot

### DIFF
--- a/src/shared/lib/boxPlotUtils.ts
+++ b/src/shared/lib/boxPlotUtils.ts
@@ -28,6 +28,7 @@ export type BoxPlotModel = {
     IQR: number;
     outliersUpper: Outliers['upper'];
     outliersLower: Outliers['lower'];
+    sortedVector: number[];
 };
 
 function calculateOutliers(
@@ -113,6 +114,7 @@ export function calculateBoxPlotModel(vector: number[]): BoxPlotModel {
         min,
         outliersUpper: outliers.upper,
         outliersLower: outliers.lower,
+        sortedVector,
     };
 }
 


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/10985

When the a boxplot is vertically compressed, user doesn't have the ability to show tooltip displaying summary stats.  This PR introduces a new mouse target the spans the entire distribution, ensuring there will always be a target.

![image](https://github.com/user-attachments/assets/084498a2-09bb-42a9-9ed9-2d5c4c2cc388)
