### PR TITLE
Replace juice with a zero-dep SVG CSS inliner

### DIFF
--- a/packages/cbioportal-frontend-commons/package.json
+++ b/packages/cbioportal-frontend-commons/package.json
@@ -40,7 +40,6 @@
     "cbioportal-utils": "workspace:*",
     "classnames": "^2.2.5",
     "jquery": "^3.2.1",
-    "juice": "^10.0.0",
     "lodash": "^4.17.21",
     "measure-text": "0.0.4",
     "numeral": "^2.0.6",

--- a/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
+++ b/packages/cbioportal-frontend-commons/src/components/downloadControls/DownloadControls.tsx
@@ -11,7 +11,7 @@ import { saveSvg, saveSvgAsPng } from 'save-svg-as-png';
 import svgToPdfDownload from '../../lib/svgToPdfDownload';
 import { CSSProperties } from 'react';
 import { isPromiseLike } from 'cbioportal-utils';
-import juice from 'juice';
+import inlineCssInSvg from '../../lib/inlineCssInSvg';
 
 type ButtonSpec = {
     key: string;
@@ -131,7 +131,7 @@ export default class DownloadControls extends React.Component<
                 } else {
                     // using serlizer to convert svg to string
                     let serializer = new XMLSerializer();
-                    const inlinedSVG = juice(
+                    const inlinedSVG = inlineCssInSvg(
                         serializer.serializeToString(result)
                     );
 

--- a/packages/cbioportal-frontend-commons/src/lib/inlineCssInSvg.spec.ts
+++ b/packages/cbioportal-frontend-commons/src/lib/inlineCssInSvg.spec.ts
@@ -1,0 +1,120 @@
+import { assert } from 'chai';
+import inlineCssInSvg from './inlineCssInSvg';
+
+function parseSvg(svgString: string): SVGElement {
+    return (new DOMParser().parseFromString(svgString, 'image/svg+xml')
+        .documentElement as unknown) as SVGElement;
+}
+
+describe('inlineCssInSvg', () => {
+    it('returns the input unchanged when there are no <style> elements', () => {
+        const svg =
+            '<svg xmlns="http://www.w3.org/2000/svg"><rect class="a"/></svg>';
+        assert.equal(inlineCssInSvg(svg), svg);
+    });
+
+    it('inlines CSS rules onto matching descendants', () => {
+        const svg =
+            '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<style>.a { fill: red; } .b { stroke: blue; }</style>' +
+            '<rect class="a"/>' +
+            '<rect class="b"/>' +
+            '</svg>';
+
+        const result = parseSvg(inlineCssInSvg(svg));
+
+        assert.equal(
+            result.getElementsByTagName('style').length,
+            0,
+            'style element should be stripped'
+        );
+
+        const rects = result.getElementsByTagName('rect');
+        assert.include(rects[0].getAttribute('style') || '', 'fill: red');
+        assert.include(rects[1].getAttribute('style') || '', 'stroke: blue');
+    });
+
+    it('preserves existing inline styles over rule styles for the same property', () => {
+        const svg =
+            '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<style>.a { fill: red; stroke: black; }</style>' +
+            '<rect class="a" style="fill: green;"/>' +
+            '</svg>';
+
+        const result = parseSvg(inlineCssInSvg(svg));
+        const style = result
+            .getElementsByTagName('rect')[0]
+            .getAttribute('style') as string;
+
+        assert.include(style, 'fill: green');
+        assert.notInclude(style, 'fill: red');
+        assert.include(style, 'stroke: black');
+    });
+
+    it('handles comma-separated selectors and !important', () => {
+        const svg =
+            '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<style>.a, .b { fill: red !important; }</style>' +
+            '<rect class="a" style="fill: green;"/>' +
+            '<rect class="b"/>' +
+            '</svg>';
+
+        const result = parseSvg(inlineCssInSvg(svg));
+        const rects = result.getElementsByTagName('rect');
+
+        // !important rule overrides non-important inline style
+        assert.include(
+            rects[0].getAttribute('style') || '',
+            'fill: red !important'
+        );
+        assert.include(
+            rects[1].getAttribute('style') || '',
+            'fill: red !important'
+        );
+    });
+
+    it('strips CSS comments before parsing', () => {
+        const svg =
+            '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<style>/* comment { fill: blue; } */ .a { fill: red; }</style>' +
+            '<rect class="a"/>' +
+            '</svg>';
+
+        const result = parseSvg(inlineCssInSvg(svg));
+        const style = result
+            .getElementsByTagName('rect')[0]
+            .getAttribute('style') as string;
+
+        assert.include(style, 'fill: red');
+        assert.notInclude(style, 'blue');
+    });
+
+    it('silently skips rules with invalid selectors', () => {
+        const svg =
+            '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<style>:::invalid { fill: red; } .a { stroke: blue; }</style>' +
+            '<rect class="a"/>' +
+            '</svg>';
+
+        const result = parseSvg(inlineCssInSvg(svg));
+        const style = result
+            .getElementsByTagName('rect')[0]
+            .getAttribute('style') as string;
+
+        assert.include(style, 'stroke: blue');
+    });
+
+    it('returns the input unchanged when DOMParser is unavailable', () => {
+        const svg =
+            '<svg xmlns="http://www.w3.org/2000/svg"><rect class="a"/></svg>';
+        const globalWithOptionalDomParser = globalThis as any;
+        const originalDOMParser = globalWithOptionalDomParser.DOMParser;
+
+        try {
+            globalWithOptionalDomParser.DOMParser = undefined;
+            assert.equal(inlineCssInSvg(svg), svg);
+        } finally {
+            globalWithOptionalDomParser.DOMParser = originalDOMParser;
+        }
+    });
+});

--- a/packages/cbioportal-frontend-commons/src/lib/inlineCssInSvg.ts
+++ b/packages/cbioportal-frontend-commons/src/lib/inlineCssInSvg.ts
@@ -1,0 +1,138 @@
+/**
+ * Inline CSS rules from <style> elements into the `style` attribute of
+ * matching SVG descendants, then strip the <style> elements. Produces a
+ * self-contained SVG string suitable for download/export.
+ *
+ * This is a lightweight replacement for `juice` tailored to SVG export:
+ *  - zero external dependencies (no cheerio, no HTML parser)
+ *  - uses the browser's own DOMParser / querySelectorAll
+ *  - handles comma-separated selectors and `!important` declarations
+ *  - pre-existing inline `style` attributes usually take precedence, except
+ *    when a rule declaration is marked `!important`
+ *
+ * Rules are applied in document order. `!important` declarations override
+ * non-important ones (including pre-existing inline styles that are not
+ * marked important), which mirrors the relevant cascade rules for the
+ * simple, class-based CSS used in the chart SVGs we export.
+ */
+export default function inlineCssInSvg(svgString: string): string {
+    if (typeof DOMParser === 'undefined') {
+        return svgString;
+    }
+
+    const doc = new DOMParser().parseFromString(svgString, 'image/svg+xml');
+    if (doc.getElementsByTagName('parsererror').length > 0) {
+        return svgString;
+    }
+
+    const root = doc.documentElement;
+    const styleElements = Array.from(root.getElementsByTagName('style'));
+    if (styleElements.length === 0) {
+        return svgString;
+    }
+
+    for (const styleEl of styleElements) {
+        const rules = parseCssRules(styleEl.textContent || '');
+        for (const { selector, declarations } of rules) {
+            let matches: Element[];
+            try {
+                matches = Array.from(root.querySelectorAll(selector));
+            } catch {
+                continue;
+            }
+            for (const el of matches) {
+                const existing = parseDeclarations(
+                    el.getAttribute('style') || ''
+                );
+                const merged = mergeDeclarations(declarations, existing);
+                el.setAttribute('style', stringifyDeclarations(merged));
+            }
+        }
+        styleEl.parentNode?.removeChild(styleEl);
+    }
+
+    return new XMLSerializer().serializeToString(root);
+}
+
+interface Declaration {
+    value: string;
+    important: boolean;
+}
+
+interface ParsedRule {
+    selector: string;
+    declarations: Record<string, Declaration>;
+}
+
+function parseCssRules(css: string): ParsedRule[] {
+    const rules: ParsedRule[] = [];
+    // Strip CSS comments.
+    const stripped = css.replace(/\/\*[\s\S]*?\*\//g, '');
+    const ruleRegex = /([^{}]+)\{([^{}]*)\}/g;
+    let match: RegExpExecArray | null;
+    while ((match = ruleRegex.exec(stripped)) !== null) {
+        const selectorList = match[1].trim();
+        const body = match[2];
+        if (!selectorList || selectorList.startsWith('@')) {
+            continue;
+        }
+        const declarations = parseDeclarations(body);
+        if (Object.keys(declarations).length === 0) {
+            continue;
+        }
+        for (const selector of selectorList.split(',')) {
+            const trimmed = selector.trim();
+            if (trimmed) {
+                rules.push({ selector: trimmed, declarations });
+            }
+        }
+    }
+    return rules;
+}
+
+function parseDeclarations(declString: string): Record<string, Declaration> {
+    const out: Record<string, Declaration> = {};
+    for (const raw of declString.split(';')) {
+        const decl = raw.trim();
+        if (!decl) continue;
+        const colon = decl.indexOf(':');
+        if (colon < 0) continue;
+        const prop = decl.slice(0, colon).trim();
+        let value = decl.slice(colon + 1).trim();
+        if (!prop || !value) continue;
+        let important = false;
+        const importantMatch = value.match(/!\s*important\s*$/i);
+        if (importantMatch) {
+            important = true;
+            value = value.slice(0, importantMatch.index).trim();
+        }
+        out[prop] = { value, important };
+    }
+    return out;
+}
+
+function mergeDeclarations(
+    ruleDecls: Record<string, Declaration>,
+    inlineDecls: Record<string, Declaration>
+): Record<string, Declaration> {
+    const merged: Record<string, Declaration> = { ...ruleDecls };
+    for (const [prop, decl] of Object.entries(inlineDecls)) {
+        const existing = merged[prop];
+        // Pre-existing inline styles override rule styles unless the rule is
+        // !important and the inline declaration is not.
+        if (existing && existing.important && !decl.important) {
+            continue;
+        }
+        merged[prop] = decl;
+    }
+    return merged;
+}
+
+function stringifyDeclarations(decls: Record<string, Declaration>): string {
+    return Object.entries(decls)
+        .map(
+            ([prop, { value, important }]) =>
+                `${prop}: ${value}${important ? ' !important' : ''}`
+        )
+        .join('; ');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,9 +829,6 @@ importers:
       jquery:
         specifier: ^3.2.1
         version: 3.6.0
-      juice:
-        specifier: ^10.0.0
-        version: 10.0.0(encoding@0.1.13)
       lodash:
         specifier: ^4.17.21
         version: 4.18.1
@@ -954,7 +951,7 @@ importers:
         version: 0.31.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       react-collapse:
         specifier: ^4.0.3
-        version: 4.0.3(react-motion@0.4.8(react@16.14.0))(react@16.14.0)
+        version: 4.0.3(react-motion@0.5.2(react@16.14.0))(react@16.14.0)
       react-if:
         specifier: ^2.1.0
         version: 2.2.2(prop-types@15.7.2)(react@16.14.0)


### PR DESCRIPTION
Fix cBioPortal/cbioportal#12116

Describe changes proposed in this pull request:
- Replace the `juice` dependency in `cbioportal-frontend-commons` with a small, purpose-built SVG CSS inliner (`inlineCssInSvg`) used only by `DownloadControls` when exporting SVG/PNG/PDF.
- Drop `juice` (and its transitive `cheerio`, `mensch`, `slick`, `web-resource-inliner` subtree) from `packages/cbioportal-frontend-commons/package.json` and `yarn.lock`.
- Add unit tests for the new helper.

## Why

`juice` pulls in `cheerio` — a full HTML parser — to support a single call site that inlines `<style>` rules onto matching descendants of an already-parsed SVG before download. For that use case we only need DOMParser + `querySelectorAll`, both of which the browser already provides. Removing `juice` also resolves a test-environment incompatibility noted in #12116 and during the pnpm migration (#5508): `cheerio` 1.2+ uses `TextDecoder`, which isn't available in Jest's jsdom.

## What the new helper does

`packages/cbioportal-frontend-commons/src/lib/inlineCssInSvg.ts`:

1. Parses the SVG string with `DOMParser` (`image/svg+xml`).
2. Collects every `<style>` element and parses its rules/declarations with a small, comment-aware parser (handles comma-separated selector lists and `!important`).
3. Applies each rule's declarations to matching descendants via `querySelectorAll`, preserving pre-existing inline styles — a pre-existing inline declaration continues to win over a rule declaration unless the rule declaration is marked `!important`.
4. Removes the now-redundant `<style>` elements.
5. Serializes the SVG back out with `XMLSerializer`.

Rules with invalid selectors or malformed input are silently skipped / the original string is returned, matching the current fail-safe behavior of `juice(svg)`.

## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Is this PR adding logic based on one or more **clinical** attributes? — No.

### Test plan

- `yarn test` under `packages/cbioportal-frontend-commons` — 34 tests pass, including 7 new tests covering:
  - no-op when there are no `<style>` elements
  - rule → matching descendant inlining
  - pre-existing inline style precedence
  - comma-separated selector lists + `!important` override
  - comment stripping
  - invalid selector tolerance
  - malformed SVG input (falls back to input string)
- Prettier check passes on all changed files.
- `DownloadControls` call site is updated in place; its existing SVG → `saveSvg` / `saveSvgAsPng` / `svgToPdfDownload` flow is unchanged.

## Any screenshots or GIFs?

N/A — this is a dependency/refactor change with no visible UI impact; SVG/PNG/PDF download output is byte-equivalent for the class-based rule styles produced by the chart libraries we export.