### PR TITLE
Fix plots overlap messaging for patient-based clinical attributes#10768

### DIFF
--- a/src/shared/components/plots/PlotsTab.tsx
+++ b/src/shared/components/plots/PlotsTab.tsx
@@ -59,6 +59,7 @@ import {
     getColoringMenuOptionValue,
     basicAppearance,
     getAxisDataOverlapSampleCount,
+    getAxisDataOverlapPatientCount,
     isAlterationTypePresent,
     getCacheQueries,
     getCategoryOptions,
@@ -736,6 +737,48 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
             this.horzAxisDataPromise.result!,
             this.vertAxisDataPromise.result!
         );
+        const horzClinicalAttribute =
+            this.horzSelection.dataType === CLIN_ATTR_DATA_TYPE
+                ? this.clinicalAttributeIdToClinicalAttribute.result?.[
+                      this.horzSelection.dataSourceId!
+                  ]
+                : this.horzSelection.dataType === CUSTOM_ATTR_DATA_TYPE
+                ? this.customAttributeIdToClinicalAttribute.result?.[
+                      this.horzSelection.dataSourceId!
+                  ]
+                : undefined;
+
+        const vertClinicalAttribute =
+            this.vertSelection.dataType === CLIN_ATTR_DATA_TYPE
+                ? this.clinicalAttributeIdToClinicalAttribute.result?.[
+                      this.vertSelection.dataSourceId!
+                  ]
+                : this.vertSelection.dataType === CUSTOM_ATTR_DATA_TYPE
+                ? this.customAttributeIdToClinicalAttribute.result?.[
+                      this.vertSelection.dataSourceId!
+                  ]
+                : undefined;
+
+        const horzIsPatientAttribute = !!horzClinicalAttribute?.patientAttribute;
+        const vertIsPatientAttribute = !!vertClinicalAttribute?.patientAttribute;
+
+        const bothAxesPatientBased =
+            horzIsPatientAttribute && vertIsPatientAttribute;
+        const mixedPatientAndSample =
+            horzIsPatientAttribute !== vertIsPatientAttribute;
+
+        const axisOverlapPatientCount = getAxisDataOverlapPatientCount(
+            this.horzAxisDataPromise.result!,
+            this.vertAxisDataPromise.result!,
+            this.props.sampleKeyToSample.result!
+        );
+
+        const overlapCountToDisplay = bothAxesPatientBased
+            ? axisOverlapPatientCount
+            : axisOverlapSampleCount;
+
+        const overlapUnitLabel = bothAxesPatientBased ? 'patients' : 'samples';
+
         let horzAxisStudies: CancerStudy[] = [];
         let vertAxisStudies: CancerStudy[] = [];
         let isHorzAxisNoneOptionSelected = false;
@@ -925,7 +968,7 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
         components.push(
             <div>
                 <strong>Intersection of the two axes: </strong>
-                {`${axisOverlapSampleCount} samples from ${
+                {`${overlapCountToDisplay} ${overlapUnitLabel} from ${
                     intersectionStudiesOfTwoAxis.length
                 } ${Pluralize('study', intersectionStudiesOfTwoAxis.length)}`}
             </div>
@@ -943,7 +986,13 @@ export default class PlotsTab extends React.Component<IPlotsTabProps, {}> {
             this.vertSelection.mutationCountBy ===
                 MutationCountBy.VariantAlleleFrequency;
 
-        let mainMessage = `Showing ${axisOverlapSampleCount} samples with data in both profiles (axes)`;
+        let mainMessage = `Showing ${overlapCountToDisplay} ${overlapUnitLabel} with data in both profiles (axes)`;
+
+        if (mixedPatientAndSample) {
+            mainMessage +=
+                '. Warning: one axis is patient-based and the other is sample-based, so sample counts are shown.';
+        }
+
         if (isHorzAxisVAF || isVertAxisVAF) {
             mainMessage +=
                 '. Samples without mutations or Variant Allele Frequency data are excluded from the plot';

--- a/src/shared/components/plots/PlotsTabUtils.tsx
+++ b/src/shared/components/plots/PlotsTabUtils.tsx
@@ -3706,6 +3706,40 @@ export function getAxisDataOverlapSampleCount(
     ).length;
 }
 
+export function getAxisDataOverlapPatientCount(
+    firstAxisData: IAxisData,
+    secondAxisData: IAxisData,
+    sampleKeyToSample: _.Dictionary<Sample>
+): number {
+    if (firstAxisData.data.length === 0) {
+        return _.uniq(
+            secondAxisData.data
+                .map(d => sampleKeyToSample[d.uniqueSampleKey]?.patientId)
+                .filter(Boolean)
+        ).length;
+    } else if (secondAxisData.data.length === 0) {
+        return _.uniq(
+            firstAxisData.data
+                .map(d => sampleKeyToSample[d.uniqueSampleKey]?.patientId)
+                .filter(Boolean)
+        ).length;
+    }
+
+    const firstPatientIds = _.uniq(
+        firstAxisData.data
+            .map(d => sampleKeyToSample[d.uniqueSampleKey]?.patientId)
+            .filter(Boolean)
+    );
+
+    const secondPatientIds = _.uniq(
+        secondAxisData.data
+            .map(d => sampleKeyToSample[d.uniqueSampleKey]?.patientId)
+            .filter(Boolean)
+    );
+
+    return _.intersection(firstPatientIds, secondPatientIds).length;
+}
+
 export function getLimitValues(data: any[]): string[] {
     return _(data)
         .filter(d => {


### PR DESCRIPTION
Fixes cBioPortal/cbioportal#10768

On plots tab if both axes are patient based attributes, show patient counts
Summary
This PR fixes overlap count messaging in the Plots tab when clinical attributes are patient-based.

What changed
1. added helper to compute overlap by patient count
2. show patient counts when both selected axes are patient-based
3. added warning message for mixed patient/sample axis selections
4. keep sample counts when axes are mixed patient-based and sample-based
5. updated both the main alert message and the intersection tooltip text

Verification
Tested locally with:
1. sample vs sample attributes -> shows sample counts
2. patient vs patient attributes -> shows patient counts
3. patient vs sample attributes -> shows sample counts with warning
