### PR TITLE
feat(patient-view): support TMB_NONSYNONYMOUS as alternative TMB attribute

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -170,6 +170,7 @@ import {
     MIS_TYPE_VALUE,
     GENOME_NEXUS_ARG_FIELD_ENUM,
     TMB_H_THRESHOLD,
+    TMB_CLINICAL_ATTRIBUTE_IDS,
     AlterationTypeConstants,
     DataTypeConstants,
 } from 'shared/constants';
@@ -2754,7 +2755,7 @@ export class PatientViewPageStore {
     @computed get sampleTmbHInfo() {
         return getSampleClinicalDataMapByThreshold(
             this.clinicalDataForSamples.result,
-            CLINICAL_ATTRIBUTE_ID_ENUM.TMB_SCORE,
+            TMB_CLINICAL_ATTRIBUTE_IDS,
             TMB_H_THRESHOLD
         );
     }

--- a/src/pages/patientView/sampleHeader/SampleSummaryList.tsx
+++ b/src/pages/patientView/sampleHeader/SampleSummaryList.tsx
@@ -12,6 +12,8 @@ import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicato
 import {
     getSampleNumericalClinicalDataValue,
     OTHER_BIOMARKERS_CLINICAL_ATTR,
+    getSampleTmbClinicalData,
+    getNumericalClinicalDataValue,
 } from 'shared/lib/StoreUtils';
 import { OtherBiomarkersQueryType } from 'oncokb-frontend-commons';
 import { OtherBiomarkerAnnotation } from '../oncokb/OtherBiomarkerAnnotation';
@@ -43,11 +45,25 @@ export default class SampleSummaryList extends React.Component<
         type: OtherBiomarkersQueryType,
         sampleId: string
     ) {
-        const numericalData = getSampleNumericalClinicalDataValue(
-            this.props.patientViewPageStore.clinicalDataForSamples.result,
-            sampleId,
-            OTHER_BIOMARKERS_CLINICAL_ATTR[type]
-        );
+        // For TMBH, resolve both the attribute ID and its numeric value in a
+        // single array scan (CVR_TMB_SCORE preferred over TMB_NONSYNONYMOUS).
+        // For all other biomarker types use the static attribute mapping.
+        let numericalData: number | undefined;
+        if (type === OtherBiomarkersQueryType.TMBH) {
+            const tmbClinicalData = getSampleTmbClinicalData(
+                this.props.patientViewPageStore.clinicalDataForSamples.result,
+                sampleId
+            );
+            numericalData = tmbClinicalData
+                ? getNumericalClinicalDataValue(tmbClinicalData)
+                : undefined;
+        } else {
+            numericalData = getSampleNumericalClinicalDataValue(
+                this.props.patientViewPageStore.clinicalDataForSamples.result,
+                sampleId,
+                OTHER_BIOMARKERS_CLINICAL_ATTR[type]
+            );
+        }
 
         return this.props.patientViewPageStore.getOtherBiomarkersOncoKbData
             .result[sampleId][type] && numericalData !== undefined ? (

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -29,7 +29,16 @@ export const enum CLINICAL_ATTRIBUTE_ID_ENUM {
     MSI_SCORE = 'MSI_SCORE',
     MSI_TYPE = 'MSI_TYPE',
     TMB_SCORE = 'CVR_TMB_SCORE',
+    TMB_NONSYNONYMOUS = 'TMB_NONSYNONYMOUS',
 }
+
+// Priority-ordered list of supported TMB clinical attribute IDs.
+// CVR_TMB_SCORE is preferred (MSK-specific); TMB_NONSYNONYMOUS is the
+// public/general equivalent used by non-MSK studies.
+export const TMB_CLINICAL_ATTRIBUTE_IDS = [
+    CLINICAL_ATTRIBUTE_ID_ENUM.TMB_SCORE,
+    CLINICAL_ATTRIBUTE_ID_ENUM.TMB_NONSYNONYMOUS,
+] as const;
 
 export const enum MIS_TYPE_VALUE {
     INSTABLE = 'Instable',

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -11,6 +11,8 @@ import {
     generateMutationIdByEvent,
     generateMutationIdByGeneAndProteinChangeAndEvent,
     getOncoKbOncogenic,
+    getSampleClinicalDataMapByThreshold,
+    getSampleTmbClinicalData,
     makeStudyToCancerTypeMap,
     mergeMutationsIncludingUncalled,
     noGenePanelUsed,
@@ -1432,6 +1434,149 @@ describe('StoreUtils', () => {
             ];
 
             assert.equal(findMrnaRankMolecularProfileId(list), null);
+        });
+    });
+
+    describe('getSampleClinicalDataMapByThreshold', () => {
+        const clinicalData = [
+            {
+                sampleId: 's1',
+                clinicalAttributeId: 'CVR_TMB_SCORE',
+                value: '15',
+            },
+            {
+                sampleId: 's2',
+                clinicalAttributeId: 'TMB_NONSYNONYMOUS',
+                value: '12',
+            },
+            {
+                sampleId: 's3',
+                clinicalAttributeId: 'CVR_TMB_SCORE',
+                value: '5',
+            },
+            {
+                sampleId: 's4',
+                clinicalAttributeId: 'MSI_SCORE',
+                value: '20',
+            },
+        ] as ClinicalData[];
+
+        it('returns matching samples when passed a single attribute ID string', () => {
+            const result = getSampleClinicalDataMapByThreshold(
+                clinicalData,
+                'CVR_TMB_SCORE',
+                10
+            );
+            assert.deepEqual(Object.keys(result), ['s1']);
+            assert.equal(result['s1'].value, '15');
+        });
+
+        it('returns matching samples when passed an array of attribute IDs', () => {
+            const result = getSampleClinicalDataMapByThreshold(
+                clinicalData,
+                ['CVR_TMB_SCORE', 'TMB_NONSYNONYMOUS'],
+                10
+            );
+            assert.deepEqual(Object.keys(result).sort(), ['s1', 's2']);
+        });
+
+        it('excludes samples below the threshold', () => {
+            const result = getSampleClinicalDataMapByThreshold(
+                clinicalData,
+                ['CVR_TMB_SCORE', 'TMB_NONSYNONYMOUS'],
+                10
+            );
+            assert.notProperty(result, 's3');
+        });
+
+        it('does not match unrelated attribute IDs', () => {
+            const result = getSampleClinicalDataMapByThreshold(
+                clinicalData,
+                ['CVR_TMB_SCORE', 'TMB_NONSYNONYMOUS'],
+                10
+            );
+            assert.notProperty(result, 's4');
+        });
+
+        it('returns empty map when no samples meet the threshold', () => {
+            const result = getSampleClinicalDataMapByThreshold(
+                clinicalData,
+                ['CVR_TMB_SCORE', 'TMB_NONSYNONYMOUS'],
+                100
+            );
+            assert.deepEqual(result, {});
+        });
+    });
+
+    describe('getSampleTmbClinicalData', () => {
+        it('returns CVR_TMB_SCORE entry when only CVR_TMB_SCORE is present', () => {
+            const clinicalData = [
+                {
+                    sampleId: 's1',
+                    clinicalAttributeId: 'CVR_TMB_SCORE',
+                    value: '15',
+                },
+            ] as ClinicalData[];
+            const result = getSampleTmbClinicalData(clinicalData, 's1');
+            assert.isDefined(result);
+            assert.equal(result!.clinicalAttributeId, 'CVR_TMB_SCORE');
+            assert.equal(result!.value, '15');
+        });
+
+        it('returns TMB_NONSYNONYMOUS entry when only TMB_NONSYNONYMOUS is present', () => {
+            const clinicalData = [
+                {
+                    sampleId: 's1',
+                    clinicalAttributeId: 'TMB_NONSYNONYMOUS',
+                    value: '12',
+                },
+            ] as ClinicalData[];
+            const result = getSampleTmbClinicalData(clinicalData, 's1');
+            assert.isDefined(result);
+            assert.equal(result!.clinicalAttributeId, 'TMB_NONSYNONYMOUS');
+            assert.equal(result!.value, '12');
+        });
+
+        it('prefers CVR_TMB_SCORE over TMB_NONSYNONYMOUS when both are present', () => {
+            const clinicalData = [
+                {
+                    sampleId: 's1',
+                    clinicalAttributeId: 'TMB_NONSYNONYMOUS',
+                    value: '12',
+                },
+                {
+                    sampleId: 's1',
+                    clinicalAttributeId: 'CVR_TMB_SCORE',
+                    value: '15',
+                },
+            ] as ClinicalData[];
+            const result = getSampleTmbClinicalData(clinicalData, 's1');
+            assert.isDefined(result);
+            assert.equal(result!.clinicalAttributeId, 'CVR_TMB_SCORE');
+        });
+
+        it('returns undefined when no TMB attribute is present for the sample', () => {
+            const clinicalData = [
+                {
+                    sampleId: 's1',
+                    clinicalAttributeId: 'MSI_SCORE',
+                    value: '5',
+                },
+            ] as ClinicalData[];
+            const result = getSampleTmbClinicalData(clinicalData, 's1');
+            assert.isUndefined(result);
+        });
+
+        it('returns undefined when clinical data is for a different sample', () => {
+            const clinicalData = [
+                {
+                    sampleId: 's2',
+                    clinicalAttributeId: 'CVR_TMB_SCORE',
+                    value: '15',
+                },
+            ] as ClinicalData[];
+            const result = getSampleTmbClinicalData(clinicalData, 's1');
+            assert.isUndefined(result);
         });
     });
 });

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -67,6 +67,7 @@ import {
     CLINICAL_ATTRIBUTE_ID_ENUM,
     DataTypeConstants,
     GENOME_NEXUS_ARG_FIELD_ENUM,
+    TMB_CLINICAL_ATTRIBUTE_IDS,
 } from 'shared/constants';
 import { normalizeMutations } from '../components/mutationMapper/MutationMapperUtils';
 import { getServerConfig } from 'config/config';
@@ -1707,13 +1708,16 @@ export function makeGetOncoKbCnaAnnotationForOncoprint(
 
 export function getSampleClinicalDataMapByThreshold(
     clinicalData: ClinicalData[],
-    clinicalAttributeId: string,
+    clinicalAttributeId: string | readonly string[],
     threshold: number
 ) {
+    const ids = Array.isArray(clinicalAttributeId)
+        ? (clinicalAttributeId as readonly string[])
+        : [clinicalAttributeId as string];
     return _.reduce(
         clinicalData,
         (acc, next) => {
-            if (next.clinicalAttributeId === clinicalAttributeId) {
+            if (ids.includes(next.clinicalAttributeId)) {
                 const value = getNumericalClinicalDataValue(next);
                 if (value && value >= threshold) {
                     acc[next.sampleId] = next;
@@ -1766,6 +1770,33 @@ export function getSampleNumericalClinicalDataValue(
     );
     if (sampleMsiData) {
         return getNumericalClinicalDataValue(sampleMsiData);
+    }
+    return undefined;
+}
+
+/**
+ * Returns the ClinicalData entry for the first TMB attribute found for the
+ * given sample, checking all supported TMB attribute IDs in a single pass.
+ * Priority order (CVR_TMB_SCORE then TMB_NONSYNONYMOUS) is enforced after
+ * the scan by picking the highest-priority match.
+ * Returns undefined if no TMB attribute is present for the sample.
+ */
+export function getSampleTmbClinicalData(
+    clinicalData: ClinicalData[],
+    sampleId: string
+): ClinicalData | undefined {
+    const tmbAttrIdSet = new Set<string>(TMB_CLINICAL_ATTRIBUTE_IDS);
+    const candidates = new Map<string, ClinicalData>();
+    for (const d of clinicalData) {
+        if (d.sampleId === sampleId && tmbAttrIdSet.has(d.clinicalAttributeId)) {
+            candidates.set(d.clinicalAttributeId, d);
+        }
+    }
+    // Return in priority order
+    for (const attrId of TMB_CLINICAL_ATTRIBUTE_IDS) {
+        if (candidates.has(attrId)) {
+            return candidates.get(attrId);
+        }
     }
     return undefined;
 }


### PR DESCRIPTION
## Summary

Support `TMB_NONSYNONYMOUS` as an alternative clinical attribute for TMB-H detection in Patient View, alongside the existing MSK-specific `CVR_TMB_SCORE`.

## Background

TMB-H samples in Patient View are identified by checking whether a sample's TMB clinical attribute is ≥ 10. Previously the code was hardcoded to only look for `CVR_TMB_SCORE` (an MSK-internal term), so public studies that use the general attribute `TMB_NONSYNONYMOUS` (e.g. `msk_impact_50k_2026` on cbioportal.org) would lose both the TMB-H badge and the OncoKB annotation icon in the sample header.

## Changes

### `src/shared/constants.ts`
- Added `TMB_NONSYNONYMOUS = 'TMB_NONSYNONYMOUS'` to `CLINICAL_ATTRIBUTE_ID_ENUM`
- Exported `TMB_CLINICAL_ATTRIBUTE_IDS` — a priority-ordered `readonly` array: `['CVR_TMB_SCORE', 'TMB_NONSYNONYMOUS']`

### `src/shared/lib/StoreUtils.ts`
- Updated `getSampleClinicalDataMapByThreshold` to accept `string | readonly string[]` (fully backward-compatible — existing single-string callers such as MSI are unaffected)
- Replaced the previous multi-pass `getTmbClinicalAttributeIdForSample` with a new single-pass helper **`getSampleTmbClinicalData(clinicalData, sampleId)`** that scans the array once using a `Set` for attribute ID lookup, collects all TMB matches, then picks the highest-priority result (`CVR_TMB_SCORE` preferred over `TMB_NONSYNONYMOUS`)

### `src/pages/patientView/clinicalInformation/PatientViewPageStore.ts`
- `sampleTmbHInfo` now passes `TMB_CLINICAL_ATTRIBUTE_IDS` so both attribute IDs are checked when identifying TMB-H samples

### `src/pages/patientView/sampleHeader/SampleSummaryList.tsx`
- `getOncoKbOtherBiomarkerAnnotationComponent` now uses `getSampleTmbClinicalData` for the TMBH path, collapsing the previous two array scans into a single pass before extracting the numerical value for the OncoKB annotation

### `src/shared/lib/StoreUtils.spec.ts`
- Added tests for `getSampleClinicalDataMapByThreshold`: single string ID (backward-compat), array of IDs, below-threshold exclusion, unrelated attribute IDs ignored, empty result
- Added tests for `getSampleTmbClinicalData`: only `CVR_TMB_SCORE` present, only `TMB_NONSYNONYMOUS` present, both present (verifies `CVR_TMB_SCORE` is preferred), no TMB attribute present, wrong sample ID

## Testing
- TypeScript compiles with no errors
- 10 new unit tests added covering both new/updated helpers
- Manual: verify TMB-H badge + OncoKB icon appear on the 50k study patient page after data is updated to use `TMB_NONSYNONYMOUS`
- MSK portal behaviour (`CVR_TMB_SCORE`) is unchanged

**Before fix:** https://www.cbioportal.org/patient?studyId=msk_chord_2024&caseId=P-0000831

**After fix:** https://deploy-preview-5497--cbioportalfrontend.netlify.app/patient?studyId=msk_chord_2024&caseId=P-0000831
