### PR TITLE
Fix e2e localdb oncoprint don't cluster test

### DIFF
--- a/end-to-end-test/remote/specs/core/oncoprint.screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/oncoprint.screenshot.spec.js
@@ -242,7 +242,7 @@ describe('track group headers', () => {
         );
         await clickElement(mrnaElements.dropdown_selector + ' li:nth-child(2)'); // Click Don't Cluster
         await browser.pause(2000); // give it time to sort
-        await (await getElement('body')).moveTo(); // move mouse out of the way
+        await clickElement('a.tabAnchor_oncoprint'); // close track header menu
         const res = await checkOncoprintElement(undefined, [
             { width: 2000, height: 1000 },
         ]);

--- a/end-to-end-test/remote/specs/core/oncoprint.screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/oncoprint.screenshot.spec.js
@@ -242,7 +242,7 @@ describe('track group headers', () => {
         );
         await clickElement(mrnaElements.dropdown_selector + ' li:nth-child(2)'); // Click Don't Cluster
         await browser.pause(2000); // give it time to sort
-        await clickElement('a.tabAnchor_oncoprint'); // close track header menu
+        await (await getElement('body')).moveTo(); // move mouse out of the way
         const res = await checkOncoprintElement(undefined, [
             { width: 2000, height: 1000 },
         ]);

--- a/end-to-end-test/shared/specUtils_Async.js
+++ b/end-to-end-test/shared/specUtils_Async.js
@@ -490,7 +490,7 @@ async function checkOncoprintElement(selector, viewports) {
     await browser.execute(() => {
         frontendOnc.clearMouseOverEffects(); // clear mouse hover effects for uniform screenshot
     });
-    return checkElementWithMouseDisabled(selector || '#oncoprintDiv', 0, {
+    return await checkElementWithMouseDisabled(selector || '#oncoprintDiv', 0, {
         hide: [
             '.qtip',
             '.dropdown-menu',


### PR DESCRIPTION
Fixes `oncoprint should return to non-clustered state correctly` test which is failing due to track header menu staying open after selecting `Don't cluster`.