### PR TITLE
Fix unauthorized study error page

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -10115,7 +10115,7 @@ export class StudyViewPageStore
 
     // Poll ClinicalEventTypeCounts API  with no filter to determine if table should be added to StudyView Page
     public readonly shouldDisplayClinicalEventTypeCounts = remoteData({
-        await: () => [this.queriedPhysicalStudyIds],
+        await: () => [this.queriedPhysicalStudyIds, this.unknownQueriedIds],
         invoke: async () => {
             if (this.unknownQueriedIds.result.length === 0) {
                 const filters: Partial<StudyViewFilter> = {};
@@ -10129,6 +10129,8 @@ export class StudyViewPageStore
                         )
                     ).length > 0
                 );
+            } else {
+                return Promise.resolve(false);
             }
         },
     });
@@ -10477,7 +10479,7 @@ export class StudyViewPageStore
     });
 
     public readonly shouldDisplayPatientTreatments = remoteData({
-        await: () => [this.queriedPhysicalStudyIds],
+        await: () => [this.queriedPhysicalStudyIds, this.unknownQueriedIds],
         invoke: () => {
             if (this.unknownQueriedIds.result.length === 0) {
                 return this.internalClient.getContainsTreatmentDataUsingPOST({
@@ -10490,7 +10492,7 @@ export class StudyViewPageStore
     });
 
     public readonly shouldDisplaySampleTreatments = remoteData({
-        await: () => [this.queriedPhysicalStudyIds],
+        await: () => [this.queriedPhysicalStudyIds, this.unknownQueriedIds],
         invoke: () => {
             if (this.unknownQueriedIds.result.length === 0) {
                 return this.internalClient.getContainsSampleTreatmentDataUsingPOST(
@@ -10511,7 +10513,7 @@ export class StudyViewPageStore
     >({
         await: () => [this.shouldDisplayPatientTreatments],
         invoke: async () => {
-            if (this.shouldDisplayPatientTreatments.result != false) {
+            if (this.shouldDisplayPatientTreatments.result) {
                 if (isClickhouseMode()) {
                     // @ts-ignore (will be available when go live with Clickhouse for all portals)
                     return await this.internalClient.fetchPatientTreatmentCountsUsingPOST(


### PR DESCRIPTION
## Fix unauthorized study error page
### Issue
When visiting the study view for an unauthorized study there are three requests that get sent that should not be sent when there are no valid studies. This results in the unauthorized error page not showing and instead we get the error page below:
![image](https://github.com/user-attachments/assets/ec055518-6b57-4370-b1c7-6db6be653dfd)

 I also see the frontend spams requests indefinitely when on this error page, which seems related to this [issue](https://github.com/cBioPortal/cbioportal/issues/11160).

### Fix
Only make the calls when there are no unauthorized studies in the study view. This results again in the unauthorized error page when a user does attempt to open a link to an unauthorized study (and the frontend no longer spams requests on the error page):
![image](https://github.com/user-attachments/assets/58eaaed2-3290-487a-9e61-2878d7bb3f53)

### Related issue
[#11479](https://github.com/cBioPortal/cbioportal/issues/11478)
 