### PR TITLE
Fix CNA civic variants crash from uninitialized gene map

### DIFF
--- a/packages/cbioportal-utils/src/civic/CivicUtils.spec.ts
+++ b/packages/cbioportal-utils/src/civic/CivicUtils.spec.ts
@@ -69,7 +69,6 @@ describe('CivicUtils', () => {
                     E545K: {
                         id: 104,
                         name: 'E545K',
-                        geneId: 37,
                         description:
                             'PIK3CA E545K/E542K are the second most recurrent PIK3CA mutations in breast cancer, and are highly recurrent mutations in many other cancer types. E545K, and possibly the other mutations in the E545 region, may present patients with a poorer prognosis than patients with either patients with other PIK3CA variant or wild-type PIK3CA. There is also data to suggest that E545/542 mutations may confer resistance to EGFR inhibitors like cetuximab. While very prevalent, targeted therapies for variants in PIK3CA are still in early clinical trial phases.',
                         url: 'https://civicdb.org/variants/104/summary',
@@ -96,7 +95,6 @@ describe('CivicUtils', () => {
                     AMPLIFICATION: {
                         id: 591,
                         name: 'AMPLIFICATION',
-                        geneId: 4767,
                         description: '',
                         url: 'https://civicdb.org/variants/591/summary',
                         evidenceCounts: {

--- a/packages/cbioportal-utils/src/civic/CivicUtils.spec.ts
+++ b/packages/cbioportal-utils/src/civic/CivicUtils.spec.ts
@@ -93,18 +93,20 @@ describe('CivicUtils', () => {
                 description: '',
                 url: 'https://civicdb.org/genes/4767/summary',
                 variants: {
-                    id: 591,
-                    name: 'AMPLIFICATION',
-                    geneId: 4767,
-                    description: '',
-                    url: 'https://civicdb.org/variants/591/summary',
-                    evidenceCounts: {
-                        prognosticCount: 1,
-                        predictiveCount: 1,
-                        diagnosticCount: 0,
-                        predisposingCount: 0,
-                        oncogenicCount: 0,
-                        functionalCount: 0,
+                    AMPLIFICATION: {
+                        id: 591,
+                        name: 'AMPLIFICATION',
+                        geneId: 4767,
+                        description: '',
+                        url: 'https://civicdb.org/variants/591/summary',
+                        evidenceCounts: {
+                            prognosticCount: 1,
+                            predictiveCount: 1,
+                            diagnosticCount: 0,
+                            predisposingCount: 0,
+                            oncogenicCount: 0,
+                            functionalCount: 0,
+                        },
                     },
                 },
             },
@@ -159,38 +161,26 @@ describe('CivicUtils', () => {
         ];
 
         it('Returns civicVariants map for PIK3CA', () => {
-            const civicVariantsPromise = getCivicVariants(
-                civicGenes,
-                mutationData
-            );
-            civicVariantsPromise
-                .then(civicVariants => {
-                    assert.equal(
+            return getCivicVariants(civicGenes, mutationData).then(
+                civicVariants => {
+                    assert.deepEqual(
                         civicVariants,
                         mutationCivicVariants,
                         'PIK3CA E545K civic variants'
                     );
-                })
-                .catch(() => {
-                    /*do nothing*/
-                });
+                }
+            );
         });
         it('Returns civicVariants map for CNA', () => {
-            const civicVariantsPromise = getCivicVariants(
-                civicCnaGenes,
-                undefined
-            );
-            civicVariantsPromise
-                .then(civicVariants => {
-                    assert.equal(
+            return getCivicVariants(civicCnaGenes, undefined).then(
+                civicVariants => {
+                    assert.deepEqual(
                         civicVariants,
                         cnaCivicVariants,
                         'CNA civic variants'
                     );
-                })
-                .catch(() => {
-                    /*do nothing*/
-                });
+                }
+            );
         });
     });
 });

--- a/packages/cbioportal-utils/src/civic/CivicUtils.ts
+++ b/packages/cbioportal-utils/src/civic/CivicUtils.ts
@@ -102,6 +102,9 @@ export function getCivicVariants(
                         variantName == CivicAlterationType.AMPLIFICATION ||
                         variantName == CivicAlterationType.DELETION
                     ) {
+                        if (!civicVariants[geneSymbol]) {
+                            civicVariants[geneSymbol] = {};
+                        }
                         civicVariants[geneSymbol][variantName] =
                             geneVariants[variantName];
                     }


### PR DESCRIPTION
getCivicVariants threw "Cannot set properties of undefined" in the CNA
branch because civicVariants[geneSymbol] was assigned without being
initialized first. The mutation branch already guards this. This caused
the patient view to fail fetching CIViC data whenever CNA civic genes
were returned. Also tighten the spec to actually await the promises
instead of swallowing errors with .catch, and correct the malformed CNA
test fixture so it exercises the real code path.

## Reproduction

- Production (broken): https://www.cbioportal.org/patient?studyId=msk_impact_50k_2026&caseId=P-0002435
- Deploy preview (fixed): https://deploy-preview-5505.preview.cbioportal.org/patient?studyId=msk_impact_50k_2026&caseId=P-0002435