### PR TITLE
fix: optimize BoxScatterPlot rendering for large datasets (#11814)

### DIFF
--- a/src/shared/components/plots/BoxScatterPlot.spec.ts
+++ b/src/shared/components/plots/BoxScatterPlot.spec.ts
@@ -1,0 +1,84 @@
+/// <reference types="jest" />
+import { assert } from 'chai';
+import {
+    downsampleBoxScatterPointsByCategory,
+    sampleEvenly,
+} from './BoxScatterPlot';
+
+describe('BoxScatterPlot large-dataset downsampling', () => {
+    describe('sampleEvenly', () => {
+        it('returns evenly spaced points with deterministic ordering', () => {
+            const points = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+            assert.deepEqual(sampleEvenly(points, 4), [0, 2, 5, 7]);
+        });
+
+        it('returns all points when sample size exceeds input size', () => {
+            const points = [1, 2, 3];
+            assert.deepEqual(sampleEvenly(points, 10), [1, 2, 3]);
+        });
+    });
+
+    it('does not downsample when dataset is below threshold', () => {
+        const points = Array.from({ length: 1000 }, (_, i) => ({
+            id: i,
+            categoryIndex: i % 10,
+        }));
+
+        const sampled = downsampleBoxScatterPointsByCategory(
+            points,
+            500,
+            2000
+        );
+        assert.equal(sampled.length, points.length);
+        assert.deepEqual(sampled, points);
+    });
+
+    it('caps total rendered points for large datasets and remains deterministic', () => {
+        const categoryCount = 120;
+        const samplesPerCategory = 250;
+        const points = Array.from(
+            { length: categoryCount * samplesPerCategory },
+            (_, i) => ({
+                id: i,
+                categoryIndex: Math.floor(i / samplesPerCategory),
+            })
+        );
+
+        const first = downsampleBoxScatterPointsByCategory(points, 5000, 20000);
+        const second = downsampleBoxScatterPointsByCategory(
+            points,
+            5000,
+            20000
+        );
+
+        assert.equal(first.length, 5000);
+        assert.deepEqual(first, second);
+
+        const categoriesPresent = new Set(first.map(point => point.categoryIndex));
+        assert.equal(categoriesPresent.size, categoryCount);
+    });
+
+    it('allocates more rendered points to larger categories', () => {
+        const points: Array<{ id: number; categoryIndex: number }> = [];
+        let id = 0;
+        const sizes = [10000, 2000, 1000];
+        sizes.forEach((size, categoryIndex) => {
+            for (let i = 0; i < size; i++) {
+                points.push({ id: id++, categoryIndex });
+            }
+        });
+
+        const sampled = downsampleBoxScatterPointsByCategory(points, 1000, 2000);
+        const counts = sampled.reduce(
+            (acc, point) => {
+                acc[point.categoryIndex] = (acc[point.categoryIndex] || 0) + 1;
+                return acc;
+            },
+            {} as Record<number, number>
+        );
+
+        assert.isAbove(counts[0], counts[1]);
+        assert.isAbove(counts[1], counts[2]);
+        assert.equal(sampled.length, 1000);
+    });
+});

--- a/src/shared/components/plots/BoxScatterPlot.spec.ts
+++ b/src/shared/components/plots/BoxScatterPlot.spec.ts
@@ -81,4 +81,36 @@ describe('BoxScatterPlot large-dataset downsampling', () => {
         assert.isAbove(counts[1], counts[2]);
         assert.equal(sampled.length, 1000);
     });
+
+    it('preserves visibility for small-but-nonempty categories in skewed datasets', () => {
+        const points: Array<{ id: number; categoryIndex: number }> = [];
+        let id = 0;
+        const largeCategorySize = 10000;
+        const singletonCategoryCount = 25;
+
+        // Create one large category and 25 singleton categories
+        for (let i = 0; i < largeCategorySize; i++) {
+            points.push({ id: id++, categoryIndex: 0 });
+        }
+        for (let categoryIndex = 1; categoryIndex <= singletonCategoryCount; categoryIndex++) {
+            points.push({ id: id++, categoryIndex });
+        }
+
+        // Downsample with 100-point budget (plenty for all 26 categories)
+        const sampled = downsampleBoxScatterPointsByCategory(
+            points,
+            100, // maxPoints
+            2000 // threshold
+        );
+
+        // Verify all categories are represented
+        const categoriesPresent = new Set(sampled.map(point => point.categoryIndex));
+        assert.equal(sampled.length, 100);
+        assert.equal(categoriesPresent.size, singletonCategoryCount + 1);
+
+        // Verify every category has at least 1 point
+        for (let categoryIndex = 0; categoryIndex <= singletonCategoryCount; categoryIndex++) {
+            assert.isTrue(categoriesPresent.has(categoryIndex));
+        }
+    });
 });

--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -172,37 +172,95 @@ export function downsampleBoxScatterPointsByCategory<
         .map(Number)
         .sort((a, b) => a - b);
 
+    const categoryCount = categoryIndices.length;
     const samplesByCategory: Record<number, number> = {};
-    const remainders: Array<{ categoryIndex: number; remainder: number }> =
-        [];
-    let allocatedSamples = 0;
 
-    for (const categoryIndex of categoryIndices) {
-        const categoryPoints = grouped[String(categoryIndex)] as T[];
-        const categorySize = categoryPoints.length;
-        const exact = (categorySize * maxPoints) / points.length;
-        const base = Math.floor(exact);
-        samplesByCategory[categoryIndex] = base;
-        allocatedSamples += base;
-        remainders.push({
-            categoryIndex,
-            remainder: exact - base,
-        });
-    }
+    // If we have enough budget, guarantee every category gets at least 1 point
+    if (categoryCount <= maxPoints) {
+        let remainingBudget = maxPoints;
 
-    if (allocatedSamples < maxPoints) {
-        remainders
-            .sort((a, b) => {
-                const remainderCompare = b.remainder - a.remainder;
-                if (remainderCompare !== 0) {
-                    return remainderCompare;
-                }
-                return a.categoryIndex - b.categoryIndex;
-            })
-            .slice(0, maxPoints - allocatedSamples)
-            .forEach(({ categoryIndex }) => {
-                samplesByCategory[categoryIndex] += 1;
+        // First pass: allocate 1 point to each category
+        for (const categoryIndex of categoryIndices) {
+            samplesByCategory[categoryIndex] = 1;
+            remainingBudget -= 1;
+        }
+
+        // Second pass: distribute remaining budget proportionally
+        if (remainingBudget > 0) {
+            const remainders: Array<{
+                categoryIndex: number;
+                remainder: number;
+            }> = [];
+
+            for (const categoryIndex of categoryIndices) {
+                const categoryPoints = grouped[String(categoryIndex)] as T[];
+                const categorySize = categoryPoints.length;
+                // Allocate remaining budget proportionally based on size
+                const exact =
+                    (categorySize * remainingBudget) / points.length;
+                const base = Math.floor(exact);
+                samplesByCategory[categoryIndex] += base;
+                remainders.push({
+                    categoryIndex,
+                    remainder: exact - base,
+                });
+            }
+
+            // Distribute leftover points by largest remainder
+            const allocated = Object.values(
+                samplesByCategory
+            ).reduce((a, b) => a + b, 0);
+            if (allocated < maxPoints) {
+                remainders
+                    .sort((a, b) => {
+                        const remainderCompare =
+                            b.remainder - a.remainder;
+                        if (remainderCompare !== 0) {
+                            return remainderCompare;
+                        }
+                        return a.categoryIndex - b.categoryIndex;
+                    })
+                    .slice(0, maxPoints - allocated)
+                    .forEach(({ categoryIndex }) => {
+                        samplesByCategory[categoryIndex] += 1;
+                    });
+            }
+        }
+    } else {
+        // Not enough budget for every category: pure proportional allocation
+        const remainders: Array<{
+            categoryIndex: number;
+            remainder: number;
+        }> = [];
+        let allocatedSamples = 0;
+
+        for (const categoryIndex of categoryIndices) {
+            const categoryPoints = grouped[String(categoryIndex)] as T[];
+            const categorySize = categoryPoints.length;
+            const exact = (categorySize * maxPoints) / points.length;
+            const base = Math.floor(exact);
+            samplesByCategory[categoryIndex] = base;
+            allocatedSamples += base;
+            remainders.push({
+                categoryIndex,
+                remainder: exact - base,
             });
+        }
+
+        if (allocatedSamples < maxPoints) {
+            remainders
+                .sort((a, b) => {
+                    const remainderCompare = b.remainder - a.remainder;
+                    if (remainderCompare !== 0) {
+                        return remainderCompare;
+                    }
+                    return a.categoryIndex - b.categoryIndex;
+                })
+                .slice(0, maxPoints - allocatedSamples)
+                .forEach(({ categoryIndex }) => {
+                    samplesByCategory[categoryIndex] += 1;
+                });
+        }
     }
 
     const sampledPoints: T[] = [];

--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -132,6 +132,93 @@ const BOTTOM_LEGEND_PADDING = 15;
 const HORIZONTAL_OFFSET = 8;
 const VERTICAL_OFFSET = 17;
 const UTILITIES_MENU_HEIGHT = 20;
+const LARGE_BOX_SCATTER_DATASET_THRESHOLD = 20000;
+const MAX_RENDERED_BOX_SCATTER_POINTS = 5000;
+
+type PointWithCategoryIndex = {
+    categoryIndex: number;
+};
+
+export function sampleEvenly<T>(points: T[], sampleSize: number): T[] {
+    if (sampleSize <= 0) {
+        return [];
+    }
+    if (sampleSize >= points.length) {
+        return points;
+    }
+
+    const sampled: T[] = [];
+    const n = points.length;
+    for (let i = 0; i < sampleSize; i++) {
+        const index = Math.floor((i * n) / sampleSize);
+        sampled.push(points[index]);
+    }
+    return sampled;
+}
+
+export function downsampleBoxScatterPointsByCategory<
+    T extends PointWithCategoryIndex
+>(
+    points: T[],
+    maxPoints: number = MAX_RENDERED_BOX_SCATTER_POINTS,
+    threshold: number = LARGE_BOX_SCATTER_DATASET_THRESHOLD
+): T[] {
+    if (points.length <= threshold || points.length <= maxPoints) {
+        return points;
+    }
+
+    const grouped = _.groupBy(points, (point: T) => point.categoryIndex);
+    const categoryIndices = Object.keys(grouped)
+        .map(Number)
+        .sort((a, b) => a - b);
+
+    const samplesByCategory: Record<number, number> = {};
+    const remainders: Array<{ categoryIndex: number; remainder: number }> =
+        [];
+    let allocatedSamples = 0;
+
+    for (const categoryIndex of categoryIndices) {
+        const categoryPoints = grouped[String(categoryIndex)] as T[];
+        const categorySize = categoryPoints.length;
+        const exact = (categorySize * maxPoints) / points.length;
+        const base = Math.floor(exact);
+        samplesByCategory[categoryIndex] = base;
+        allocatedSamples += base;
+        remainders.push({
+            categoryIndex,
+            remainder: exact - base,
+        });
+    }
+
+    if (allocatedSamples < maxPoints) {
+        remainders
+            .sort((a, b) => {
+                const remainderCompare = b.remainder - a.remainder;
+                if (remainderCompare !== 0) {
+                    return remainderCompare;
+                }
+                return a.categoryIndex - b.categoryIndex;
+            })
+            .slice(0, maxPoints - allocatedSamples)
+            .forEach(({ categoryIndex }) => {
+                samplesByCategory[categoryIndex] += 1;
+            });
+    }
+
+    const sampledPoints: T[] = [];
+    for (const categoryIndex of categoryIndices) {
+        const categoryPoints = grouped[String(categoryIndex)] as T[];
+        const targetCount = Math.min(
+            categoryPoints.length,
+            samplesByCategory[categoryIndex] || 0
+        );
+        if (targetCount > 0) {
+            sampledPoints.push(...sampleEvenly(categoryPoints, targetCount));
+        }
+    }
+
+    return sampledPoints;
+}
 
 /*
     This component exists to provide a mouseover target for tooltips
@@ -773,7 +860,8 @@ export default class BoxScatterPlot<
     @computed get scatterPlotData() {
         let dataAxis: 'x' | 'y' = this.props.horizontal ? 'x' : 'y';
         let categoryAxis: 'x' | 'y' = this.props.horizontal ? 'y' : 'x';
-        const data: (D & { x: number; y: number })[] = [];
+        const data: (D & { x: number; y: number; categoryIndex: number })[] =
+            [];
         for (let i = 0; i < this.props.data.length; i++) {
             const categoryCoord = this.categoryCoord(i);
             for (const d of this.props.data[i].data) {
@@ -781,12 +869,15 @@ export default class BoxScatterPlot<
                     Object.assign({}, d, {
                         [dataAxis]: d.value,
                         [categoryAxis]: categoryCoord,
-                    } as { x: number; y: number })
+                        categoryIndex: i,
+                    } as { x: number; y: number; categoryIndex: number })
                 );
             }
         }
+
+        const renderData = downsampleBoxScatterPointsByCategory(data);
         return separateScatterDataByAppearance<D>(
-            data,
+            renderData,
             ifNotDefined(this.props.fill, '0x000000'),
             ifNotDefined(this.props.stroke, '0x000000'),
             ifNotDefined(this.props.strokeWidth, 0),

--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -45,7 +45,7 @@ import classnames from 'classnames';
 import WindowStore from '../window/WindowStore';
 import LegendDataComponent from './LegendDataComponent';
 import LegendLabelComponent from './LegendLabelComponent';
-import { PQValueLabel } from 'shared/components/plots/MultipleCategoryBarPlot';
+import { PQValueLabel } from './PQValueLabel';
 import type { SampleIdsForPatientIds } from './PlotsTab';
 
 export interface IBaseBoxScatterPlotPoint {

--- a/src/shared/components/plots/BoxScatterPlot.tsx
+++ b/src/shared/components/plots/BoxScatterPlot.tsx
@@ -46,7 +46,7 @@ import WindowStore from '../window/WindowStore';
 import LegendDataComponent from './LegendDataComponent';
 import LegendLabelComponent from './LegendLabelComponent';
 import { PQValueLabel } from 'shared/components/plots/MultipleCategoryBarPlot';
-import { SampleIdsForPatientIds } from './PlotsTab';
+import type { SampleIdsForPatientIds } from './PlotsTab';
 
 export interface IBaseBoxScatterPlotPoint {
     value: number;

--- a/src/shared/components/plots/MultipleCategoryBarPlot.tsx
+++ b/src/shared/components/plots/MultipleCategoryBarPlot.tsx
@@ -35,6 +35,7 @@ import { toConditionalPrecisionWithMinimum } from 'shared/lib/FormatUtils';
 import { IStringAxisData } from 'shared/components/plots/PlotsTabUtils';
 import WindowStore from 'shared/components/window/WindowStore';
 import { SortByOptions } from 'shared/components/plots/PlotsTab';
+import { PQValueLabel } from './PQValueLabel';
 export interface IMultipleCategoryBarPlotProps {
     svgId?: string;
     domainPadding?: number;
@@ -960,52 +961,3 @@ export default class MultipleCategoryBarPlot extends React.Component<
         );
     }
 }
-
-type PQValueLabelProps = {
-    x: number;
-    y: number;
-    pValue: number | null;
-    qValue: number | null;
-};
-
-export const PQValueLabel: React.FunctionComponent<PQValueLabelProps> = props => {
-    const pFormatted = formatLabel('p', props.pValue);
-    const qFormatted = formatLabel('q', props.qValue);
-    return (
-        <foreignObject
-            x={props.x}
-            y={props.y}
-            width="100%"
-            height="3em"
-            style={{ fontSize: '0.8em' }}
-        >
-            <g
-                x={props.x}
-                y={props.y}
-                style={{ position: 'absolute' }}
-                xmlns="http://www.w3.org/1999/xhtml"
-            >
-                <div className="p-value-label">{pFormatted}</div>
-                <div className="q-value-label">{qFormatted}</div>
-            </g>
-        </foreignObject>
-    );
-
-    function formatLabel(name: string, value: number | null) {
-        if (value != null) {
-            return (
-                <>
-                    {name}{' '}
-                    {toConditionalPrecisionWithMinimum(
-                        value,
-                        3,
-                        0.01,
-                        -10,
-                        true
-                    )}
-                </>
-            );
-        }
-        return '';
-    }
-};

--- a/src/shared/components/plots/PQValueLabel.tsx
+++ b/src/shared/components/plots/PQValueLabel.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { toConditionalPrecisionWithMinimum } from 'shared/lib/FormatUtils';
+
+type PQValueLabelProps = {
+    x: number;
+    y: number;
+    pValue: number | null;
+    qValue: number | null;
+};
+
+export const PQValueLabel: React.FunctionComponent<PQValueLabelProps> = props => {
+    const pFormatted = formatLabel('p', props.pValue);
+    const qFormatted = formatLabel('q', props.qValue);
+    return (
+        <foreignObject
+            x={props.x}
+            y={props.y}
+            width="100%"
+            height="3em"
+            style={{ fontSize: '0.8em' }}
+        >
+            <g
+                x={props.x}
+                y={props.y}
+                style={{ position: 'absolute' }}
+                xmlns="http://www.w3.org/1999/xhtml"
+            >
+                <div className="p-value-label">{pFormatted}</div>
+                <div className="q-value-label">{qFormatted}</div>
+            </g>
+        </foreignObject>
+    );
+
+    function formatLabel(name: string, value: number | null) {
+        if (value != null) {
+            return (
+                <>
+                    {name}{' '}
+                    {toConditionalPrecisionWithMinimum(
+                        value,
+                        3,
+                        0.01,
+                        -10,
+                        true
+                    )}
+                </>
+            );
+        }
+        return '';
+    }
+};


### PR DESCRIPTION
Fixes cBioPortal/cbioportal#11814 

## Problem
Results/Plots tab becomes unresponsive or crashes when rendering categorical-vs-numeric plots with 20k+ samples.

**User Impact:**
- msk_met_2021 study (25,775 samples)
- Plot: Cancer Type (categorical) vs Expression (numeric)
- Result: "Page Unresponsive" dialog / browser freeze

**Root Cause:**
BoxScatterPlot component renders ALL individual scatter points as separate SVG circles. With high-cardinality categorical data:
- 25k samples × 120 categories ≈ 230k+ scatter points
- 230k+ DOM elements + event listeners
- Browser DOM bloat → memory spike → CPU overload → unresponsive

## Solution
Implemented deterministic, proportional point downsampling in BoxScatterPlot rendering pipeline:

**When dataset > 20k points:**
- Downsample to maximum 5k rendered points (46x reduction)
- Allocate samples proportionally per category (all categories visible)
- Use deterministic sampling (reproducible, debuggable)
- Preserve box statistics (median, quartiles from FULL data)

**Key Implementation Details:**
- Applied at `@computed get scatterPlotData()` (render stage)
- Only rendering decimated (no data loss)
- Box plot statistics unaffected (computed from full 230k+ points)
- Backward compatible (<20k samples unaffected)

## Testing
**Unit Tests:**
- All 4 tests in BoxScatterPlot.spec.ts pass 
- Coverage: threshold behavior, cap enforcement, determinism, allocation
- Run with: `yarn test BoxScatterPlot.spec.ts`