### PR TITLE
Improve prettier check in circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           name: 'Check code style with Prettier'
           command: |
             cd cbioportal-frontend
-            yarn add prettier
+            yarn add -W prettier
             yarn run prettierCheckCircleCI
 
   pull_cbioportal_test_codebase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,7 @@ jobs:
           name: 'Check code style with Prettier'
           command: |
             cd cbioportal-frontend
+            yarn add prettier
             yarn run prettierCheckCircleCI
 
   pull_cbioportal_test_codebase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,8 @@ workflows:
       - pull_cbioportal_test_codebase
       - checkout
       - prettier:
+          requires:
+            - checkout
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,6 +371,12 @@ workflows:
     jobs:
       - pull_cbioportal_test_codebase
       - checkout
+      - prettier:
+          filters:
+            branches:
+              ignore:
+                - master
+                - release-*
       - check_forgotten_spec_only_statements:
           requires:
             - checkout
@@ -380,14 +386,6 @@ workflows:
       - build_frontend:
           requires:
             - checkout
-      - prettier:
-          requires:
-            - build_frontend
-          filters:
-            branches:
-              ignore:
-                - master
-                - release-*
       - e2e_localdb_tests:
           requires:
             - pull_cbioportal_test_codebase


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Prettier checks are now faster as they don't have to wait for project build to finish.

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
