### PR TITLE
Fix screenshot tracking in circleci localdb tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,9 +330,17 @@ jobs:
             cd $PORTAL_SOURCE_DIR
             $TEST_HOME/docker_compose/test.sh
       - run:
+          environment:
+            TEST_HOME: /tmp/repo/cbioportal-frontend/end-to-end-test/local
           name: Make sure all screenshots are tracked (otherwise the test will always be successful)
           command: |
-            for f in $TEST_HOME/screenshots/reference/*.png; do git ls-files --error-unmatch $f > /dev/null 2> /dev/null || (echo -e "\033[0;31m $f not tracked \033[0m" && touch screenshots_not_tracked); done; ls screenshots_not_tracked > /dev/null 2> /dev/null && exit 1 || exit 0
+            for f in $TEST_HOME/screenshots/reference/*.png; do
+              git ls-files --error-unmatch $f > /dev/null 2> /dev/null ||
+              (echo -e "\033[0;31m $f not tracked \033[0m" && touch screenshots_not_tracked);
+            done;
+            ls screenshots_not_tracked > /dev/null 2> /dev/null && exit 1 || exit 0
+      - store_artifacts:
+          path: /tmp/repo/docker-compose-logs.txt
       - store_artifacts:
           path: /tmp/repo/cbioportal-frontend/end-to-end-test/local/screenshots
           destination: /screenshots


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Fixes screenshot tracking for localdb tests on circleci.

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
