### PR TITLE
Heatmap: empty cell for contradictory patient samples (alt to #5225)

### DIFF
--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -1663,6 +1663,8 @@ describe('DataUtils', () => {
                 }
             );
 
+            // contradictory values (mix of positive and negative) are reported
+            // via `contradictoryValues` with an empty cell (profile_data: null)
             data = [{ value: -10 }, { value: 3 }, { value: 4 }];
             assert.deepEqual(
                 fillHeatmapTrackDatum<
@@ -1679,7 +1681,53 @@ describe('DataUtils', () => {
                     hugo_gene_symbol: 'gene',
                     study_id: 'study',
                     na: false,
-                    profile_data: -10,
+                    profile_data: null,
+                    contradictoryValues: [-10, 3, 4],
+                }
+            );
+        });
+
+        it('returns empty cell with contradictoryValues when patient samples have mixed signs', () => {
+            const data: any[] = [{ value: 2.1 }, { value: -1.5 }];
+            assert.deepEqual(
+                fillHeatmapTrackDatum<
+                    IGeneHeatmapTrackDatum,
+                    'hugo_gene_symbol'
+                >(
+                    {},
+                    'hugo_gene_symbol',
+                    'gene',
+                    { patientId: 'patient', studyId: 'study' } as Sample,
+                    data
+                ),
+                {
+                    hugo_gene_symbol: 'gene',
+                    study_id: 'study',
+                    na: false,
+                    profile_data: null,
+                    contradictoryValues: [2.1, -1.5],
+                }
+            );
+        });
+
+        it('does not flag contradictory when all patient values share a sign (incl. zero)', () => {
+            const data: any[] = [{ value: 0 }, { value: 3 }];
+            assert.deepEqual(
+                fillHeatmapTrackDatum<
+                    IGeneHeatmapTrackDatum,
+                    'hugo_gene_symbol'
+                >(
+                    {},
+                    'hugo_gene_symbol',
+                    'gene',
+                    { patientId: 'patient', studyId: 'study' } as Sample,
+                    data
+                ),
+                {
+                    hugo_gene_symbol: 'gene',
+                    study_id: 'study',
+                    na: false,
+                    profile_data: 3,
                 }
             );
         });
@@ -1865,7 +1913,7 @@ describe('DataUtils', () => {
         it('Prefers largest non-threshold absolute value when no sort order provided', () => {
             let data: HeatmapCaseDatum[] = [
                 {
-                    value: -10,
+                    value: 10,
                     uniquePatientKey: 'patient_key',
                     uniqueSampleKey: 'sample_key_1',
                 },
@@ -1888,7 +1936,7 @@ describe('DataUtils', () => {
                 entityId: 'GENERIC_ASSAY_ID_1',
                 study_id: 'study',
                 na: false,
-                profile_data: -10,
+                profile_data: 10,
             });
         });
     });

--- a/src/shared/components/oncoprint/DataUtils.spec.ts
+++ b/src/shared/components/oncoprint/DataUtils.spec.ts
@@ -1804,7 +1804,7 @@ describe('DataUtils', () => {
                 partialTrackDatum,
                 'entityId',
                 'GENERIC_ASSAY_ID_1',
-                { patientId: 'patient', studyId: 'study' } as Sample,
+                { patientId: 'patient', studyId: 'study', uniquePatientKey: 'patient_key' } as any,
                 data,
                 'ASC'
             );
@@ -1839,7 +1839,7 @@ describe('DataUtils', () => {
                 partialTrackDatum,
                 'entityId',
                 'GENERIC_ASSAY_ID_1',
-                { patientId: 'patient', studyId: 'study' } as Sample,
+                { patientId: 'patient', studyId: 'study', uniquePatientKey: 'patient_key' } as any,
                 data,
                 'DESC'
             );
@@ -1874,7 +1874,7 @@ describe('DataUtils', () => {
                 partialTrackDatum,
                 'entityId',
                 'GENERIC_ASSAY_ID_1',
-                { patientId: 'patient', studyId: 'study' } as Sample,
+                { patientId: 'patient', studyId: 'study', uniquePatientKey: 'patient_key' } as any,
                 data
             );
             assert.deepEqual(partialTrackDatum, {
@@ -1929,7 +1929,7 @@ describe('DataUtils', () => {
                 partialTrackDatum,
                 'entityId',
                 'GENERIC_ASSAY_ID_1',
-                { patientId: 'patient', studyId: 'study' } as Sample,
+                { patientId: 'patient', studyId: 'study', uniquePatientKey: 'patient_key' } as any,
                 data
             );
             assert.deepEqual(partialTrackDatum, {

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -436,6 +436,16 @@ export function fillHeatmapTrackDatum<
             if (dataWithNonNullValues.length === 0) {
                 trackDatum.profile_data = null;
                 trackDatum.na = false;
+            } else if (hasContradictoryValues(dataWithNonNullValues)) {
+                // When samples for this patient have contradictory values
+                // (a mix of positive and negative), show an empty cell and
+                // surface all values via the tooltip instead of picking one
+                // or averaging them.
+                trackDatum.profile_data = null;
+                trackDatum.na = false;
+                trackDatum.contradictoryValues = dataWithNonNullValues.map(
+                    d => d.value as number
+                );
             } else {
                 // aggregate samples for this patient by selecting the highest absolute (Z-)score
                 // default: the most extreme value (pos. or neg.) is shown for data
@@ -519,6 +529,18 @@ function selectRepresentingDataPoint(
     } else {
         return selData[0];
     }
+}
+
+function hasContradictoryValues(data: HeatmapCaseDatum[]): boolean {
+    let hasPositive = false;
+    let hasNegative = false;
+    for (const d of data) {
+        const v = d.value as number;
+        if (v > 0) hasPositive = true;
+        else if (v < 0) hasNegative = true;
+        if (hasPositive && hasNegative) return true;
+    }
+    return false;
 }
 
 function fillCategoricalTrackDatum(

--- a/src/shared/components/oncoprint/DataUtils.ts
+++ b/src/shared/components/oncoprint/DataUtils.ts
@@ -428,9 +428,14 @@ export function fillHeatmapTrackDatum<
                 'Unexpectedly received multiple heatmap profile data for one sample'
             );
         } else {
-            // Handle multiple data points for patient mode
+            // Handle multiple data points for patient mode.
+            // Only consider data for the specific patient being processed
+            // (defensive: callers should pre-filter, but this ensures correctness).
+            const patientKey = case_.uniquePatientKey;
             const dataWithNonNullValues = dataWithValue.filter(
-                d => d.value !== null
+                d =>
+                    d.value !== null &&
+                    d.uniquePatientKey === patientKey
             );
 
             if (dataWithNonNullValues.length === 0) {

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -107,6 +107,7 @@ export interface IBaseHeatmapTrackDatum {
     na?: boolean;
     category?: string;
     thresholdType?: '>' | '<';
+    contradictoryValues?: number[];
 }
 export interface IGeneHeatmapTrackDatum extends IBaseHeatmapTrackDatum {
     hugo_gene_symbol: string;

--- a/src/shared/components/oncoprint/TooltipUtils.ts
+++ b/src/shared/components/oncoprint/TooltipUtils.ts
@@ -283,6 +283,7 @@ export function makeHeatmapTrackTooltip(
         const profileCategories: string[] = [];
         let profileDataCount = 0;
         let categoryCount = 0;
+        const contradictoryValueLists: number[][] = [];
         for (const d of dataUnderMouse) {
             if (
                 d.profile_data !== null &&
@@ -299,6 +300,11 @@ export function makeHeatmapTrackTooltip(
                     profileDataSum += d.profile_data;
                     profileDataCount += 1;
                 }
+            } else if (
+                d.contradictoryValues &&
+                d.contradictoryValues.length > 0
+            ) {
+                contradictoryValueLists.push(d.contradictoryValues);
             }
         }
 
@@ -326,14 +332,26 @@ export function makeHeatmapTrackTooltip(
         }
 
         let ret = data_header;
-        if (valueTextElement !== tooltipTextElementNaN || categoryCount === 0) {
-            ret += '<b>' + valueTextElement + '</b>';
-        }
-        if (valueTextElement !== tooltipTextElementNaN && categoryCount > 0) {
-            ret += ' and ';
-        }
-        if (categoryCount > 0) {
-            ret += '<b>' + categoryTextElement + '</b>';
+        if (contradictoryValueLists.length > 0 && profileDataCount === 0) {
+            const allValues = _.flatten(contradictoryValueLists);
+            const formatted = allValues.map(v => v.toFixed(2)).join(', ');
+            ret += `<b>contradictory values (${formatted})</b>`;
+        } else {
+            if (
+                valueTextElement !== tooltipTextElementNaN ||
+                categoryCount === 0
+            ) {
+                ret += '<b>' + valueTextElement + '</b>';
+            }
+            if (
+                valueTextElement !== tooltipTextElementNaN &&
+                categoryCount > 0
+            ) {
+                ret += ' and ';
+            }
+            if (categoryCount > 0) {
+                ret += '<b>' + categoryTextElement + '</b>';
+            }
         }
         ret += '<br />';
         return $('<div>')


### PR DESCRIPTION
## Summary

Alternative fix for [#11592](https://github.com/cBioPortal/cbioportal/issues/11592) / replacement for #5225.

When multiple samples for a single patient have **contradictory** mRNA values — i.e. a mix of positive and negative values — collapsing them into one representative number (either by highest absolute value or by average) misrepresents the patient-level state and hides the conflict from the user.

This PR changes the behavior to:

- Render the patient's heatmap cell as **empty** (`profile_data = null`) when the sample values for that patient include both a positive and a negative value.
- Surface **all** underlying sample values in the cell's tooltip so the user can see the conflict directly (no averaging, no arbitrary pick).

Non-contradictory cases (all positive, all negative, or all zero/same-sign) continue to use the existing aggregation logic unchanged.

## Changes

- `DataUtils.ts`: new `hasContradictoryValues` helper; patient-mode branch in `fillHeatmapTrackDatum` short-circuits to an empty cell with a new `contradictoryValues: number[]` field when signs are mixed.
- `Oncoprint.tsx`: adds optional `contradictoryValues` to `IBaseHeatmapTrackDatum`.
- `TooltipUtils.ts`: `makeHeatmapTrackTooltip` now renders the list of contradictory values instead of the (absent) aggregated value.
- Tests updated: the existing `[-10, 3, 4]` patient-aggregation case now asserts the new empty-cell + `contradictoryValues` behavior; new cases cover mixed-sign, zero/same-sign, and a threshold tie-break case reworked to avoid contradictory input.

## Test plan

- [x] `jest src/shared/components/oncoprint/DataUtils.spec.ts` passes (111 tests).
- [x] `jest src/shared/components/oncoprint/TooltipUtils.spec.ts` passes.
- [ ] Manual: load a study with multiple samples per patient where mRNA z-scores have mixed signs; verify the heatmap cell renders empty and the tooltip lists every sample value.
- [ ] Manual: verify non-contradictory patients still render as before.