### PR TITLE
When only RNA profile present in study, show it by default

### DIFF
--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -469,15 +469,23 @@ export class QueryStore {
                     });
 
                     // Fall back to RNA expression profiles for RNA-only studies
-                    if (_.isEmpty(selectedIdSet)) {
-                        _(this.getFilteredProfiles('MRNA_EXPRESSION'))
-                            .groupBy(profile => profile.studyId)
-                            .forEach(profiles => {
+                    // (only for studies that have no standard genomic profiles)
+                    const studyIdsWithProfiles = new Set(
+                        altTypes.flatMap(altType =>
+                            this.getFilteredProfiles(altType).map(
+                                p => p.studyId
+                            )
+                        )
+                    );
+                    _(this.getFilteredProfiles('MRNA_EXPRESSION'))
+                        .groupBy(profile => profile.studyId)
+                        .forEach((profiles, studyId) => {
+                            if (!studyIdsWithProfiles.has(studyId)) {
                                 selectedIdSet[
                                     getSuffixOfMolecularProfile(profiles[0])
                                 ] = true;
-                            });
-                    }
+                            }
+                        });
                 }
             } else {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -439,6 +439,13 @@ export class QueryStore {
                             this.getFilteredProfiles(altType)
                         );
 
+                        // Fall back to RNA expression profiles for RNA-only studies
+                        if (profiles.length === 0) {
+                            profiles = this.getFilteredProfiles(
+                                'MRNA_EXPRESSION'
+                            );
+                        }
+
                         profiles.forEach(profile => {
                             selectedIdSet[
                                 getSuffixOfMolecularProfile(profile)
@@ -460,6 +467,17 @@ export class QueryStore {
                                 ] = true;
                             });
                     });
+
+                    // Fall back to RNA expression profiles for RNA-only studies
+                    if (_.isEmpty(selectedIdSet)) {
+                        _(this.getFilteredProfiles('MRNA_EXPRESSION'))
+                            .groupBy(profile => profile.studyId)
+                            .forEach(profiles => {
+                                selectedIdSet[
+                                    getSuffixOfMolecularProfile(profiles[0])
+                                ] = true;
+                            });
+                    }
                 }
             } else {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -115,6 +115,18 @@ export function getDefaultGeneSetProfile(profiles: MolecularProfile[]) {
     );
 }
 
+export function getDefaultRNAProfile(
+    profiles: MolecularProfile[]
+): MolecularProfile | undefined {
+    return _.find(
+        profiles,
+        profile =>
+            profile.molecularAlterationType ===
+                AlterationTypeConstants.MRNA_EXPRESSION &&
+            profile.showProfileInAnalysisTab
+    );
+}
+
 export function getFilteredMolecularProfiles(
     profiles: MolecularProfile[],
     queriedProfileSuffixes?: string[],
@@ -151,6 +163,12 @@ export function getFilteredMolecularProfiles(
                 defaultProfiles.push(
                     getDefaultStructuralVariantProfile(profiles)
                 );
+        }
+
+        // If no profiles were selected (e.g. RNA-only study), fall back to
+        // the first RNA expression profile with showProfileInAnalysisTab=true
+        if (_.compact(defaultProfiles).length === 0) {
+            defaultProfiles.push(getDefaultRNAProfile(profiles));
         }
     }
     // get rid of any undefined items


### PR DESCRIPTION
Fix cBioPortal/cbioportal#11569

Describe changes proposed in this pull request:
- a When only RNA profile present in study, show it by default
<img width="1152" height="540" alt="issue" src="https://github.com/user-attachments/assets/ad2bcde8-61d1-4ddd-b494-dbfcc7a6bc37" />



## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
