### PR TITLE
Added a support to remove "Reference genome" form the search dropdown…

### DIFF
--- a/src/shared/components/query/CancerStudySelector.tsx
+++ b/src/shared/components/query/CancerStudySelector.tsx
@@ -35,6 +35,13 @@ import {
     DataTypeFilter,
     IFilterDef,
 } from 'shared/components/query/DataTypeFilter';
+import { ReferenceGenomeFilter } from 'shared/components/query/ReferenceGenomeFilter';
+import { createQueryUpdate } from 'shared/components/query/filteredSearch/field/CheckboxFilterField';
+import {
+    addClauses,
+    removePhrase,
+    toQueryString,
+} from 'shared/lib/query/textQueryUtils';
 import {
     getSampleCountsPerFilter,
     getStudyCountPerFilter,
@@ -182,6 +189,48 @@ export default class CancerStudySelector extends React.Component<
         if (option) {
             option.checked = !option.checked;
         }
+    }
+
+    @action
+    toggleReferenceGenome(genome: string) {
+        const current = this.selectedReferenceGenomes;
+        const isSelected = current.includes(genome);
+        const newSelected = isSelected
+            ? current.filter(g => g !== genome)
+            : [...current, genome];
+
+        // Remove existing reference-genome clauses from search text
+        let queryString = toQueryString(this.store.searchClauses);
+        queryString = queryString.replace(/reference-genome:\S+/g, '').trim();
+
+        // Add new ones
+        if (newSelected.length > 0) {
+            const additions = newSelected
+                .map(g => `reference-genome:${g}`)
+                .join(' ');
+            queryString = queryString
+                ? `${queryString} ${additions}`
+                : additions;
+        }
+
+        this.store.searchClauses = this.store.queryParser.parseSearchQuery(
+            queryString
+        );
+    }
+
+    @computed
+    get selectedReferenceGenomes(): string[] {
+        const prefix = 'reference-genome';
+        const selected: string[] = [];
+        for (const clause of this.store.searchClauses) {
+            for (const phrase of clause.getPhrases()) {
+                if ((phrase as any).prefix === prefix) {
+                    const list = (phrase as any).phraseList || [];
+                    selected.push(...list);
+                }
+            }
+        }
+        return selected;
     }
 
     private computeCountsForFilterOptions(
@@ -357,6 +406,26 @@ export default class CancerStudySelector extends React.Component<
                                             isLoading={
                                                 !this.store.resourceDefinitions
                                                     .isComplete
+                                            }
+                                        />
+                                    </div>
+                                    <div
+                                        style={{
+                                            display: 'inline-block',
+                                            alignItems: 'center',
+                                        }}
+                                    >
+                                        <ReferenceGenomeFilter
+                                            referenceGenomes={[
+                                                ...this.store.referenceGenomes,
+                                            ]}
+                                            selectedGenomes={
+                                                this.selectedReferenceGenomes
+                                            }
+                                            onToggle={(genome: string) =>
+                                                this.toggleReferenceGenome(
+                                                    genome
+                                                )
                                             }
                                         />
                                     </div>

--- a/src/shared/components/query/ReferenceGenomeFilter.tsx
+++ b/src/shared/components/query/ReferenceGenomeFilter.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { FunctionComponent } from 'react';
+import { Dropdown } from 'react-bootstrap';
+import { DropdownToggleProps } from 'react-bootstrap/lib/DropdownToggle';
+import { DropdownMenuProps } from 'react-bootstrap/lib/DropdownMenu';
+
+export type IReferenceGenomeFilterProps = {
+    referenceGenomes: string[];
+    selectedGenomes: string[];
+    onToggle: (genome: string) => void;
+};
+
+export const ReferenceGenomeFilter: FunctionComponent<IReferenceGenomeFilterProps> = props => {
+    const selectedCount = props.selectedGenomes.length;
+
+    return (
+        <div style={{ paddingRight: 5 }}>
+            <div className="input-group input-group-sm input-group-toggle">
+                <Dropdown id="dropdown-reference-genome-filter">
+                    <Dropdown.Toggle
+                        {...({
+                            rootCloseEvent: 'click',
+                        } as DropdownToggleProps)}
+                        className="btn-sm"
+                        style={{
+                            width: 170,
+                            textAlign: 'right',
+                            float: 'right',
+                            paddingRight: 5,
+                        }}
+                    >
+                        <span
+                            style={{
+                                float: 'left',
+                                paddingLeft: 0,
+                                marginLeft: 0,
+                            }}
+                        >
+                            Reference genome
+                        </span>
+                        {selectedCount > 0 && (
+                            <span
+                                className="oncoprintDropdownCount"
+                                style={{ marginLeft: 5 }}
+                            >
+                                {selectedCount} /{' '}
+                                {props.referenceGenomes.length}
+                            </span>
+                        )}
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu
+                        {...({ bsRole: 'menu' } as DropdownMenuProps)}
+                        style={{
+                            paddingLeft: 10,
+                            paddingRight: 10,
+                            minWidth: 200,
+                        }}
+                    >
+                        <div style={{ paddingTop: 8, paddingBottom: 8 }}>
+                            Filter studies by reference genome
+                        </div>
+                        {props.referenceGenomes.map(genome => (
+                            <div key={genome} style={{ paddingBottom: 6 }}>
+                                <label
+                                    style={{
+                                        fontWeight: 'normal',
+                                        cursor: 'pointer',
+                                    }}
+                                >
+                                    <input
+                                        type="checkbox"
+                                        style={{ marginRight: 5 }}
+                                        checked={props.selectedGenomes.includes(
+                                            genome
+                                        )}
+                                        onChange={() => props.onToggle(genome)}
+                                    />
+                                    {genome}
+                                </label>
+                            </div>
+                        ))}
+                    </Dropdown.Menu>
+                </Dropdown>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
Added a support to remove "Reference genome" form the search dropdown into it own component dropdown.

Fix cBioPortal/cbioportal# (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- a : I worked on the second todos @https://github.com/cBioPortal/cbioportal/issues/10754 "Move reference genome to a separate button (reference genome) similar to datatype". I removed "Reference genome" checkbox from the search dropdown and created a separate component filter to toggle between similar to "Data Type" dropdown




## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
