### PR TITLE
Enable mutation mapper data type for oncoprinter

### DIFF
--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.spec.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.spec.ts
@@ -133,23 +133,5 @@ describe('OncoprinterGeneticUtils', () => {
                 error: undefined,
             });
         });
-        it('parses a line with sample, cancer_type, chr, start, end, ref, alt correctly', async () => {
-            const parsed = await parseGeneticInput(
-                'TCGA-49-4494-01    Lung Adenocarcinoma   7  55249071    55249071	C	T'
-            );
-            assert.deepEqual(parsed, {
-                parseSuccess: true,
-                result: [
-                    {
-                        sampleId: 'TCGA-49-4494-01',
-                        hugoGeneSymbol: 'EGFR',
-                        alteration: 'missense',
-                        proteinChange: 'T790M',
-                        trackName: undefined,
-                    },
-                ],
-                error: undefined,
-            });
-        });
     });
 });

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.spec.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.spec.ts
@@ -3,111 +3,107 @@ import { parseGeneticInput } from './OncoprinterGeneticUtils';
 
 describe('OncoprinterGeneticUtils', () => {
     describe('parseGeneticInput', () => {
-        it('skips header line', () => {
-            assert.deepEqual(
-                parseGeneticInput(
-                    'sample gene alteration type\nsample_id TP53 FUSION FUSION\n'
-                ),
-                {
-                    parseSuccess: true,
-                    result: [
-                        {
-                            sampleId: 'sample_id',
-                            hugoGeneSymbol: 'TP53',
-                            alteration: 'structuralVariant',
-                            eventInfo: 'FUSION',
-                            trackName: undefined,
-                        },
-                    ],
-                    error: undefined,
-                }
+        it('skips header line', async () => {
+            const parsed = await parseGeneticInput(
+                'sample gene alteration type\nsample_id TP53 FUSION FUSION\n'
             );
+            assert.deepEqual(parsed, {
+                parseSuccess: true,
+                result: [
+                    {
+                        sampleId: 'sample_id',
+                        hugoGeneSymbol: 'TP53',
+                        alteration: 'structuralVariant',
+                        eventInfo: 'FUSION',
+                        trackName: undefined,
+                    },
+                ],
+                error: undefined,
+            });
         });
-        it('parses fusion command correctly', () => {
-            assert.deepEqual(
-                parseGeneticInput('sample_id TP53 FUSION FUSION'),
-                {
-                    parseSuccess: true,
-                    result: [
-                        {
-                            sampleId: 'sample_id',
-                            hugoGeneSymbol: 'TP53',
-                            alteration: 'structuralVariant',
-                            eventInfo: 'FUSION',
-                            trackName: undefined,
-                        },
-                    ],
-                    error: undefined,
-                }
+        it('parses fusion command correctly', async () => {
+            const parsed = await parseGeneticInput(
+                'sample_id TP53 FUSION FUSION'
             );
+            assert.deepEqual(parsed, {
+                parseSuccess: true,
+                result: [
+                    {
+                        sampleId: 'sample_id',
+                        hugoGeneSymbol: 'TP53',
+                        alteration: 'structuralVariant',
+                        eventInfo: 'FUSION',
+                        trackName: undefined,
+                    },
+                ],
+                error: undefined,
+            });
         });
-        it('throws an error if fusion is not specified correctly', () => {
+        it('throws an error if fusion is not specified correctly', async () => {
             try {
-                const parsed = parseGeneticInput(
+                const parsed = await parseGeneticInput(
                     'sample_id TP53 FUSION apsoidjfpaos'
                 );
                 assert(false);
             } catch (e) {}
         });
-        it('parses germline mutation correctly', () => {
-            assert.deepEqual(
-                parseGeneticInput('sampleid	BRCA1	Q1538A	MISSENSE_GERMLINE'),
-                {
-                    parseSuccess: true,
-                    result: [
-                        {
-                            sampleId: 'sampleid',
-                            hugoGeneSymbol: 'BRCA1',
-                            alteration: 'missense',
-                            proteinChange: 'Q1538A',
-                            isGermline: true,
-                            trackName: undefined,
-                        },
-                    ],
-                    error: undefined,
-                }
+        it('parses germline mutation correctly', async () => {
+            const parsed = await parseGeneticInput(
+                'sampleid	BRCA1	Q1538A	MISSENSE_GERMLINE'
             );
+            assert.deepEqual(parsed, {
+                parseSuccess: true,
+                result: [
+                    {
+                        sampleId: 'sampleid',
+                        hugoGeneSymbol: 'BRCA1',
+                        alteration: 'missense',
+                        proteinChange: 'Q1538A',
+                        isGermline: true,
+                        trackName: undefined,
+                    },
+                ],
+                error: undefined,
+            });
         });
-        it('parses driver mutation correctly', () => {
-            assert.deepEqual(
-                parseGeneticInput('sampleid	BRCA1	Q1538A	TRUNC_DRIVER'),
-                {
-                    parseSuccess: true,
-                    result: [
-                        {
-                            sampleId: 'sampleid',
-                            hugoGeneSymbol: 'BRCA1',
-                            alteration: 'trunc',
-                            proteinChange: 'Q1538A',
-                            isCustomDriver: true,
-                            trackName: undefined,
-                        },
-                    ],
-                    error: undefined,
-                }
+        it('parses driver mutation correctly', async () => {
+            const parsed = await parseGeneticInput(
+                'sampleid	BRCA1	Q1538A	TRUNC_DRIVER'
             );
+            assert.deepEqual(parsed, {
+                parseSuccess: true,
+                result: [
+                    {
+                        sampleId: 'sampleid',
+                        hugoGeneSymbol: 'BRCA1',
+                        alteration: 'trunc',
+                        proteinChange: 'Q1538A',
+                        isCustomDriver: true,
+                        trackName: undefined,
+                    },
+                ],
+                error: undefined,
+            });
         });
-        it('parses germline & driver mutation correctly', () => {
-            assert.deepEqual(
-                parseGeneticInput(
-                    'sampleid	BRCA1	Q1538A	MISSENSE_GERMLINE_DRIVER'
-                ),
-                {
-                    parseSuccess: true,
-                    result: [
-                        {
-                            sampleId: 'sampleid',
-                            hugoGeneSymbol: 'BRCA1',
-                            alteration: 'missense',
-                            proteinChange: 'Q1538A',
-                            isGermline: true,
-                            isCustomDriver: true,
-                            trackName: undefined,
-                        },
-                    ],
-                    error: undefined,
-                }
+        it('parses germline & driver mutation correctly', async () => {
+            const parsed = await parseGeneticInput(
+                'sampleid	BRCA1	Q1538A	MISSENSE_GERMLINE_DRIVER'
             );
+            assert.deepEqual(parsed, {
+                parseSuccess: true,
+                result: [
+                    {
+                        sampleId: 'sampleid',
+                        hugoGeneSymbol: 'BRCA1',
+                        alteration: 'missense',
+                        proteinChange: 'Q1538A',
+                        isGermline: true,
+                        isCustomDriver: true,
+                        trackName: undefined,
+                    },
+                ],
+                error: undefined,
+            });
         });
         it('throws an error for an invalid mutation modifier', () => {
             try {
@@ -117,27 +113,43 @@ describe('OncoprinterGeneticUtils', () => {
                 assert(false);
             } catch (e) {}
         });
-        it('parses a line with a given track name correctly', () => {
-            assert.deepEqual(
-                parseGeneticInput(
-                    'sampleid	BRCA1	Q1538A	MISSENSE_GERMLINE_DRIVER	testTrackName'
-                ),
-                {
-                    parseSuccess: true,
-                    result: [
-                        {
-                            sampleId: 'sampleid',
-                            hugoGeneSymbol: 'BRCA1',
-                            alteration: 'missense',
-                            proteinChange: 'Q1538A',
-                            isGermline: true,
-                            isCustomDriver: true,
-                            trackName: 'testTrackName',
-                        },
-                    ],
-                    error: undefined,
-                }
+        it('parses a line with a given track name correctly', async () => {
+            const parsed = await parseGeneticInput(
+                'sampleid	BRCA1	Q1538A	MISSENSE_GERMLINE_DRIVER	testTrackName'
             );
+            assert.deepEqual(parsed, {
+                parseSuccess: true,
+                result: [
+                    {
+                        sampleId: 'sampleid',
+                        hugoGeneSymbol: 'BRCA1',
+                        alteration: 'missense',
+                        proteinChange: 'Q1538A',
+                        isGermline: true,
+                        isCustomDriver: true,
+                        trackName: 'testTrackName',
+                    },
+                ],
+                error: undefined,
+            });
+        });
+        it('parses a line with sample, cancer_type, chr, start, end, ref, alt correctly', async () => {
+            const parsed = await parseGeneticInput(
+                'TCGA-49-4494-01    Lung Adenocarcinoma   7  55249071    55249071	C	T'
+            );
+            assert.deepEqual(parsed, {
+                parseSuccess: true,
+                result: [
+                    {
+                        sampleId: 'TCGA-49-4494-01',
+                        hugoGeneSymbol: 'EGFR',
+                        alteration: 'missense',
+                        proteinChange: 'T790M',
+                        trackName: undefined,
+                    },
+                ],
+                error: undefined,
+            });
         });
     });
 });

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterGeneticUtils.ts
@@ -898,10 +898,11 @@ export async function parseGeneticInput(
       }
     | { parseSuccess: false; result: undefined; error: string }
 > {
+    const separator = input.indexOf('\t') > 0 ? /\t/ : /\s+/;
     const lines = input
         .trim()
         .split('\n')
-        .map(line => line.trim().split(/\t/));
+        .map(line => line.trim().split(separator));
     try {
         const result = await Promise.all(
             lines.map(async (line, lineIndex) => {

--- a/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
+++ b/src/pages/staticPages/tools/oncoprinter/OncoprinterStore.ts
@@ -1,5 +1,12 @@
 import { DriverAnnotationSettings } from '../../../../shared/alterationFiltering/AnnotationFilteringSettings';
-import { action, computed, makeObservable, observable } from 'mobx';
+import {
+    action,
+    computed,
+    makeObservable,
+    observable,
+    reaction,
+    runInAction,
+} from 'mobx';
 import { getServerConfig } from 'config/config';
 import {
     annotateGeneticTrackData,
@@ -82,9 +89,22 @@ export default class OncoprinterStore {
         };
     } = {};
 
+    @observable parsedGeneticInputLinesResult: {
+        error: any;
+        result: any[] | null;
+    } = { error: null, result: [] };
+    @observable isParsingGeneticInputLines: boolean = false;
+
     constructor() {
         makeObservable(this);
         this.initialize();
+
+        reaction(
+            () => this._geneticDataInput,
+            () => {
+                this._getParsedGeneticInput();
+            }
+        );
 
         const clinicalTracksColorConfig = localStorage.getItem(
             ONCOPRINTER_COLOR_CONFIG
@@ -221,25 +241,49 @@ export default class OncoprinterStore {
         if (this._studyIds) return JSON.parse(this._studyIds);
     }
 
-    @computed get parsedGeneticInputLines() {
-        if (!this._geneticDataInput) {
+    @computed
+    get parsedGeneticInputLines() {
+        if (!this._geneticDataInput || this.isParsingGeneticInputLines) {
             return {
                 error: null,
                 result: [],
             };
         }
+        return this.parsedGeneticInputLinesResult;
+    }
 
-        const parsed = parseGeneticInput(this._geneticDataInput);
-        if (!parsed.parseSuccess) {
-            return {
-                error: parsed.error,
+    @action
+    async _getParsedGeneticInput() {
+        if (this.isParsingGeneticInputLines) return;
+
+        runInAction(() => {
+            this.isParsingGeneticInputLines = true;
+        });
+
+        try {
+            const parsed = await parseGeneticInput(
+                this._geneticDataInput ?? ''
+            );
+            if (!parsed.parseSuccess) {
+                this.parsedGeneticInputLinesResult = {
+                    error: parsed.error,
+                    result: null,
+                };
+            } else {
+                this.parsedGeneticInputLinesResult = {
+                    error: null,
+                    result: parsed.result,
+                };
+            }
+        } catch (error) {
+            this.parsedGeneticInputLinesResult = {
+                error: error,
                 result: null,
             };
-        } else {
-            return {
-                error: null,
-                result: parsed.result,
-            };
+        } finally {
+            runInAction(() => {
+                this.isParsingGeneticInputLines = false;
+            });
         }
     }
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#11214

Describe changes proposed in this pull request:
- Updated `OncoprinterGeneticUtils` to process MutationMapper type of data
- Added async function `fetchGeneticMutationAnnotation` to that annotates the mutation data with Genome Nexus
- Changed the function `parseGeneticInput` to be async, and other related modifications

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
![cBioPortal for Cancer Genomics__Oncoprinter - Google Chrome 2025-03-08 23-47-21-small](https://github.com/user-attachments/assets/5d69d23c-51d8-4783-9dbf-654900bdca2e)
