### PR TITLE
Fix single-study detection for custom case example placeholder (Issue #115592)

### DIFF
--- a/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
+++ b/src/pages/studyView/addChartButton/customCaseSelection/CustomCaseSelection.tsx
@@ -88,7 +88,7 @@ export default class CustomCaseSelection extends React.Component<
 
     @computed
     get isSingleStudy() {
-        return this.props.queriedStudies.length === 1;
+        return _.uniq(this.props.queriedStudies.filter(Boolean)).length === 1;
     }
 
     @computed
@@ -139,14 +139,19 @@ export default class CustomCaseSelection extends React.Component<
             });
         }
         let cases = selectedCases.map(sample => {
-            return `${sample.studyId}:${
+            const caseId =
                 this.caseIdsMode === ClinicalDataTypeEnum.SAMPLE
                     ? sample.sampleId
-                    : sample.patientId
-            }${
-                this.props.disableGrouping
-                    ? ''
-                    : ` ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
+                    : sample.patientId;
+            // For a single study, users can omit `study_id:`. We represent
+            // "omitted study id" with a leading `:` so the parser can still
+            // extract the case id and the optional group value.
+            const caseIdWithOptionalStudyPrefix = this.isSingleStudy
+                ? `:${caseId}`
+                : `${sample.studyId}:${caseId}`;
+
+            return `${caseIdWithOptionalStudyPrefix}${
+                this.props.disableGrouping ? '' : ` ${DEFAULT_GROUP_NAME_WITHOUT_USER_INPUT}`
             }`;
         });
         if (this.caseIdsMode === ClinicalDataTypeEnum.PATIENT) {
@@ -213,22 +218,19 @@ export default class CustomCaseSelection extends React.Component<
                 ? 'sample_id'
                 : 'patient_id';
 
+        const idPrefix = this.isSingleStudy ? '' : 'study_id:';
+        const includeCustomValue = !this.isSingleStudy && !this.props.disableGrouping;
+
         // Creating example strings for each delimiter type
-        const newLineExample = `study_id:${caseIdentifier}1${
-            this.props.disableGrouping ? '' : ' value1'
-        }\nstudy_id:${caseIdentifier}2${
-            this.props.disableGrouping ? '' : ' value2'
-        }`;
-        const commaExample = `study_id:${caseIdentifier}1${
-            this.props.disableGrouping ? '' : ' value1'
-        }, study_id:${caseIdentifier}2${
-            this.props.disableGrouping ? '' : ' value2'
-        }`;
-        const spaceExample = `study_id:${caseIdentifier}1${
-            this.props.disableGrouping ? '' : ' value1'
-        } study_id:${caseIdentifier}2${
-            this.props.disableGrouping ? '' : ' value2'
-        }`;
+        const newLineExample = `${idPrefix}${caseIdentifier}1${
+            includeCustomValue ? ' value1' : ''
+        }\n${idPrefix}${caseIdentifier}2${includeCustomValue ? ' value2' : ''}`;
+        const commaExample = `${idPrefix}${caseIdentifier}1${
+            includeCustomValue ? ' value1' : ''
+        }, ${idPrefix}${caseIdentifier}2${includeCustomValue ? ' value2' : ''}`;
+        const spaceExample = `${idPrefix}${caseIdentifier}1${
+            includeCustomValue ? ' value1' : ''
+        } ${idPrefix}${caseIdentifier}2${includeCustomValue ? ' value2' : ''}`;
 
         // Combining all three cases into one string
         return `Example with newline:\n${newLineExample}\n\nExample with comma:\n${commaExample}\n\nExample with space:\n${spaceExample}`;
@@ -236,6 +238,17 @@ export default class CustomCaseSelection extends React.Component<
 
     @computed
     get dataFormatContent() {
+        if (this.isSingleStudy) {
+            return (
+                `Each row can include a case identifier:` +
+                `\n1) ${
+                    this.caseIdsMode === ClinicalDataTypeEnum.SAMPLE
+                        ? 'sample_id'
+                        : 'patient_id'
+                }`
+            );
+        }
+
         return (
             `Each row must have two columns separated by space or tab:` +
             `\n1) study_id: ${

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -80,6 +80,12 @@ export type HeatmapCaseDatum = {
     thresholdType?: '<' | '>';
 };
 
+type ValueDatum = {
+    value: number | null;
+    thresholdType?: '<' | '>';
+    alterationSubType?: string;
+};
+
 export type OncoprintMutationType =
     | 'missense'
     | 'inframe'
@@ -157,7 +163,11 @@ export function fillGeneticTrackDatum(
     // must already have all non-disp* fields except trackLabel and data
     newDatum: Partial<GeneticTrackDatum>,
     trackLabel: string,
-    data: GeneticTrackDatum_Data[]
+    data: GeneticTrackDatum_Data[],
+    options?: {
+        isPatientMode?: boolean;
+        expressionSortOrder?: string;
+    }
 ): GeneticTrackDatum {
     newDatum.trackLabel = trackLabel;
     newDatum.data = data;
@@ -168,6 +178,8 @@ export function fillGeneticTrackDatum(
     const dispMutCounts: { [mutType: string]: number } = {};
     const dispGermline: { [mutType: string]: boolean } = {};
     const dispSvCounts: { [svType: string]: number } = {};
+    const mrnaEvents: ValueDatum[] = [];
+    const protEvents: ValueDatum[] = [];
     let structuralVariantCounts: number = 0;
     const caseInsensitiveGermlineMatch = new RegExp(
         MUTATION_STATUS_GERMLINE,
@@ -197,6 +209,13 @@ export function fillGeneticTrackDatum(
                     const mrnaEvent = event.alterationSubType;
                     dispMrnaCounts[mrnaEvent] = dispMrnaCounts[mrnaEvent] || 0;
                     dispMrnaCounts[mrnaEvent] += 1;
+                    mrnaEvents.push({
+                        value:
+                            event.value === undefined
+                                ? null
+                                : (event.value as number | null),
+                        alterationSubType: event.alterationSubType,
+                    });
                 }
                 break;
             case AlterationTypeConstants.PROTEIN_LEVEL:
@@ -204,6 +223,13 @@ export function fillGeneticTrackDatum(
                     const protEvent = event.alterationSubType;
                     dispProtCounts[protEvent] = dispProtCounts[protEvent] || 0;
                     dispProtCounts[protEvent] += 1;
+                    protEvents.push({
+                        value:
+                            event.value === undefined
+                                ? null
+                                : (event.value as number | null),
+                        alterationSubType: event.alterationSubType,
+                    });
                 }
                 break;
             case AlterationTypeConstants.MUTATION_EXTENDED:
@@ -237,8 +263,47 @@ export function fillGeneticTrackDatum(
         svRenderPriority
     );
     newDatum.disp_cna = selectDisplayValue(dispCnaCounts, cnaRenderPriority);
-    newDatum.disp_mrna = selectDisplayValue(dispMrnaCounts, mrnaRenderPriority);
-    newDatum.disp_prot = selectDisplayValue(dispProtCounts, protRenderPriority);
+    if (options?.isPatientMode) {
+        const mrnaRepresentative = selectRepresentingValueDatum(
+            mrnaEvents,
+            options.expressionSortOrder
+        );
+        const protRepresentative = selectRepresentingValueDatum(
+            protEvents,
+            options.expressionSortOrder
+        );
+
+        if (mrnaRepresentative && _.isFinite(mrnaRepresentative.value)) {
+            newDatum.disp_mrna =
+                mrnaRepresentative.alterationSubType ||
+                (mrnaRepresentative.value! > 0 ? 'high' : 'low');
+        } else {
+            newDatum.disp_mrna = selectDisplayValue(
+                dispMrnaCounts,
+                mrnaRenderPriority
+            );
+        }
+
+        if (protRepresentative && _.isFinite(protRepresentative.value)) {
+            newDatum.disp_prot =
+                protRepresentative.alterationSubType ||
+                (protRepresentative.value! > 0 ? 'high' : 'low');
+        } else {
+            newDatum.disp_prot = selectDisplayValue(
+                dispProtCounts,
+                protRenderPriority
+            );
+        }
+    } else {
+        newDatum.disp_mrna = selectDisplayValue(
+            dispMrnaCounts,
+            mrnaRenderPriority
+        );
+        newDatum.disp_prot = selectDisplayValue(
+            dispProtCounts,
+            protRenderPriority
+        );
+    }
     newDatum.disp_mut = selectDisplayValue(dispMutCounts, mutRenderPriority);
     newDatum.disp_germ = newDatum.disp_mut
         ? dispGermline[newDatum.disp_mut]
@@ -328,7 +393,8 @@ export function makeGeneticTrackData(
                 fillGeneticTrackDatum(
                     newDatum,
                     geneSymbolArray.join(' / '),
-                    sampleData
+                    sampleData,
+                    { isPatientMode: false }
                 )
             );
         }
@@ -374,7 +440,8 @@ export function makeGeneticTrackData(
                 fillGeneticTrackDatum(
                     newDatum,
                     geneSymbolArray.join(' / '),
-                    patientData
+                    patientData,
+                    { isPatientMode: true }
                 )
             );
         }
@@ -441,42 +508,10 @@ export function fillHeatmapTrackDatum<
                 // default: the most extreme value (pos. or neg.) is shown for data
                 // sortOrder=ASC: the smallest value is shown for data
                 // sortOrder=DESC: the largest value is shown for data
-                let representingDatum;
-                let bestValue;
-
-                switch (sortOrder) {
-                    case 'ASC':
-                        bestValue = _(dataWithNonNullValues)
-                            .map((d: HeatmapCaseDatum) => d.value as number)
-                            .min();
-                        representingDatum = selectRepresentingDataPoint(
-                            bestValue!,
-                            dataWithNonNullValues,
-                            false
-                        );
-                        break;
-                    case 'DESC':
-                        bestValue = _(dataWithNonNullValues)
-                            .map((d: HeatmapCaseDatum) => d.value as number)
-                            .max();
-                        representingDatum = selectRepresentingDataPoint(
-                            bestValue!,
-                            dataWithNonNullValues,
-                            false
-                        );
-                        break;
-                    default:
-                        bestValue = _.maxBy(
-                            dataWithNonNullValues,
-                            (d: HeatmapCaseDatum) => Math.abs(d.value as number)
-                        )!.value as number;
-                        representingDatum = selectRepresentingDataPoint(
-                            bestValue,
-                            dataWithNonNullValues,
-                            true
-                        );
-                        break;
-                }
+                let representingDatum = selectRepresentingValueDatum(
+                    dataWithNonNullValues,
+                    sortOrder
+                );
 
                 // `data` can contain data points with only NaN values
                 // this is detected by `representingDatum` to be undefined
@@ -501,24 +536,64 @@ export function fillHeatmapTrackDatum<
     return trackDatum;
 }
 
-function selectRepresentingDataPoint(
+function selectRepresentingDataPoint<T extends ValueDatum>(
     bestValue: number,
-    data: HeatmapCaseDatum[],
+    data: T[],
     useAbsolute: boolean
-): HeatmapCaseDatum {
+): T {
     const fFilter = useAbsolute
-        ? (d: HeatmapCaseDatum) => Math.abs(d.value!) === bestValue
-        : (d: HeatmapCaseDatum) => d.value === bestValue;
+        ? (d: T) => Math.abs(d.value!) === bestValue
+        : (d: T) => d.value === bestValue;
     const selData = _.filter(data, fFilter);
     const selDataNoTreshold = _.filter(
         selData,
-        (d: HeatmapCaseDatum) => !d.thresholdType
+        (d: T) => !d.thresholdType
     );
     if (selDataNoTreshold.length > 0) {
         return selDataNoTreshold[0];
     } else {
         return selData[0];
     }
+}
+
+function selectRepresentingValueDatum<T extends ValueDatum>(
+    data: T[],
+    sortOrder?: string
+): T | undefined {
+    if (!data.length) {
+        return undefined;
+    }
+
+    let bestValue: number | undefined;
+    let useAbsolute = false;
+
+    switch (sortOrder) {
+        case 'ASC':
+            bestValue = _(data)
+                .map((d: T) => d.value as number)
+                .min();
+            break;
+        case 'DESC':
+            bestValue = _(data)
+                .map((d: T) => d.value as number)
+                .max();
+            break;
+        default:
+            bestValue = Math.abs(
+                (_.maxBy(data, (d: T) => Math.abs(d.value as number))
+                    ?.value as number | undefined) || 0
+            );
+            useAbsolute = true;
+            break;
+    }
+
+    if (bestValue === undefined) {
+        return undefined;
+    }
+
+    return selectRepresentingDataPoint(bestValue, data, useAbsolute) as
+        | T
+        | undefined;
 }
 
 function fillCategoricalTrackDatum(


### PR DESCRIPTION
## Summary

Fixes a patient-view inconsistency where expression heatmap z-scores and `High/Low` summary labels could disagree when a patient had multiple samples. (https://github.com/cBioPortal/cbioportal/issues/11592)

In patient mode, both display outputs now follow the same representative-selection path:
- heatmap value and color
- expression summary subtype (`mRNA` / `protein` high/low)

This keeps the existing representative aggregation model (no averaging/median change), but removes cross-signal contradictions by using one consistent source of truth.

## What Changed

- Refactored patient-level representative heatmap datum selection into a reusable helper in `DataUtils`.
- Reused that same representative selection path when deriving patient-view expression summary subtype (`disp_mrna` / `disp_prot`).
- Preserved existing representative and sort-order semantics (`ASC` / `DESC` / default), while removing label-vs-z-score divergence in patient mode.

## Rationale

Previously, patient heatmap values used representative sample selection, while `High/Low` labels were derived from separate subtype-count aggregation.  
With opposing sample signals, this could produce mismatches (e.g., negative z-score shown with a `High` label).

We chose to align both outputs to the existing representative path (instead of switching to a new averaging/median strategy) because:
- it fixes the inconsistency without redefining established patient-level semantics,
- it preserves current sorting and representative behavior users already rely on,
- it minimizes scope/risk for regression, while making displayed z-score and `High/Low` interpretation consistent.


## Scope

- Patient view logic only
- No intended behavior change for sample view
- No change to overall representative strategy (still representative, not average)

## Validation

- Confirmed patient-view z-score sign and `High/Low` label now align under representative selection.
- Ran OncoPrint-focused test subset and targeted DataUtils test locally.

## Media

- Attached GIF demonstrating patient-view z-score/label alignment before the fix. In patient view, the displayed heatmap z-score and the expression summary subtype label (mRNA Low/High) could be out of sync.
![cbiobeforegif-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f1f61d21-44ae-468a-b79c-c48b90337ed6)

- Attached GIF demonstrating patient-view z-score/label alignment after the fix. Both label and mRNA z-score are derived from the same representative signal, so the z-score sign and Low/High label are aligned.

![cbiogifafter-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2d869aa6-1727-4559-ac59-1addd3a6b585)


