### PR TITLE
feat : Use of path URL for comparison subtabs

### DIFF
--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -330,6 +330,12 @@ export default class ResultsViewURLWrapper
     pathContext = '/results';
 
     @computed public get tabId() {
+        const pathParts = this.pathName.split('/');
+
+        // Handle paths like "/results/comparison/survival"
+        if (pathParts[1] === 'results' && pathParts[2] === 'comparison') {
+            return ResultsViewTab.COMPARISON;
+        }
         const tabInPath = this.pathName.split('/').pop();
         if (tabInPath && tabInPath in oldTabToNewTabRoute) {
             // map legacy tab ids
@@ -390,6 +396,15 @@ export default class ResultsViewURLWrapper
     }
 
     @computed public get comparisonSubTabId() {
+        const pathParts = this.pathName.split('/');
+        if (
+            pathParts.length >= 4 &&
+            pathParts[1] === 'results' &&
+            pathParts[2] === 'comparison' &&
+            pathParts[3]
+        ) {
+            return pathParts[3];
+        }
         return this.query.comparison_subtab || GroupComparisonTab.OVERLAP;
     }
 
@@ -400,7 +415,7 @@ export default class ResultsViewURLWrapper
 
     @autobind
     public setComparisonSubTabId(tabId: GroupComparisonTab) {
-        this.updateURL({ comparison_subtab: tabId });
+        this.updateURL({}, `results/comparison/${tabId}`);
     }
 
     @computed public get selectedEnrichmentEventTypes() {

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -330,10 +330,7 @@ export default class ResultsViewURLWrapper
     pathContext = '/results';
 
     @computed public get tabId() {
-        const pathParts = this.pathName.split('/');
-
-        // Handle paths like "/results/comparison/survival"
-        if (pathParts[1] === 'results' && pathParts[2] === 'comparison') {
+        if (this.pathName.match(/\/results\/comparison(\/|$)/)) {
             return ResultsViewTab.COMPARISON;
         }
         const tabInPath = this.pathName.split('/').pop();
@@ -396,16 +393,8 @@ export default class ResultsViewURLWrapper
     }
 
     @computed public get comparisonSubTabId() {
-        const pathParts = this.pathName.split('/');
-        if (
-            pathParts.length >= 4 &&
-            pathParts[1] === 'results' &&
-            pathParts[2] === 'comparison' &&
-            pathParts[3]
-        ) {
-            return pathParts[3];
-        }
-        return this.query.comparison_subtab || GroupComparisonTab.OVERLAP;
+        const subtabMatch = this.pathName.match(/\/comparison\/([^\/?#]+)/);
+        return subtabMatch ? subtabMatch[1] : GroupComparisonTab.OVERLAP;
     }
 
     @autobind

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -168,6 +168,24 @@ function LocationValidationWrapper(
 function ResultsViewQueryParamsAdjuster(oldParams: ResultsViewURLQuery) {
     let changeMade = false;
     const newParams = _.cloneDeep(oldParams);
+    if (
+        newParams.comparison_subtab ===
+        LegacyResultsViewComparisonSubTab.MUTATIONS
+    ) {
+        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
+        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
+            ...mutationGroup,
+        ]);
+        changeMade = true;
+    } else if (
+        newParams.comparison_subtab === LegacyResultsViewComparisonSubTab.CNA
+    ) {
+        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
+        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
+            ...cnaGroup,
+        ]);
+        changeMade = true;
+    }
     // we used to call the structural variant alteration class "fusions"
     // we have generalized it to structural variants
     const profileRegex = /fusion/;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -168,25 +168,6 @@ function LocationValidationWrapper(
 function ResultsViewQueryParamsAdjuster(oldParams: ResultsViewURLQuery) {
     let changeMade = false;
     const newParams = _.cloneDeep(oldParams);
-    if (
-        newParams.comparison_subtab ===
-        LegacyResultsViewComparisonSubTab.MUTATIONS
-    ) {
-        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
-        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
-            ...mutationGroup,
-        ]);
-        changeMade = true;
-    } else if (
-        newParams.comparison_subtab === LegacyResultsViewComparisonSubTab.CNA
-    ) {
-        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
-        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
-            ...cnaGroup,
-        ]);
-        changeMade = true;
-    }
-
     // we used to call the structural variant alteration class "fusions"
     // we have generalized it to structural variants
     const profileRegex = /fusion/;
@@ -340,10 +321,7 @@ export const makeRoutes = () => {
                 <Route
                     path={`/results/${ResultsViewTab.SURVIVAL_REDIRECT}`}
                     component={getBlankPage(() => {
-                        redirectTo(
-                            { comparison_subtab: 'survival' },
-                            '/results/comparison'
-                        );
+                        redirectTo({}, '/results/comparison/survival');
                     })}
                 />
                 {/* Redirect legacy expression route directly to plots tab with mrna vs study */}
@@ -376,6 +354,33 @@ export const makeRoutes = () => {
                             { comparison_subtab: 'mutations' },
                             '/results/comparison'
                         );
+                    })}
+                />
+                <Route
+                    path="/results/comparison/:subtab"
+                    component={LocationValidationWrapper(
+                        ResultsViewPage,
+                        tabParamValidator(ResultsViewComparisonSubTab),
+                        ResultsViewQueryParamsAdjuster
+                    )}
+                />
+                <Route
+                    path="/results/comparison"
+                    component={getBlankPage(() => {
+                        const query = parse(
+                            getBrowserWindow().location.search,
+                            {
+                                ignoreQueryPrefix: true,
+                            }
+                        );
+                        if (query.comparison_subtab) {
+                            redirectTo(
+                                {},
+                                `/results/comparison/${query.comparison_subtab}`
+                            );
+                        } else {
+                            redirectTo({}, '/results/comparison/overlap');
+                        }
                     })}
                 />
                 <Route


### PR DESCRIPTION
Fix [cBioPortal/cbioportal#9762 ](https://github.com/cBioPortal/cbioportal/issues/9762)

Describe changes proposed in this pull request:
- Use the path of URL instead of query parameter for comparison subtabs

## Checks
- [ ✓] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [✓ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [✓ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
![Screenshot 2025-03-25 222117](https://github.com/user-attachments/assets/efcea900-f808-463f-a998-be28fee41176)



