### PR TITLE
Fix prettier version for circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           name: 'Check code style with Prettier'
           command: |
             cd cbioportal-frontend
-            yarn add -W prettier
+            yarn add -W prettier@1.19.1
             yarn run prettierCheckCircleCI
 
   pull_cbioportal_test_codebase:


### PR DESCRIPTION
We use a specific version of prettier in the frontend repo.

https://github.com/cBioPortal/cbioportal-frontend/blob/377e48051771f9e1eea2c485f691410b8caafb73/package.json#L374

circleci config should also use the same version.