### PR TITLE
remove quick search beta

### DIFF
--- a/src/shared/components/query/QueryAndDownloadTabs.tsx
+++ b/src/shared/components/query/QueryAndDownloadTabs.tsx
@@ -136,8 +136,7 @@ export default class QueryAndDownloadTabs extends React.Component<
                         id={QUICK_SEARCH_TAB_ID}
                         linkText={
                             <span>
-                                Quick Search{' '}
-                                <strong className={'beta-text'}>Beta!</strong>
+                                Quick Search
                             </span>
                         }
                         hide={!this.props.showQuickSearchTab}


### PR DESCRIPTION
Remove beta lable on quick search:


<img width="241" alt="image" src="https://github.com/user-attachments/assets/3873fca6-732e-4af1-9744-c9415196b6e9" />
