### PR TITLE
Fix "Open in Oncoprinter" button doing nothing on results view

### DIFF
--- a/end-to-end-test/remote/specs/core/oncoprint.spec.js
+++ b/end-to-end-test/remote/specs/core/oncoprint.spec.js
@@ -735,4 +735,77 @@ describe('oncoprint', function() {
             );
         });
     });
+
+    describe('Open in Oncoprinter button', () => {
+        // Regression for a bug where the click handler awaited a promise
+        // (mutationsByGene) that is not needed for the Oncoprinter launch.
+        // When that promise stayed pending — which happened in production for
+        // many studies — window.open was never called and the button did
+        // nothing.
+        it('calls window.open with the Oncoprinter URL and posts genetic data', async () => {
+            await goToUrlAndSetLocalStorage(
+                `${CBIOPORTAL_URL}/results?cancer_study_list=coadread_tcga_pub&cancer_study_id=coadread_tcga_pub&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=coadread_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=coadread_tcga_pub_gistic&Z_SCORE_THRESHOLD=2.0&case_set_id=coadread_tcga_pub_nonhypermut&gene_list=KRAS%20NRAS%20BRAF&gene_set_choice=user-defined-list`
+            );
+            await waitForOncoprint();
+
+            // Stub window.open so we capture the call without actually opening
+            // a new tab, and so we can observe the clientPostedData assignment.
+            await browser.execute(() => {
+                window.__openedOncoprinterUrls = [];
+                window.__openedOncoprinterPostedData = null;
+                window.open = function(url) {
+                    window.__openedOncoprinterUrls.push(url);
+                    const fake = {};
+                    Object.defineProperty(fake, 'clientPostedData', {
+                        set(v) {
+                            window.__openedOncoprinterPostedData = v;
+                        },
+                        get() {
+                            return window.__openedOncoprinterPostedData;
+                        },
+                    });
+                    return fake;
+                };
+            });
+
+            // Open the Download dropdown, then click "Open in Oncoprinter".
+            // The button is identified by the EVENT_KEY value (`29.1`).
+            await clickElement('#downloadDropdownButton');
+            await clickElement('button[name="29.1"]');
+
+            // If the handler is broken and never reaches window.open, this
+            // waitUntil times out — the assertion the regression needs.
+            await browser.waitUntil(
+                async () => {
+                    const urls = await browser.execute(
+                        () => window.__openedOncoprinterUrls
+                    );
+                    return urls && urls.length > 0;
+                },
+                {
+                    timeout: 15000,
+                    timeoutMsg:
+                        'window.open was never called after clicking "Open in Oncoprinter"',
+                }
+            );
+
+            const openedUrl = await browser.execute(
+                () => window.__openedOncoprinterUrls[0]
+            );
+            assert.match(
+                openedUrl,
+                /\/oncoprinter(\?|#|$)/,
+                `expected opened URL to target /oncoprinter, got: ${openedUrl}`
+            );
+
+            const posted = await browser.execute(
+                () => window.__openedOncoprinterPostedData
+            );
+            assert(posted, 'clientPostedData should have been set');
+            assert(
+                typeof posted.genetic === 'string' && posted.genetic.length > 0,
+                'posted genetic input should be non-empty'
+            );
+        });
+    });
 });

--- a/end-to-end-test/remote/specs/core/oncoprint.spec.js
+++ b/end-to-end-test/remote/specs/core/oncoprint.spec.js
@@ -737,11 +737,10 @@ describe('oncoprint', function() {
     });
 
     describe('Open in Oncoprinter button', () => {
-        // Regression for a bug where the click handler awaited a promise
-        // (mutationsByGene) that is not needed for the Oncoprinter launch.
-        // When that promise stayed pending — which happened in production for
-        // many studies — window.open was never called and the button did
-        // nothing.
+        // Regression for a bug where the click handler was coupled to MobxPromise
+        // readiness for data it did not need. Some of those promises could stay
+        // in a non-complete state indefinitely (`mutationsByGene`, `heatmapTracks`),
+        // so `window.open` was never called and the button did nothing.
         it('calls window.open with the Oncoprinter URL and posts genetic data', async () => {
             await goToUrlAndSetLocalStorage(
                 `${CBIOPORTAL_URL}/results?cancer_study_list=coadread_tcga_pub&cancer_study_id=coadread_tcga_pub&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=coadread_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=coadread_tcga_pub_gistic&Z_SCORE_THRESHOLD=2.0&case_set_id=coadread_tcga_pub_nonhypermut&gene_list=KRAS%20NRAS%20BRAF&gene_set_choice=user-defined-list`
@@ -773,37 +772,44 @@ describe('oncoprint', function() {
             await clickElement('#downloadDropdownButton');
             await clickElement('button[name="29.1"]');
 
-            // If the handler is broken and never reaches window.open, this
-            // waitUntil times out — the assertion the regression needs.
+            // Wait for both window.open AND the clientPostedData assignment
+            // that follows it. Polling both avoids a race where we sample
+            // __openedOncoprinterPostedData between the two statements. If
+            // the handler is broken and never reaches window.open at all,
+            // the waitUntil times out — the regression the test guards.
             await browser.waitUntil(
                 async () => {
-                    const urls = await browser.execute(
-                        () => window.__openedOncoprinterUrls
+                    const state = await browser.execute(() => ({
+                        urls: window.__openedOncoprinterUrls,
+                        posted: window.__openedOncoprinterPostedData,
+                    }));
+                    return (
+                        state.urls &&
+                        state.urls.length > 0 &&
+                        state.posted &&
+                        typeof state.posted.genetic === 'string' &&
+                        state.posted.genetic.length > 0
                     );
-                    return urls && urls.length > 0;
                 },
                 {
                     timeout: 15000,
                     timeoutMsg:
-                        'window.open was never called after clicking "Open in Oncoprinter"',
+                        '"Open in Oncoprinter" did not call window.open with a non-empty posted genetic payload',
                 }
             );
 
-            const openedUrl = await browser.execute(
-                () => window.__openedOncoprinterUrls[0]
-            );
+            const state = await browser.execute(() => ({
+                url: window.__openedOncoprinterUrls[0],
+                posted: window.__openedOncoprinterPostedData,
+            }));
             assert.match(
-                openedUrl,
+                state.url,
                 /\/oncoprinter(\?|#|$)/,
-                `expected opened URL to target /oncoprinter, got: ${openedUrl}`
+                `expected opened URL to target /oncoprinter, got: ${state.url}`
             );
-
-            const posted = await browser.execute(
-                () => window.__openedOncoprinterPostedData
-            );
-            assert(posted, 'clientPostedData should have been set');
             assert(
-                typeof posted.genetic === 'string' && posted.genetic.length > 0,
+                typeof state.posted.genetic === 'string' &&
+                    state.posted.genetic.length > 0,
                 'posted genetic input should be non-empty'
             );
         });

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -1067,109 +1067,95 @@ export default class ResultsViewOncoprint extends React.Component<
                             }
                         );
                         break;
-                    case 'oncoprinter':
-                        onMobxPromise(
-                            [
-                                this.props.store.samples,
-                                this.props.store.patients,
-                                this.geneticTracks,
-                                this.clinicalTracks,
-                                this.heatmapTracks,
-                                this.genesetHeatmapTracks,
-                                this.props.store
-                                    .clinicalAttributeIdToClinicalAttribute,
-                                this.props.store.studyIds,
-                            ],
-                            (
-                                samples: Sample[],
-                                patients: Patient[],
-                                geneticTracks: GeneticTrackSpec[],
-                                clinicalTracks: ClinicalTrackSpec[],
-                                heatmapTracks: IHeatmapTrackSpec[],
-                                genesetHeatmapTracks: IGenesetHeatmapTrackSpec[],
-                                attributeIdToAttribute: {
-                                    [attributeId: string]: ClinicalAttribute;
-                                },
-                                studyIds: string[]
-                            ) => {
-                                const caseIds =
-                                    this.oncoprintAnalysisCaseType ===
-                                    OncoprintAnalysisCaseType.SAMPLE
-                                        ? samples.map(s => s.sampleId)
-                                        : patients.map(p => p.patientId);
+                    case 'oncoprinter': {
+                        // Open the Oncoprinter window synchronously inside the
+                        // user gesture so popup blockers allow it and so the
+                        // launch is not coupled to MobxPromise readiness. The
+                        // button is only rendered once the Oncoprint has
+                        // loaded, so the track results below are populated
+                        // even when their isComplete flag has been flipped
+                        // back to false by an unrelated re-computation.
+                        const oncoprinterWindow = window.open(
+                            buildCBioPortalPageUrl('/oncoprinter')
+                        ) as any;
 
-                                let geneticInput = '';
-                                if (geneticTracks.length > 0) {
-                                    geneticInput = getOncoprinterGeneticInput(
-                                        geneticTracks,
-                                        caseIds,
-                                        this.oncoprintAnalysisCaseType
-                                    );
-                                }
+                        const samples = this.props.store.samples.result || [];
+                        const patients = this.props.store.patients.result || [];
+                        const studyIds = this.props.store.studyIds.result || [];
+                        const attributeIdToAttribute =
+                            this.props.store
+                                .clinicalAttributeIdToClinicalAttribute
+                                .result || {};
+                        const geneticTracks = this.geneticTracks.result || [];
+                        const clinicalTracks = this.clinicalTracks.result || [];
+                        const heatmapTracks = this.heatmapTracks.result || [];
+                        const genesetHeatmapTracks =
+                            this.genesetHeatmapTracks.result || [];
+                        const mutationsByGenes: {
+                            [gene: string]: Mutation[];
+                        } = this.props.store.mutationsByGene.result || {};
 
-                                let clinicalInput = '';
-                                if (clinicalTracks.length > 0) {
-                                    const oncoprintClinicalData = _.flatMap(
-                                        clinicalTracks,
-                                        (track: ClinicalTrackSpec) => track.data
-                                    );
-                                    clinicalInput = getOncoprinterClinicalInput(
-                                        oncoprintClinicalData,
-                                        caseIds,
-                                        clinicalTracks.map(
-                                            track => track.attributeId
-                                        ),
-                                        attributeIdToAttribute,
-                                        this.oncoprintAnalysisCaseType
-                                    );
-                                }
+                        const caseIds =
+                            this.oncoprintAnalysisCaseType ===
+                            OncoprintAnalysisCaseType.SAMPLE
+                                ? samples.map(s => s.sampleId)
+                                : patients.map(p => p.patientId);
 
-                                let heatmapInput = '';
-                                if (heatmapTracks.length > 0) {
-                                    heatmapInput = getOncoprinterHeatmapInput(
-                                        heatmapTracks,
-                                        caseIds,
-                                        this.oncoprintAnalysisCaseType
-                                    );
-                                }
+                        let geneticInput = '';
+                        if (geneticTracks.length > 0) {
+                            geneticInput = getOncoprinterGeneticInput(
+                                geneticTracks,
+                                caseIds,
+                                this.oncoprintAnalysisCaseType
+                            );
+                        }
 
-                                if (genesetHeatmapTracks.length > 0) {
-                                    alert(
-                                        'Oncoprinter does not support geneset heatmaps - all other tracks will still be exported.'
-                                    );
-                                }
+                        let clinicalInput = '';
+                        if (clinicalTracks.length > 0) {
+                            const oncoprintClinicalData = _.flatMap(
+                                clinicalTracks,
+                                (track: ClinicalTrackSpec) => track.data
+                            );
+                            clinicalInput = getOncoprinterClinicalInput(
+                                oncoprintClinicalData,
+                                caseIds,
+                                clinicalTracks.map(track => track.attributeId),
+                                attributeIdToAttribute,
+                                this.oncoprintAnalysisCaseType
+                            );
+                        }
 
-                                const oncoprinterWindow = window.open(
-                                    buildCBioPortalPageUrl('/oncoprinter')
-                                ) as any;
+                        let heatmapInput = '';
+                        if (heatmapTracks.length > 0) {
+                            heatmapInput = getOncoprinterHeatmapInput(
+                                heatmapTracks,
+                                caseIds,
+                                this.oncoprintAnalysisCaseType
+                            );
+                        }
 
-                                // Optional enrichment for the Jupyter-notebook
-                                // button on the Oncoprinter page. Read
-                                // opportunistically so the Oncoprinter launch
-                                // is not blocked by a still-pending
-                                // mutationsByGene query.
-                                const mutationsByGenes: {
-                                    [gene: string]: Mutation[];
-                                } =
-                                    this.props.store.mutationsByGene.result ||
-                                    {};
-                                const allMutations = Object.values(
-                                    mutationsByGenes
-                                ).reduce(
-                                    (acc, geneArray) => [...acc, ...geneArray],
-                                    []
-                                );
+                        if (genesetHeatmapTracks.length > 0) {
+                            alert(
+                                'Oncoprinter does not support geneset heatmaps - all other tracks will still be exported.'
+                            );
+                        }
 
-                                oncoprinterWindow.clientPostedData = {
-                                    genetic: geneticInput,
-                                    clinical: clinicalInput,
-                                    heatmap: heatmapInput,
-                                    mutations: JSON.stringify(allMutations),
-                                    studyIds: JSON.stringify(studyIds),
-                                };
-                            }
+                        const allMutations = Object.values(
+                            mutationsByGenes
+                        ).reduce(
+                            (acc, geneArray) => [...acc, ...geneArray],
+                            []
                         );
+
+                        oncoprinterWindow.clientPostedData = {
+                            genetic: geneticInput,
+                            clinical: clinicalInput,
+                            heatmap: heatmapInput,
+                            mutations: JSON.stringify(allMutations),
+                            studyIds: JSON.stringify(studyIds),
+                        };
                         break;
+                    }
                     case 'jupyterNoteBook':
                         onMobxPromise(
                             [

--- a/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
+++ b/src/shared/components/oncoprint/ResultsViewOncoprint.tsx
@@ -1078,7 +1078,6 @@ export default class ResultsViewOncoprint extends React.Component<
                                 this.genesetHeatmapTracks,
                                 this.props.store
                                     .clinicalAttributeIdToClinicalAttribute,
-                                this.props.store.mutationsByGene,
                                 this.props.store.studyIds,
                             ],
                             (
@@ -1090,9 +1089,6 @@ export default class ResultsViewOncoprint extends React.Component<
                                 genesetHeatmapTracks: IGenesetHeatmapTrackSpec[],
                                 attributeIdToAttribute: {
                                     [attributeId: string]: ClinicalAttribute;
-                                },
-                                mutationsByGenes: {
-                                    [gene: string]: Mutation[];
                                 },
                                 studyIds: string[]
                             ) => {
@@ -1147,7 +1143,16 @@ export default class ResultsViewOncoprint extends React.Component<
                                     buildCBioPortalPageUrl('/oncoprinter')
                                 ) as any;
 
-                                // extra data that needs to be send for jupyter-notebook
+                                // Optional enrichment for the Jupyter-notebook
+                                // button on the Oncoprinter page. Read
+                                // opportunistically so the Oncoprinter launch
+                                // is not blocked by a still-pending
+                                // mutationsByGene query.
+                                const mutationsByGenes: {
+                                    [gene: string]: Mutation[];
+                                } =
+                                    this.props.store.mutationsByGene.result ||
+                                    {};
                                 const allMutations = Object.values(
                                     mutationsByGenes
                                 ).reduce(
@@ -1464,8 +1469,7 @@ export default class ResultsViewOncoprint extends React.Component<
 
     private onDeleteGeneticTrack(trackIndex: number): void {
         if (!this.isHidden) {
-            const currentGeneList =
-                this.urlWrapper.query.gene_list || '';
+            const currentGeneList = this.urlWrapper.query.gene_list || '';
             // Derive the genes to remove from the parsed gene_list at
             // trackIndex — this correctly handles merged tracks where the
             // display label is not a plain space-separated gene list.


### PR DESCRIPTION
## Summary

The **Open in Oncoprinter** button on the results-view Oncoprint tab opens a blank tab and never navigates to the Oncoprinter page.

**Root cause.** The click handler (`onClickDownload('oncoprinter')`) wrapped `window.open` in an `onMobxPromise([...], cb)` that awaited eight promises — `samples`, `patients`, `geneticTracks`, `clinicalTracks`, `heatmapTracks`, `genesetHeatmapTracks`, `clinicalAttributeIdToClinicalAttribute`, `studyIds` (plus `mutationsByGene` added by #4856). Probing `window.resultsViewPageStore` / `window.resultsViewOncoprint` on the reproduction study showed two of those promises in a stuck state even though the Oncoprint was fully rendered:

- `mutationsByGene` → `isPending: true, hasResult: false` indefinitely. The OncoKB annotation chain actually completes fine; the hang comes from `mutationsReportByGene` / `structuralVariantsReportByGene` being lazy `remoteData` promises that are never activated on the Oncoprint tab. Filed as a separate follow-up: cBioPortal/cbioportal#12124.
- `heatmapTracks` → `isComplete: false, isPending: false, hasResult: true` — the data is there but the `isComplete` flag never flips. Caused by a `@computed get` that returns `{...basePromise, result: filteredTracks}`; object spread doesn't copy the class-prototype `@computed get` accessors on `MobxPromiseImpl` (`isComplete`, `isPending`, `status`), so the returned object reads as "not a real MobxPromise" to `onMobxPromise`. Introduced by #5237.

Either promise alone is enough to prevent the `onMobxPromise` callback from firing, so `window.open` never runs and the new tab stays blank.

**Fix.** The button is only rendered once the Oncoprint has loaded, so every `.result` we need is already populated even when the paired MobxPromise flag is unreliable. The case is rewritten to:

1. Call `window.open(buildCBioPortalPageUrl('/oncoprinter'))` synchronously as the first line, inside the user gesture — popup blockers allow it and the launch is no longer coupled to MobxPromise readiness.
2. Read `samples`, `patients`, `studyIds`, tracks, and `mutationsByGene` directly via `.result || <default>`.
3. Build the Oncoprinter inputs and assign `oncoprinterWindow.clientPostedData` synchronously.

This is a narrow fix for the Oncoprinter-launch path; the underlying reactivity issues are tracked in cBioPortal/cbioportal#12124 and should be addressed separately.

Adds an e2e regression test in `oncoprint.spec.js` that stubs `window.open`, clicks the button, and asserts the handler reaches `window.open` with an Oncoprinter URL and non-empty posted genetic data.

Regression from #4856 (Jupyter-notebook feature) — that PR added `mutationsByGene` to the await list, which exposed the hang on studies where the promise is never activated. The `heatmapTracks` stuck-state issue from #5237 was latent even before that and is now also sidestepped.

## Reproduction

- Production (broken): https://www.cbioportal.org/results?cancer_study_list=coadread_tcga_pub&cancer_study_id=coadread_tcga_pub&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=coadread_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=coadread_tcga_pub_gistic&Z_SCORE_THRESHOLD=2.0&case_set_id=coadread_tcga_pub_nonhypermut&gene_list=KRAS%20NRAS%20BRAF&gene_set_choice=user-defined-list
- Deploy preview (fixed): https://deploy-preview-5532.preview.cbioportal.org/results?cancer_study_list=coadread_tcga_pub&cancer_study_id=coadread_tcga_pub&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=coadread_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=coadread_tcga_pub_gistic&Z_SCORE_THRESHOLD=2.0&case_set_id=coadread_tcga_pub_nonhypermut&gene_list=KRAS%20NRAS%20BRAF&gene_set_choice=user-defined-list

### Steps

1. Open the production link above and wait for the Oncoprint to render.
2. In the Oncoprint controls bar, open **Download** → click **Open in Oncoprinter**.
3. **Broken:** a new tab opens as `about:blank` and never navigates. Verified with Puppeteer: `window.open` is never called, `mutationsByGene.isPending === true` and `heatmapTracks.isComplete === false` indefinitely on the Oncoprint page.
4. **Fixed:** a new tab opens and loads the Oncoprinter page, rendering the KRAS/NRAS/BRAF oncoprint across 165 samples with the same alterations as the source tab.

## Follow-up

- cBioPortal/cbioportal#12124 — lazy-activation of `mutationsReportByGene` / `structuralVariantsReportByGene` on the Oncoprint tab. Not a blocker for this fix but worth resolving independently so other code paths don't trip on the same hang.

## Test plan

- [ ] Existing CI passes (unit, e2e).
- [x] New e2e spec `Open in Oncoprinter button › calls window.open with the Oncoprinter URL and posts genetic data` passes.
- [x] Manual end-to-end check on the deploy preview — clicking **Open in Oncoprinter** on the reproduction URL opens a new tab that loads the Oncoprinter page with KRAS / NRAS / BRAF pre-populated and the oncoprint rendered (verified with Puppeteer, screenshot captured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)