### PR TITLE
Add CLAUDE.md / AGENTS.md symlinks and document screenshot-artifact workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,6 +81,22 @@ This repository contains the frontend code for cBioPortal, a comprehensive cance
 - **Important**: Reference screenshots created on host system differ from dockerized setup (e.g., CircleCI) and cannot be used as references
 - Failed test screenshots are in `screenshots/diff` and `screenshots/error` folders for debugging
 
+#### Updating stale reference screenshots after an upstream data change
+
+When an upstream data source (Genome Nexus, OncoKB, cBioPortal backend) changes and the e2e reference screenshots go stale, CircleCI will fail on screenshot comparison. The fastest way to refresh the references is to **pull the "actual" screenshot from the failing CircleCI job's artifacts** — that image already shows the new correct data, rendered in the same dockerized environment the reference must match.
+
+```bash
+curl -L 'https://output.circle-artifacts.com/output/job/<job-uuid>/artifacts/0/./screenshots/screen/<screenshot-name>.png' \
+  > 'end-to-end-test/remote/screenshots/reference/<screenshot-name>.png'
+git add 'end-to-end-test/remote/screenshots/reference/<screenshot-name>.png'
+```
+
+Get the `<job-uuid>` from the failing CircleCI check on the PR (click through to the job → Artifacts tab → copy a screenshot URL and extract the UUID).
+
+Don't regenerate screenshots locally unless CircleCI can't produce them — per the note above, host-rendered images won't match the dockerized reference.
+
+Only update the screenshots affected by the upstream change. Don't bundle unrelated screenshot updates. One upstream fix, one PR. PR #5514 (CCDS ID fix) is a reference example.
+
 ### Code Quality
 - Pre-commit hooks automatically format code with Prettier
 - CircleCI runs prettier checks on pull requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
## Summary

- Symlink `CLAUDE.md` and `AGENTS.md` at the repo root to the existing `.github/copilot-instructions.md` so AI coding tools looking for either conventional filename pick up the same guidance (no content duplication to keep in sync).
- Add a new subsection to the Screenshot Testing docs describing the shortcut of pulling the "actual" screenshot from a failing CircleCI job's artifacts when an upstream data source (Genome Nexus, OncoKB, backend) changes. This is much faster than regenerating references locally and guaranteed to match the dockerized CI environment. PR #5514 (CCDS ID fix) is cited as a reference example.

Documentation-only change — no runtime effect, no deploy preview needed.

## Test plan

- [x] `CLAUDE.md` and `AGENTS.md` resolve to `.github/copilot-instructions.md` via symlink
- [x] Screenshot-artifact subsection renders correctly in the markdown