### PR TITLE
Improve loading behavior of charts on results comparison alterations tab

### DIFF
--- a/src/pages/groupComparison/AlterationEnrichments.tsx
+++ b/src/pages/groupComparison/AlterationEnrichments.tsx
@@ -38,6 +38,7 @@ export default class AlterationEnrichments extends React.Component<
 
     readonly enrichmentsUI = MakeMobxView({
         await: () => [
+            this.props.store.alterationEnrichmentRowData,
             this.props.store.alterationsEnrichmentData,
             this.props.store.alterationsEnrichmentAnalysisGroups,
             this.props.store.selectedStudyMutationEnrichmentProfileMap,


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11390

Charts now load fully when finished instead of getting populated later