### PR TITLE
UI: StudyView enable log scale toggle for all numerical variables

### DIFF
--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -3937,8 +3937,15 @@ export function getBinBounds(bins: DensityPlotBin[]) {
     };
 }
 
-export function logScalePossible(clinicalAttributeId: string) {
-    return clinicalAttributeId === SpecialChartsUniqueKeyEnum.MUTATION_COUNT;
+export function logScalePossible(
+    clinicalAttributeId: string,
+    attributeMap: { [id: string]: ClinicalAttribute }
+): boolean {
+    const attr = attributeMap[clinicalAttributeId];
+    if (!attr) {
+        return false; // not found => can't be log scale
+    }
+    return attr.datatype === DataType.NUMBER;
 }
 
 export function makeXvsYUniqueKey(xAttrId: string, yAttrId: string) {

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -643,9 +643,14 @@ export class StudySummaryTab extends React.Component<
                     }),
                     axisLabelX: chartInfo.categoricalAttr.displayName,
                     axisLabelY: chartInfo.numericalAttr.displayName,
-                    showLogScaleToggle: logScalePossible(
-                        chartInfo.numericalAttr.clinicalAttributeId
-                    ),
+                    showLogScaleToggle: this.props.store
+                        .clinicalAttributeIdToClinicalAttribute.isComplete
+                        ? logScalePossible(
+                              chartInfo.numericalAttr.clinicalAttributeId,
+                              this.props.store
+                                  .clinicalAttributeIdToClinicalAttribute.result
+                          )
+                        : false,
                     logScaleChecked: settings.violinLogScale,
                     onToggleLogScale: () => {
                         const settings = this.store.getXvsYChartSettings(
@@ -726,12 +731,22 @@ export class StudySummaryTab extends React.Component<
                         xAxisLogScale: !!settings.xLogScale,
                         yAxisLogScale: !!settings.yLogScale,
                     }),
-                    showLogScaleXToggle: logScalePossible(
-                        chartInfo.xAttr.clinicalAttributeId
-                    ),
-                    showLogScaleYToggle: logScalePossible(
-                        chartInfo.yAttr.clinicalAttributeId
-                    ),
+                    showLogScaleXToggle: this.props.store
+                        .clinicalAttributeIdToClinicalAttribute.isComplete
+                        ? logScalePossible(
+                              chartInfo.xAttr.clinicalAttributeId,
+                              this.props.store
+                                  .clinicalAttributeIdToClinicalAttribute.result
+                          )
+                        : false,
+                    showLogScaleYToggle: this.props.store
+                        .clinicalAttributeIdToClinicalAttribute.isComplete
+                        ? logScalePossible(
+                              chartInfo.yAttr.clinicalAttributeId,
+                              this.props.store
+                                  .clinicalAttributeIdToClinicalAttribute.result
+                          )
+                        : false,
                     logScaleXChecked: settings.xLogScale,
                     logScaleYChecked: settings.yLogScale,
                     onToggleLogScaleX: () => {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#11261 (https://github.com/cBioPortal/cbioportal/issues/11261)

Describe changes proposed in this pull request:
- enabled log scale for all numerical variables in study view x vs y chart
- 
![pr](https://github.com/user-attachments/assets/60b60389-08ad-46bc-915d-1e6b3a915044)


## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [X] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
@inodb @alisman 
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
