### PR TITLE
Fix single-study detection (Issue #10445)

### DIFF
--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.spec.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.spec.tsx
@@ -52,7 +52,7 @@ describe('CustomCaseSelection', () => {
             const textarea = wrapper.find('[data-test="CustomCaseSetInput"]');
             assert.equal(
                 textarea.prop('value'),
-                `:sample1 ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+                `sample1 ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
             );
         });
 
@@ -74,7 +74,7 @@ describe('CustomCaseSelection', () => {
             const textarea = wrapper.find('[data-test="CustomCaseSetInput"]');
             assert.equal(
                 textarea.prop('value'),
-                `:sample2 ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+                `sample2 ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
             );
         });
 

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.spec.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.spec.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { assert } from 'chai';
+import { mount, ReactWrapper } from 'enzyme';
+import CustomCaseSelection from './CustomCaseSelection';
+import { DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT } from './CustomCaseSelectionUtils';
+import { Sample } from 'cbioportal-ts-api-client';
+
+function makeSample(
+    studyId: string,
+    sampleId: string,
+    patientId: string
+): Sample {
+    return ({
+        studyId,
+        sampleId,
+        patientId,
+        uniqueSampleKey: `${studyId}_${sampleId}`,
+        uniquePatientKey: `${studyId}_${patientId}`,
+        copyNumberSegmentPresent: false,
+        sampleType: 'Primary Solid Tumor',
+        sequenced: true,
+    } as unknown) as Sample;
+}
+
+describe('CustomCaseSelection', () => {
+    const s1 = makeSample('study1', 'sample1', 'patient1');
+    const s2 = makeSample('study1', 'sample2', 'patient2');
+    const s3 = makeSample('study2', 'sample3', 'patient3');
+
+    let wrapper: ReactWrapper;
+
+    afterEach(() => {
+        wrapper.unmount();
+    });
+
+    describe('single-study mode', () => {
+        it('auto-populates selected cases without study prefix', () => {
+            wrapper = mount(
+                <CustomCaseSelection
+                    allSamples={[s1, s2]}
+                    selectedSamples={[s1]}
+                    queriedStudies={['study1']}
+                    onSubmit={() => {}}
+                />
+            );
+
+            wrapper
+                .find('[data-test="AddCurrentlySelectedCases"]')
+                .simulate('click');
+            wrapper.update();
+
+            const textarea = wrapper.find('[data-test="CustomCaseSetInput"]');
+            assert.equal(
+                textarea.prop('value'),
+                `:sample1 ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+            );
+        });
+
+        it('auto-populates unselected cases without study prefix', () => {
+            wrapper = mount(
+                <CustomCaseSelection
+                    allSamples={[s1, s2]}
+                    selectedSamples={[s1]}
+                    queriedStudies={['study1']}
+                    onSubmit={() => {}}
+                />
+            );
+
+            wrapper
+                .find('[data-test="AddCurrentlyUnselectedCases"]')
+                .simulate('click');
+            wrapper.update();
+
+            const textarea = wrapper.find('[data-test="CustomCaseSetInput"]');
+            assert.equal(
+                textarea.prop('value'),
+                `:sample2 ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+            );
+        });
+
+        it('placeholder omits study_id prefix', () => {
+            wrapper = mount(
+                <CustomCaseSelection
+                    allSamples={[s1, s2]}
+                    selectedSamples={[]}
+                    queriedStudies={['study1']}
+                    onSubmit={() => {}}
+                />
+            );
+
+            const placeholder = wrapper
+                .find('[data-test="CustomCaseSetInput"]')
+                .prop('placeholder') as string;
+            assert.isFalse(
+                placeholder.includes('study_id:'),
+                'single-study placeholder should not contain study_id:'
+            );
+        });
+    });
+
+    describe('multi-study mode', () => {
+        it('auto-populates selected cases with study prefix', () => {
+            wrapper = mount(
+                <CustomCaseSelection
+                    allSamples={[s1, s2, s3]}
+                    selectedSamples={[s1]}
+                    queriedStudies={['study1', 'study2']}
+                    onSubmit={() => {}}
+                />
+            );
+
+            wrapper
+                .find('[data-test="AddCurrentlySelectedCases"]')
+                .simulate('click');
+            wrapper.update();
+
+            const textarea = wrapper.find('[data-test="CustomCaseSetInput"]');
+            assert.equal(
+                textarea.prop('value'),
+                `study1:sample1 ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+            );
+        });
+
+        it('placeholder includes study_id prefix', () => {
+            wrapper = mount(
+                <CustomCaseSelection
+                    allSamples={[s1, s2, s3]}
+                    selectedSamples={[]}
+                    queriedStudies={['study1', 'study2']}
+                    onSubmit={() => {}}
+                />
+            );
+
+            const placeholder = wrapper
+                .find('[data-test="CustomCaseSetInput"]')
+                .prop('placeholder') as string;
+            assert.isTrue(
+                placeholder.includes('study_id:'),
+                'multi-study placeholder should contain study_id:'
+            );
+        });
+    });
+});

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
@@ -88,7 +88,7 @@ export default class CustomCaseSelection extends React.Component<
 
     @computed
     get isSingleStudy() {
-        return this.props.queriedStudies.length === 1;
+        return _.uniq(this.props.queriedStudies.filter(Boolean)).length === 1;
     }
 
     @computed
@@ -139,14 +139,19 @@ export default class CustomCaseSelection extends React.Component<
             });
         }
         let cases = selectedCases.map(sample => {
-            return `${sample.studyId}:${
+            const caseId =
                 this.caseIdsMode === ClinicalDataTypeEnum.SAMPLE
                     ? sample.sampleId
-                    : sample.patientId
-            }${
-                this.props.disableGrouping
-                    ? ''
-                    : ` ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+                    : sample.patientId;
+            // For a single study, users can omit `study_id:`. We represent
+            // "omitted study id" with a leading `:` so the parser can still
+            // extract the case id and the optional group value.
+            const caseIdWithOptionalStudyPrefix = this.isSingleStudy
+                ? `:${caseId}`
+                : `${sample.studyId}:${caseId}`;
+
+            return `${caseIdWithOptionalStudyPrefix}${
+                this.props.disableGrouping ? '' : ` ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
             }`;
         });
         if (this.caseIdsMode === ClinicalDataTypeEnum.PATIENT) {
@@ -213,22 +218,19 @@ export default class CustomCaseSelection extends React.Component<
                 ? 'sample_id'
                 : 'patient_id';
 
+        const idPrefix = this.isSingleStudy ? '' : 'study_id:';
+        const includeCustomValue = !this.isSingleStudy && !this.props.disableGrouping;
+
         // Creating example strings for each delimiter type
-        const newLineExample = `study_id:${caseIdentifier}1${
-            this.props.disableGrouping ? '' : ' value1'
-        }\nstudy_id:${caseIdentifier}2${
-            this.props.disableGrouping ? '' : ' value2'
-        }`;
-        const commaExample = `study_id:${caseIdentifier}1${
-            this.props.disableGrouping ? '' : ' value1'
-        }, study_id:${caseIdentifier}2${
-            this.props.disableGrouping ? '' : ' value2'
-        }`;
-        const spaceExample = `study_id:${caseIdentifier}1${
-            this.props.disableGrouping ? '' : ' value1'
-        } study_id:${caseIdentifier}2${
-            this.props.disableGrouping ? '' : ' value2'
-        }`;
+        const newLineExample = `${idPrefix}${caseIdentifier}1${
+            includeCustomValue ? ' value1' : ''
+        }\n${idPrefix}${caseIdentifier}2${includeCustomValue ? ' value2' : ''}`;
+        const commaExample = `${idPrefix}${caseIdentifier}1${
+            includeCustomValue ? ' value1' : ''
+        }, ${idPrefix}${caseIdentifier}2${includeCustomValue ? ' value2' : ''}`;
+        const spaceExample = `${idPrefix}${caseIdentifier}1${
+            includeCustomValue ? ' value1' : ''
+        } ${idPrefix}${caseIdentifier}2${includeCustomValue ? ' value2' : ''}`;
 
         // Combining all three cases into one string
         return `Example with newline:\n${newLineExample}\n\nExample with comma:\n${commaExample}\n\nExample with space:\n${spaceExample}`;
@@ -236,6 +238,17 @@ export default class CustomCaseSelection extends React.Component<
 
     @computed
     get dataFormatContent() {
+        if (this.isSingleStudy) {
+            return (
+                `Each row can include a case identifier:` +
+                `\n1) ${
+                    this.caseIdsMode === ClinicalDataTypeEnum.SAMPLE
+                        ? 'sample_id'
+                        : 'patient_id'
+                }`
+            );
+        }
+
         return (
             `Each row must have two columns separated by space or tab:` +
             `\n1) study_id: ${

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
@@ -326,6 +326,7 @@ export default class CustomCaseSelection extends React.Component<
                         }}
                     >
                         <span
+                            data-test="AddCurrentlySelectedCases"
                             className={styles.selection}
                             onClick={() => {
                                 this.onClick(SelectMode.SELECTED);
@@ -340,6 +341,7 @@ export default class CustomCaseSelection extends React.Component<
                             </span>
                         </span>
                         <span
+                            data-test="AddCurrentlyUnselectedCases"
                             className={styles.selection}
                             onClick={() => {
                                 this.onClick(SelectMode.UNSELECTED);

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
@@ -143,11 +143,8 @@ export default class CustomCaseSelection extends React.Component<
                 this.caseIdsMode === ClinicalDataTypeEnum.SAMPLE
                     ? sample.sampleId
                     : sample.patientId;
-            // For a single study, users can omit `study_id:`. We represent
-            // "omitted study id" with a leading `:` so the parser can still
-            // extract the case id and the optional group value.
             const caseIdWithOptionalStudyPrefix = this.isSingleStudy
-                ? `:${caseId}`
+                ? caseId
                 : `${sample.studyId}:${caseId}`;
 
             return `${caseIdWithOptionalStudyPrefix}${

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
@@ -88,7 +88,7 @@ export default class CustomCaseSelection extends React.Component<
 
     @computed
     get isSingleStudy() {
-        return _.uniq(this.props.queriedStudies.filter(Boolean)).length === 1;
+        return _.uniq(this.props.queriedStudies).length === 1;
     }
 
     @computed
@@ -151,7 +151,9 @@ export default class CustomCaseSelection extends React.Component<
                 : `${sample.studyId}:${caseId}`;
 
             return `${caseIdWithOptionalStudyPrefix}${
-                this.props.disableGrouping ? '' : ` ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+                this.props.disableGrouping
+                    ? ''
+                    : ` ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
             }`;
         });
         if (this.caseIdsMode === ClinicalDataTypeEnum.PATIENT) {
@@ -219,7 +221,8 @@ export default class CustomCaseSelection extends React.Component<
                 : 'patient_id';
 
         const idPrefix = this.isSingleStudy ? '' : 'study_id:';
-        const includeCustomValue = !this.isSingleStudy && !this.props.disableGrouping;
+        const includeCustomValue =
+            !this.isSingleStudy && !this.props.disableGrouping;
 
         // Creating example strings for each delimiter type
         const newLineExample = `${idPrefix}${caseIdentifier}1${

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.spec.ts
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.spec.ts
@@ -60,6 +60,19 @@ describe('CustomCaseSelectionUtils', () => {
             );
         });
 
+        it('resolves sample when studyId is empty string (auto-populated single-study format)', () => {
+            const result = getData(
+                [{ line: ':c1', studyId: '', caseId: 'c1' }],
+                's1',
+                ClinicalDataTypeEnum.SAMPLE,
+                [s1],
+                false
+            );
+            assert.equal(result.length, 1);
+            assert.equal(result[0].sampleId, 'c1');
+            assert.equal(result[0].studyId, 's1');
+        });
+
         it("group name should be NA when it's specified by user", () => {
             const sampleIdentifiersWithData = getData(
                 [

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.spec.ts
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.spec.ts
@@ -120,6 +120,12 @@ describe('CustomCaseSelectionUtils', () => {
             assert.equal(result.caseId, 'test1');
             assert.equal(result.value, 'group1');
         });
+        it('bare case id with group value (single-study auto-populate format) is split correctly', () => {
+            const result = getLine('test1 group1');
+            assert.isUndefined(result.studyId);
+            assert.equal(result.caseId, 'test1');
+            assert.equal(result.value, 'group1');
+        });
     });
 
     describe('getLines', () => {

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.tsx
@@ -318,10 +318,9 @@ export function getData(
                 ? DEFAULT_GROUP_NAME_WITH_USER_INPUT
                 : DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT);
 
-        const caseId =
-            line.studyId === undefined
-                ? `${singleStudyId}:${line.caseId}`
-                : `${line.studyId}:${line.caseId}`;
+        const caseId = !line.studyId
+            ? `${singleStudyId}:${line.caseId}`
+            : `${line.studyId}:${line.caseId}`;
         const caseMap = isPatientId ? patientMap[caseId] : [sampleMap[caseId]];
 
         return caseMap.map(sample => {

--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelectionUtils.tsx
@@ -67,7 +67,11 @@ export function getLine(line: string): InputLine {
 
     const content = line.split(':');
     if (content.length === 1) {
-        parsedResult.caseId = content[0];
+        const groupInfo = content[0].split(/\s|\t/g);
+        parsedResult.caseId = groupInfo[0];
+        if (groupInfo.length > 1) {
+            parsedResult.value = groupInfo[1];
+        }
     } else if (content.length > 1) {
         parsedResult.studyId = content[0];
         const groupInfo = content[1].split(/\s|\t/g);


### PR DESCRIPTION
Fixes cBioPortal/cbioportal#10445

This PR clarifies the custom case selection UX for single-study views. In practice, users are not always required to provide a study_id: prefix when only one study is in scope, but the existing placeholder/help examples still display study_id: and make it look mandatory. This mismatch is confusing and suggests a stricter input requirement than intended. The update aligns the examples/help text with actual single-study behavior while preserving the existing multi-study format where study_id: remains appropriate.

### What changed
- Single-study detection now uses unique non-empty study IDs, so duplicate entries for the same study no longer force multi-study behavior.
- Example/help content now adapts to context:
  - **Single study:** no `study_id:` prefix implied.
  - **Multiple studies:** existing `study_id:` format remains unchanged.
- Generated custom case lines stay compatible with existing parser behavior in both modes.

### Testing
Manually validated in Study View for both scenarios (single-study and multi-study).  
No automated test was added in this PR (UI/formatting behavior adjustment); a focused follow-up test can be added for placeholder/help toggling by study-count context.

### Screenshots
1. **Single study selected**: example no longer shows `study_id:` prefix.
<img width="367" height="269" alt="Screenshot 2026-03-19 at 8 34 21 PM" src="https://github.com/user-attachments/assets/685912cb-54a5-468b-a9be-3a62ba704d53" />

2. **Multiple studies selected**: example still shows `study_id:` prefix.
<img width="369" height="269" alt="Screenshot 2026-03-19 at 8 34 32 PM" src="https://github.com/user-attachments/assets/5bebac81-ae46-4874-b8d9-7d9f428b7f7b" />


