### PR TITLE
Fix bugs in OncoPrint's tabular download due to OQL

### DIFF
--- a/src/shared/components/oncoprint/tabularDownload.spec.ts
+++ b/src/shared/components/oncoprint/tabularDownload.spec.ts
@@ -129,7 +129,120 @@ describe('getTabularDownloadData', () => {
     it('downloads counts map tracks successfully, patient mode', () => {
         assert.deepEqual(
             getTabularDownloadData(
-                [],
+                [
+                    {
+                        key: 'GENETICTRACK_0',
+                        label: 'TP53',
+                        sublabel: ': MUT',
+                        oql: 'TP53: MUT',
+                        info: '',
+                        data: [
+                            {
+                                disp_mut: 'trunc_rec',
+                                disp_germ: false,
+                                patient: 'sample1',
+                                uid: 'sample1',
+                                not_profiled_in: [],
+                                study_id: 'study1',
+                                trackLabel: 'TP53',
+                                data: [
+                                    {
+                                        alterationSubType: 'frameshift',
+                                        alterationType: 'MUTATION_EXTENDED',
+                                        entrezGeneId: 7157,
+                                        hugoGeneSymbol: 'TP53',
+                                        isHotspot: false,
+                                        molecularProfileAlterationType:
+                                            'MUTATION_EXTENDED',
+                                        mutationStatus: '.',
+                                        mutationType: 'Frame_Shift_Del',
+                                        oncoKbOncogenic: 'Likely Oncogenic',
+                                        proteinChange: 'H168Cfs*8',
+                                        putativeDriver: true,
+                                        driverFilter: '',
+                                        driverFilterAnnotation: '',
+                                        driverTiersFilter: '',
+                                        driverTiersFilterAnnotation: '',
+                                        eventInfo: '',
+                                        value: 0,
+                                    },
+                                ],
+                            },
+                            {
+                                patient: 'sample2',
+                                uid: 'sample2',
+                                not_profiled_in: [],
+                                study_id: 'study1',
+                                trackLabel: 'TP53',
+                                data: [],
+                            },
+                            {
+                                patient: 'sample3',
+                                uid: 'sample3',
+                                not_profiled_in: [],
+                                study_id: 'study1',
+                                trackLabel: 'TP53',
+                                data: [],
+                            },
+                        ],
+                    },
+                    {
+                        key: 'GENETICTRACK_1',
+                        label: 'TP53',
+                        sublabel: ': HOMDEL',
+                        oql: 'TP53: HOMDEL',
+                        info: '',
+                        data: [
+                            {
+                                patient: 'sample1',
+                                uid: 'sample1',
+                                not_profiled_in: [],
+                                study_id: 'study1',
+                                trackLabel: 'TP53',
+                                data: [],
+                            },
+                            {
+                                disp_cna: 'homdel_rec',
+                                patient: 'sample2',
+                                uid: 'sample2',
+                                not_profiled_in: [],
+                                study_id: 'study1',
+                                trackLabel: 'TP53',
+                                data: [
+                                    {
+                                        alterationSubType: 'homdel',
+                                        alterationType:
+                                            'COPY_NUMBER_ALTERATION',
+                                        entrezGeneId: 7157,
+                                        hugoGeneSymbol: 'TP53',
+                                        molecularProfileAlterationType:
+                                            'COPY_NUMBER_ALTERATION',
+                                        oncoKbOncogenic: 'Likely Oncogenic',
+                                        putativeDriver: true,
+                                        value: -2,
+                                        proteinChange: '',
+                                        driverFilter: '',
+                                        driverFilterAnnotation: '',
+                                        driverTiersFilter: '',
+                                        driverTiersFilterAnnotation: '',
+                                        mutationType: '',
+                                        isHotspot: false,
+                                        mutationStatus: '',
+                                        eventInfo: '',
+                                    },
+                                ],
+                            },
+                            {
+                                patient: 'sample3',
+                                uid: 'sample3',
+                                not_profiled_in: [],
+                                study_id: 'study1',
+                                trackLabel: 'TP53',
+                                data: [],
+                            },
+                        ],
+                    },
+                ],
                 [
                     {
                         key: '',
@@ -247,7 +360,12 @@ describe('getTabularDownloadData', () => {
                 'mutation spectrum (T>C)\tCLINICAL\t12\t18\t126\n' +
                 'mutation spectrum (T>G)\tCLINICAL\t50\t110\t26\n' +
                 `other counts (a)\tCLINICAL\t82\t\t134\n` +
-                'other counts (b)\tCLINICAL\t8\t\t46\n'
+                'other counts (b)\tCLINICAL\t8\t\t46\n' +
+                'TP53\tCNA\t\thomdel_rec\t\n' +
+                'TP53\tMUTATIONS\tTruncating mutation\t\t\n' +
+                'TP53\tMRNA\t\t\t\n' +
+                'TP53\tPROTEIN\t\t\t\n' +
+                'TP53\tSTRUCTURAL_VARIANT\t\t\t\n'
         );
     });
 });

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -106,7 +106,7 @@ export function getTabularDownloadData(
                     : geneticTrackDatum.patient!;
 
             // Only initialize each alteration for sample/patient if it doesn't exist
-            // That can happen when we have multiple OncoPrint tracks of the same gene (using OQL)
+            // It may already exist if there are multiple OncoPrint tracks of the same gene
             if (oncoprintData.CNA[currentGeneName][id] == undefined) {
                 oncoprintData.CNA[currentGeneName][id] = '';
             }
@@ -154,7 +154,8 @@ export function getTabularDownloadData(
                 if (
                     oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] ==
                         '' ||
-                    oncoprintData.CNA[currentGeneName][id] == current_value
+                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] ==
+                        current_value
                 ) {
                     oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
                         id
@@ -162,10 +163,9 @@ export function getTabularDownloadData(
                 } else {
                     oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
                         id
-                    ] = oncoprintData.CNA[currentGeneName][id].concat(
-                        ', ',
-                        current_value
-                    );
+                    ] = oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
+                        id
+                    ].concat(', ', current_value);
                 }
             }
             if (geneticTrackDatum.disp_mrna !== undefined) {
@@ -174,13 +174,16 @@ export function getTabularDownloadData(
                     : geneticTrackDatum.disp_mrna;
                 if (
                     oncoprintData.MRNA[currentGeneName][id] == '' ||
-                    oncoprintData.CNA[currentGeneName][id] == current_value
+                    oncoprintData.MRNA[currentGeneName][id] == current_value
                 ) {
                     oncoprintData.MRNA[currentGeneName][id] = current_value;
                 } else {
-                    oncoprintData.MRNA[currentGeneName][id] = oncoprintData.CNA[
-                        currentGeneName
-                    ][id].concat(', ', current_value);
+                    oncoprintData.MRNA[currentGeneName][
+                        id
+                    ] = oncoprintData.MRNA[currentGeneName][id].concat(
+                        ', ',
+                        current_value
+                    );
                 }
             }
             if (geneticTrackDatum.disp_prot !== undefined) {
@@ -189,13 +192,13 @@ export function getTabularDownloadData(
                     : geneticTrackDatum.disp_prot;
                 if (
                     oncoprintData.PROTEIN[currentGeneName][id] == '' ||
-                    oncoprintData.CNA[currentGeneName][id] == current_value
+                    oncoprintData.PROTEIN[currentGeneName][id] == current_value
                 ) {
                     oncoprintData.PROTEIN[currentGeneName][id] = current_value;
                 } else {
                     oncoprintData.PROTEIN[currentGeneName][
                         id
-                    ] = oncoprintData.CNA[currentGeneName][id].concat(
+                    ] = oncoprintData.PROTEIN[currentGeneName][id].concat(
                         ', ',
                         current_value
                     );
@@ -207,7 +210,8 @@ export function getTabularDownloadData(
                     : geneticTrackDatum.disp_mut;
                 if (
                     oncoprintData.MUTATIONS[currentGeneName][id] == '' ||
-                    oncoprintData.CNA[currentGeneName][id] == current_value
+                    oncoprintData.MUTATIONS[currentGeneName][id] ==
+                        current_value
                 ) {
                     oncoprintData.MUTATIONS[currentGeneName][
                         id
@@ -215,7 +219,7 @@ export function getTabularDownloadData(
                 } else {
                     oncoprintData.MUTATIONS[currentGeneName][
                         id
-                    ] = oncoprintData.CNA[currentGeneName][id].concat(
+                    ] = oncoprintData.MUTATIONS[currentGeneName][id].concat(
                         ', ',
                         current_value
                     );

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -133,7 +133,8 @@ export function getTabularDownloadData(
                     const map = geneticAlterationMap[alteration];
                     const currentValue = map[dispValue] ?? dispValue;
 
-                    const geneTrack = oncoprintData[alteration][currentGeneName];
+                    const geneTrack =
+                        oncoprintData[alteration][currentGeneName];
                     const existingValue = geneTrack[id];
 
                     if (!existingValue || existingValue === currentValue) {

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -104,49 +104,122 @@ export function getTabularDownloadData(
                 columnMode === 'sample'
                     ? geneticTrackDatum.sample!
                     : geneticTrackDatum.patient!;
-            oncoprintData.CNA[currentGeneName][id] = '';
-            oncoprintData.MUTATIONS[currentGeneName][id] = '';
-            oncoprintData.MRNA[currentGeneName][id] = '';
-            oncoprintData.PROTEIN[currentGeneName][id] = '';
-            oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] = '';
+
+            // Only initialize each alteration for sample/patient if it doesn't exist
+            // That can happen when we have multiple OncoPrint tracks of the same gene (using OQL)
+            if (oncoprintData.CNA[currentGeneName][id] == undefined) {
+                oncoprintData.CNA[currentGeneName][id] = '';
+            }
+            if (oncoprintData.MUTATIONS[currentGeneName][id] == undefined) {
+                oncoprintData.MUTATIONS[currentGeneName][id] = '';
+            }
+            if (oncoprintData.MRNA[currentGeneName][id] == undefined) {
+                oncoprintData.MRNA[currentGeneName][id] = '';
+            }
+            if (oncoprintData.PROTEIN[currentGeneName][id] == undefined) {
+                oncoprintData.PROTEIN[currentGeneName][id] = '';
+            }
+            if (
+                oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] ==
+                undefined
+            ) {
+                oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] = '';
+            }
+
+            // Check if the sample/patient is initialized, and combine both results in case they are different
             if (geneticTrackDatum.disp_cna !== undefined) {
-                oncoprintData.CNA[currentGeneName][id] = cnaMap[
-                    geneticTrackDatum.disp_cna
-                ]
+                var current_value = cnaMap[geneticTrackDatum.disp_cna]
                     ? cnaMap[geneticTrackDatum.disp_cna]
                     : geneticTrackDatum.disp_cna;
+
+                if (
+                    oncoprintData.CNA[currentGeneName][id] == '' ||
+                    oncoprintData.CNA[currentGeneName][id] == current_value
+                ) {
+                    oncoprintData.CNA[currentGeneName][id] = current_value;
+                } else {
+                    oncoprintData.CNA[currentGeneName][id] = oncoprintData.CNA[
+                        currentGeneName
+                    ][id].concat(', ', current_value);
+                }
             }
             if (geneticTrackDatum.disp_structuralVariant !== undefined) {
-                oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
-                    id
-                ] = structuralVariantMap[
+                var current_value = structuralVariantMap[
                     geneticTrackDatum.disp_structuralVariant + ''
                 ]
                     ? structuralVariantMap[
                           geneticTrackDatum.disp_structuralVariant + ''
                       ]
                     : geneticTrackDatum.disp_structuralVariant;
+                if (
+                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] ==
+                        '' ||
+                    oncoprintData.CNA[currentGeneName][id] == current_value
+                ) {
+                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
+                        id
+                    ] = current_value;
+                } else {
+                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
+                        id
+                    ] = oncoprintData.CNA[currentGeneName][id].concat(
+                        ', ',
+                        current_value
+                    );
+                }
             }
             if (geneticTrackDatum.disp_mrna !== undefined) {
-                oncoprintData.MRNA[currentGeneName][id] = mrnaMap[
-                    geneticTrackDatum.disp_mrna
-                ]
+                var current_value = mrnaMap[geneticTrackDatum.disp_mrna]
                     ? mrnaMap[geneticTrackDatum.disp_mrna]
                     : geneticTrackDatum.disp_mrna;
+                if (
+                    oncoprintData.MRNA[currentGeneName][id] == '' ||
+                    oncoprintData.CNA[currentGeneName][id] == current_value
+                ) {
+                    oncoprintData.MRNA[currentGeneName][id] = current_value;
+                } else {
+                    oncoprintData.MRNA[currentGeneName][id] = oncoprintData.CNA[
+                        currentGeneName
+                    ][id].concat(', ', current_value);
+                }
             }
             if (geneticTrackDatum.disp_prot !== undefined) {
-                oncoprintData.PROTEIN[currentGeneName][id] = proteinMap[
-                    geneticTrackDatum.disp_prot
-                ]
+                var current_value = proteinMap[geneticTrackDatum.disp_prot]
                     ? proteinMap[geneticTrackDatum.disp_prot]
                     : geneticTrackDatum.disp_prot;
+                if (
+                    oncoprintData.PROTEIN[currentGeneName][id] == '' ||
+                    oncoprintData.CNA[currentGeneName][id] == current_value
+                ) {
+                    oncoprintData.PROTEIN[currentGeneName][id] = current_value;
+                } else {
+                    oncoprintData.PROTEIN[currentGeneName][
+                        id
+                    ] = oncoprintData.CNA[currentGeneName][id].concat(
+                        ', ',
+                        current_value
+                    );
+                }
             }
             if (geneticTrackDatum.disp_mut !== undefined) {
-                oncoprintData.MUTATIONS[currentGeneName][id] = mutationMap[
-                    geneticTrackDatum.disp_mut
-                ]
+                var current_value = mutationMap[geneticTrackDatum.disp_mut]
                     ? mutationMap[geneticTrackDatum.disp_mut]
                     : geneticTrackDatum.disp_mut;
+                if (
+                    oncoprintData.MUTATIONS[currentGeneName][id] == '' ||
+                    oncoprintData.CNA[currentGeneName][id] == current_value
+                ) {
+                    oncoprintData.MUTATIONS[currentGeneName][
+                        id
+                    ] = current_value;
+                } else {
+                    oncoprintData.MUTATIONS[currentGeneName][
+                        id
+                    ] = oncoprintData.CNA[currentGeneName][id].concat(
+                        ', ',
+                        current_value
+                    );
+                }
             }
         }
     }

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -94,7 +94,7 @@ export function getTabularDownloadData(
         //Add the currentGeneName to the oncoprintData if it does not exist
         for (const alteration in alterationsMap) {
             if (oncoprintData[alteration][currentGeneName] === undefined) {
-                oncoprintData[alteration][currentGeneName] ??= {};
+                oncoprintData[alteration][currentGeneName] = {};
             }
         }
 

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -94,7 +94,7 @@ export function getTabularDownloadData(
         //Add the currentGeneName to the oncoprintData if it does not exist
         for (const alteration in alterationsMap) {
             if (oncoprintData[alteration][currentGeneName] === undefined) {
-                oncoprintData[alteration][currentGeneName] = {};
+                oncoprintData[alteration][currentGeneName] ??= {};
             }
         }
 
@@ -111,41 +111,35 @@ export function getTabularDownloadData(
                 if (
                     oncoprintData[alteration][currentGeneName][id] === undefined
                 ) {
-                    oncoprintData[alteration][currentGeneName][id] = '';
+                    oncoprintData[alteration][currentGeneName][id] ??= '';
                 }
             }
 
             // Check if the sample/patient is initialized, and combine both results in case they are different
             for (const alteration in alterationsMap) {
-                var disp = alterationsMap[alteration] as keyof typeof string;
-                if (geneticTrackDatum[disp] !== undefined) {
-                    const geneticAlterationMap: any = {
-                        CNA: cnaMap,
-                        MUTATIONS: mutationMap,
-                        MRNA: mrnaMap,
-                        PROTEIN: proteinMap,
-                        STRUCTURAL_VARIANT: structuralVariantMap,
-                    };
+                const disp = alterationsMap[alteration];
+                // @ts-ignore
+                const dispValue = geneticTrackDatum[disp];
 
-                    const currentMap = geneticAlterationMap[alteration];
-                    var current_value = currentMap[geneticTrackDatum[disp]]
-                        ? currentMap[geneticTrackDatum[disp]]
-                        : geneticTrackDatum[disp];
+                const geneticAlterationMap: any = {
+                    CNA: cnaMap,
+                    MUTATIONS: mutationMap,
+                    MRNA: mrnaMap,
+                    PROTEIN: proteinMap,
+                    STRUCTURAL_VARIANT: structuralVariantMap,
+                };
 
-                    if (
-                        oncoprintData[alteration][currentGeneName][id] == '' ||
-                        oncoprintData[alteration][currentGeneName][id] ==
-                            current_value
-                    ) {
-                        oncoprintData[alteration][currentGeneName][
-                            id
-                        ] = current_value;
+                if (dispValue !== undefined) {
+                    const map = geneticAlterationMap[alteration];
+                    const currentValue = map[dispValue] ?? dispValue;
+
+                    const geneTrack = oncoprintData[alteration][currentGeneName];
+                    const existingValue = geneTrack[id];
+
+                    if (!existingValue || existingValue === currentValue) {
+                        geneTrack[id] = currentValue;
                     } else {
-                        oncoprintData[alteration][currentGeneName][
-                            id
-                        ] = oncoprintData[alteration][currentGeneName][
-                            id
-                        ].concat(', ', current_value);
+                        geneTrack[id] = `${existingValue}, ${currentValue}`;
                     }
                 }
             }

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -111,7 +111,7 @@ export function getTabularDownloadData(
                 if (
                     oncoprintData[alteration][currentGeneName][id] === undefined
                 ) {
-                    oncoprintData[alteration][currentGeneName][id] ??= '';
+                    oncoprintData[alteration][currentGeneName][id] = '';
                 }
             }
 

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -119,8 +119,17 @@ export function getTabularDownloadData(
             for (const alteration in alterationsMap) {
                 var disp = alterationsMap[alteration] as keyof typeof string;
                 if (geneticTrackDatum[disp] !== undefined) {
-                    var current_value = cnaMap[geneticTrackDatum[disp]]
-                        ? cnaMap[geneticTrackDatum[disp]]
+                    const geneticAlterationMap: any = {
+                        CNA: cnaMap,
+                        MUTATIONS: mutationMap,
+                        MRNA: mrnaMap,
+                        PROTEIN: proteinMap,
+                        STRUCTURAL_VARIANT: structuralVariantMap,
+                    };
+
+                    const currentMap = geneticAlterationMap[alteration];
+                    var current_value = currentMap[geneticTrackDatum[disp]]
+                        ? currentMap[geneticTrackDatum[disp]]
                         : geneticTrackDatum[disp];
 
                     if (

--- a/src/shared/components/oncoprint/tabularDownload.ts
+++ b/src/shared/components/oncoprint/tabularDownload.ts
@@ -7,6 +7,7 @@ import Oncoprint, {
 } from './Oncoprint';
 import fileDownload from 'react-file-download';
 import ifNotDefined from '../../lib/ifNotDefined';
+import { string } from 'yargs';
 
 export function getTabularDownloadData(
     geneticTracks: GeneticTrackSpec[],
@@ -78,26 +79,25 @@ export function getTabularDownloadData(
         true: 'Structural Variant',
     };
 
+    const alterationsMap: any = {
+        CNA: 'disp_cna',
+        MUTATIONS: 'disp_mut',
+        MRNA: 'disp_mrna',
+        PROTEIN: 'disp_prot',
+        STRUCTURAL_VARIANT: 'disp_structuralVariant',
+    };
+
     //Add genetic data
     for (const geneticTrack of geneticTracks) {
         const currentTrackData = geneticTrack.data;
         const currentGeneName = currentTrackData[0].trackLabel; // the label is the same for all entries of the track
         //Add the currentGeneName to the oncoprintData if it does not exist
-        if (oncoprintData.CNA[currentGeneName] === undefined) {
-            oncoprintData.CNA[currentGeneName] = {};
+        for (const alteration in alterationsMap) {
+            if (oncoprintData[alteration][currentGeneName] === undefined) {
+                oncoprintData[alteration][currentGeneName] = {};
+            }
         }
-        if (oncoprintData.MUTATIONS[currentGeneName] === undefined) {
-            oncoprintData.MUTATIONS[currentGeneName] = {};
-        }
-        if (oncoprintData.MRNA[currentGeneName] === undefined) {
-            oncoprintData.MRNA[currentGeneName] = {};
-        }
-        if (oncoprintData.PROTEIN[currentGeneName] === undefined) {
-            oncoprintData.PROTEIN[currentGeneName] = {};
-        }
-        if (oncoprintData.STRUCTURAL_VARIANT[currentGeneName] === undefined) {
-            oncoprintData.STRUCTURAL_VARIANT[currentGeneName] = {};
-        }
+
         //Iterate over all patients/samples of the track and add them to oncoprintData
         for (const geneticTrackDatum of currentTrackData) {
             let id: string =
@@ -107,122 +107,37 @@ export function getTabularDownloadData(
 
             // Only initialize each alteration for sample/patient if it doesn't exist
             // It may already exist if there are multiple OncoPrint tracks of the same gene
-            if (oncoprintData.CNA[currentGeneName][id] == undefined) {
-                oncoprintData.CNA[currentGeneName][id] = '';
-            }
-            if (oncoprintData.MUTATIONS[currentGeneName][id] == undefined) {
-                oncoprintData.MUTATIONS[currentGeneName][id] = '';
-            }
-            if (oncoprintData.MRNA[currentGeneName][id] == undefined) {
-                oncoprintData.MRNA[currentGeneName][id] = '';
-            }
-            if (oncoprintData.PROTEIN[currentGeneName][id] == undefined) {
-                oncoprintData.PROTEIN[currentGeneName][id] = '';
-            }
-            if (
-                oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] ==
-                undefined
-            ) {
-                oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] = '';
+            for (const alteration in alterationsMap) {
+                if (
+                    oncoprintData[alteration][currentGeneName][id] === undefined
+                ) {
+                    oncoprintData[alteration][currentGeneName][id] = '';
+                }
             }
 
             // Check if the sample/patient is initialized, and combine both results in case they are different
-            if (geneticTrackDatum.disp_cna !== undefined) {
-                var current_value = cnaMap[geneticTrackDatum.disp_cna]
-                    ? cnaMap[geneticTrackDatum.disp_cna]
-                    : geneticTrackDatum.disp_cna;
+            for (const alteration in alterationsMap) {
+                var disp = alterationsMap[alteration] as keyof typeof string;
+                if (geneticTrackDatum[disp] !== undefined) {
+                    var current_value = cnaMap[geneticTrackDatum[disp]]
+                        ? cnaMap[geneticTrackDatum[disp]]
+                        : geneticTrackDatum[disp];
 
-                if (
-                    oncoprintData.CNA[currentGeneName][id] == '' ||
-                    oncoprintData.CNA[currentGeneName][id] == current_value
-                ) {
-                    oncoprintData.CNA[currentGeneName][id] = current_value;
-                } else {
-                    oncoprintData.CNA[currentGeneName][id] = oncoprintData.CNA[
-                        currentGeneName
-                    ][id].concat(', ', current_value);
-                }
-            }
-            if (geneticTrackDatum.disp_structuralVariant !== undefined) {
-                var current_value = structuralVariantMap[
-                    geneticTrackDatum.disp_structuralVariant + ''
-                ]
-                    ? structuralVariantMap[
-                          geneticTrackDatum.disp_structuralVariant + ''
-                      ]
-                    : geneticTrackDatum.disp_structuralVariant;
-                if (
-                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] ==
-                        '' ||
-                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][id] ==
-                        current_value
-                ) {
-                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
-                        id
-                    ] = current_value;
-                } else {
-                    oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
-                        id
-                    ] = oncoprintData.STRUCTURAL_VARIANT[currentGeneName][
-                        id
-                    ].concat(', ', current_value);
-                }
-            }
-            if (geneticTrackDatum.disp_mrna !== undefined) {
-                var current_value = mrnaMap[geneticTrackDatum.disp_mrna]
-                    ? mrnaMap[geneticTrackDatum.disp_mrna]
-                    : geneticTrackDatum.disp_mrna;
-                if (
-                    oncoprintData.MRNA[currentGeneName][id] == '' ||
-                    oncoprintData.MRNA[currentGeneName][id] == current_value
-                ) {
-                    oncoprintData.MRNA[currentGeneName][id] = current_value;
-                } else {
-                    oncoprintData.MRNA[currentGeneName][
-                        id
-                    ] = oncoprintData.MRNA[currentGeneName][id].concat(
-                        ', ',
-                        current_value
-                    );
-                }
-            }
-            if (geneticTrackDatum.disp_prot !== undefined) {
-                var current_value = proteinMap[geneticTrackDatum.disp_prot]
-                    ? proteinMap[geneticTrackDatum.disp_prot]
-                    : geneticTrackDatum.disp_prot;
-                if (
-                    oncoprintData.PROTEIN[currentGeneName][id] == '' ||
-                    oncoprintData.PROTEIN[currentGeneName][id] == current_value
-                ) {
-                    oncoprintData.PROTEIN[currentGeneName][id] = current_value;
-                } else {
-                    oncoprintData.PROTEIN[currentGeneName][
-                        id
-                    ] = oncoprintData.PROTEIN[currentGeneName][id].concat(
-                        ', ',
-                        current_value
-                    );
-                }
-            }
-            if (geneticTrackDatum.disp_mut !== undefined) {
-                var current_value = mutationMap[geneticTrackDatum.disp_mut]
-                    ? mutationMap[geneticTrackDatum.disp_mut]
-                    : geneticTrackDatum.disp_mut;
-                if (
-                    oncoprintData.MUTATIONS[currentGeneName][id] == '' ||
-                    oncoprintData.MUTATIONS[currentGeneName][id] ==
-                        current_value
-                ) {
-                    oncoprintData.MUTATIONS[currentGeneName][
-                        id
-                    ] = current_value;
-                } else {
-                    oncoprintData.MUTATIONS[currentGeneName][
-                        id
-                    ] = oncoprintData.MUTATIONS[currentGeneName][id].concat(
-                        ', ',
-                        current_value
-                    );
+                    if (
+                        oncoprintData[alteration][currentGeneName][id] == '' ||
+                        oncoprintData[alteration][currentGeneName][id] ==
+                            current_value
+                    ) {
+                        oncoprintData[alteration][currentGeneName][
+                            id
+                        ] = current_value;
+                    } else {
+                        oncoprintData[alteration][currentGeneName][
+                            id
+                        ] = oncoprintData[alteration][currentGeneName][
+                            id
+                        ].concat(', ', current_value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The logic of building the tabular download for OncoPrint assumes each track is a different gene. This causes issues when creating the tabular file for a query with multiple tracks of the same gene, only keeping the alterations of the last track of the gene.

For example, for the query with CDKN2B:MUT and CDKN2B:HOMDEL, when we have HOMDELs as the second track, only HOMDELs are shown in the downloaded tabular file (and no MUTs): https://www.cbioportal.org/results/oncoprint?cancer_study_list=ccle_broad_2019&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cstructural_variants%2Ccna&case_set_id=ccle_broad_2019_cnaseq&gene_list=CDKN2B%253AMUT%250ACDKN2B%253AHOMDEL&geneset_list=%20&tab_index=tab_visualize&Action=Submit&show_samples=true 

When the same query is with MUT displayed in the second track, and HOMDELs in the first track, then we only see the MUT (and no HOMDELs) in the tabular file: https://www.cbioportal.org/results/oncoprint?cancer_study_list=ccle_broad_2019&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cstructural_variants%2Ccna&case_set_id=ccle_broad_2019_cnaseq&gene_list=CDKN2B%253AHOMDEL%250ACDKN2B%253AMUT&geneset_list=%20&tab_index=tab_visualize&Action=Submit&show_samples=true

This PR fixes this issue, combining the alterations that occur in multiple tracks when they belong to the same gene.