### PR TITLE
feat : Use of path URL for comparison and pathways subtab

### DIFF
--- a/end-to-end-test/remote/specs/core/screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/screenshot.spec.js
@@ -149,6 +149,7 @@ function runResultsTestSuite(prefix, options = {}) {
             await getElement('div[data-test="GroupComparisonMRNAEnrichments"]')
         ).waitForDisplayed();
         await clickElement(options.mrnaEnrichmentsRowSelector || 'b=ETV5');
+        await (await getElement('body')).moveTo({ xOffset: 0, yOffset: 0 });
         await waitForElementDisplayed('div[data-test="MiniBoxPlot"]');
         const res = await browser.checkElement(
             'div[data-test="ComparisonTabDiv"]'

--- a/src/pages/resultsView/ResultsViewPageHelpers.spec.ts
+++ b/src/pages/resultsView/ResultsViewPageHelpers.spec.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import {
     getTabId,
+    getSubTabId,
     parseSamplesSpecifications,
     ResultsViewTab,
 } from './ResultsViewPageHelpers';
@@ -23,6 +24,35 @@ describe('ResultsViewPageHelpers', () => {
         });
     });
 
+    describe('getSubTabId', () => {
+        it('should return the correct subtab for comparison path', () => {
+            assert.equal(getSubTabId('/results/comparison/overlap'), 'overlap');
+            assert.equal(
+                getSubTabId('/results/comparison/survival'),
+                'survival'
+            );
+            assert.equal(
+                getSubTabId('/results/comparison/dna_methylation'),
+                'dna_methylation'
+            );
+        });
+
+        it('should return the correct subtab for pathways path', () => {
+            assert.equal(
+                getSubTabId('/results/pathways/pathwaymapper'),
+                'pathwaymapper'
+            );
+            assert.equal(
+                getSubTabId('/results/pathways/ndex-cancer-pathways'),
+                'ndex-cancer-pathways'
+            );
+        });
+
+        it('should return undefined for invalid paths', () => {
+            assert.equal(getSubTabId('/results/comparison/'), undefined);
+            assert.equal(getSubTabId('/results/pathways/'), undefined);
+        });
+    });
     describe('parseSamplesSpecifications', () => {
         it('should parse session caseids with \\r/\\n delimter', () => {
             let query = {

--- a/src/pages/resultsView/ResultsViewPageHelpers.tsx
+++ b/src/pages/resultsView/ResultsViewPageHelpers.tsx
@@ -55,22 +55,6 @@ export function getTabId(pathname: string) {
     }
 }
 
-export const PathwaysSlugToEnumMap: Record<
-    string,
-    ResultsViewPathwaysSubTab
-> = {
-    'pathway-mapper': ResultsViewPathwaysSubTab.PATHWAY_MAPPER,
-    ndex: ResultsViewPathwaysSubTab.NDEX,
-};
-
-export const PathwaysEnumToSlugMap: Record<
-    ResultsViewPathwaysSubTab,
-    string
-> = Object.entries(PathwaysSlugToEnumMap).reduce((acc, [slug, enumValue]) => {
-    acc[enumValue] = slug;
-    return acc;
-}, {} as Record<ResultsViewPathwaysSubTab, string>);
-
 export const oldTabToNewTabRoute: { [legacyTabId: string]: ResultsViewTab } = {
     oncoprint: ResultsViewTab.ONCOPRINT,
     cancer_types_summary: ResultsViewTab.CANCER_TYPES_SUMMARY,

--- a/src/pages/resultsView/ResultsViewPageHelpers.tsx
+++ b/src/pages/resultsView/ResultsViewPageHelpers.tsx
@@ -55,6 +55,20 @@ export function getTabId(pathname: string) {
     }
 }
 
+export function getSubTabId(pathName: string) {
+    const tabSegment = getTabId(pathName);
+    if (!tabSegment) {
+        return undefined;
+    }
+    // Extract subtab name after "results/tabSegment/" in the URL path
+    const subtabMatch = pathName.match(/\/results\/[^\/]+\/([^\/?#]+)/);
+    if (subtabMatch) {
+        return subtabMatch?.[1];
+    } else {
+        return undefined;
+    }
+}
+
 export const oldTabToNewTabRoute: { [legacyTabId: string]: ResultsViewTab } = {
     oncoprint: ResultsViewTab.ONCOPRINT,
     cancer_types_summary: ResultsViewTab.CANCER_TYPES_SUMMARY,

--- a/src/pages/resultsView/ResultsViewPageHelpers.tsx
+++ b/src/pages/resultsView/ResultsViewPageHelpers.tsx
@@ -55,6 +55,22 @@ export function getTabId(pathname: string) {
     }
 }
 
+export const PathwaysSlugToEnumMap: Record<
+    string,
+    ResultsViewPathwaysSubTab
+> = {
+    'pathway-mapper': ResultsViewPathwaysSubTab.PATHWAY_MAPPER,
+    ndex: ResultsViewPathwaysSubTab.NDEX,
+};
+
+export const PathwaysEnumToSlugMap: Record<
+    ResultsViewPathwaysSubTab,
+    string
+> = Object.entries(PathwaysSlugToEnumMap).reduce((acc, [slug, enumValue]) => {
+    acc[enumValue] = slug;
+    return acc;
+}, {} as Record<ResultsViewPathwaysSubTab, string>);
+
 export const oldTabToNewTabRoute: { [legacyTabId: string]: ResultsViewTab } = {
     oncoprint: ResultsViewTab.ONCOPRINT,
     cancer_types_summary: ResultsViewTab.CANCER_TYPES_SUMMARY,

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -330,6 +330,12 @@ export default class ResultsViewURLWrapper
     pathContext = '/results';
 
     @computed public get tabId() {
+        const pathParts = this.pathName.split('/');
+
+        // Handle paths like "/results/comparison/survival"
+        if (pathParts[1] === 'results' && pathParts[2] === 'comparison') {
+            return ResultsViewTab.COMPARISON;
+        }
         const tabInPath = this.pathName.split('/').pop();
         if (tabInPath && tabInPath in oldTabToNewTabRoute) {
             // map legacy tab ids
@@ -390,6 +396,15 @@ export default class ResultsViewURLWrapper
     }
 
     @computed public get comparisonSubTabId() {
+        const pathParts = this.pathName.split('/');
+        if (
+            pathParts.length >= 4 &&
+            pathParts[1] === 'results' &&
+            pathParts[2] === 'comparison' &&
+            pathParts[3]
+        ) {
+            return pathParts[3];
+        }
         return this.query.comparison_subtab || GroupComparisonTab.OVERLAP;
     }
 
@@ -400,7 +415,7 @@ export default class ResultsViewURLWrapper
 
     @autobind
     public setComparisonSubTabId(tabId: GroupComparisonTab) {
-        this.updateURL({ comparison_subtab: tabId });
+        this.updateURL({}, `results/comparison/${tabId}`);
     }
 
     @computed public get selectedEnrichmentEventTypes() {

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -406,9 +406,11 @@ export default class ResultsViewURLWrapper
         this.updateURL({}, `results/${tabId}`, false, replace);
     }
 
-    public get getSubTab() {
+    public get subTab() {
         const tabSegment = this.getCurrentTabSegment();
-        if (!tabSegment) return '';
+        if (!tabSegment) {
+            return '';
+        }
 
         // Extract subtab name after "results/tabSegment/" in the URL path
         const subtabMatch = this.pathName.match(

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -330,10 +330,7 @@ export default class ResultsViewURLWrapper
     pathContext = '/results';
 
     @computed public get tabId() {
-        const pathParts = this.pathName.split('/');
-
-        // Handle paths like "/results/comparison/survival"
-        if (pathParts[1] === 'results' && pathParts[2] === 'comparison') {
+        if (this.pathName.match(/\/results\/comparison(\/|$)/)) {
             return ResultsViewTab.COMPARISON;
         }
         const tabInPath = this.pathName.split('/').pop();
@@ -396,16 +393,8 @@ export default class ResultsViewURLWrapper
     }
 
     @computed public get comparisonSubTabId() {
-        const pathParts = this.pathName.split('/');
-        if (
-            pathParts.length >= 4 &&
-            pathParts[1] === 'results' &&
-            pathParts[2] === 'comparison' &&
-            pathParts[3]
-        ) {
-            return pathParts[3];
-        }
-        return this.query.comparison_subtab || GroupComparisonTab.OVERLAP;
+        const subtabMatch = this.pathName.match(/\/comparison\/([^\/?#]+)/);
+        return subtabMatch ? subtabMatch[1] : GroupComparisonTab.OVERLAP;
     }
 
     @autobind

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -3,6 +3,7 @@ import ExtendedRouterStore from '../../shared/lib/ExtendedRouterStore';
 import { computed, makeObservable, observable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
+    getTabId,
     LegacyResultsViewComparisonSubTab,
     oldTabToNewTabRoute,
     ResultsViewComparisonSubTab,
@@ -336,7 +337,7 @@ export default class ResultsViewURLWrapper
     pathContext = '/results';
 
     @computed public get tabId() {
-        const tabSegment = this.getCurrentTabSegment();
+        const tabSegment = this.currentTabSegment;
         if (tabSegment) {
             // Match enum VALUE (right side) to URL segment
             const matchedTab = Object.values(ResultsViewTab).find(
@@ -413,7 +414,7 @@ export default class ResultsViewURLWrapper
     }
 
     public get subTab() {
-        const tabSegment = this.getCurrentTabSegment();
+        const tabSegment = this.currentTabSegment;
         if (!tabSegment) {
             return '';
         }
@@ -429,17 +430,15 @@ export default class ResultsViewURLWrapper
     public setSubTab(
         subtab: ResultsViewComparisonSubTab | ResultsViewPathwaysSubTab
     ) {
-        const tabSegment = this.getCurrentTabSegment();
+        const tabSegment = this.currentTabSegment;
         if (tabSegment) {
             const sanitized = sanitizeForUrl(subtab);
             this.updateURL({}, `results/${tabSegment}/${sanitized}`);
         }
     }
 
-    private getCurrentTabSegment(): string | undefined {
-        // Extract tab name after "/results/" in the URL path
-        const match = this.pathName.match(/\/results\/([^\/]+)/);
-        return match?.[1];
+    private get currentTabSegment(): string | undefined {
+        return getTabId(this.pathName);
     }
 
     @computed public get selectedEnrichmentEventTypes() {

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -3,6 +3,7 @@ import ExtendedRouterStore from '../../shared/lib/ExtendedRouterStore';
 import { computed, makeObservable, observable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
+    getSubTabId,
     getTabId,
     LegacyResultsViewComparisonSubTab,
     oldTabToNewTabRoute,
@@ -414,16 +415,7 @@ export default class ResultsViewURLWrapper
     }
 
     public get subTab() {
-        const tabSegment = this.currentTabSegment;
-        if (!tabSegment) {
-            return '';
-        }
-
-        // Extract subtab name after "results/tabSegment/" in the URL path
-        const subtabMatch = this.pathName.match(
-            new RegExp(`\/results\/${tabSegment}\/([^\/?#]+)`)
-        );
-        return subtabMatch?.[1] || '';
+        return getSubTabId(this.pathName);
     }
 
     @autobind

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -338,10 +338,16 @@ export default class ResultsViewURLWrapper
     @computed public get tabId() {
         const tabSegment = this.getCurrentTabSegment();
         if (tabSegment) {
-            return ResultsViewTab[
-                tabSegment.toUpperCase() as keyof typeof ResultsViewTab
-            ];
+            // Match enum VALUE (right side) to URL segment
+            const matchedTab = Object.values(ResultsViewTab).find(
+                tabValue => tabValue.toLowerCase() === tabSegment.toLowerCase()
+            );
+
+            if (matchedTab) {
+                return matchedTab;
+            }
         }
+
         const tabInPath = this.pathName.split('/').pop();
         if (tabInPath && tabInPath in oldTabToNewTabRoute) {
             // map legacy tab ids

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -331,9 +331,13 @@ export default class ResultsViewURLWrapper
     pathContext = '/results';
 
     @computed public get tabId() {
+        // Ensure top-level tab is correctly identified for routes with static subtabs.
+        // This condition checks if the URL matches exactly "/results/comparison"
         if (this.pathName.match(/\/results\/comparison(\/|$)/)) {
             return ResultsViewTab.COMPARISON;
         }
+
+        // Similarly, this checks for the "/results/pathways" route.
         if (this.pathName.match(/\/results\/pathways(\/|$)/)) {
             return ResultsViewTab.PATHWAYS;
         }
@@ -397,6 +401,7 @@ export default class ResultsViewURLWrapper
     }
 
     @computed public get comparisonSubTabId() {
+        // Extract subtab name after "/comparison/" in the URL path.
         const subtabMatch = this.pathName.match(/\/comparison\/([^\/?#]+)/);
         return subtabMatch ? subtabMatch[1] : GroupComparisonTab.OVERLAP;
     }
@@ -412,6 +417,7 @@ export default class ResultsViewURLWrapper
     }
 
     @computed public get pathwaysSubTabId() {
+        // Extract subtab name after "/pathways/" in the URL path.
         const subtabMatch = this.pathName.match(/\/pathways\/([^\/?#]+)/);
         return subtabMatch
             ? subtabMatch[1]

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -5,6 +5,8 @@ import autobind from 'autobind-decorator';
 import {
     LegacyResultsViewComparisonSubTab,
     oldTabToNewTabRoute,
+    PathwaysEnumToSlugMap,
+    PathwaysSlugToEnumMap,
     ResultsViewComparisonSubTab,
     ResultsViewPathwaysSubTab,
     ResultsViewTab,
@@ -419,14 +421,20 @@ export default class ResultsViewURLWrapper
     @computed public get pathwaysSubTabId() {
         // Extract subtab name after "/pathways/" in the URL path.
         const subtabMatch = this.pathName.match(/\/pathways\/([^\/?#]+)/);
-        return subtabMatch
-            ? subtabMatch[1]
-            : ResultsViewPathwaysSubTab.PATHWAY_MAPPER;
+        if (subtabMatch) {
+            const slug = subtabMatch[1].toLowerCase();
+            return (
+                PathwaysSlugToEnumMap[slug] ||
+                ResultsViewPathwaysSubTab.PATHWAY_MAPPER
+            );
+        }
+        return ResultsViewPathwaysSubTab.PATHWAY_MAPPER;
     }
 
     @autobind
     public setPathwaysSubTabId(tabId: ResultsViewPathwaysSubTab) {
-        this.updateURL({}, `results/pathways/${tabId}`);
+        const slug = PathwaysEnumToSlugMap[tabId] || 'pathway-mapper';
+        this.updateURL({}, `results/pathways/${slug}`);
     }
 
     @computed public get selectedEnrichmentEventTypes() {

--- a/src/pages/resultsView/ResultsViewURLWrapper.ts
+++ b/src/pages/resultsView/ResultsViewURLWrapper.ts
@@ -6,6 +6,7 @@ import {
     LegacyResultsViewComparisonSubTab,
     oldTabToNewTabRoute,
     ResultsViewComparisonSubTab,
+    ResultsViewPathwaysSubTab,
     ResultsViewTab,
 } from 'pages/resultsView/ResultsViewPageHelpers';
 import { getServerConfig } from 'config/config';
@@ -333,6 +334,9 @@ export default class ResultsViewURLWrapper
         if (this.pathName.match(/\/results\/comparison(\/|$)/)) {
             return ResultsViewTab.COMPARISON;
         }
+        if (this.pathName.match(/\/results\/pathways(\/|$)/)) {
+            return ResultsViewTab.PATHWAYS;
+        }
         const tabInPath = this.pathName.split('/').pop();
         if (tabInPath && tabInPath in oldTabToNewTabRoute) {
             // map legacy tab ids
@@ -405,6 +409,18 @@ export default class ResultsViewURLWrapper
     @autobind
     public setComparisonSubTabId(tabId: GroupComparisonTab) {
         this.updateURL({}, `results/comparison/${tabId}`);
+    }
+
+    @computed public get pathwaysSubTabId() {
+        const subtabMatch = this.pathName.match(/\/pathways\/([^\/?#]+)/);
+        return subtabMatch
+            ? subtabMatch[1]
+            : ResultsViewPathwaysSubTab.PATHWAY_MAPPER;
+    }
+
+    @autobind
+    public setPathwaysSubTabId(tabId: ResultsViewPathwaysSubTab) {
+        this.updateURL({}, `results/pathways/${tabId}`);
     }
 
     @computed public get selectedEnrichmentEventTypes() {

--- a/src/pages/resultsView/comparison/ComparisonTab.tsx
+++ b/src/pages/resultsView/comparison/ComparisonTab.tsx
@@ -147,7 +147,7 @@ export default class ComparisonTab extends React.Component<
             return (
                 <MSKTabs
                     unmountOnHide={false}
-                    activeTabId={this.props.urlWrapper.getSubTab}
+                    activeTabId={this.props.urlWrapper.subTab}
                     onTabClick={this.props.urlWrapper.setSubTab}
                     className="secondaryNavigation comparisonTabSubTabs"
                 >

--- a/src/pages/resultsView/comparison/ComparisonTab.tsx
+++ b/src/pages/resultsView/comparison/ComparisonTab.tsx
@@ -147,8 +147,8 @@ export default class ComparisonTab extends React.Component<
             return (
                 <MSKTabs
                     unmountOnHide={false}
-                    activeTabId={this.props.urlWrapper.comparisonSubTabId}
-                    onTabClick={this.props.urlWrapper.setComparisonSubTabId}
+                    activeTabId={this.props.urlWrapper.getSubTab}
+                    onTabClick={this.props.urlWrapper.setSubTab}
                     className="secondaryNavigation comparisonTabSubTabs"
                 >
                     <MSKTab id={GroupComparisonTab.OVERLAP} linkText="Overlap">

--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -128,9 +128,7 @@ const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerPro
         urlWrapper,
     }: IPathwayMapperContainerProps) {
         const store = useLocalObservable(() => ({
-            activeTab:
-                urlWrapper.query.pathways_source ||
-                ResultsViewPathwaysSubTab.PATHWAY_MAPPER,
+            activeTab: urlWrapper.pathwaysSubTabId,
         }));
 
         return (
@@ -149,9 +147,7 @@ const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerPro
                     onTabClick={(id: ResultsViewPathwaysSubTab) => {
                         runInAction(() => {
                             store.activeTab = id;
-                            urlWrapper.updateURL({
-                                pathways_source: id,
-                            });
+                            urlWrapper.setPathwaysSubTabId(id);
                         });
                     }}
                     className="pillTabs resultsPagePathwaysTabs"

--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -128,7 +128,7 @@ const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerPro
         urlWrapper,
     }: IPathwayMapperContainerProps) {
         const store = useLocalObservable(() => ({
-            activeTab: urlWrapper.getSubTab,
+            activeTab: urlWrapper.subTab,
         }));
 
         return (

--- a/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
+++ b/src/pages/resultsView/pathwayMapper/PathWayMapperContainer.tsx
@@ -128,7 +128,7 @@ const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerPro
         urlWrapper,
     }: IPathwayMapperContainerProps) {
         const store = useLocalObservable(() => ({
-            activeTab: urlWrapper.pathwaysSubTabId,
+            activeTab: urlWrapper.getSubTab,
         }));
 
         return (
@@ -147,7 +147,7 @@ const PathWayMapperContainer: React.FunctionComponent<IPathwayMapperContainerPro
                     onTabClick={(id: ResultsViewPathwaysSubTab) => {
                         runInAction(() => {
                             store.activeTab = id;
-                            urlWrapper.setPathwaysSubTabId(id);
+                            urlWrapper.setSubTab(id);
                         });
                     }}
                     className="pillTabs resultsPagePathwaysTabs"

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -99,6 +99,7 @@ import { PagePath } from 'shared/enums/PagePaths';
 import {
     LegacyResultsViewComparisonSubTab,
     ResultsViewComparisonSubTab,
+    ResultsViewPathwaysSubTab,
     ResultsViewTab,
 } from 'pages/resultsView/ResultsViewPageHelpers';
 import {
@@ -398,6 +399,33 @@ export const makeRoutes = () => {
                             );
                         } else {
                             redirectTo({}, '/results/comparison/overlap');
+                        }
+                    })}
+                />
+                <Route
+                    path="/results/pathways/:subtab"
+                    component={LocationValidationWrapper(
+                        ResultsViewPage,
+                        tabParamValidator(ResultsViewPathwaysSubTab),
+                        ResultsViewQueryParamsAdjuster
+                    )}
+                />
+                <Route
+                    path="/results/pathways"
+                    component={getBlankPage(() => {
+                        const query = parse(
+                            getBrowserWindow().location.search,
+                            {
+                                ignoreQueryPrefix: true,
+                            }
+                        );
+                        if (query.pathways_source) {
+                            redirectTo(
+                                {},
+                                `/results/pathways/${query.pathways_source}`
+                            );
+                        } else {
+                            redirectTo({}, '/results/pathways/PathwayMapper');
                         }
                     })}
                 />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -98,7 +98,6 @@ import { seekUrlHash } from 'shared/lib/seekUrlHash';
 import { PagePath } from 'shared/enums/PagePaths';
 import {
     LegacyResultsViewComparisonSubTab,
-    PathwaysEnumToSlugMap,
     ResultsViewComparisonSubTab,
     ResultsViewPathwaysSubTab,
     ResultsViewTab,
@@ -120,7 +119,10 @@ import {
     mutationGroup,
 } from 'shared/lib/comparison/ComparisonStoreUtils';
 import { MapValues } from 'shared/lib/TypeScriptUtils';
-import { ResultsViewURLQuery } from 'pages/resultsView/ResultsViewURLWrapper';
+import {
+    ResultsViewURLQuery,
+    sanitizeForUrl,
+} from 'pages/resultsView/ResultsViewURLWrapper';
 import { EnumDeclaration, EnumType } from 'typescript';
 
 function SuspenseWrapper(Component: any) {
@@ -431,19 +433,15 @@ export const makeRoutes = () => {
                             }
                         );
                         if (query.pathways_source) {
+                            const sanitizedValue = sanitizeForUrl(
+                                query.pathways_source as string
+                            );
                             redirectTo(
                                 {},
-                                `/results/pathways/${query.pathways_source}`
+                                `/results/pathways/${sanitizedValue}`
                             );
                         } else {
-                            redirectTo(
-                                {},
-                                `/results/pathways/${
-                                    PathwaysEnumToSlugMap[
-                                        ResultsViewPathwaysSubTab.PATHWAY_MAPPER
-                                    ]
-                                }`
-                            );
+                            redirectTo({}, '/results/pathways/pathwaymapper');
                         }
                     })}
                 />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -401,9 +401,12 @@ export const makeRoutes = () => {
                             }
                         );
                         if (query.comparison_subtab) {
+                            const sanitizedValue = sanitizeForUrl(
+                                query.comparison_subtab as string
+                            );
                             redirectTo(
                                 {},
-                                `/results/comparison/${query.comparison_subtab}`
+                                `/results/comparison/${sanitizedValue}`
                             );
                         } else {
                             redirectTo({}, '/results/comparison/overlap');

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -168,6 +168,24 @@ function LocationValidationWrapper(
 function ResultsViewQueryParamsAdjuster(oldParams: ResultsViewURLQuery) {
     let changeMade = false;
     const newParams = _.cloneDeep(oldParams);
+    if (
+        newParams.comparison_subtab ===
+        LegacyResultsViewComparisonSubTab.MUTATIONS
+    ) {
+        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
+        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
+            ...mutationGroup,
+        ]);
+        changeMade = true;
+    } else if (
+        newParams.comparison_subtab === LegacyResultsViewComparisonSubTab.CNA
+    ) {
+        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
+        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
+            ...cnaGroup,
+        ]);
+        changeMade = true;
+    }
     // we used to call the structural variant alteration class "fusions"
     // we have generalized it to structural variants
     const profileRegex = /fusion/;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -375,6 +375,11 @@ export const makeRoutes = () => {
                         );
                     })}
                 />
+                {/* 
+                 This route handles backward compatibility for comparison subtabs:
+                 - Supports both old query parameter format
+                 - And new URL path format (/results/comparison/:subtab)
+                */}
                 <Route
                     path="/results/comparison/:subtab"
                     component={LocationValidationWrapper(
@@ -402,6 +407,11 @@ export const makeRoutes = () => {
                         }
                     })}
                 />
+                {/* 
+                 This route handles backward compatibility for pathways subtabs:
+                 - Supports both old query parameter format 
+                 - And new URL path format (/results/pathways/:subtab)
+                */}
                 <Route
                     path="/results/pathways/:subtab"
                     component={LocationValidationWrapper(

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -168,25 +168,6 @@ function LocationValidationWrapper(
 function ResultsViewQueryParamsAdjuster(oldParams: ResultsViewURLQuery) {
     let changeMade = false;
     const newParams = _.cloneDeep(oldParams);
-    if (
-        newParams.comparison_subtab ===
-        LegacyResultsViewComparisonSubTab.MUTATIONS
-    ) {
-        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
-        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
-            ...mutationGroup,
-        ]);
-        changeMade = true;
-    } else if (
-        newParams.comparison_subtab === LegacyResultsViewComparisonSubTab.CNA
-    ) {
-        newParams.comparison_subtab = ResultsViewComparisonSubTab.ALTERATIONS;
-        newParams.comparison_selectedEnrichmentEventTypes = JSON.stringify([
-            ...cnaGroup,
-        ]);
-        changeMade = true;
-    }
-
     // we used to call the structural variant alteration class "fusions"
     // we have generalized it to structural variants
     const profileRegex = /fusion/;
@@ -340,10 +321,7 @@ export const makeRoutes = () => {
                 <Route
                     path={`/results/${ResultsViewTab.SURVIVAL_REDIRECT}`}
                     component={getBlankPage(() => {
-                        redirectTo(
-                            { comparison_subtab: 'survival' },
-                            '/results/comparison'
-                        );
+                        redirectTo({}, '/results/comparison/survival');
                     })}
                 />
                 {/* Redirect legacy expression route directly to plots tab with mrna vs study */}
@@ -376,6 +354,33 @@ export const makeRoutes = () => {
                             { comparison_subtab: 'mutations' },
                             '/results/comparison'
                         );
+                    })}
+                />
+                <Route
+                    path="/results/comparison/:subtab"
+                    component={LocationValidationWrapper(
+                        ResultsViewPage,
+                        tabParamValidator(ResultsViewComparisonSubTab),
+                        ResultsViewQueryParamsAdjuster
+                    )}
+                />
+                <Route
+                    path="/results/comparison"
+                    component={getBlankPage(() => {
+                        const query = parse(
+                            getBrowserWindow().location.search,
+                            {
+                                ignoreQueryPrefix: true,
+                            }
+                        );
+                        if (query.comparison_subtab) {
+                            redirectTo(
+                                {},
+                                `/results/comparison/${query.comparison_subtab}`
+                            );
+                        } else {
+                            redirectTo({}, '/results/comparison/overlap');
+                        }
                     })}
                 />
                 <Route

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -98,6 +98,7 @@ import { seekUrlHash } from 'shared/lib/seekUrlHash';
 import { PagePath } from 'shared/enums/PagePaths';
 import {
     LegacyResultsViewComparisonSubTab,
+    PathwaysEnumToSlugMap,
     ResultsViewComparisonSubTab,
     ResultsViewPathwaysSubTab,
     ResultsViewTab,
@@ -435,7 +436,14 @@ export const makeRoutes = () => {
                                 `/results/pathways/${query.pathways_source}`
                             );
                         } else {
-                            redirectTo({}, '/results/pathways/PathwayMapper');
+                            redirectTo(
+                                {},
+                                `/results/pathways/${
+                                    PathwaysEnumToSlugMap[
+                                        ResultsViewPathwaysSubTab.PATHWAY_MAPPER
+                                    ]
+                                }`
+                            );
                         }
                     })}
                 />


### PR DESCRIPTION
Fix [cBioportal/cBioportal#9762](https://github.com/cBioPortal/cbioportal/issues/9762)

Describe changes proposed in this pull request:
- Use of path URL instead of query parameter for comparison subtabs
- Use of path URL instead of query parameter for pathways subtabs
## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [✔] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
For comparison subtabs
![Screenshot 2025-04-17 195656](https://github.com/user-attachments/assets/ee295136-9fc6-41f2-88dc-fdac9d854ea8)
For pathways subtabs
![Screenshot 2025-04-17 195745](https://github.com/user-attachments/assets/cdbf268b-765a-4e75-a6d8-c3ec269e9517)
