### PR TITLE
Hide pie button if user unauthorized

### DIFF
--- a/src/shared/components/query/studyList/StudyList.tsx
+++ b/src/shared/components/query/studyList/StudyList.tsx
@@ -405,7 +405,7 @@ export default class StudyList extends QueryStoreComponent<
 
                         return content;
                     })}
-                    {study.studyId && (
+                    {study.studyId && study.readPermission === true && (
                         <DefaultTooltip
                             mouseEnterDelay={0}
                             placement="top"


### PR DESCRIPTION
## Hide pie button if user unauthorized

At the moment the pie chart button on the homepage is clickable even when a user is not authorized (results in error). 

Proposing to only show it when a user is authorized for a given study:

![image](https://github.com/user-attachments/assets/691ca9e5-5b79-48e9-aa37-94052c093836)
