### PR TITLE
fix eager loading of clinical data

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -641,13 +641,6 @@ export default class StudyViewPage extends React.Component<
                                 onBookmarkClick={this.onBookmarkClick}
                             />
 
-                            {
-                                // this is hidden, it's just to eagerly load
-                            }
-                            <div className={'hide'}>
-                                {this.store.dataWithCount.isComplete}
-                            </div>
-
                             <div className={styles.mainTabs}>
                                 <MSKTabs
                                     id="studyViewTabs"

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -644,6 +644,13 @@ export default class StudyViewPage extends React.Component<
                                 onBookmarkClick={this.onBookmarkClick}
                             />
 
+                            {
+                                // this is hidden, it's just to eagerly load
+                            }
+                            <div className={'hide'}>
+                                {this.store.dataWithCount.isComplete}
+                            </div>
+
                             <div className={styles.mainTabs}>
                                 <MSKTabs
                                     id="studyViewTabs"

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -597,9 +597,6 @@ export default class StudyViewPage extends React.Component<
     }
 
     content() {
-        // this is just to eagerly  this data so that the add charts functionality opens faster
-        const _eager = this.store.dataWithCount.isComplete;
-
         return (
             <div className="studyView">
                 {this.showBookmarkModal && this.bookmarkModal}
@@ -821,6 +818,20 @@ export default class StudyViewPage extends React.Component<
                                                         <Then>
                                                             {summary}
                                                             {buttons}
+                                                            {
+                                                                // this is hidden, it's just to eagerly load
+                                                            }
+                                                            <div
+                                                                className={
+                                                                    'hide'
+                                                                }
+                                                            >
+                                                                {
+                                                                    this.store
+                                                                        .dataWithCount
+                                                                        .isComplete
+                                                                }
+                                                            </div>
                                                         </Then>
                                                         <Else>
                                                             <LoadingIndicator


### PR DESCRIPTION
This fixes an issue where a previous attempt to eagerly load was causing a request before filters had been set, resulting in a backend error