### PR TITLE
Update url navigation to fix failing e2e localdb tests on backend and restore localdb errors screenshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ jobs:
           path: /tmp/repo/cbioportal-frontend/end-to-end-test/local/junit/completeResults.json
           destination: /completeResults.json
       - store_artifacts:
-          path: /tmp/repo/cbioportal-frontend/end-to-end-test/local/juniterrors
+          path: /tmp/repo/cbioportal-frontend/end-to-end-test/local/junit/errors
           destination: /errors
             
 

--- a/end-to-end-test/local/specs/core/studyview.screenshot.spec.js
+++ b/end-to-end-test/local/specs/core/studyview.screenshot.spec.js
@@ -292,14 +292,8 @@ describe('study view x vs y charts', function() {
 
 describe('study view editable breadcrumbs', () => {
     it('breadcrumbs are editable for mutation count chart', async () => {
-        const url = `${CBIOPORTAL_URL}/study/summary?id=lgg_ucsf_2014_test_generic_assay`;
-        // set up the page without filters
+        const url = `${CBIOPORTAL_URL}/study/summary?id=lgg_ucsf_2014_test_generic_assay#filterJson={"clinicalDataFilters":[{"attributeId":"MUTATION_COUNT","values":[{"start":15,"end":20},{"start":20,"end":25},{"start":25,"end":30},{"start":30,"end":35},{"start":35,"end":40},{"start":40,"end":45}]}],"studyIds":["lgg_ucsf_2014_test_generic_assay"],"alterationFilter":{"copyNumberAlterationEventTypes":{"AMP":true,"HOMDEL":true},"mutationEventTypes":{"any":true},"structuralVariants":null,"includeDriver":true,"includeVUS":true,"includeUnknownOncogenicity":true,"includeUnknownTier":true,"includeGermline":true,"includeSomatic":true,"includeUnknownStatus":true,"tiersBooleanMap":{}}}`;
         await goToUrlAndSetLocalStorage(url, true);
-        await waitForNetworkQuiet();
-        // add filters (this is necessary to do separately because goToUrlAndSetLocalStorage doesn't play nice with hash params
-        await browser.url(
-            `${url}#filterJson={"clinicalDataFilters":[{"attributeId":"MUTATION_COUNT","values":[{"start":15,"end":20},{"start":20,"end":25},{"start":25,"end":30},{"start":30,"end":35},{"start":35,"end":40},{"start":40,"end":45}]}],"studyIds":["lgg_ucsf_2014_test_generic_assay"],"alterationFilter":{"copyNumberAlterationEventTypes":{"AMP":true,"HOMDEL":true},"mutationEventTypes":{"any":true},"structuralVariants":null,"includeDriver":true,"includeVUS":true,"includeUnknownOncogenicity":true,"includeUnknownTier":true,"includeGermline":true,"includeSomatic":true,"includeUnknownStatus":true,"tiersBooleanMap":{}}}`
-        );
         await waitForNetworkQuiet();
         await waitForElementDisplayed('.userSelections');
 

--- a/end-to-end-test/shared/specUtils_Async.js
+++ b/end-to-end-test/shared/specUtils_Async.js
@@ -258,6 +258,8 @@ async function goToUrlAndSetLocalStorage(url, authenticated = false) {
     const currentUrl = await browser.getUrl();
     const needToLogin =
         authenticated && (!currentUrl || !currentUrl.includes('http'));
+    // navigate to blank page first to prevent issues with url hash params
+    await browser.url('about:blank');
     if (!useExternalFrontend) {
         await browser.url(url);
         console.log('Connecting to: ' + url);

--- a/end-to-end-test/shared/wdio/wdio.conf.js
+++ b/end-to-end-test/shared/wdio/wdio.conf.js
@@ -108,8 +108,8 @@ function saveErrorImage(
             fs.mkdirSync(errorDir, 0744);
         }
         const title = test.title.trim().replace(/\s/g, '_');
-        const img = `${errorDir}/${title}.png`;
-        console.log('ERROR SHOT PATH' + img);
+        const img = `${errorDir}${title}.png`;
+        console.log('ERROR SHOT PATH: ' + img);
         browser.saveScreenshot(img);
 
         networkLog[title.trim()] = browser.execute(function() {


### PR DESCRIPTION
Fix failing localdb tests on the backend by updating url navigation to first go to a blank page (issues with hash params). Also restore localdb errors screenshots on circleci due to incorrect paths