### PR TITLE
Fix(query): default-select sole molecular profile (fixes #11569)

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -275,7 +275,10 @@ import StudyViewURLWrapper from './StudyViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
-import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from 'shared/lib/molecularProfileUtils';
 import {
     createAlteredGeneComparisonSession,
     doesChartHaveComparisonGroupsLimit,
@@ -10401,6 +10404,20 @@ export class StudyViewPageStore
                 .map(profile => getSuffixOfMolecularProfile(profile))
                 .uniq()
                 .value();
+        }
+
+        if (
+            this.filteredVirtualStudies.result.length === 0 &&
+            this.studyIds.length === 1 &&
+            molecularProfileFilters.length === 0 &&
+            this.molecularProfiles.isComplete
+        ) {
+            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+                this.molecularProfiles.result
+            );
+            if (singleSuffix) {
+                molecularProfileFilters.push(singleSuffix);
+            }
         }
 
         if (molecularProfileFilters.length > 0) {

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -472,7 +472,6 @@ export class QueryStore {
         // matched (e.g. RNA-only studies). Only when selection is still empty so we
         // do not override mutation/CNA/SV defaults in mixed cohorts (see PR #5462).
         if (
-            this.profileFilterSet === undefined &&
             this.validProfileIdSetForSelectedStudies.isComplete &&
             _.isEmpty(selectedIdSet) &&
             _.isEmpty(this.profileFilterSetFromUrl) &&

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -66,7 +66,10 @@ import {
     ResultsViewURLQueryEnum,
 } from 'pages/resultsView/ResultsViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
-import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from 'shared/lib/molecularProfileUtils';
 import { VirtualStudy } from 'shared/api/session-service/sessionServiceModels';
 import { isQueriedStudyAuthorized } from 'pages/studyView/StudyViewUtils';
 import { toQueryString } from 'shared/lib/query/textQueryUtils';
@@ -463,6 +466,24 @@ export class QueryStore {
                 }
             } else {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());
+            }
+        }
+        // #11569: default-select the only molecular profile when nothing else
+        // matched (e.g. RNA-only studies). Only when selection is still empty so we
+        // do not override mutation/CNA/SV defaults in mixed cohorts (see PR #5462).
+        if (
+            this.profileFilterSet === undefined &&
+            this.validProfileIdSetForSelectedStudies.isComplete &&
+            _.isEmpty(selectedIdSet) &&
+            _.isEmpty(this.profileFilterSetFromUrl) &&
+            _.isEmpty(this.profileIdsFromUrl)
+        ) {
+            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+                this.molecularProfilesInSelectedStudies.result || [],
+                { forDownloadTab: this.forDownloadTab }
+            );
+            if (singleSuffix) {
+                selectedIdSet[singleSuffix] = true;
             }
         }
         return selectedIdSet;

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -2275,6 +2275,7 @@ export class QueryStore {
         );
 
         this.profileIdsFromUrl = _.compact(profileIds);
+        this.profileFilterSetFromUrl = undefined;
         this.zScoreThreshold = params.Z_SCORE_THRESHOLD || '2.0';
         this.rppaScoreThreshold = params.RPPA_SCORE_THRESHOLD || '2.0';
         if (params.data_priority) {
@@ -2282,7 +2283,9 @@ export class QueryStore {
         }
         if (params.profileFilter) {
             if (isNaN(parseInt(params.profileFilter, 10))) {
-                this.profileFilterSetFromUrl = params.profileFilter.split(',');
+                this.profileFilterSetFromUrl = _.compact(
+                    params.profileFilter.split(',')
+                );
             }
         }
 

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1111,6 +1111,13 @@ export class QueryStore {
                 this.studiesHaveChangedSinceInitialization
             ) {
                 this.profileFilterSet = undefined;
+
+                // Keep default auto-selection in the load lifecycle so UI
+                // reflects the checked profile immediately after profiles load.
+                const defaultProfile = this.defaultProfileToSelect;
+                if (defaultProfile) {
+                    this.selectMolecularProfile(defaultProfile, true);
+                }
             }
         },
     });
@@ -1813,6 +1820,58 @@ export class QueryStore {
             this.defaultProfilesForOql &&
             this.defaultProfilesForOql[AlterationTypeConstants.PROTEIN_LEVEL]
         );
+    }
+
+    @computed get shouldSelectDefaultProfile() {
+        if (Object.keys(this.selectedProfileIdSet).length > 0) {
+            return false;
+        }
+        if (
+            !_.isEmpty(this.profileFilterSetFromUrl) ||
+            !_.isEmpty(this.profileIdsFromUrl)
+        ) {
+            return false;
+        }
+
+        let profileTypeCount = 0;
+        Object.values(AlterationTypeConstants).forEach(profileType => {
+            if (
+                this.getFilteredProfiles(
+                    profileType as MolecularProfile['molecularAlterationType']
+                ).length > 0
+            ) {
+                profileTypeCount++;
+            }
+        });
+
+        if (profileTypeCount === 1) {
+            return true;
+        }
+
+        const hasMutationProfile =
+            this.getFilteredProfiles(AlterationTypeConstants.MUTATION_EXTENDED)
+                .length > 0;
+        const hasMrnaProfile =
+            this.getFilteredProfiles(AlterationTypeConstants.MRNA_EXPRESSION)
+                .length > 0;
+
+        return !hasMutationProfile && hasMrnaProfile;
+    }
+
+    @computed get defaultProfileToSelect() {
+        if (!this.shouldSelectDefaultProfile) {
+            return undefined;
+        }
+
+        for (const profileType of Object.values(AlterationTypeConstants)) {
+            const profiles = this.getFilteredProfiles(
+                profileType as MolecularProfile['molecularAlterationType']
+            );
+            if (profiles.length > 0) {
+                return profiles[0];
+            }
+        }
+        return undefined;
     }
 
     // SAMPLE LIST

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -153,6 +153,11 @@ export function getFilteredMolecularProfiles(
                 );
         }
     }
-    // get rid of any undefined items
+    if (_.compact(defaultProfiles).length === 0) {
+        const selectable = profiles.filter(p => p.showProfileInAnalysisTab);
+        if (selectable.length === 1) {
+            defaultProfiles = [selectable[0]];
+        }
+    }
     return _.compact(defaultProfiles);
 }

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -1,6 +1,11 @@
 import { assert } from 'chai';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
-import { getSuffixOfMolecularProfile } from './molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from './molecularProfileUtils';
+import { getFilteredMolecularProfiles } from './getDefaultMolecularProfiles';
+import { AlterationTypeConstants } from 'shared/constants';
 
 describe('MolecularProfileUtils', () => {
     describe('getSuffixOfMolecularProfile', () => {
@@ -12,6 +17,79 @@ describe('MolecularProfileUtils', () => {
             const suffix = 'CCLE_drug_treatment_IC50';
             const result = getSuffixOfMolecularProfile(profile);
             assert.equal(result, suffix);
+        });
+    });
+
+    describe('getSingleSelectableProfileSuffixIfUnique', () => {
+        it('returns suffix when exactly one showProfileInAnalysisTab profile', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_rna_geo',
+                    molecularAlterationType: 'MRNA_EXPRESSION',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getSingleSelectableProfileSuffixIfUnique(profiles),
+                'rna_geo'
+            );
+        });
+
+        it('returns undefined when two distinct suffixes exist', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_gistic',
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.isUndefined(getSingleSelectableProfileSuffixIfUnique(profiles));
+        });
+
+        it('returns one suffix when two studies share the same suffix', () => {
+            const profiles = [
+                {
+                    studyId: 'a',
+                    molecularProfileId: 'a_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'b',
+                    molecularProfileId: 'b_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getSingleSelectableProfileSuffixIfUnique(profiles),
+                'mutations'
+            );
+        });
+    });
+
+    describe('getFilteredMolecularProfiles single-profile fallback', () => {
+        it('selects the only RNA profile when mutation/CNA defaults are empty', () => {
+            const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_geo_mx',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            const out = getFilteredMolecularProfiles(profiles, undefined, 0);
+            assert.equal(out.length, 1);
+            assert.equal(out[0]!.molecularProfileId, 'g_geo_mx');
         });
     });
 });

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -1,5 +1,33 @@
 import { MolecularProfile } from 'cbioportal-ts-api-client';
+import _ from 'lodash';
 
 export function getSuffixOfMolecularProfile(profile: MolecularProfile) {
     return profile.molecularProfileId.replace(profile.studyId + '_', '');
+}
+
+/**
+ * When the cohort exposes exactly one selectable analysis profile (one suffix),
+ * return that suffix so the query UI can default-check it. Covers RNA-only and
+ * other single-profile studies (#11569). Multiple studies sharing the same
+ * suffix still count as one checkbox column — one suffix is returned.
+ */
+export function getSingleSelectableProfileSuffixIfUnique(
+    profiles: MolecularProfile[],
+    options?: { forDownloadTab?: boolean }
+): string | undefined {
+    if (!profiles?.length) {
+        return undefined;
+    }
+    const forDownloadTab = options?.forDownloadTab ?? false;
+    const selectable = profiles.filter(
+        p => p.showProfileInAnalysisTab || forDownloadTab
+    );
+    if (!selectable.length) {
+        return undefined;
+    }
+    const bySuffix = _.groupBy(selectable, p =>
+        getSuffixOfMolecularProfile(p)
+    );
+    const suffixes = Object.keys(bySuffix);
+    return suffixes.length === 1 ? suffixes[0] : undefined;
 }


### PR DESCRIPTION
Fix cBioPortal/cbioportal#11569

## Summary
- auto-select the molecular profile when exactly one selectable profile suffix exists
- align Query behavior with #5215-style store/on-load default selection so checkbox state is applied reliably
- preserve #5462 constraints: do not override existing selections; skip auto-select when URL profile filters/IDs are provided
- include Study View -> Query fallback for single-profile cases

## Follow-up fixes in this PR
- allow fallback when profile filter map exists but is empty
- reset stale `profileFilterSetFromUrl` on each URL parse

## Demo
Verified on deploy preview: https://deploy-preview-5518.preview.cbioportal.org  
![single-profile-autoselect](https://private-user-images.githubusercontent.com/84051465/455319097-608dc16c-0718-43ba-b6f5-511075a1d0e9.gif)

## Test plan
- [x] Single-profile study defaults checked on Query page
- [x] Verified on deploy preview (#5518)
- [x] Multi-profile / mixed-cohort regression checks
- [x] URL-profile override checks
<img width="1107" height="810" alt="img" src="https://github.com/user-attachments/assets/dc48f479-484b-4c21-85ad-37f146de3e23" />


Multi-profile / mixed-cohort regression check (deploy-preview-5518): query behavior remains normal; no unintended forced single-profile selection.
<img width="1540" height="923" alt="image" src="https://github.com/user-attachments/assets/809e9f61-558d-42dc-abfe-72e66f0c5ec4" />

URL profile override 
https://deploy-preview-5518.preview.cbioportal.org/results/oncoprint?cancer_study_list=ovary_geomx_gray_foundation_2024&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&profileFilter=mrna_seq_read_counts_Zscores&case_set_id=ovary_geomx_gray_foundation_2024_all&gene_list=SOX9%2520RAN%2520TNK2%2520EP300%2520PXN%2520NCOA2%2520AR%2520NRIP1%2520NCOR1%2520NCOR2&geneset_list=%20&tab_index=tab_visualize&Action=Submit

<img width="1591" height="950" alt="image" src="https://github.com/user-attachments/assets/8e6a0452-1277-4142-89bb-fa42b6283e1c" />






