### PR TITLE
Stabilize flaky unprofiled samples oncoprint and breadcrumbs tests

### DIFF
--- a/end-to-end-test/remote/specs/core/screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/screenshot.spec.js
@@ -28,6 +28,8 @@ async function waitForAndCheckPlotsTab() {
 function runResultsTestSuite(prefix, options = {}) {
     it(`${prefix} render the oncoprint`, async function() {
         await waitForOncoprint();
+        await (await getElement('body')).moveTo({ xOffset: 0, yOffset: 0 }); // move mouse out of the way
+        browser.pause(100);
         const res = await checkElementWithMouseDisabled('.oncoprintContainer');
         assertScreenShotMatch(res);
     });

--- a/end-to-end-test/shared/specUtils_Async.js
+++ b/end-to-end-test/shared/specUtils_Async.js
@@ -222,6 +222,7 @@ async function setDropdownOpen(
                         : button_selector_or_elt;
                 await button_elt.waitForExist();
                 await button_elt.click();
+                await browser.pause(100);
                 return false;
             }
         },

--- a/src/globalStyles/e2etest.scss
+++ b/src/globalStyles/e2etest.scss
@@ -26,6 +26,10 @@
         pointer-events: none;
     }
 
+    .disablePointerEvents:hover {
+        all: unset !important;
+    }
+
     .local-dev-banner {
         display: none;
     }

--- a/src/globalStyles/e2etest.scss
+++ b/src/globalStyles/e2etest.scss
@@ -26,10 +26,6 @@
         pointer-events: none;
     }
 
-    .disablePointerEvents:hover {
-        all: unset !important;
-    }
-
     .local-dev-banner {
         display: none;
     }


### PR DESCRIPTION
Excluding unprofiled samples oncoprint test is flaky due to mouse hovering effects. This attempts to stabilize that. Breadcrumbs test is still flaky, potentially due to reset charts button not being clicked. Added brief pause to let add charts button contents load.