### PR TITLE
Add WebMCP add-gene tool to Results View oncoprint

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -35,6 +35,7 @@ import {
 import CoExpressionTab from './coExpression/CoExpressionTab';
 import Helmet from 'react-helmet';
 import {
+    addGenesToQuery,
     parseConfigDisabledTabs,
     ResultsViewTab,
 } from './ResultsViewPageHelpers';
@@ -166,11 +167,57 @@ export default class ResultsViewPage extends React.Component<
         const newParams = _.clone(this.routing.query);
         newParams[USER_SETTINGS_QUERY_PARAM] = undefined;
         this.routing.updateRoute(newParams);
+
+        this.registerWebMCPTools();
     }
 
     componentWillUnmount() {
+        this.unregisterWebMCPTools();
         this.resultsViewPageStore.destroy();
         this.urlWrapper.destroy();
+    }
+
+    private registerWebMCPTools() {
+        if (!navigator.modelContext) {
+            return;
+        }
+
+        const urlWrapper = this.urlWrapper;
+
+        navigator.modelContext.registerTool({
+            name: 'add-gene',
+            description:
+                'Add a gene to the oncoprint query. Takes a HUGO gene symbol (e.g. TP53, BRCA1) and appends it to the current gene list.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    gene: {
+                        type: 'string',
+                        description: 'HUGO gene symbol to add (e.g. TP53)',
+                    },
+                },
+                required: ['gene'],
+            },
+            async execute(params) {
+                const gene = String(params.gene).toUpperCase();
+                addGenesToQuery(urlWrapper, [gene]);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Added ${gene} to the oncoprint query.`,
+                        },
+                    ],
+                };
+            },
+        });
+    }
+
+    private unregisterWebMCPTools() {
+        if (!navigator.modelContext) {
+            return;
+        }
+        navigator.modelContext.unregisterTool('add-gene');
     }
 
     @computed

--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -198,9 +198,11 @@ export default class ResultsViewPage extends React.Component<
                 },
                 required: ['gene'],
             },
-            async execute(params) {
+            execute(params) {
                 const gene = String(params.gene).toUpperCase();
-                addGenesToQuery(urlWrapper, [gene]);
+                setTimeout(() => {
+                    addGenesToQuery(urlWrapper, [gene]);
+                }, 0);
                 return {
                     content: [
                         {

--- a/typings/webmcp.d.ts
+++ b/typings/webmcp.d.ts
@@ -1,0 +1,21 @@
+interface WebMCPToolResult {
+    content: Array<{ type: string; text: string }>;
+}
+
+interface WebMCPToolDescriptor {
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    execute(
+        params: Record<string, unknown>
+    ): WebMCPToolResult | Promise<WebMCPToolResult>;
+}
+
+interface ModelContext {
+    registerTool(descriptor: WebMCPToolDescriptor): void;
+    unregisterTool(name: string): void;
+}
+
+interface Navigator {
+    modelContext?: ModelContext;
+}


### PR DESCRIPTION
## Summary

- Registers a WebMCP `add-gene` tool on the Results View page via Chrome's experimental `navigator.modelContext` API (Chrome 146+)
- Lets browser-side AI agents add HUGO gene symbols to the oncoprint query by calling into the existing `addGenesToQuery()` helper
- Silently degrades in browsers without WebMCP support — no errors for normal users

## Preview

https://deploy-preview-5507.preview.cbioportal.org/results/oncoprint?cancer_study_list=msk_impact_2017&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mutations%2Cfusion%2Ccna&case_set_id=msk_impact_2017_cnaseq&gene_list=TP53&geneset_list=%20&tab_index=tab_visualize&Action=Submit

## Demo

<img width="1057" height="657" alt="image" src="https://github.com/user-attachments/assets/ec396c32-6ad3-46d9-a904-ed11eaf6b091" />

The screenshot above shows the `add-gene` tool being invoked via the [Model Context Tool Inspector](https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd) Chrome extension, adding PIK3CA to the oncoprint alongside TP53.

## Current limitations

- **WebMCP is experimental** — requires Chrome 146+ Canary with `chrome://flags/#enable-webmcp-testing` enabled.
- **Gemini sidebar does not consume WebMCP tools yet.** The tool registers correctly (`navigator.modelContextTesting.listTools()` shows it), but Chrome's built-in Gemini AI does not call page-registered tools as of April 2026.
- **Testing requires the Model Context Tool Inspector extension** or manual calls via `navigator.modelContextTesting.executeTool('add-gene', '{"gene": "EGFR"}')` in the devtools console.
- Broad AI client support for WebMCP is expected mid-to-late 2026.

## Test plan

- [ ] Open the deploy preview in Chrome 146+ Canary with `chrome://flags/#enable-webmcp-testing` enabled
- [ ] Verify `navigator.modelContextTesting.listTools()` returns the `add-gene` tool
- [ ] Execute via console: `navigator.modelContextTesting.executeTool('add-gene', '{"gene": "EGFR"}')`
- [ ] Confirm EGFR appears in the oncoprint
- [ ] Verify no console errors in a normal browser without WebMCP support

🤖 Generated with [Claude Code](https://claude.com/claude-code)