### PR TITLE
Stabilize clicking query by gene tests

### DIFF
--- a/end-to-end-test/shared/specUtils_Async.js
+++ b/end-to-end-test/shared/specUtils_Async.js
@@ -593,19 +593,11 @@ async function checkElementWithElementHidden(
 }
 
 async function clickQueryByGeneButton() {
-    // TODO: does this really happen ? do we need to wait for it to disappear?
-    // const el = await $('.disabled[data-test="queryByGeneButton"]');
-    // await el.waitForExist({
-    //     reverse: true,
-    //     timeout: 5000
-    // });
-    //const el = await getElementByTestHandle('queryByGeneButton');
-    await clickElement('[data-test=queryByGeneButton]');
-
-    const body = await $('body');
-    await body.scrollIntoView();
-
-    await browser.pause(1000);
+    await (await $('.disabled[data-test=queryByGeneButton]')).waitForExist({
+        reverse: true,
+    });
+    await (await getElementByTestHandle('queryByGeneButton')).click();
+    await (await $('body')).scrollIntoView();
 }
 
 async function clickModifyStudySelectionButton() {


### PR DESCRIPTION
Home page tests dealing with the `Query By Gene` button click interaction are flaky. This modifies the function responsible for this interaction in an attempt to stabilize related tests