### PR TITLE
Remove NA label when NA=0 in filter chart

### DIFF
--- a/src/pages/studyView/charts/barChart/BarChart.tsx
+++ b/src/pages/studyView/charts/barChart/BarChart.tsx
@@ -278,18 +278,21 @@ export default class BarChart extends React.Component<IBarChartProps, {}>
             const labelNA = this.barDataWithNA
                 .map((element: BarDatum) => element.dataBin.count)
                 .join(', ');
-            return (
-                <VictoryLabel
-                    text={`NA: ${labelNA}`}
-                    textAnchor="end"
-                    datum={{ x: this.maximumX, y: this.maximumY }}
-                    style={{
-                        fontFamily:
-                            VICTORY_THEME.axis.style.tickLabels.fontFamily,
-                        fontSize: VICTORY_THEME.axis.style.tickLabels.fontSize,
-                    }}
-                />
-            );
+            if (labelNA !== '0') {
+                return (
+                    <VictoryLabel
+                        text={`NA: ${labelNA}`}
+                        textAnchor="end"
+                        datum={{ x: this.maximumX, y: this.maximumY }}
+                        style={{
+                            fontFamily:
+                                VICTORY_THEME.axis.style.tickLabels.fontFamily,
+                            fontSize:
+                                VICTORY_THEME.axis.style.tickLabels.fontSize,
+                        }}
+                    />
+                );
+            }
         }
         return null;
     }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#11056

I can reproduce this issue. Checking the [code](
https://github.com/cBioPortal/cbioportal-frontend/blob/7a2006b3d46f42d1cb156c1adfba6a07e684bd44/src/pages/studyView/charts/barChart/BarChart.tsx#L276), it was due to thecomputed method `labelShowingNA` is not checking whether `NA=0`. A simple fix would be adding an if clause so that when `labelNA==='0'` then return `null`. I don't think backend changes are needed here.

Describe changes proposed in this pull request:
- If the count of the data bin with NA is zero, return null for the computed method that renders the NA label on the chart.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
![fix-na-label](https://github.com/user-attachments/assets/6c603f76-1bf3-4763-bea6-07cc1d3dd968)



