### PR TITLE
Fix Clinical Data table headers disappearing while scrolling

### DIFF
--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -378,6 +378,7 @@ export class ClinicalDataTab extends React.Component<
                                 <Else>
                                     <ClinicalDataTabTableComponent
                                         initialItemsPerPage={20}
+                                        tableMaxHeight="calc(100vh - 220px)"
                                         headerComponent={
                                             <div className={'positionAbsolute'}>
                                                 <strong>

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -1317,6 +1317,8 @@ export default class LazyMobXTable<T> extends React.Component<
                     overflowX: this.props.enableHorizontalScroll
                         ? 'auto'
                         : 'visible',
+                    maxHeight: 'calc(100vh - 220px)',
+                    overflowY: 'auto',
                 }}
             >
                 {(this.props.showLoading && this.props.loadingComponent) ||

--- a/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
+++ b/src/shared/components/lazyMobXTable/LazyMobXTable.tsx
@@ -77,6 +77,7 @@ export type Column<T> = {
 };
 
 type LazyMobXTableProps<T> = {
+    tableMaxHeight?: string;
     className?: string;
     columns: Column<T>[];
     data?: T[];
@@ -1317,8 +1318,11 @@ export default class LazyMobXTable<T> extends React.Component<
                     overflowX: this.props.enableHorizontalScroll
                         ? 'auto'
                         : 'visible',
-                    maxHeight: 'calc(100vh - 220px)',
-                    overflowY: 'auto',
+
+                    ...(this.props.tableMaxHeight && {
+                        maxHeight: this.props.tableMaxHeight,
+                        overflowY: 'auto',
+                    }),
                 }}
             >
                 {(this.props.showLoading && this.props.loadingComponent) ||

--- a/src/shared/components/lazyMobXTable/styles.scss
+++ b/src/shared/components/lazyMobXTable/styles.scss
@@ -45,3 +45,11 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.lazy-mobx-table table thead th {
+    position: sticky;
+    top: 0;
+    background: #ffffff;
+    z-index: 10;
+    border-bottom: 2px solid #ddd;
+}

--- a/src/shared/components/simpleTable/styles.scss
+++ b/src/shared/components/simpleTable/styles.scss
@@ -38,17 +38,3 @@
         background-color: $borderColor;
     }
 }
-
-.lazy-mobx-table table thead {
-    position: sticky;
-    top: 0px;
-    z-index: 200;
-}
-
-.lazy-mobx-table table thead th {
-    position: sticky;
-    top: 0px;
-    background: #ffffff;
-    z-index: 201;
-    border-bottom: 2px solid #ddd;
-}

--- a/src/shared/components/simpleTable/styles.scss
+++ b/src/shared/components/simpleTable/styles.scss
@@ -2,7 +2,7 @@
     th {
         padding-left: 10px;
         padding-bottom: 5px;
-        background-color: rgb(255, 255, 255); // solid background
+        background-color: rgb(255, 255, 255);
     }
 
     tbody > tr:nth-of-type(odd).highlighted {
@@ -10,7 +10,6 @@
     }
 
     tbody > tr:nth-of-type(even) {
-        // solid background - hard coded hack, react-bootstrap .table-striped makes ODD # rows grey
         background-color: rgb(255, 255, 255);
     }
 
@@ -38,4 +37,18 @@
         border-color: transparent !important;
         background-color: $borderColor;
     }
+}
+
+.lazy-mobx-table table thead {
+    position: sticky;
+    top: 0px;
+    z-index: 200;
+}
+
+.lazy-mobx-table table thead th {
+    position: sticky;
+    top: 0px;
+    background: #ffffff;
+    z-index: 201;
+    border-bottom: 2px solid #ddd;
 }


### PR DESCRIPTION
### Problem

When scrolling through large datasets in the Clinical Data tab, table headers disappear, making it difficult to understand column values.

### Solution

Implemented a sticky table header and added a scroll container for the table using dynamic viewport height (`calc(100vh - 220px)`).

### Result

* Headers remain visible during scrolling
* Table scrolling works correctly
* Extra whitespace below the table is removed

This improves usability when browsing large clinical datasets.