### PR TITLE
Change NA to Not Profiled in gene-specific CNA chart

### DIFF
--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -1901,6 +1901,11 @@ export function getExponent(value: number): number {
 }
 
 export function getCNAByAlteration(alteration: string | number) {
+    // "NA" here actually means "Not Profiled"
+    // See details in https://github.com/cBioPortal/cbioportal/issues/10809
+    if (alteration === 'NA') {
+        return 'Not Profiled';
+    }
     const numberValue = Number(alteration);
     return !isNaN(numberValue) ? CNA_TO_ALTERATION[numberValue] || '' : 'NA';
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#10809

Describe changes proposed in this pull request:
- Changed "NA" to "Not Profiled" for the gene-specific CNA charts in study view.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
![image](https://github.com/user-attachments/assets/e4143573-cb68-429d-911c-5ee3c1c93689)
