### PR TITLE
Fix e2e remote quick search test

### DIFF
--- a/end-to-end-test/remote/specs/core/quickSearch.spec.js
+++ b/end-to-end-test/remote/specs/core/quickSearch.spec.js
@@ -15,7 +15,7 @@ describe('Quick Search', () => {
     beforeEach(async () => {
         const url = `${CBIOPORTAL_URL}`;
         await goToUrlAndSetLocalStorage(url);
-        await clickElement('strong=Beta!');
+        await clickElement('a.tabAnchor_quickSearch');
         await (
             await getElement('div=e.g. Lung, EGFR, TCGA-OR-A5J2')
         ).waitForExist();


### PR DESCRIPTION
Fix quick search test as a result of https://github.com/cBioPortal/cbioportal-frontend/pull/5150
Previously, the test depended on using the `Beta!` text to click the `Quick Search` tab