### PR TITLE
Add filter studies by imaging data type option on home page

### DIFF
--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -82,6 +82,11 @@ const StudyFilterOptionsFormatted = [
         name: 'Treatment',
         checked: false,
     },
+    {
+        id: 'imagingSampleCount',
+        name: 'Imaging',
+        checked: false,
+    },
 ];
 
 @observer


### PR DESCRIPTION
Adds additional filter studies by data type option on home page for imaging data.

Should be merged with https://github.com/cBioPortal/cbioportal/pull/11459

![Screenshot 2025-03-20 at 11 50 46 AM](https://github.com/user-attachments/assets/3fc592d9-265a-4c7e-8540-3f5e07e3b533)
