### PR TITLE
Fix missing onToggleLogScale handler for bar charts in study view

### DIFF
--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -290,6 +290,7 @@ export class StudySummaryTab extends React.Component<
             [ChartTypeEnum.BAR_CHART]: () => ({
                 commonProps: {
                     onToggleNAValue: this.handlers.onToggleNAValue,
+                    onToggleLogScale: this.handlers.onToggleLogScale,
                     logScaleChecked: this.store.isLogScaleChecked(
                         chartMeta.uniqueKey
                     ),


### PR DESCRIPTION
Fix cBioPortal/cbioportal#12096 

Describe changes proposed in this pull request:
- Added missing `onToggleLogScale` handler to the `BAR_CHART` `commonProps` in `SummaryTab.tsx` 
- The handler was defined but never passed to `ChartContainer`, causing the log scale checkbox to render, but do 
  nothing when clicked

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created → No new test needed.
  This is a one-line fix, connecting an existing handler to an existing prop. The behavior is already covered by the existing         `onToggleLogScale` logic in `StudyViewPageStore`.
- [x] The commit log is comprehensible.
- [x] Is this PR adding logic based on one or more **clinical** attributes? → No, this PR does not add any new clinical
  attribute logic.

## Any screenshots or GIFs?
 N/A — no visual changes. The checkbox is already rendered. This PR only fixes its toggle-on-click behavior.

## Notify reviewers
Tagging @qlu-cls as they have the most context on the `BAR_CHART` config in `SummaryTab.tsx`. Would appreciate a review when you get a chance.
