### PR TITLE
Feature/study view log scale numerical 11261

### DIFF
--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -54,6 +54,7 @@ import {
     isLogScaleByDataBins,
     isLogScaleByValues,
     isOccupied,
+    logScalePossible,
     makePatientToClinicalAnalysisGroup,
     needAdditionShiftForLogScaleBarChart,
     pickClinicalDataColors,
@@ -5200,5 +5201,140 @@ describe('StudyViewUtils', () => {
                 );
             }
         );
+    });
+
+    describe('logScalePossible', () => {
+        it('should return true for clinical attribute with NUMBER datatype', () => {
+            const numberAttribute = {
+                clinicalAttributeId: 'AGE',
+                datatype: 'NUMBER',
+                displayName: 'Age',
+            } as any;
+            assert.isTrue(logScalePossible(numberAttribute));
+        });
+
+        it('should return true for MUTATION_COUNT with NUMBER datatype', () => {
+            const mutationCountAttribute = {
+                clinicalAttributeId: 'MUTATION_COUNT',
+                datatype: 'NUMBER',
+                displayName: 'Mutation Count',
+            } as any;
+            assert.isTrue(logScalePossible(mutationCountAttribute));
+        });
+
+        it('should return false for clinical attribute with STRING datatype', () => {
+            const stringAttribute = {
+                clinicalAttributeId: 'GENDER',
+                datatype: 'STRING',
+                displayName: 'Gender',
+            } as any;
+            assert.isFalse(logScalePossible(stringAttribute));
+        });
+
+        it('should return false for clinical attribute with undefined datatype', () => {
+            const undefinedAttribute = {
+                clinicalAttributeId: 'UNKNOWN',
+                displayName: 'Unknown',
+            } as any;
+            assert.isFalse(logScalePossible(undefinedAttribute));
+        });
+
+        it('should return false for null clinical attribute', () => {
+            const nullAttribute = null as any;
+            assert.isFalse(logScalePossible(nullAttribute));
+        });
+
+        it('should return false for clinical attribute with null datatype', () => {
+            const nullDatatypeAttribute = {
+                clinicalAttributeId: 'TEST',
+                datatype: null,
+                displayName: 'Test',
+            } as any;
+            assert.isFalse(logScalePossible(nullDatatypeAttribute));
+        });
+
+        it('should return false for clinical attribute with empty string datatype', () => {
+            const emptyDatatypeAttribute = {
+                clinicalAttributeId: 'TEST',
+                datatype: '',
+                displayName: 'Test',
+            } as any;
+            assert.isFalse(logScalePossible(emptyDatatypeAttribute));
+        });
+
+        it('should handle case sensitivity - lowercase "number" should not work', () => {
+            const lowerCaseAttribute = {
+                clinicalAttributeId: 'AGE',
+                datatype: 'number',
+                displayName: 'Age',
+            } as any;
+            assert.isFalse(logScalePossible(lowerCaseAttribute));
+        });
+
+        it('should handle case sensitivity - mixed case should not work', () => {
+            const mixedCaseAttribute = {
+                clinicalAttributeId: 'AGE',
+                datatype: 'Number',
+                displayName: 'Age',
+            } as any;
+            assert.isFalse(logScalePossible(mixedCaseAttribute));
+        });
+
+        it('should return true for FRACTION_GENOME_ALTERED with NUMBER datatype', () => {
+            const fgaAttribute = {
+                clinicalAttributeId: 'FRACTION_GENOME_ALTERED',
+                datatype: 'NUMBER',
+                displayName: 'Fraction Genome Altered',
+            } as any;
+            assert.isTrue(logScalePossible(fgaAttribute));
+        });
+
+        it('should return true for TMB_NONSYNONYMOUS with NUMBER datatype', () => {
+            const tmbAttribute = {
+                clinicalAttributeId: 'TMB_NONSYNONYMOUS',
+                datatype: 'NUMBER',
+                displayName: 'TMB',
+            } as any;
+            assert.isTrue(logScalePossible(tmbAttribute));
+        });
+
+        it('should return false for CANCER_TYPE with STRING datatype', () => {
+            const cancerTypeAttribute = {
+                clinicalAttributeId: 'CANCER_TYPE',
+                datatype: 'STRING',
+                displayName: 'Cancer Type',
+            } as any;
+            assert.isFalse(logScalePossible(cancerTypeAttribute));
+        });
+
+        it('should return false for unknown datatype', () => {
+            const unknownDatatypeAttribute = {
+                clinicalAttributeId: 'TEST',
+                datatype: 'BOOLEAN',
+                displayName: 'Test',
+            } as any;
+            assert.isFalse(logScalePossible(unknownDatatypeAttribute));
+        });
+
+        it('should return false for attribute with datatype containing whitespace', () => {
+            const whitespaceAttribute = {
+                clinicalAttributeId: 'TEST',
+                datatype: ' NUMBER ',
+                displayName: 'Test',
+            } as any;
+            assert.isFalse(logScalePossible(whitespaceAttribute));
+        });
+
+        it('should return false for empty object', () => {
+            const emptyAttribute = {} as any;
+            assert.isFalse(logScalePossible(emptyAttribute));
+        });
+
+        it('should return false for attribute with only displayName', () => {
+            const onlyDisplayName = {
+                displayName: 'Test',
+            } as any;
+            assert.isFalse(logScalePossible(onlyDisplayName));
+        });
     });
 });

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -12,6 +12,7 @@ import {
     clinicalDataCountComparator,
     customBinsAreValid,
     DataBin,
+    DataType,
     driverTierFilterActive,
     filterCategoryBins,
     filterIntervalBins,
@@ -57,6 +58,7 @@ import {
     isLogScaleByDataBins,
     isLogScaleByValues,
     isOccupied,
+    logScalePossible,
     makePatientToClinicalAnalysisGroup,
     needAdditionShiftForLogScaleBarChart,
     pickClinicalDataColors,
@@ -5423,6 +5425,47 @@ describe('StudyViewUtils', () => {
                     { AMP: true, HOMDEL: false }
                 );
             });
+        });
+    });
+        describe('logScalePossible', () => {
+        it('should return true for clinical attribute with NUMBER datatype', () => {
+            const numberAttribute = {
+                clinicalAttributeId: 'AGE',
+                datatype: DataType.NUMBER,
+                displayName: 'Age',
+            } as ClinicalAttribute;
+
+            assert.isTrue(logScalePossible(numberAttribute));
+        });
+
+        it('should return true for MUTATION_COUNT with NUMBER datatype', () => {
+            const mutationCountAttribute = {
+                clinicalAttributeId: 'MUTATION_COUNT',
+                datatype: DataType.NUMBER,
+                displayName: 'Mutation Count',
+            } as ClinicalAttribute;
+
+            assert.isTrue(logScalePossible(mutationCountAttribute));
+        });
+
+        it('should return false for clinical attribute with STRING datatype', () => {
+            const stringAttribute = {
+                clinicalAttributeId: 'GENDER',
+                datatype: DataType.STRING,
+                displayName: 'Gender',
+            } as ClinicalAttribute;
+
+            assert.isFalse(logScalePossible(stringAttribute));
+        });
+
+        it('should return false for MUTATION_COUNT when datatype is not NUMBER', () => {
+            const mutationCountStringAttribute = {
+                clinicalAttributeId: 'MUTATION_COUNT',
+                datatype: DataType.STRING,
+                displayName: 'Mutation Count',
+            } as ClinicalAttribute;
+
+            assert.isFalse(logScalePossible(mutationCountStringAttribute));
         });
     });
 });

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -4071,8 +4071,8 @@ export function getBinBounds(bins: DensityPlotBin[]) {
     };
 }
 
-export function logScalePossible(clinicalAttributeId: string) {
-    return clinicalAttributeId === SpecialChartsUniqueKeyEnum.MUTATION_COUNT;
+export function logScalePossible(clinicalAttribute: ClinicalAttribute) {
+    return clinicalAttribute?.datatype === DataType.NUMBER;
 }
 
 export function makeXvsYUniqueKey(xAttrId: string, yAttrId: string) {

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -4185,8 +4185,8 @@ export function getBinBounds(bins: DensityPlotBin[]) {
     };
 }
 
-export function logScalePossible(clinicalAttributeId: string) {
-    return clinicalAttributeId === SpecialChartsUniqueKeyEnum.MUTATION_COUNT;
+export function logScalePossible(clinicalAttribute: ClinicalAttribute) {
+    return clinicalAttribute.datatype === DataType.NUMBER;
 }
 
 export function makeXvsYUniqueKey(xAttrId: string, yAttrId: string) {

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -681,7 +681,7 @@ export class StudySummaryTab extends React.Component<
                     axisLabelX: chartInfo.categoricalAttr.displayName,
                     axisLabelY: chartInfo.numericalAttr.displayName,
                     showLogScaleToggle: logScalePossible(
-                        chartInfo.numericalAttr.clinicalAttributeId
+                        chartInfo.numericalAttr
                     ),
                     logScaleChecked: settings.violinLogScale,
                     onToggleLogScale: () => {
@@ -764,10 +764,10 @@ export class StudySummaryTab extends React.Component<
                         yAxisLogScale: !!settings.yLogScale,
                     }),
                     showLogScaleXToggle: logScalePossible(
-                        chartInfo.xAttr.clinicalAttributeId
+                        chartInfo.xAttr
                     ),
                     showLogScaleYToggle: logScalePossible(
-                        chartInfo.yAttr.clinicalAttributeId
+                        chartInfo.yAttr
                     ),
                     logScaleXChecked: settings.xLogScale,
                     logScaleYChecked: settings.yLogScale,

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -682,7 +682,7 @@ export class StudySummaryTab extends React.Component<
                     axisLabelX: chartInfo.categoricalAttr.displayName,
                     axisLabelY: chartInfo.numericalAttr.displayName,
                     showLogScaleToggle: logScalePossible(
-                        chartInfo.numericalAttr.clinicalAttributeId
+                        chartInfo.numericalAttr
                     ),
                     logScaleChecked: settings.violinLogScale,
                     onToggleLogScale: () => {
@@ -764,12 +764,8 @@ export class StudySummaryTab extends React.Component<
                         xAxisLogScale: !!settings.xLogScale,
                         yAxisLogScale: !!settings.yLogScale,
                     }),
-                    showLogScaleXToggle: logScalePossible(
-                        chartInfo.xAttr.clinicalAttributeId
-                    ),
-                    showLogScaleYToggle: logScalePossible(
-                        chartInfo.yAttr.clinicalAttributeId
-                    ),
+                    showLogScaleXToggle: logScalePossible(chartInfo.xAttr),
+                    showLogScaleYToggle: logScalePossible(chartInfo.yAttr),
                     logScaleXChecked: settings.xLogScale,
                     logScaleYChecked: settings.yLogScale,
                     onToggleLogScaleX: () => {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#11261 

- Modified `logScalePossible` function in `StudyViewUtils.tsx` to check `datatype === DataType.NUMBER` instead of hardcoding `clinicalAttributeId === MUTATION_COUNT`
- Updated `SummaryTab.tsx` to pass the full `ClinicalAttribute` object to `logScalePossible` instead of just the ID
- Added comprehensive unit tests for the `logScalePossible` function

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?

**Before:** Only "Log Scale Y" appears (for Mutation Count)

<img width="413" height="372" alt="image" src="https://github.com/user-attachments/assets/e57d981a-fc65-4fa0-bdab-6b7bf7288dd5" />


**After:** Both "Log Scale X" and "Log Scale Y" appear for any numerical attribute

<img width="413" height="372" alt="Screenshot 2025-12-28 at 9 16 26 PM" src="https://github.com/user-attachments/assets/f926273d-cf6f-4e36-b9d7-99009f0dc3c2" />

## Notify reviewers
@inodb 