### PR TITLE
Add aria-labels to buttons on query page

### DIFF
--- a/src/shared/components/StudyLink/StudyLink.tsx
+++ b/src/shared/components/StudyLink/StudyLink.tsx
@@ -3,7 +3,11 @@ import { CancerStudy } from 'cbioportal-ts-api-client';
 import { Link } from 'react-router-dom';
 
 export class StudyLink extends React.Component<
-    { studyId: string; className?: string },
+    {
+        studyId: string;
+        className?: string;
+        studyName?: string;
+    },
     {}
 > {
     render() {
@@ -11,6 +15,7 @@ export class StudyLink extends React.Component<
             <Link
                 to={`/study?id=${this.props.studyId}`}
                 className={this.props.className}
+                aria-label={`Open the study summary page for ${this.props.studyName} in a new tab`}
             >
                 {this.props.children}
             </Link>

--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -296,10 +296,12 @@ export default class StudyList extends QueryStoreComponent<
                 icon: string;
                 onClick?: string | (() => void);
                 tooltip?: string;
+                ariaLabel?: string;
             }[] = [
                 {
                     icon: 'info-circle',
                     tooltip: '',
+                    ariaLabel: `View study info tooltip for ${study.name}`,
                 },
             ];
 
@@ -315,6 +317,7 @@ export default class StudyList extends QueryStoreComponent<
             } else {
                 links.push({
                     icon: 'book',
+                    ariaLabel: `Open ${study.name} in PubMed`,
                     onClick: study.pmid && getPubMedUrl(study.pmid),
                     tooltip: study.pmid && 'PubMed',
                 });
@@ -340,6 +343,7 @@ export default class StudyList extends QueryStoreComponent<
                         if (link.onClick) {
                             let anchorProps: any = {
                                 key: i,
+                                'aria-label': link.ariaLabel,
                             };
                             if (typeof link.onClick === 'string') {
                                 anchorProps.href = link.onClick;
@@ -389,7 +393,12 @@ export default class StudyList extends QueryStoreComponent<
                                     placement="top"
                                     iconType={IconType.INFO_ICON}
                                 >
-                                    <a>{content}</a>
+                                    <a
+                                        role={'tooltip'}
+                                        aria-label={`Display study info tooltip for ${study.name}`}
+                                    >
+                                        {content}
+                                    </a>
                                 </StudyTagsTooltip>
                             );
                         }
@@ -409,6 +418,7 @@ export default class StudyList extends QueryStoreComponent<
                             <span>
                                 <StudyLink
                                     studyId={study.studyId}
+                                    studyName={study.name}
                                     className={classNames(
                                         styles.summaryIcon,
                                         'ci ci-pie-chart'


### PR DESCRIPTION
This PR adds aria-label attributes to some of the buttons on the study selector of the cBioPortal homepage, to improve 508 compliance.