### PR TITLE
WIP: Resource table improvements (needs rebase)

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -6,6 +6,7 @@ import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls
 import {
     DefaultTooltip,
     toggleColumnVisibility,
+    pluralize,
 } from 'cbioportal-frontend-commons';
 import {
     PatientViewPageStore,
@@ -480,15 +481,19 @@ export class PatientViewPageInner extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
+                    const displayName =
+                        data.length > 1
+                            ? pluralize(def.displayName, data.length)
+                            : def.displayName;
                     list.push(
                         <MSKTab
                             key={getPatientViewResourceTabId(def.resourceId)}
                             id={getPatientViewResourceTabId(def.resourceId)}
-                            linkText={def.displayName}
+                            linkText={displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
-                                resourceDisplayName={def.displayName}
+                                resourceDisplayName={displayName}
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
                             />

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -481,19 +481,15 @@ export class PatientViewPageInner extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
-                    const displayName =
-                        data.length > 1
-                            ? pluralize(def.displayName, data.length)
-                            : def.displayName;
                     list.push(
                         <MSKTab
                             key={getPatientViewResourceTabId(def.resourceId)}
                             id={getPatientViewResourceTabId(def.resourceId)}
-                            linkText={displayName}
+                            linkText={def.displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
-                                resourceDisplayName={displayName}
+                                resourceDisplayName={def.displayName}
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
                             />

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -488,6 +488,7 @@ export class PatientViewPageInner extends React.Component<
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
+                                resourceDisplayName={def.displayName}
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
                             />

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -62,7 +62,7 @@ import ResourceTab from '../../shared/components/resources/ResourceTab';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
 import ResourcesTab, { RESOURCES_TAB_NAME } from './resources/ResourcesTab';
 import { ResourceData } from 'cbioportal-ts-api-client';
-import { getResourceConfig } from 'shared/lib/ResourceUtils';
+import { getResourceConfig } from 'shared/lib/ResourceConfig';
 import $ from 'jquery';
 import { StudyViewComparisonGroup } from 'pages/groupComparison/GroupComparisonUtils';
 import { parse } from 'query-string';

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -551,6 +551,7 @@ export default class StudyViewPage extends React.Component<
                             <ResourceTab
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
+                                resourceDisplayName={def.displayName}
                             />
                         </MSKTab>
                     );
@@ -742,6 +743,16 @@ export default class StudyViewPage extends React.Component<
                                     >
                                         <div>
                                             <ResourcesTab
+                                                resourceDisplayName={
+                                                    this.store
+                                                        .resourceDefinitions
+                                                        .result?.length == 1
+                                                        ? this.store
+                                                              .resourceDefinitions
+                                                              .result[0]
+                                                              .displayName
+                                                        : RESOURCES_TAB_NAME
+                                                }
                                                 store={this.store}
                                                 openResource={this.openResource}
                                             />

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -62,6 +62,7 @@ import ResourceTab from '../../shared/components/resources/ResourceTab';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
 import ResourcesTab, { RESOURCES_TAB_NAME } from './resources/ResourcesTab';
 import { ResourceData } from 'cbioportal-ts-api-client';
+import { getResourceConfig } from 'shared/lib/ResourceUtils';
 import $ from 'jquery';
 import { StudyViewComparisonGroup } from 'pages/groupComparison/GroupComparisonUtils';
 import { parse } from 'query-string';
@@ -545,21 +546,25 @@ export default class StudyViewPage extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
-                    const displayName =
+                    const config = getResourceConfig(def);
+                    const originalDisplayName =
                         data.length > 1
                             ? pluralize(def.displayName, data.length)
                             : def.displayName;
+                    const customDisplayName =
+                        config.customizedDisplayName || originalDisplayName;
+
                     list.push(
                         <MSKTab
                             key={getStudyViewResourceTabId(def.resourceId)}
                             id={getStudyViewResourceTabId(def.resourceId)}
-                            linkText={displayName}
+                            linkText={originalDisplayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
-                                resourceDisplayName={displayName}
+                                resourceDisplayName={customDisplayName}
                             />
                         </MSKTab>
                     );

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -21,6 +21,7 @@ import {
     getBrowserWindow,
     onMobxPromise,
     remoteData,
+    pluralize,
 } from 'cbioportal-frontend-commons';
 import { PageLayout } from '../../shared/components/PageLayout/PageLayout';
 import IFrameLoader from '../../shared/components/iframeLoader/IFrameLoader';
@@ -379,7 +380,10 @@ export default class StudyViewPage extends React.Component<
     }
 
     @computed get shouldShowResources() {
-        if (this.store.resourceDefinitions.isComplete) {
+        if (
+            this.store.resourceDefinitions.isComplete &&
+            this.store.resourceIdToResourceData.isComplete
+        ) {
             return this.store.resourceDefinitions.result.length > 0;
         } else {
             return false;
@@ -541,17 +545,21 @@ export default class StudyViewPage extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
+                    const displayName =
+                        data.length > 1
+                            ? pluralize(def.displayName, data.length)
+                            : def.displayName;
                     list.push(
                         <MSKTab
                             key={getStudyViewResourceTabId(def.resourceId)}
                             id={getStudyViewResourceTabId(def.resourceId)}
-                            linkText={def.displayName}
+                            linkText={displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
-                                resourceDisplayName={def.displayName}
+                                resourceDisplayName={displayName}
                             />
                         </MSKTab>
                     );
@@ -735,8 +743,13 @@ export default class StudyViewPage extends React.Component<
                                         linkText={
                                             this.store.resourceDefinitions
                                                 .result?.length == 1
-                                                ? this.store.resourceDefinitions
-                                                      .result[0].displayName
+                                                ? pluralize(
+                                                      this.store
+                                                          .resourceDefinitions
+                                                          .result[0]
+                                                          .displayName,
+                                                      2
+                                                  )
                                                 : RESOURCES_TAB_NAME
                                         }
                                         hide={!this.shouldShowResources}
@@ -747,10 +760,13 @@ export default class StudyViewPage extends React.Component<
                                                     this.store
                                                         .resourceDefinitions
                                                         .result?.length == 1
-                                                        ? this.store
-                                                              .resourceDefinitions
-                                                              .result[0]
-                                                              .displayName
+                                                        ? pluralize(
+                                                              this.store
+                                                                  .resourceDefinitions
+                                                                  .result[0]
+                                                                  .displayName,
+                                                              2
+                                                          )
                                                         : RESOURCES_TAB_NAME
                                                 }
                                                 store={this.store}

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -547,18 +547,14 @@ export default class StudyViewPage extends React.Component<
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
                     const config = getResourceConfig(def);
-                    const originalDisplayName =
-                        data.length > 1
-                            ? pluralize(def.displayName, data.length)
-                            : def.displayName;
                     const customDisplayName =
-                        config.customizedDisplayName || originalDisplayName;
+                        config.customizedDisplayName || def.displayName;
 
                     list.push(
                         <MSKTab
                             key={getStudyViewResourceTabId(def.resourceId)}
                             id={getStudyViewResourceTabId(def.resourceId)}
-                            linkText={originalDisplayName}
+                            linkText={def.displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
@@ -748,13 +744,8 @@ export default class StudyViewPage extends React.Component<
                                         linkText={
                                             this.store.resourceDefinitions
                                                 .result?.length == 1
-                                                ? pluralize(
-                                                      this.store
-                                                          .resourceDefinitions
-                                                          .result[0]
-                                                          .displayName,
-                                                      2
-                                                  )
+                                                ? this.store.resourceDefinitions
+                                                      .result[0].displayName
                                                 : RESOURCES_TAB_NAME
                                         }
                                         hide={!this.shouldShowResources}
@@ -765,13 +756,10 @@ export default class StudyViewPage extends React.Component<
                                                     this.store
                                                         .resourceDefinitions
                                                         .result?.length == 1
-                                                        ? pluralize(
-                                                              this.store
-                                                                  .resourceDefinitions
-                                                                  .result[0]
-                                                                  .displayName,
-                                                              2
-                                                          )
+                                                        ? this.store
+                                                              .resourceDefinitions
+                                                              .result[0]
+                                                              .displayName
                                                         : RESOURCES_TAB_NAME
                                                 }
                                                 store={this.store}

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -21,7 +21,8 @@ import {
     ClinicalData,
     StudyViewFilter,
 } from 'cbioportal-ts-api-client';
-import { getResourceConfig } from 'shared/lib/ResourceUtils';
+import { getResourceConfig } from 'shared/lib/ResourceConfig';
+import { hasNonEmptyDescriptionInDefinitions } from 'shared/lib/ResourceUtils';
 
 export interface IFilesLinksTable {
     resourceDisplayName: string;
@@ -384,12 +385,19 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
             });
         }
 
-        defaultColumns.push({
-            ...this.getDefaultColumnConfig('description', 'Description'),
-            render: (data: { [id: string]: string }) => {
-                return <div>{data.description}</div>;
-            },
-        });
+        // Only show Description column if at least one resource definition has a non-empty description
+        if (
+            hasNonEmptyDescriptionInDefinitions(
+                this.props.store.resourceDefinitions.result
+            )
+        ) {
+            defaultColumns.push({
+                ...this.getDefaultColumnConfig('description', 'Description'),
+                render: (data: { [id: string]: string }) => {
+                    return <div>{data.description}</div>;
+                },
+            });
+        }
 
         // Conditionally add the last column if not hidden
         if (!shouldHideResourcesPerPatientColumn) {

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -301,7 +301,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
             },
 
             {
-                ...this.getDefaultColumnConfig('resourceUrl', 'Resource URL'),
+                ...this.getDefaultColumnConfig('url', 'Resource URL'),
                 render: (data: { [id: string]: string }) => {
                     return (
                         <div>
@@ -377,7 +377,10 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                 showColumnVisibility={false}
                                 showCountHeader={false}
                                 showFilterClearButton={false}
-                                showCopyDownload={false}
+                                showCopyDownload={true}
+                                copyDownloadProps={{
+                                    showCopy: false,
+                                }}
                                 initialSortColumn={'resourcesPerPatient'}
                                 initialSortDirection={'desc'}
                             />

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -241,6 +241,23 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
     });
 
     @computed get columns() {
+        // Determine if there's only one unique resource type
+        const uniqueResourceTypes =
+            this.resourceData.result && this.resourceData.result.data
+                ? _.uniq(
+                      this.resourceData.result.data.map(
+                          item => item.typeOfResource as string
+                      )
+                  )
+                : [];
+        const resourcesPerPatientColumnName =
+            uniqueResourceTypes.length === 1 && uniqueResourceTypes[0]
+                ? `${pluralize(
+                      uniqueResourceTypes[0] as string,
+                      2
+                  )} per Patient`
+                : 'Resources per Patient';
+
         let defaultColumns: Column<{ [id: string]: any }>[] = [
             {
                 ...this.getDefaultColumnConfig('patientId', 'Patient ID'),
@@ -293,7 +310,16 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                     path,
                                     data.patientId
                                 )}
+                                style={{ fontSize: 10 }}
                             >
+                                <i
+                                    className={`fa fa-user fa-sm`}
+                                    style={{
+                                        marginRight: 5,
+                                        color: 'black',
+                                    }}
+                                    title="Open in Patient View"
+                                />
                                 {data.typeOfResource}
                             </a>
                         </div>
@@ -335,7 +361,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
             {
                 ...this.getDefaultColumnConfig(
                     'resourcesPerPatient',
-                    'Resources per Patient',
+                    resourcesPerPatientColumnName,
                     true
                 ),
                 render: (data: { [id: string]: number }) => {
@@ -369,11 +395,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                                 this.resourceData.result
                                                     ?.totalItems
                                             }{' '}
-                                            {pluralize(
-                                                this.props.resourceDisplayName,
-                                                this.resourceData.result
-                                                    ?.totalItems || 1
-                                            )}
+                                            {this.props.resourceDisplayName}
                                         </strong>
                                     </div>
                                 }

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -15,7 +15,7 @@ import {
     getPatientViewUrlWithPathname,
 } from 'shared/api/urls';
 import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
-import { isUrl, remoteData } from 'cbioportal-frontend-commons';
+import { isUrl, pluralize, remoteData } from 'cbioportal-frontend-commons';
 import { makeObservable, observable, computed } from 'mobx';
 import {
     ResourceData,
@@ -24,6 +24,7 @@ import {
 } from 'cbioportal-ts-api-client';
 
 export interface IFilesLinksTable {
+    resourceDisplayName: string;
     store: StudyViewPageStore;
 }
 
@@ -368,7 +369,11 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                                 this.resourceData.result
                                                     ?.totalItems
                                             }{' '}
-                                            resources
+                                            {pluralize(
+                                                this.props.resourceDisplayName,
+                                                this.resourceData.result
+                                                    ?.totalItems || 1
+                                            )}
                                         </strong>
                                     </div>
                                 }

--- a/src/pages/studyView/resources/ResourcesTab.tsx
+++ b/src/pages/studyView/resources/ResourcesTab.tsx
@@ -10,6 +10,7 @@ import ResourceTable from 'shared/components/resources/ResourceTable';
 import { FilesAndLinks } from './FilesAndLinks';
 
 export interface IResourcesTabProps {
+    resourceDisplayName: string;
     store: StudyViewPageStore;
     openResource: (resource: ResourceData) => void;
 }
@@ -68,9 +69,12 @@ export default class ResourcesTab extends React.Component<
                 <div className="resourcesTab">
                     <div className="resourcesSection">
                         <h4 className="blackHeader">
-                            Patient and Sample Resources
+                            Patient and Sample {this.props.resourceDisplayName}
                         </h4>
-                        <FilesAndLinks store={this.props.store}></FilesAndLinks>
+                        <FilesAndLinks
+                            resourceDisplayName={this.props.resourceDisplayName}
+                            store={this.props.store}
+                        ></FilesAndLinks>
                     </div>
                 </div>
             </div>

--- a/src/pages/studyView/resources/ResourcesTab.tsx
+++ b/src/pages/studyView/resources/ResourcesTab.tsx
@@ -68,9 +68,6 @@ export default class ResourcesTab extends React.Component<
                 </div>
                 <div className="resourcesTab">
                     <div className="resourcesSection">
-                        <h4 className="blackHeader">
-                            Patient and Sample {this.props.resourceDisplayName}
-                        </h4>
                         <FilesAndLinks
                             resourceDisplayName={this.props.resourceDisplayName}
                             store={this.props.store}

--- a/src/pages/studyView/styles.scss
+++ b/src/pages/studyView/styles.scss
@@ -98,7 +98,6 @@ iframe.mdacc-heatmap-iframe {
 
 .resourcesTab {
     .resourcesSection {
-        @include dashed-border-section;
         margin-bottom: 30px;
 
         &:last-child {

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -13,6 +13,7 @@ import { getServerConfig } from 'config/config';
 import { CUSTOM_URL_TRANSFORMERS } from 'shared/components/resources/customResourceHelpers';
 
 export interface IResourceTabProps {
+    resourceDisplayName: string;
     resourceData: ResourceData[];
     urlWrapper: {
         setResourceUrl: (resourceUrl: string) => void;

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -118,10 +118,7 @@ export default class ResourceTab extends React.Component<
             <div>
                 <div style={{ display: 'flex', alignItems: 'flex-end' }}>
                     <FeatureTitle
-                        title={
-                            this.currentResourceDatum.resourceDefinition
-                                .displayName
-                        }
+                        title={this.props.resourceDisplayName}
                         isLoading={false}
                         className="pull-left"
                         style={{ marginBottom: 10 }}
@@ -130,9 +127,10 @@ export default class ResourceTab extends React.Component<
                         {this.currentResourceDatum.sampleId
                             ? this.currentResourceDatum.sampleId
                             : this.currentResourceDatum.patientId}
-                        {this.currentResourceDatum.resourceDefinition
-                            .description &&
-                            ` | ${this.currentResourceDatum.resourceDefinition.description}`}
+                        {` | ${this.props.resourceDisplayName}`}
+                        {` | ${this.currentResourceIndex + 1} of ${
+                            this.props.resourceData.length
+                        }`}
                     </p>
                 </div>
                 <div

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -7,6 +7,7 @@ import LazyMobXTable, {
     Column,
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
 import _ from 'lodash';
+import { hasNonEmptyDescriptionInResources } from 'shared/lib/ResourceUtils';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
@@ -162,8 +163,12 @@ const ResourceTable = observer(
                 sortBy: row => row.url,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.url.toUpperCase().includes(filterStringUpper ?? ''),
-            },
-            {
+            }
+        );
+
+        // Only show Description column if at least one resource has a non-empty description
+        if (hasNonEmptyDescriptionInResources(resources)) {
+            columns.push({
                 name: 'Description',
                 headerRender: () => (
                     <span data-test={'Description'}>{'Description'}</span>
@@ -175,8 +180,8 @@ const ResourceTable = observer(
                     (row.description ?? '')
                         .toUpperCase()
                         .includes(filterStringUpper ?? ''),
-            }
-        );
+            });
+        }
 
         return (
             <ResourceMobXTable

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -6,6 +6,7 @@ import { useLocalObservable } from 'mobx-react-lite';
 import LazyMobXTable, {
     Column,
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
+import _ from 'lodash';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
@@ -102,11 +103,18 @@ const ResourceTable = observer(
             });
         }
 
+        // Determine if there's only one unique resource type
+        const uniqueResourceNames = _.uniq(state.data.map(d => d.resourceName));
+        const resourceColumnName =
+            uniqueResourceNames.length === 1 && uniqueResourceNames[0]
+                ? uniqueResourceNames[0]
+                : 'Resource';
+
         columns.push(
             {
-                name: 'Resource',
+                name: resourceColumnName,
                 headerRender: () => (
-                    <span data-test={'Resource'}>{'Resource'}</span>
+                    <span data-test={'Resource'}>{resourceColumnName}</span>
                 ),
                 render: row => (
                     <a onClick={() => openResource(row.resource)}>
@@ -123,8 +131,10 @@ const ResourceTable = observer(
                         .includes(filterStringUpper ?? ''),
             },
             {
-                name: '',
-                headerRender: () => <span></span>,
+                name: 'Resource URL',
+                headerRender: () => (
+                    <span data-test={'Resource URL'}>{'Resource URL'}</span>
+                ),
                 render: row => (
                     <a
                         href={row.url}
@@ -148,11 +158,11 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Description'}>{'Description'}</span>
                 ),
-                render: row => <span>{row.description}</span>,
-                download: row => row.description || '',
-                sortBy: row => row.description || '',
+                render: row => <span>{row.description ?? ''}</span>,
+                download: row => row.description ?? '',
+                sortBy: row => row.description ?? '',
                 filter: (row, _filterString, filterStringUpper) =>
-                    (row.description || '')
+                    (row.description ?? '')
                         .toUpperCase()
                         .includes(filterStringUpper ?? ''),
             }

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { getFileExtension } from './ResourcesTableUtils';
 import { ResourceData } from 'cbioportal-ts-api-client';
-import _ from 'lodash';
 import { useLocalObservable } from 'mobx-react-lite';
+import LazyMobXTable, {
+    Column,
+} from 'shared/components/lazyMobXTable/LazyMobXTable';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
@@ -45,68 +47,131 @@ function icon(resource: ResourceData) {
     }
 }
 
+class ResourceMobXTable extends LazyMobXTable<{
+    resource: ResourceData;
+    resourceName: string;
+    url: string;
+    description?: string;
+    priority: string | number;
+    sampleId?: React.ReactNode;
+}> {}
+
 const ResourceTable = observer(
     ({ resources, isTabOpen, openResource, sampleId }: IResourceTableProps) => {
-        const resourceTable = useLocalObservable(() => ({
+        const state = useLocalObservable(() => ({
             get data() {
-                return _.sortBy(resources, r => r.resourceDefinition.priority);
+                // Map incoming resources into row data for the MobX table
+                return resources.map(r => ({
+                    resource: r,
+                    resourceName: r.resourceDefinition?.displayName ?? r.url,
+                    url: r.url,
+                    description: r.resourceDefinition?.description,
+                    priority: r.resourceDefinition?.priority ?? 0,
+                    sampleId,
+                }));
             },
         }));
 
-        return resourceTable.data.length === 0 ? (
-            <p>There are no resources for this sample.</p>
-        ) : (
-            <table className="simple-table table table-striped table-border-top">
-                <thead>
-                    <tr>
-                        {sampleId && <th>Sample ID</th>}
-                        <th>Resource</th>
-                        <th></th>
-                        {resourceTable.data.length > 0 && <th>Description</th>}
-                    </tr>
-                </thead>
-                <tbody>
-                    {resourceTable.data.length === 0 ? (
-                        <tr>
-                            <td colSpan={3} style={{ textAlign: 'center' }}>
-                                There are no results
-                            </td>
-                        </tr>
-                    ) : (
-                        resourceTable.data.map(resource => (
-                            <tr>
-                                {sampleId && <td>{sampleId}</td>}
-                                <td>
-                                    <a onClick={() => openResource(resource)}>
-                                        {icon(resource)}
-                                        {resource.resourceDefinition
-                                            .displayName || resource.url}
-                                    </a>
-                                </td>
-                                <td>
-                                    <a
-                                        href={resource.url}
-                                        style={{ fontSize: 10 }}
-                                        target={'_blank'}
-                                    >
-                                        <i
-                                            className={`fa fa-external-link fa-sm`}
-                                            style={{
-                                                marginRight: 5,
-                                                color: 'black',
-                                            }}
-                                        />
-                                        Open in new window
-                                    </a>
-                                </td>
-                                <td>
-                                    {resource.resourceDefinition.description}
-                                </td>
-                            </tr>
-                        ))
-                    )}
-                </tbody>
-            </table>
+        if (state.data.length === 0) {
+            return <p>There are no resources for this sample.</p>;
+        }
+
+        const columns: Column<{
+            resource: ResourceData;
+            resourceName: string;
+            url: string;
+            description?: string;
+            priority: string | number;
+            sampleId?: React.ReactNode;
+        }>[] = [];
+
+        if (sampleId) {
+            columns.push({
+                name: 'Sample ID',
+                headerRender: () => (
+                    <span data-test={'Sample ID'}>{'Sample ID'}</span>
+                ),
+                render: row => <span>{row.sampleId}</span>,
+                download: row => `${row.resource.sampleId ?? ''}`,
+                sortBy: row => `${row.resource.sampleId ?? ''}`,
+                filter: (row, _filterString, filterStringUpper) => {
+                    const value = `${row.resource.sampleId ??
+                        ''}`.toUpperCase();
+                    return value.includes(filterStringUpper ?? '');
+                },
+            });
+        }
+
+        columns.push(
+            {
+                name: 'Resource',
+                headerRender: () => (
+                    <span data-test={'Resource'}>{'Resource'}</span>
+                ),
+                render: row => (
+                    <a onClick={() => openResource(row.resource)}>
+                        {icon(row.resource)}
+                        {row.resourceName}
+                    </a>
+                ),
+                download: row => row.resourceName,
+                // Sort by priority to mirror previous initial ordering
+                sortBy: row => row.priority,
+                filter: (row, _filterString, filterStringUpper) =>
+                    row.resourceName
+                        .toUpperCase()
+                        .includes(filterStringUpper ?? ''),
+            },
+            {
+                name: '',
+                headerRender: () => <span></span>,
+                render: row => (
+                    <a
+                        href={row.url}
+                        style={{ fontSize: 10 }}
+                        target={'_blank'}
+                    >
+                        <i
+                            className={`fa fa-external-link fa-sm`}
+                            style={{ marginRight: 5, color: 'black' }}
+                        />
+                        Open in new window
+                    </a>
+                ),
+                download: row => row.url,
+                sortBy: row => row.url,
+                filter: (row, _filterString, filterStringUpper) =>
+                    row.url.toUpperCase().includes(filterStringUpper ?? ''),
+            },
+            {
+                name: 'Description',
+                headerRender: () => (
+                    <span data-test={'Description'}>{'Description'}</span>
+                ),
+                render: row => <span>{row.description}</span>,
+                download: row => row.description || '',
+                sortBy: row => row.description || '',
+                filter: (row, _filterString, filterStringUpper) =>
+                    (row.description || '')
+                        .toUpperCase()
+                        .includes(filterStringUpper ?? ''),
+            }
+        );
+
+        return (
+            <ResourceMobXTable
+                initialItemsPerPage={20}
+                data={state.data}
+                columns={columns}
+                showColumnVisibility={false}
+                showCountHeader={false}
+                showFilterClearButton={false}
+                showCopyDownload={true}
+                copyDownloadProps={{ showCopy: false }}
+                // Use the 'Resource' column which sorts by priority via sortBy
+                initialSortColumn={'Resource'}
+                initialSortDirection={'asc'}
+            />
         );
     }
 );

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -117,8 +117,18 @@ const ResourceTable = observer(
                     <span data-test={'Resource'}>{resourceColumnName}</span>
                 ),
                 render: row => (
-                    <a onClick={() => openResource(row.resource)}>
-                        {icon(row.resource)}
+                    <a
+                        onClick={() => openResource(row.resource)}
+                        style={{ fontSize: 10 }}
+                    >
+                        <i
+                            className={`fa fa-user fa-sm`}
+                            style={{
+                                marginRight: 5,
+                                color: 'black',
+                            }}
+                            title="Open in Patient View"
+                        />
                         {row.resourceName}
                     </a>
                 ),

--- a/src/shared/components/resources/styles.module.scss
+++ b/src/shared/components/resources/styles.module.scss
@@ -14,3 +14,56 @@
         }
     }
 }
+
+.warningBanner {
+    padding: 20px 30px;
+    background-color: #fff3cd;
+    border: 2px solid #ffc107;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    max-width: 450px;
+    margin: 0 auto;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.warningIcon {
+    color: #856404;
+    font-size: 36px;
+    margin-bottom: 12px;
+}
+
+.warningText {
+    color: #856404;
+    font-size: 14px;
+    line-height: 1.5;
+    font-weight: 500;
+    margin-bottom: 16px;
+}
+
+.refreshButton {
+    padding: 8px 16px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+        opacity: 0.9;
+        transform: translateY(-1px);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    &:active {
+        opacity: 0.8;
+        transform: translateY(0);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/src/shared/components/resources/styles.module.scss.d.ts
+++ b/src/shared/components/resources/styles.module.scss.d.ts
@@ -1,6 +1,10 @@
 declare const styles: {
   readonly "active": string;
   readonly "carouselButton": string;
+  readonly "refreshButton": string;
+  readonly "warningBanner": string;
+  readonly "warningIcon": string;
+  readonly "warningText": string;
 };
 export = styles;
 

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -1,0 +1,82 @@
+import { ResourceDefinition } from 'cbioportal-ts-api-client';
+
+/**
+ * Configuration options for customizing resource display and behavior.
+ */
+export interface ResourceCustomConfig {
+    /**
+     * Custom display name for the resource (e.g., "Samples with H&E Slides")
+     * Used in: Study View (tab name and count header)
+     */
+    customizedDisplayName?: string;
+
+    /**
+     * Whether to hide the "Resources per Patient" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hidePerPatientColumn?: boolean;
+
+    /**
+     * Mapping to rename column headers (e.g., { 'Type Of Resource': 'View' })
+     * Used in: Study View (Files & Links tab)
+     */
+    columnNameMapping?: Record<string, string>;
+
+    /**
+     * Whether to hide the "Resource URL" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hideUrlColumn?: boolean;
+
+    /**
+     * Whether resource links should open in a new tab
+     * Used in: Study View (Files & Links tab)
+     */
+    openInNewTab?: boolean;
+}
+
+export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
+    HE: {
+        customizedDisplayName: 'Samples with H&E Slides',
+        hidePerPatientColumn: true,
+        columnNameMapping: { 'Type Of Resource': 'View' },
+        hideUrlColumn: true,
+        openInNewTab: true,
+    },
+};
+
+// Type for ResourceDefinition with optional customMetaData field
+type ExtendedResourceDefinition = ResourceDefinition & {
+    customMetaData?: string;
+};
+
+export function getResourceConfig(
+    def: ResourceDefinition
+): ResourceCustomConfig {
+    let config: ResourceCustomConfig = {};
+    const extendedDef = def as ExtendedResourceDefinition;
+
+    // 1. Load from local dictionary
+    if (def.resourceId && RESOURCE_CUSTOM_CONFIGS[def.resourceId]) {
+        config = { ...RESOURCE_CUSTOM_CONFIGS[def.resourceId] };
+    }
+
+    // 2. Override with customMetaData
+    if (extendedDef.customMetaData) {
+        try {
+            const customConfig = JSON.parse(
+                extendedDef.customMetaData
+            ) as Partial<ResourceCustomConfig>;
+            // Merge all properties from customConfig into config
+            // This automatically handles all current and future properties
+            Object.assign(config, customConfig);
+        } catch (e) {
+            console.warn(
+                `Failed to parse customMetaData for resource ${def.resourceId}`,
+                e
+            );
+        }
+    }
+
+    return config;
+}

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -33,6 +33,12 @@ export interface ResourceCustomConfig {
      * Used in: Study View (Files & Links tab)
      */
     openInNewTab?: boolean;
+
+    /**
+     * Custom error message to show when iframe fails to load
+     * Used in: Patient View (resource iframe)
+     */
+    iframeErrorMessage?: string;
 }
 
 export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
@@ -42,6 +48,8 @@ export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
         columnNameMapping: { 'Type Of Resource': 'View' },
         hideUrlColumn: true,
         openInNewTab: true,
+        iframeErrorMessage:
+            'This resource requires VPN access. Please connect to VPN and refresh the page.',
     },
 };
 

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -42,7 +42,7 @@ export interface ResourceCustomConfig {
 }
 
 export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
-    HE: {
+    MSK_HNE: {
         customizedDisplayName: 'Samples with H&E Slides',
         hidePerPatientColumn: true,
         columnNameMapping: { 'Type Of Resource': 'View' },

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -1,16 +1,47 @@
 import { ResourceDefinition } from 'cbioportal-ts-api-client';
 
+/**
+ * Configuration options for customizing resource display and behavior.
+ */
 export interface ResourceCustomConfig {
+    /**
+     * Custom display name for the resource (e.g., "Samples with H&E Slides")
+     * Used in: Study View (tab name and count header)
+     */
     customizedDisplayName?: string;
-    columnHeader?: string;
-    hideResourcesPerPatientColumn?: boolean;
+
+    /**
+     * Whether to hide the "Resources per Patient" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hidePerPatientColumn?: boolean;
+
+    /**
+     * Mapping to rename column headers (e.g., { 'Type Of Resource': 'View' })
+     * Used in: Study View (Files & Links tab)
+     */
+    columnNameMapping?: Record<string, string>;
+
+    /**
+     * Whether to hide the "Resource URL" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hideUrlColumn?: boolean;
+
+    /**
+     * Whether resource links should open in a new tab
+     * Used in: Study View (Files & Links tab)
+     */
+    openInNewTab?: boolean;
 }
 
 export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
     HE: {
-        customizedDisplayName: 'H&E Samples with Slides',
-        columnHeader: 'H&E Slides per Sample',
-        hideResourcesPerPatientColumn: true,
+        customizedDisplayName: 'Samples with H&E Slides',
+        hidePerPatientColumn: true,
+        columnNameMapping: { 'Type Of Resource': 'View' },
+        hideUrlColumn: true,
+        openInNewTab: true,
     },
 };
 
@@ -33,21 +64,12 @@ export function getResourceConfig(
     // 2. Override with customMetaData
     if (extendedDef.customMetaData) {
         try {
-            const customConfig = JSON.parse(extendedDef.customMetaData);
-            if (customConfig.customizedDisplayName) {
-                config.customizedDisplayName =
-                    customConfig.customizedDisplayName;
-            } else if (customConfig.tabLabel) {
-                // Fallback for backward compatibility
-                config.customizedDisplayName = customConfig.tabLabel;
-            }
-            if (customConfig.columnHeader) {
-                config.columnHeader = customConfig.columnHeader;
-            }
-            if (customConfig.hideResourcesPerPatientColumn !== undefined) {
-                config.hideResourcesPerPatientColumn =
-                    customConfig.hideResourcesPerPatientColumn;
-            }
+            const customConfig = JSON.parse(
+                extendedDef.customMetaData
+            ) as Partial<ResourceCustomConfig>;
+            // Merge all properties from customConfig into config
+            // This automatically handles all current and future properties
+            Object.assign(config, customConfig);
         } catch (e) {
             console.warn(
                 `Failed to parse customMetaData for resource ${def.resourceId}`,

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -1,82 +1,33 @@
 import { ResourceDefinition } from 'cbioportal-ts-api-client';
+import _ from 'lodash';
 
 /**
- * Configuration options for customizing resource display and behavior.
+ * Helper function to check if a string is non-empty
  */
-export interface ResourceCustomConfig {
-    /**
-     * Custom display name for the resource (e.g., "Samples with H&E Slides")
-     * Used in: Study View (tab name and count header)
-     */
-    customizedDisplayName?: string;
-
-    /**
-     * Whether to hide the "Resources per Patient" column
-     * Used in: Study View (Files & Links tab)
-     */
-    hidePerPatientColumn?: boolean;
-
-    /**
-     * Mapping to rename column headers (e.g., { 'Type Of Resource': 'View' })
-     * Used in: Study View (Files & Links tab)
-     */
-    columnNameMapping?: Record<string, string>;
-
-    /**
-     * Whether to hide the "Resource URL" column
-     * Used in: Study View (Files & Links tab)
-     */
-    hideUrlColumn?: boolean;
-
-    /**
-     * Whether resource links should open in a new tab
-     * Used in: Study View (Files & Links tab)
-     */
-    openInNewTab?: boolean;
+function isNonEmptyString(value: string | undefined): boolean {
+    return !_.isEmpty(value);
 }
 
-export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
-    HE: {
-        customizedDisplayName: 'Samples with H&E Slides',
-        hidePerPatientColumn: true,
-        columnNameMapping: { 'Type Of Resource': 'View' },
-        hideUrlColumn: true,
-        openInNewTab: true,
-    },
-};
-
-// Extend ResourceDefinition to include customMetaData if it's missing in the types
-interface ExtendedResourceDefinition extends ResourceDefinition {
-    customMetaData?: string;
+/**
+ * Checks if any resource definition has a non-empty description.
+ * @param definitions Array of resource definitions to check
+ * @returns true if at least one definition has a non-empty description
+ */
+export function hasNonEmptyDescriptionInDefinitions(
+    definitions: ResourceDefinition[] | undefined
+): boolean {
+    return definitions?.some(def => isNonEmptyString(def.description)) ?? false;
 }
 
-export function getResourceConfig(
-    def: ResourceDefinition
-): ResourceCustomConfig {
-    let config: ResourceCustomConfig = {};
-    const extendedDef = def as ExtendedResourceDefinition;
-
-    // 1. Load from local dictionary
-    if (def.resourceId && RESOURCE_CUSTOM_CONFIGS[def.resourceId]) {
-        config = { ...RESOURCE_CUSTOM_CONFIGS[def.resourceId] };
-    }
-
-    // 2. Override with customMetaData
-    if (extendedDef.customMetaData) {
-        try {
-            const customConfig = JSON.parse(
-                extendedDef.customMetaData
-            ) as Partial<ResourceCustomConfig>;
-            // Merge all properties from customConfig into config
-            // This automatically handles all current and future properties
-            Object.assign(config, customConfig);
-        } catch (e) {
-            console.warn(
-                `Failed to parse customMetaData for resource ${def.resourceId}`,
-                e
-            );
-        }
-    }
-
-    return config;
+/**
+ * Checks if any resource has a non-empty description in its resource definition.
+ * @param resources Array of resource data to check
+ * @returns true if at least one resource has a non-empty description
+ */
+export function hasNonEmptyDescriptionInResources(
+    resources: { resourceDefinition?: ResourceDefinition }[]
+): boolean {
+    return resources.some(r =>
+        isNonEmptyString(r.resourceDefinition?.description)
+    );
 }

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -1,0 +1,60 @@
+import { ResourceDefinition } from 'cbioportal-ts-api-client';
+
+export interface ResourceCustomConfig {
+    customizedDisplayName?: string;
+    columnHeader?: string;
+    hideResourcesPerPatientColumn?: boolean;
+}
+
+export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
+    HE: {
+        customizedDisplayName: 'H&E Samples with Slides',
+        columnHeader: 'H&E Slides per Sample',
+        hideResourcesPerPatientColumn: true,
+    },
+};
+
+// Extend ResourceDefinition to include customMetaData if it's missing in the types
+interface ExtendedResourceDefinition extends ResourceDefinition {
+    customMetaData?: string;
+}
+
+export function getResourceConfig(
+    def: ResourceDefinition
+): ResourceCustomConfig {
+    let config: ResourceCustomConfig = {};
+    const extendedDef = def as ExtendedResourceDefinition;
+
+    // 1. Load from local dictionary
+    if (def.resourceId && RESOURCE_CUSTOM_CONFIGS[def.resourceId]) {
+        config = { ...RESOURCE_CUSTOM_CONFIGS[def.resourceId] };
+    }
+
+    // 2. Override with customMetaData
+    if (extendedDef.customMetaData) {
+        try {
+            const customConfig = JSON.parse(extendedDef.customMetaData);
+            if (customConfig.customizedDisplayName) {
+                config.customizedDisplayName =
+                    customConfig.customizedDisplayName;
+            } else if (customConfig.tabLabel) {
+                // Fallback for backward compatibility
+                config.customizedDisplayName = customConfig.tabLabel;
+            }
+            if (customConfig.columnHeader) {
+                config.columnHeader = customConfig.columnHeader;
+            }
+            if (customConfig.hideResourcesPerPatientColumn !== undefined) {
+                config.hideResourcesPerPatientColumn =
+                    customConfig.hideResourcesPerPatientColumn;
+            }
+        } catch (e) {
+            console.warn(
+                `Failed to parse customMetaData for resource ${def.resourceId}`,
+                e
+            );
+        }
+    }
+
+    return config;
+}


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11682

### How to test:
- Please set `localStorage.netlify = "deploy-preview-5270--cbioportalfrontend"` in the browser console first and refresh the page
- [Study view page](https://triage.cbioportal.mskcc.org/study/filesAndLinks?id=coad_msk_2025)
- Patient view page

### Changes Made

#### Study View - Files & Links Table
- Made table **searchable** and **downloadable** (CSV export)
<img width="269" height="59" alt="image" src="https://github.com/user-attachments/assets/52aa4637-1f9d-4ca6-a28e-b2c68e58c00a" />

- Added **visual indicators** for navigation clarity:
  - **User icon** (fa-user) with "Open in Patient View" tooltip on "Type Of Resource" column -
opens resource in Patient View
  - **External link icon** (fa-external-link) with "Open in new window" text on "Resource URL"
column - opens URL in new tab
    <img width="451" height="75" alt="image" src="https://github.com/user-attachments/assets/71a9bb99-cdb0-45de-b906-7b01f6031117" />

- **Dynamic column naming**: When all resources are the same type, "Resources per Patient"
column header changes to specific type (e.g., "Pathology Reports per Patient")
- **Consistent pluralization**: Tab name and header always show plural form when single
resource type (e.g., "H&E Slides")
  <img width="545" height="136" alt="image" src="https://github.com/user-attachments/assets/99cffa41-56bc-4fd9-8fca-90a82552a91d" />
- **Show customized text for samples**: Since now we only have one link per sample, so we need to change the text to better convey what do we have: e.g. `xx H&E Samples with Slides`
  <img width="327" height="86" alt="image" src="https://github.com/user-attachments/assets/9fb2941f-6019-4784-bbb1-ffade7de2d66" />
- **Hide Recources Per Patient column**: For the same reason (we only have one link per sample), we should hide this column too


#### Patient View - Files & Links Table
- Made table **searchable** and **downloadable** (CSV export)
<img width="269" height="59" alt="image" src="https://github.com/user-attachments/assets/52aa4637-1f9d-4ca6-a28e-b2c68e58c00a" />

- Added **user icon** (fa-user) on resource name column to indicate it opens in Patient View
- Added **external link icon** (fa-external-link) on "Resource URL" column for external links
    <img width="451" height="75" alt="image" src="https://github.com/user-attachments/assets/71a9bb99-cdb0-45de-b906-7b01f6031117" />

- **Dynamic column naming**: When all resources are the same type, column shows resource type
name instead of generic "Resource"
    <img width="202" height="108" alt="image" src="https://github.com/user-attachments/assets/957fe36b-0517-49dc-a05b-942a62988120" />

- **Smart tab name pluralization**:
  - Single resource: "Pathology Report"
  - Multiple resources: "Pathology Reports (3)"

#### Patient View - Resource Viewer
- Added **resource counter** display: "1 of 3", "2 of 3", etc.
- Uses pluralized resource names throughout (title and metadata)
- Helps users track position when navigating through multiple resources
<img width="709" height="99" alt="Screenshot 2025-11-06 at 5 28 36 PM" src="https://github.com/user-attachments/assets/41ae36e7-f7d1-443f-9026-a86bb2943798" />
