### PR TITLE
Fix the option to configure default view oncoprint

### DIFF
--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -180,6 +180,7 @@ export interface IServerConfig {
     oncoprint_clinical_tracks_config_json: string;
     oncoprint_clustered_default: boolean; // this has a default
     enable_cross_study_expression: string;
+    oncoprint_defaultview: string; // this has a default
     studyview_max_samples_selected: number;
     study_download_url: string;
     studyview_clinical_attribute_chart_count: number;

--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -40,7 +40,7 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
     oncoprint_hide_vus_default: false,
     oncokb_public_api_url: 'oncokb.org/api/v1',
     oncokb_merge_icons_by_default: true,
-
+    oncoprint_defaultview: 'patient',
     pubmed_url: 'https://www.ncbi.nlm.nih.gov/pubmed/<%=pmid%>',
 
     show_hotspot: true,

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -496,7 +496,6 @@ export default class ResultsViewOncoprint extends React.Component<
         (window as any).resultsViewOncoprint = this;
 
         const self = this;
-
         this.setSessionClinicalTracks = this.setSessionClinicalTracks.bind(
             this
         );
@@ -1711,9 +1710,15 @@ export default class ResultsViewOncoprint extends React.Component<
 
     // @computed
     public get oncoprintAnalysisCaseType() {
-        return this.urlWrapper.query.show_samples === 'true'
-            ? OncoprintAnalysisCaseType.SAMPLE
-            : OncoprintAnalysisCaseType.PATIENT;
+        if (this.urlWrapper.query.show_samples == undefined) {
+            return getServerConfig().oncoprint_defaultview === 'patient'
+                ? OncoprintAnalysisCaseType.PATIENT
+                : OncoprintAnalysisCaseType.SAMPLE;
+        } else {
+            return this.urlWrapper.query.show_samples === 'true'
+                ? OncoprintAnalysisCaseType.SAMPLE
+                : OncoprintAnalysisCaseType.PATIENT;
+        }
     }
 
     @computed get sortOrder() {


### PR DESCRIPTION
This fixes the bug described in [#11422](https://github.com/cBioPortal/cbioportal/issues/11422):

- User can set `sample` or `patient` via `oncoprint.defaultview` in `application.properties`
- By default the view is set to `patient` (as defined previously in `application.properties`)
