### PR TITLE
Add dev server proxy and mobile error overlay for local development

### DIFF
--- a/my-index.ejs
+++ b/my-index.ejs
@@ -8,7 +8,32 @@
 
         window.devContext = true;
         window.frontendConfig = {
+            apiRoot: window.location.origin + '/',
+            baseUrl: window.location.host
         }
+
+        // Visible error display for mobile debugging
+        window.onerror = function(msg, url, line, col, error) {
+            var errorDiv = document.getElementById('mobileErrorLog');
+            if (!errorDiv) {
+                errorDiv = document.createElement('div');
+                errorDiv.id = 'mobileErrorLog';
+                errorDiv.style.cssText = 'position:fixed;bottom:0;left:0;right:0;max-height:40vh;overflow:auto;background:#ff000099;color:white;padding:10px;font-size:12px;z-index:99999;font-family:monospace;';
+                document.body.appendChild(errorDiv);
+            }
+            errorDiv.innerHTML += '<div style="border-bottom:1px solid white;padding:5px 0;">' + msg + '<br>at ' + url + ':' + line + '</div>';
+            return false;
+        };
+        window.addEventListener('unhandledrejection', function(e) {
+            var errorDiv = document.getElementById('mobileErrorLog');
+            if (!errorDiv) {
+                errorDiv = document.createElement('div');
+                errorDiv.id = 'mobileErrorLog';
+                errorDiv.style.cssText = 'position:fixed;bottom:0;left:0;right:0;max-height:40vh;overflow:auto;background:#ff000099;color:white;padding:10px;font-size:12px;z-index:99999;font-family:monospace;';
+                document.body.appendChild(errorDiv);
+            }
+            errorDiv.innerHTML += '<div style="border-bottom:1px solid white;padding:5px 0;">Promise: ' + (e.reason ? e.reason.message || e.reason : 'unknown') + '</div>';
+        });
 
         /* REMOVED: This is an example of how to add custom tabs to the patient page. Enabling this will clobber localStorage.frontendConfig that is set through the browser console
         localStorage.frontendConfig = JSON.stringify(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -390,13 +390,32 @@ var config = {
             },
         },
         https: false,
-        host: 'localhost',
+        host: '0.0.0.0',
         headers: { 'Access-Control-Allow-Origin': '*' },
         allowedHosts: 'all',
         devMiddleware: {
             publicPath: '/',
             stats: 'errors-only',
         },
+        proxy: process.env.CBIOPORTAL_URL
+            ? {
+                  '/api': {
+                      target: process.env.CBIOPORTAL_URL,
+                      changeOrigin: true,
+                      secure: true,
+                  },
+                  '/config_service': {
+                      target: process.env.CBIOPORTAL_URL,
+                      changeOrigin: true,
+                      secure: true,
+                  },
+                  '/proxy': {
+                      target: process.env.CBIOPORTAL_URL,
+                      changeOrigin: true,
+                      secure: true,
+                  },
+              }
+            : undefined,
     },
 };
 


### PR DESCRIPTION
## Summary
- Add API proxy to webpack dev server to avoid CORS issues when accessing from remote devices (e.g., mobile via SSH port forwarding)
- Configure frontendConfig to use local origin for API requests
- Add visible error overlay for debugging on devices without console access
- Change dev server host to 0.0.0.0 to allow network access

## Test plan
- Run `yarn run start` or the lean dev server setup
- Access from a remote device via port forwarding
- Verify study view loads without CORS errors

🤖 Generated with [Claude Code](https://claude.ai/code)