### PR TITLE
Study view: eagerly load data for charts menu so you don't have to wait

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -597,9 +597,8 @@ export default class StudyViewPage extends React.Component<
     }
 
     content() {
-        // this is just to eagerlyload this data so that the add charts functionality
-        // opens faster
-        const eager = this.store.dataWithCount.isComplete;
+        // this is just to eagerly  this data so that the add charts functionality opens faster
+        const _eager = this.store.dataWithCount.isComplete;
 
         return (
             <div className="studyView">


### PR DESCRIPTION
The clinical charts list of the study view depends on a fetch that is expensive (even when cached).  This PR eagerly loads the data before the user has clicked the add charts button so that the menu will show instantaneously.