### PR TITLE
Fix usual charts not shown in Study View by default

### DIFF
--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -2674,8 +2674,18 @@ export function clinicalAttributeSortingComparator(
     a: ClinicalAttributeSorting,
     b: ClinicalAttributeSorting
 ): number {
+    const specialOrder: Record<string, number> = {
+        'Cancer Type': 2,
+        'Cancer Type Detailed': 1,
+    };
+
+    const aSpecial = specialOrder[a.displayName] ?? 0;
+    const bSpecial = specialOrder[b.displayName] ?? 0;
+
     return (
-        b.priority - a.priority || a.displayName.localeCompare(b.displayName)
+        bSpecial - aSpecial ||
+        b.priority - a.priority ||
+        a.displayName.localeCompare(b.displayName)
     );
 }
 


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10952

Describe changes proposed in this pull request:
- Modified the clinicalAttributeSortingComparator so that it always prioritizes 'Cancer Type' and 'Cancer Type Detailed' charts.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
After making this change:
![image](https://github.com/user-attachments/assets/bc350197-c952-49b2-8ef0-a33dee65a716)
