### PR TITLE
[draft] Add OncoKB germline annotation column to patient view mutations table

### DIFF
--- a/env/master.sh
+++ b/env/master.sh
@@ -1,2 +1,2 @@
-export CBIOPORTAL_URL="https://www.cbioportal.org"
+export CBIOPORTAL_URL="https://master.cbioportal.org"
 export GENOME_NEXUS_URL="${GENOME_NEXUS_URL:-https://www.genomenexus.org}"

--- a/packages/cbioportal-utils/src/api/apiUtils.ts
+++ b/packages/cbioportal-utils/src/api/apiUtils.ts
@@ -4,7 +4,13 @@ import * as request from 'superagent';
 // import {getServerConfig} from "../../../../src/config/config";
 // import {getBrowserWindow} from "cbioportal-frontend-commons";
 
-const BASE64_ENCODING = 'base64';
+// Use URL-safe base64 (alphabet `-_`, no `=` padding) so the encoded path can
+// safely sit inside a URL path segment without `+` becoming a space, `/`
+// splitting the path, or padding chars getting stripped. The backend's
+// Apache Commons Codec Base64 decoder accepts both alphabets, and Node's
+// Buffer treats the two encodings as interchangeable on decode, so the
+// switch is backward-compatible with previously cached responses.
+const BASE64_ENCODING = 'base64url';
 const UTF8_ENCODING = 'utf8';
 
 export async function chunkCalls<ParamData, ResponseData>(

--- a/packages/cbioportal-utils/src/api/apiUtils.ts
+++ b/packages/cbioportal-utils/src/api/apiUtils.ts
@@ -4,14 +4,30 @@ import * as request from 'superagent';
 // import {getServerConfig} from "../../../../src/config/config";
 // import {getBrowserWindow} from "cbioportal-frontend-commons";
 
-// Use URL-safe base64 (alphabet `-_`, no `=` padding) so the encoded path can
-// safely sit inside a URL path segment without `+` becoming a space, `/`
-// splitting the path, or padding chars getting stripped. The backend's
-// Apache Commons Codec Base64 decoder accepts both alphabets, and Node's
-// Buffer treats the two encodings as interchangeable on decode, so the
-// switch is backward-compatible with previously cached responses.
-const BASE64_ENCODING = 'base64url';
+const BASE64_ENCODING = 'base64';
 const UTF8_ENCODING = 'utf8';
+
+// Convert standard base64 to URL-safe (alphabet `-_`, no `=` padding) so the
+// encoded path can sit inside a URL path segment without `+` becoming a space,
+// `/` splitting the path, or padding chars getting stripped. We do the
+// conversion manually rather than relying on Buffer's `'base64url'` encoding
+// because the browser-side `buffer` polyfill (v5.x) doesn't recognize it and
+// throws `Unknown encoding: base64url`. The cbioportal backend's Apache
+// Commons Codec Base64 decoder accepts both alphabets transparently.
+function toUrlSafeBase64(b64: string) {
+    return b64
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+}
+
+// Convert URL-safe base64 back to standard before decoding, also restoring
+// the `=` padding the standard decoder requires.
+function fromUrlSafeBase64(urlSafe: string) {
+    const standard = urlSafe.replace(/-/g, '+').replace(/_/g, '/');
+    const pad = standard.length % 4;
+    return pad ? standard + '='.repeat(4 - pad) : standard;
+}
 
 export async function chunkCalls<ParamData, ResponseData>(
     callback: (chunk: ParamData[]) => Promise<ResponseData[]>,
@@ -24,14 +40,18 @@ export async function chunkCalls<ParamData, ResponseData>(
 }
 
 function monkify(obj: any) {
-    return Buffer.from(_.isString(obj) ? obj : JSON.stringify(obj)).toString(
-        BASE64_ENCODING
+    return toUrlSafeBase64(
+        Buffer.from(_.isString(obj) ? obj : JSON.stringify(obj)).toString(
+            BASE64_ENCODING
+        )
     );
 }
 
 function unmonkify(base64String: string) {
     return JSON.parse(
-        Buffer.from(base64String, BASE64_ENCODING).toString(UTF8_ENCODING)
+        Buffer.from(fromUrlSafeBase64(base64String), BASE64_ENCODING).toString(
+            UTF8_ENCODING
+        )
     );
 }
 

--- a/packages/cbioportal-utils/src/model/OncoKB.ts
+++ b/packages/cbioportal-utils/src/model/OncoKB.ts
@@ -1,4 +1,7 @@
-import { IndicatorQueryResp } from 'oncokb-ts-api-client';
+import {
+    IndicatorQueryResp,
+    GermlineVariantAnnotation,
+} from 'oncokb-ts-api-client';
 
 export type Query = {
     id: string;
@@ -9,6 +12,10 @@ export type Query = {
 
 export interface IOncoKbData {
     indicatorMap: { [id: string]: IndicatorQueryResp } | null;
+}
+
+export interface IGermlineOncoKbData {
+    indicatorMap: { [id: string]: GermlineVariantAnnotation } | null;
 }
 
 export enum OncoKbCardDataType {

--- a/packages/oncokb-frontend-commons/src/model/OncoKB.ts
+++ b/packages/oncokb-frontend-commons/src/model/OncoKB.ts
@@ -1,4 +1,7 @@
-import { IndicatorQueryResp } from 'oncokb-ts-api-client';
+import {
+    IndicatorQueryResp,
+    GermlineVariantAnnotation,
+} from 'oncokb-ts-api-client';
 
 export type Query = {
     id: string;
@@ -9,6 +12,10 @@ export type Query = {
 
 export interface IOncoKbData {
     indicatorMap: { [id: string]: IndicatorQueryResp } | null;
+}
+
+export interface IGermlineOncoKbData {
+    indicatorMap: { [id: string]: GermlineVariantAnnotation } | null;
 }
 
 export enum OncoKbCardDataType {

--- a/packages/oncokb-ts-api-client/src/generated/OncoKbAPI.ts
+++ b/packages/oncokb-ts-api-client/src/generated/OncoKbAPI.ts
@@ -333,6 +333,74 @@ export type GermlineQuery = {
     'germline': boolean
 
 };
+export type GenomicIndicator = {
+    'description': string
+
+        'inheritanceMechanism': "AUTOSOMAL_DOMINANT" | "AUTOSOMAL_RECESSIVE" | "X_LINKED_RECESSIVE" | "CARRIER"
+
+        'name': string
+
+};
+export type VariantAnnotationTumorType = {
+    'evidences': Array < any >
+
+        'relevantTumorType': boolean
+
+        'tumorType': TumorType
+
+};
+export type GermlineVariantAnnotation = {
+    'alleleExist': boolean
+
+        'clinVarId': string
+
+        'dataVersion': string
+
+        'diagnosticImplications': Array < Implication >
+
+        'diagnosticSummary': string
+
+        'geneExist': boolean
+
+        'geneSummary': string
+
+        'genomicIndicators': Array < GenomicIndicator >
+
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+
+        'lastUpdate': string
+
+        'mutationEffect': MutationEffectResp
+
+        'pathogenic': string
+
+        'penetrance': string
+
+        'prognosticImplications': Array < Implication >
+
+        'prognosticSummary': string
+
+        'query': Query
+
+        'treatments': Array < IndicatorQueryTreatment >
+
+        'tumorTypeSummary': string
+
+        'tumorTypes': Array < VariantAnnotationTumorType >
+
+        'variantExist': boolean
+
+        'variantSummary': string
+
+        'vus': boolean
+
+};
 export type AnnotateMutationByProteinChangeQuery = {
     'alteration': string
 
@@ -2294,6 +2362,145 @@ export default class OncoKbAPI {
             $domain ? : string
     }): Promise < string > {
         return this.utilsCancerGeneListTxtGetUsingGET_1WithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+
+    utilsVariantAnnotationGermlineGetURL(parameters: {
+        'hugoSymbol' ? : string,
+        'entrezGeneId' ? : number,
+        'alteration' ? : string,
+        'hgvsg' ? : string,
+        'genomicChange' ? : string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/utils/variantAnnotation/germline';
+        if (parameters['hugoSymbol'] !== undefined) {
+            queryParameters['hugoSymbol'] = parameters['hugoSymbol'];
+        }
+        if (parameters['entrezGeneId'] !== undefined) {
+            queryParameters['entrezGeneId'] = parameters['entrezGeneId'];
+        }
+        if (parameters['alteration'] !== undefined) {
+            queryParameters['alteration'] = parameters['alteration'];
+        }
+        if (parameters['hgvsg'] !== undefined) {
+            queryParameters['hgvsg'] = parameters['hgvsg'];
+        }
+        if (parameters['genomicChange'] !== undefined) {
+            queryParameters['genomicChange'] = parameters['genomicChange'];
+        }
+        if (parameters['referenceGenome'] !== undefined) {
+            queryParameters['referenceGenome'] = parameters['referenceGenome'];
+        }
+        if (parameters['tumorType'] !== undefined) {
+            queryParameters['tumorType'] = parameters['tumorType'];
+        }
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Get germline variant annotation.
+     * @method
+     * @name OncoKbAPI#utilsVariantAnnotationGermlineGetUsingGET
+     * @param {string} hugoSymbol - Gene hugo symbol
+     * @param {integer} entrezGeneId - Entrez gene ID
+     * @param {string} alteration - Variant alteration
+     * @param {string} hgvsg - HGVS genomic format
+     * @param {string} genomicChange - Genomic change format
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. Default: GRCh37
+     * @param {string} tumorType - OncoTree tumor type
+     */
+    utilsVariantAnnotationGermlineGetUsingGETWithHttpInfo(parameters: {
+        'hugoSymbol' ? : string,
+        'entrezGeneId' ? : number,
+        'alteration' ? : string,
+        'hgvsg' ? : string,
+        'genomicChange' ? : string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/utils/variantAnnotation/germline';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['hugoSymbol'] !== undefined) {
+                queryParameters['hugoSymbol'] = parameters['hugoSymbol'];
+            }
+            if (parameters['entrezGeneId'] !== undefined) {
+                queryParameters['entrezGeneId'] = parameters['entrezGeneId'];
+            }
+            if (parameters['alteration'] !== undefined) {
+                queryParameters['alteration'] = parameters['alteration'];
+            }
+            if (parameters['hgvsg'] !== undefined) {
+                queryParameters['hgvsg'] = parameters['hgvsg'];
+            }
+            if (parameters['genomicChange'] !== undefined) {
+                queryParameters['genomicChange'] = parameters['genomicChange'];
+            }
+            if (parameters['referenceGenome'] !== undefined) {
+                queryParameters['referenceGenome'] = parameters['referenceGenome'];
+            }
+            if (parameters['tumorType'] !== undefined) {
+                queryParameters['tumorType'] = parameters['tumorType'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+        });
+    };
+
+    /**
+     * Get germline variant annotation.
+     * @method
+     * @name OncoKbAPI#utilsVariantAnnotationGermlineGetUsingGET
+     * @param {string} hugoSymbol - Gene hugo symbol
+     * @param {integer} entrezGeneId - Entrez gene ID
+     * @param {string} alteration - Variant alteration
+     * @param {string} hgvsg - HGVS genomic format
+     * @param {string} genomicChange - Genomic change format
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. Default: GRCh37
+     * @param {string} tumorType - OncoTree tumor type
+     */
+    utilsVariantAnnotationGermlineGetUsingGET(parameters: {
+        'hugoSymbol' ? : string,
+        'entrezGeneId' ? : number,
+        'alteration' ? : string,
+        'hgvsg' ? : string,
+        'genomicChange' ? : string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < GermlineVariantAnnotation > {
+        return this.utilsVariantAnnotationGermlineGetUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });
     };

--- a/packages/oncokb-ts-api-client/src/generated/OncoKbAPI.ts
+++ b/packages/oncokb-ts-api-client/src/generated/OncoKbAPI.ts
@@ -2504,4 +2504,64 @@ export default class OncoKbAPI {
             return response.body;
         });
     };
+
+    /**
+     * Annotate germline mutations by genomic change. Batched POST.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByGenomicChangeGermlinePostUsingPOST
+     * @param {} body - List of AnnotateMutationByGenomicChangeQuery.
+     */
+    annotateMutationsByGenomicChangeGermlinePostUsingPOSTWithHttpInfo(parameters: {
+        'body': Array < AnnotateMutationByGenomicChangeQuery > ,
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/annotate/germline/mutations/byGenomicChange';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['body'] !== undefined) {
+                body = parameters['body'];
+            }
+
+            if (parameters['body'] === undefined) {
+                reject(new Error('Missing required  parameter: body'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+        });
+    };
+
+    /**
+     * Annotate germline mutations by genomic change. Batched POST.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByGenomicChangeGermlinePostUsingPOST
+     * @param {} body - List of AnnotateMutationByGenomicChangeQuery.
+     */
+    annotateMutationsByGenomicChangeGermlinePostUsingPOST(parameters: {
+            'body': Array < AnnotateMutationByGenomicChangeQuery > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < GermlineVariantAnnotation >
+        > {
+            return this.annotateMutationsByGenomicChangeGermlinePostUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
 }

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -70,6 +70,7 @@ import {
     fetchMutationData,
     fetchMutSigData,
     fetchOncoKbCancerGenes,
+    fetchGermlineOncoKbData,
     fetchOncoKbData,
     fetchOncoKbDataForOncoprint,
     fetchOncoKbInfo,
@@ -100,6 +101,7 @@ import {
     mergeDiscreteCNAData,
     mergeMutations,
     mergeMutationsIncludingUncalled,
+    GERMLINE_ONCOKB_DEFAULT,
     ONCOKB_DEFAULT,
     generateStructuralVariantId,
     fetchStructuralVariantOncoKbData,
@@ -153,6 +155,7 @@ import {
     getMyVariantInfoAnnotationsFromIndexedVariantAnnotations,
     ICivicGeneIndex,
     ICivicVariantIndex,
+    IGermlineOncoKbData,
     IHotspotIndex,
     IMyVariantInfoIndex,
     indexHotspotsData,
@@ -1883,6 +1886,35 @@ export class PatientViewPageStore {
             },
         },
         ONCOKB_DEFAULT
+    );
+
+    readonly germlineOncoKbData = remoteData<IGermlineOncoKbData | Error>(
+        {
+            await: () => [
+                this.oncoKbAnnotatedGenes,
+                this.mutationData,
+                this.uncalledMutationData,
+                this.clinicalDataForSamples,
+                this.studiesForSamplesWithoutCancerTypeClinicalData,
+                this.studies,
+            ],
+            invoke: () => {
+                if (getServerConfig().show_oncokb) {
+                    return fetchGermlineOncoKbData(
+                        this.uniqueSampleKeyToTumorType,
+                        this.oncoKbAnnotatedGenes.result || {},
+                        this.mutationData,
+                        this.uncalledMutationData
+                    );
+                } else {
+                    return Promise.resolve(GERMLINE_ONCOKB_DEFAULT);
+                }
+            },
+            onError: (err: Error) => {
+                // fail silently
+            },
+        },
+        GERMLINE_ONCOKB_DEFAULT
     );
 
     readonly civicGenes = remoteData<ICivicGeneIndex | undefined>(

--- a/src/pages/patientView/mutation/MutationTableWrapper.tsx
+++ b/src/pages/patientView/mutation/MutationTableWrapper.tsx
@@ -234,6 +234,9 @@ export default class MutationTableWrapper extends React.Component<
                                 mutSigData={this.pageStore.mutSigData.result}
                                 hotspotData={this.pageStore.indexedHotspotData}
                                 oncoKbData={this.pageStore.oncoKbData}
+                                germlineOncoKbData={
+                                    this.pageStore.germlineOncoKbData
+                                }
                                 oncoKbCancerGenes={
                                     this.pageStore.oncoKbCancerGenes
                                 }

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -65,7 +65,6 @@ export default class PatientViewMutationTable extends MutationTable<
             MutationTableColumnType.ASCN_METHOD,
             MutationTableColumnType.ASCN_COPY_NUM,
             MutationTableColumnType.ANNOTATION,
-            MutationTableColumnType.GERMLINE_ONCOKB,
             MutationTableColumnType.CUSTOM_DRIVER,
             MutationTableColumnType.CUSTOM_DRIVER_TIER,
             MutationTableColumnType.HGVSG,
@@ -314,10 +313,6 @@ export default class PatientViewMutationTable extends MutationTable<
         this._columns[MutationTableColumnType.GENE_PANEL].order = 25;
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].order = 30;
         this._columns[MutationTableColumnType.ANNOTATION].order = 35;
-        this._columns[MutationTableColumnType.GERMLINE_ONCOKB].order = 35.5;
-        this._columns[
-            MutationTableColumnType.GERMLINE_ONCOKB
-        ].visible = getServerConfig().show_oncokb;
         this._columns[MutationTableColumnType.CUSTOM_DRIVER].order = 36;
         this._columns[MutationTableColumnType.CUSTOM_DRIVER_TIER].order = 37;
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -65,6 +65,7 @@ export default class PatientViewMutationTable extends MutationTable<
             MutationTableColumnType.ASCN_METHOD,
             MutationTableColumnType.ASCN_COPY_NUM,
             MutationTableColumnType.ANNOTATION,
+            MutationTableColumnType.GERMLINE_ONCOKB,
             MutationTableColumnType.CUSTOM_DRIVER,
             MutationTableColumnType.CUSTOM_DRIVER_TIER,
             MutationTableColumnType.HGVSG,
@@ -179,9 +180,7 @@ export default class PatientViewMutationTable extends MutationTable<
         // This can lead to cases where there are multiple icons/tooltips in a single cell
         // therefore patient view needs sampleManager to indicate which values match which samples
 
-        this._columns[
-            MutationTableColumnType.CANCER_CELL_FRACTION
-        ] = {
+        this._columns[MutationTableColumnType.CANCER_CELL_FRACTION] = {
             ...getDefaultCancerCellFractionColumnDefinition(
                 this.getSamples(),
                 this.props.sampleManager
@@ -200,9 +199,7 @@ export default class PatientViewMutationTable extends MutationTable<
             this.props.sampleManager
         );
 
-        this._columns[
-            MutationTableColumnType.EXPECTED_ALT_COPIES
-        ] = {
+        this._columns[MutationTableColumnType.EXPECTED_ALT_COPIES] = {
             ...getDefaultExpectedAltCopiesColumnDefinition(
                 this.getSamples(),
                 this.props.sampleManager
@@ -317,6 +314,10 @@ export default class PatientViewMutationTable extends MutationTable<
         this._columns[MutationTableColumnType.GENE_PANEL].order = 25;
         this._columns[MutationTableColumnType.PROTEIN_CHANGE].order = 30;
         this._columns[MutationTableColumnType.ANNOTATION].order = 35;
+        this._columns[MutationTableColumnType.GERMLINE_ONCOKB].order = 35.5;
+        this._columns[
+            MutationTableColumnType.GERMLINE_ONCOKB
+        ].visible = getServerConfig().show_oncokb;
         this._columns[MutationTableColumnType.CUSTOM_DRIVER].order = 36;
         this._columns[MutationTableColumnType.CUSTOM_DRIVER_TIER].order = 37;
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -50,7 +50,7 @@ import {
     observable,
     reaction,
 } from 'mobx';
-import { IOncoKbData } from 'cbioportal-utils';
+import { IGermlineOncoKbData, IOncoKbData } from 'cbioportal-utils';
 import {
     deriveStructuralVariantType,
     generateQueryStructuralVariantId,
@@ -89,6 +89,8 @@ import {
     mapSampleIdToClinicalData,
     ONCOKB_DEFAULT,
     fetchOncoKbInfo,
+    fetchGermlineOncoKbData,
+    GERMLINE_ONCOKB_DEFAULT,
 } from 'shared/lib/StoreUtils';
 import {
     CoverageInformation,
@@ -5401,6 +5403,31 @@ export class ResultsViewPageStore extends AnalysisStore
             },
         },
         undefined
+    );
+
+    readonly germlineOncoKbData = remoteData<IGermlineOncoKbData | Error>(
+        {
+            await: () => [
+                this.oncoKbAnnotatedGenes,
+                this.mutations,
+                this.uniqueSampleKeyToTumorType,
+            ],
+            invoke: () => {
+                if (getServerConfig().show_oncokb) {
+                    return fetchGermlineOncoKbData(
+                        this.uniqueSampleKeyToTumorType.result!,
+                        this.oncoKbAnnotatedGenes.result || {},
+                        this.mutations
+                    );
+                } else {
+                    return Promise.resolve(GERMLINE_ONCOKB_DEFAULT);
+                }
+            },
+            onError: () => {
+                // fail silently
+            },
+        },
+        GERMLINE_ONCOKB_DEFAULT
     );
 
     readonly structuralVariantOncoKbDataForOncoprint = remoteData<

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -257,6 +257,7 @@ export default class Mutations extends React.Component<
                         }
                         onOncoKbIconToggle={this.handleOncoKbIconToggle}
                         store={mutationMapperStore}
+                        germlineOncoKbData={this.props.store.germlineOncoKbData}
                         isPutativeDriver={
                             this.props.store.driverAnnotationSettings
                                 .driversAnnotated

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -10,7 +10,11 @@ import {
 import { observer } from 'mobx-react';
 import { action, computed, observable, makeObservable } from 'mobx';
 
-import { getRemoteDataGroupStatus } from 'cbioportal-utils';
+import {
+    getRemoteDataGroupStatus,
+    IGermlineOncoKbData,
+    RemoteData,
+} from 'cbioportal-utils';
 import { Mutation } from 'cbioportal-ts-api-client';
 import { EnsemblTranscript } from 'genome-nexus-ts-api-client';
 import {
@@ -56,6 +60,12 @@ export interface IResultsViewMutationMapperProps extends IMutationMapperProps {
     userDisplayName: string;
     onClickSettingMenu?: (visible: boolean) => void;
     enableCustomDriver: boolean;
+    // Page-store-level OncoKB germline data (one fetch covers all genes
+    // shown in the results view). Passed through to the mutation table so
+    // the Annotation column can render the germline tooltip on
+    // germline-marked rows. Optional because non-results-view callers of
+    // the mutation table don't need to provide it.
+    germlineOncoKbData?: RemoteData<IGermlineOncoKbData | Error | undefined>;
 }
 
 @observer
@@ -228,6 +238,7 @@ export default class ResultsViewMutationMapper extends MutationMapper<
                     this.props.store.indexedMyVariantInfoAnnotations
                 }
                 oncoKbData={this.props.store.oncoKbData}
+                germlineOncoKbData={this.props.germlineOncoKbData}
                 usingPublicOncoKbInstance={
                     getServerConfig().show_oncokb &&
                     this.props.store.usingPublicOncoKbInstance

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -60,6 +60,7 @@ import {
     genomicLocationString,
 } from 'cbioportal-utils';
 import { isNotGermlineMutation } from 'shared/lib/MutationUtils';
+import { germlineOncoKbKeyForMutation } from 'shared/lib/StoreUtils';
 import {
     DownloadControlOption,
     MobxPromise,
@@ -959,14 +960,10 @@ export default class MutationTable<
                     !(germlineData.result instanceof Error) &&
                     germlineData.result.indicatorMap
                 ) {
-                    const queryId = generateQueryVariantId(
-                        mutation.entrezGeneId,
-                        null,
-                        mutation.proteinChange,
-                        mutation.mutationType
-                    );
                     germlineAnnotation =
-                        germlineData.result.indicatorMap[queryId];
+                        germlineData.result.indicatorMap[
+                            germlineOncoKbKeyForMutation(mutation)
+                        ];
                 }
                 return (
                     <span id="mutation-annotation">

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -32,6 +32,7 @@ import MutationStatusColumnFormatter from './column/MutationStatusColumnFormatte
 import ValidationStatusColumnFormatter from './column/ValidationStatusColumnFormatter';
 import StudyColumnFormatter from './column/StudyColumnFormatter';
 import AnnotationColumnFormatter from './column/AnnotationColumnFormatter';
+import GermlineOncoKbIcon from './column/GermlineOncoKbIcon';
 import ExonColumnFormatter from './column/ExonColumnFormatter';
 import { IMutSigData } from 'shared/model/MutSig';
 import DiscreteCNACache from 'shared/cache/DiscreteCNACache';
@@ -48,6 +49,7 @@ import classnames from 'classnames';
 import { IPaginationControlsProps } from '../paginationControls/PaginationControls';
 import { IColumnVisibilityControlsProps } from '../columnVisibilityControls/ColumnVisibilityControls';
 import {
+    IGermlineOncoKbData,
     IOncoKbData,
     ICivicGeneIndex,
     ICivicVariantIndex,
@@ -63,7 +65,7 @@ import {
 } from 'cbioportal-frontend-commons';
 import { generateQueryVariantId } from 'oncokb-frontend-commons';
 import { VariantAnnotation } from 'genome-nexus-ts-api-client';
-import { CancerGene } from 'oncokb-ts-api-client';
+import { CancerGene, GermlineVariantAnnotation } from 'oncokb-ts-api-client';
 import { getAnnotationData, IAnnotation } from 'react-mutation-mapper';
 import HgvscColumnFormatter from './column/HgvscColumnFormatter';
 import HgvsgColumnFormatter from './column/HgvsgColumnFormatter';
@@ -118,6 +120,7 @@ export interface IMutationTableProps {
         IMyVariantInfoIndex | undefined
     >;
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
+    germlineOncoKbData?: RemoteData<IGermlineOncoKbData | Error | undefined>;
     oncoKbDataForCancerType?: RemoteData<IOncoKbData | Error | undefined>;
     oncoKbDataForUnknownPrimary?: RemoteData<IOncoKbData | Error | undefined>;
     usingPublicOncoKbInstance: boolean;
@@ -213,6 +216,7 @@ export enum MutationTableColumnType {
     SELECTED = 'Selected',
     DBSNP = 'dbSNP',
     GENE_PANEL = 'Gene panel',
+    GERMLINE_ONCOKB = 'Germline OncoKB',
     SIGNAL = 'SIGNAL',
     NUM_MUTATED_GROUP_A = '(A) Group',
     NUM_MUTATED_GROUP_B = '(B) Group',
@@ -1041,6 +1045,104 @@ export default class MutationTable<
                     this.resolveTumorType
                 );
             },
+        };
+
+        this._columns[MutationTableColumnType.GERMLINE_ONCOKB] = {
+            name: MutationTableColumnType.GERMLINE_ONCOKB,
+            render: (d: Mutation[]) => {
+                const mutation = d ? d[0] : undefined;
+                if (!mutation) return <span />;
+
+                const germlineData = this.props.germlineOncoKbData;
+                if (
+                    !germlineData ||
+                    !germlineData.result ||
+                    germlineData.result instanceof Error ||
+                    !germlineData.result.indicatorMap
+                ) {
+                    if (germlineData && germlineData.isPending) {
+                        return (
+                            <span
+                                style={{
+                                    display: 'inline-block',
+                                    width: 22,
+                                    height: 22,
+                                }}
+                            >
+                                <i
+                                    className="fa fa-spinner fa-pulse"
+                                    style={{ fontSize: 12 }}
+                                />
+                            </span>
+                        );
+                    }
+                    return <span />;
+                }
+
+                const queryId = generateQueryVariantId(
+                    mutation.entrezGeneId,
+                    null,
+                    mutation.proteinChange,
+                    mutation.mutationType
+                );
+                const annotation: GermlineVariantAnnotation | undefined =
+                    germlineData.result.indicatorMap[queryId];
+                if (!annotation) return <span />;
+
+                return <GermlineOncoKbIcon annotation={annotation} />;
+            },
+            download: (d: Mutation[]) => {
+                const mutation = d ? d[0] : undefined;
+                if (!mutation) return '';
+                const germlineData = this.props.germlineOncoKbData;
+                if (
+                    !germlineData ||
+                    !germlineData.result ||
+                    germlineData.result instanceof Error ||
+                    !germlineData.result.indicatorMap
+                )
+                    return '';
+                const queryId = generateQueryVariantId(
+                    mutation.entrezGeneId,
+                    null,
+                    mutation.proteinChange,
+                    mutation.mutationType
+                );
+                const annotation = germlineData.result.indicatorMap[queryId];
+                if (!annotation) return '';
+                return `Pathogenic: ${annotation.pathogenic ||
+                    'N/A'}, Penetrance: ${annotation.penetrance || 'N/A'}`;
+            },
+            sortBy: (d: Mutation[]) => {
+                const mutation = d ? d[0] : undefined;
+                if (!mutation) return [0];
+                const germlineData = this.props.germlineOncoKbData;
+                if (
+                    !germlineData ||
+                    !germlineData.result ||
+                    germlineData.result instanceof Error ||
+                    !germlineData.result.indicatorMap
+                )
+                    return [0];
+                const queryId = generateQueryVariantId(
+                    mutation.entrezGeneId,
+                    null,
+                    mutation.proteinChange,
+                    mutation.mutationType
+                );
+                const annotation = germlineData.result.indicatorMap[queryId];
+                if (!annotation) return [0];
+                // Sort by pathogenicity level
+                const pathogenicOrder: { [key: string]: number } = {
+                    Pathogenic: 4,
+                    'Likely Pathogenic': 3,
+                    VUS: 2,
+                    'Likely Benign': 1,
+                    Benign: 0,
+                };
+                return [pathogenicOrder[annotation.pathogenic] ?? 0];
+            },
+            visible: false,
         };
 
         this._columns[MutationTableColumnType.CUSTOM_DRIVER] = {

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -32,7 +32,7 @@ import MutationStatusColumnFormatter from './column/MutationStatusColumnFormatte
 import ValidationStatusColumnFormatter from './column/ValidationStatusColumnFormatter';
 import StudyColumnFormatter from './column/StudyColumnFormatter';
 import AnnotationColumnFormatter from './column/AnnotationColumnFormatter';
-import GermlineOncoKbIcon from './column/GermlineOncoKbIcon';
+import GermlineOncoKbTooltip from './column/GermlineOncoKbTooltip';
 import ExonColumnFormatter from './column/ExonColumnFormatter';
 import { IMutSigData } from 'shared/model/MutSig';
 import DiscreteCNACache from 'shared/cache/DiscreteCNACache';
@@ -946,10 +946,40 @@ export default class MutationTable<
                 ),
             render: (d: Mutation[]) => {
                 const mutation = d ? d[0] : undefined;
-                // For mutations explicitly marked germline, prefer the germline
-                // OncoKB tooltip when an annotation is available; fall back to
-                // the standard somatic annotation column rendering otherwise so
-                // that hotspot / civic / reVUE indicators still show.
+                // Render the standard Annotation icons for every row. For
+                // germline-marked rows where an OncoKB germline annotation
+                // is available, wrap the icons in a tooltip surfacing
+                // germline-specific content (pathogenicity, penetrance,
+                // genomic indicators, levels). The icon visual is unchanged
+                // from somatic -- germline status is signalled by the
+                // indicator on the Protein Change column.
+                const annotationContent = AnnotationColumnFormatter.renderFunction(
+                    d,
+                    {
+                        hotspotData: this.props.hotspotData,
+                        oncoKbData: this.props.oncoKbData,
+                        oncoKbCancerGenes: this.props.oncoKbCancerGenes,
+                        usingPublicOncoKbInstance: this.props
+                            .usingPublicOncoKbInstance,
+                        mergeOncoKbIcons: this.props.mergeOncoKbIcons,
+                        oncoKbContentPadding: calculateOncoKbContentPadding(
+                            this.oncokbWidth
+                        ),
+                        pubMedCache: this.props.pubMedCache,
+                        civicGenes: this.props.civicGenes,
+                        civicVariants: this.props.civicVariants,
+                        enableCivic: this.props.enableCivic as boolean,
+                        enableOncoKb: this.props.enableOncoKb as boolean,
+                        enableHotspot: this.props.enableHotspot as boolean,
+                        enableRevue:
+                            !!this.props.enableRevue && this.shouldShowRevue,
+                        userDisplayName: this.props.userDisplayName,
+                        indexedVariantAnnotations: this.props
+                            .indexedVariantAnnotations,
+                        resolveTumorType: this.resolveTumorType,
+                    }
+                );
+
                 const germlineData = this.props.germlineOncoKbData;
                 let germlineAnnotation: GermlineVariantAnnotation | undefined;
                 if (
@@ -968,36 +998,13 @@ export default class MutationTable<
                 return (
                     <span id="mutation-annotation">
                         {germlineAnnotation ? (
-                            <GermlineOncoKbIcon
+                            <GermlineOncoKbTooltip
                                 annotation={germlineAnnotation}
-                            />
+                            >
+                                {annotationContent}
+                            </GermlineOncoKbTooltip>
                         ) : (
-                            AnnotationColumnFormatter.renderFunction(d, {
-                                hotspotData: this.props.hotspotData,
-                                oncoKbData: this.props.oncoKbData,
-                                oncoKbCancerGenes: this.props.oncoKbCancerGenes,
-                                usingPublicOncoKbInstance: this.props
-                                    .usingPublicOncoKbInstance,
-                                mergeOncoKbIcons: this.props.mergeOncoKbIcons,
-                                oncoKbContentPadding: calculateOncoKbContentPadding(
-                                    this.oncokbWidth
-                                ),
-                                pubMedCache: this.props.pubMedCache,
-                                civicGenes: this.props.civicGenes,
-                                civicVariants: this.props.civicVariants,
-                                enableCivic: this.props.enableCivic as boolean,
-                                enableOncoKb: this.props
-                                    .enableOncoKb as boolean,
-                                enableHotspot: this.props
-                                    .enableHotspot as boolean,
-                                enableRevue:
-                                    !!this.props.enableRevue &&
-                                    this.shouldShowRevue,
-                                userDisplayName: this.props.userDisplayName,
-                                indexedVariantAnnotations: this.props
-                                    .indexedVariantAnnotations,
-                                resolveTumorType: this.resolveTumorType,
-                            })
+                            annotationContent
                         )}
                     </span>
                 );

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -59,6 +59,7 @@ import {
     extractGenomicLocation,
     genomicLocationString,
 } from 'cbioportal-utils';
+import { isNotGermlineMutation } from 'shared/lib/MutationUtils';
 import {
     DownloadControlOption,
     MobxPromise,
@@ -216,7 +217,6 @@ export enum MutationTableColumnType {
     SELECTED = 'Selected',
     DBSNP = 'dbSNP',
     GENE_PANEL = 'Gene panel',
-    GERMLINE_ONCOKB = 'Germline OncoKB',
     SIGNAL = 'SIGNAL',
     NUM_MUTATED_GROUP_A = '(A) Group',
     NUM_MUTATED_GROUP_B = '(B) Group',
@@ -943,33 +943,68 @@ export default class MutationTable<
                     this.handleOncoKbIconModeToggle,
                     this.shouldShowRevue
                 ),
-            render: (d: Mutation[]) => (
-                <span id="mutation-annotation">
-                    {AnnotationColumnFormatter.renderFunction(d, {
-                        hotspotData: this.props.hotspotData,
-                        oncoKbData: this.props.oncoKbData,
-                        oncoKbCancerGenes: this.props.oncoKbCancerGenes,
-                        usingPublicOncoKbInstance: this.props
-                            .usingPublicOncoKbInstance,
-                        mergeOncoKbIcons: this.props.mergeOncoKbIcons,
-                        oncoKbContentPadding: calculateOncoKbContentPadding(
-                            this.oncokbWidth
-                        ),
-                        pubMedCache: this.props.pubMedCache,
-                        civicGenes: this.props.civicGenes,
-                        civicVariants: this.props.civicVariants,
-                        enableCivic: this.props.enableCivic as boolean,
-                        enableOncoKb: this.props.enableOncoKb as boolean,
-                        enableHotspot: this.props.enableHotspot as boolean,
-                        enableRevue:
-                            !!this.props.enableRevue && this.shouldShowRevue,
-                        userDisplayName: this.props.userDisplayName,
-                        indexedVariantAnnotations: this.props
-                            .indexedVariantAnnotations,
-                        resolveTumorType: this.resolveTumorType,
-                    })}
-                </span>
-            ),
+            render: (d: Mutation[]) => {
+                const mutation = d ? d[0] : undefined;
+                // For mutations explicitly marked germline, prefer the germline
+                // OncoKB tooltip when an annotation is available; fall back to
+                // the standard somatic annotation column rendering otherwise so
+                // that hotspot / civic / reVUE indicators still show.
+                const germlineData = this.props.germlineOncoKbData;
+                let germlineAnnotation: GermlineVariantAnnotation | undefined;
+                if (
+                    mutation &&
+                    !isNotGermlineMutation(mutation) &&
+                    germlineData &&
+                    germlineData.result &&
+                    !(germlineData.result instanceof Error) &&
+                    germlineData.result.indicatorMap
+                ) {
+                    const queryId = generateQueryVariantId(
+                        mutation.entrezGeneId,
+                        null,
+                        mutation.proteinChange,
+                        mutation.mutationType
+                    );
+                    germlineAnnotation =
+                        germlineData.result.indicatorMap[queryId];
+                }
+                return (
+                    <span id="mutation-annotation">
+                        {germlineAnnotation ? (
+                            <GermlineOncoKbIcon
+                                annotation={germlineAnnotation}
+                            />
+                        ) : (
+                            AnnotationColumnFormatter.renderFunction(d, {
+                                hotspotData: this.props.hotspotData,
+                                oncoKbData: this.props.oncoKbData,
+                                oncoKbCancerGenes: this.props.oncoKbCancerGenes,
+                                usingPublicOncoKbInstance: this.props
+                                    .usingPublicOncoKbInstance,
+                                mergeOncoKbIcons: this.props.mergeOncoKbIcons,
+                                oncoKbContentPadding: calculateOncoKbContentPadding(
+                                    this.oncokbWidth
+                                ),
+                                pubMedCache: this.props.pubMedCache,
+                                civicGenes: this.props.civicGenes,
+                                civicVariants: this.props.civicVariants,
+                                enableCivic: this.props.enableCivic as boolean,
+                                enableOncoKb: this.props
+                                    .enableOncoKb as boolean,
+                                enableHotspot: this.props
+                                    .enableHotspot as boolean,
+                                enableRevue:
+                                    !!this.props.enableRevue &&
+                                    this.shouldShowRevue,
+                                userDisplayName: this.props.userDisplayName,
+                                indexedVariantAnnotations: this.props
+                                    .indexedVariantAnnotations,
+                                resolveTumorType: this.resolveTumorType,
+                            })
+                        )}
+                    </span>
+                );
+            },
             filter: (
                 d: Mutation[],
                 filterString: string,
@@ -1045,104 +1080,6 @@ export default class MutationTable<
                     this.resolveTumorType
                 );
             },
-        };
-
-        this._columns[MutationTableColumnType.GERMLINE_ONCOKB] = {
-            name: MutationTableColumnType.GERMLINE_ONCOKB,
-            render: (d: Mutation[]) => {
-                const mutation = d ? d[0] : undefined;
-                if (!mutation) return <span />;
-
-                const germlineData = this.props.germlineOncoKbData;
-                if (
-                    !germlineData ||
-                    !germlineData.result ||
-                    germlineData.result instanceof Error ||
-                    !germlineData.result.indicatorMap
-                ) {
-                    if (germlineData && germlineData.isPending) {
-                        return (
-                            <span
-                                style={{
-                                    display: 'inline-block',
-                                    width: 22,
-                                    height: 22,
-                                }}
-                            >
-                                <i
-                                    className="fa fa-spinner fa-pulse"
-                                    style={{ fontSize: 12 }}
-                                />
-                            </span>
-                        );
-                    }
-                    return <span />;
-                }
-
-                const queryId = generateQueryVariantId(
-                    mutation.entrezGeneId,
-                    null,
-                    mutation.proteinChange,
-                    mutation.mutationType
-                );
-                const annotation: GermlineVariantAnnotation | undefined =
-                    germlineData.result.indicatorMap[queryId];
-                if (!annotation) return <span />;
-
-                return <GermlineOncoKbIcon annotation={annotation} />;
-            },
-            download: (d: Mutation[]) => {
-                const mutation = d ? d[0] : undefined;
-                if (!mutation) return '';
-                const germlineData = this.props.germlineOncoKbData;
-                if (
-                    !germlineData ||
-                    !germlineData.result ||
-                    germlineData.result instanceof Error ||
-                    !germlineData.result.indicatorMap
-                )
-                    return '';
-                const queryId = generateQueryVariantId(
-                    mutation.entrezGeneId,
-                    null,
-                    mutation.proteinChange,
-                    mutation.mutationType
-                );
-                const annotation = germlineData.result.indicatorMap[queryId];
-                if (!annotation) return '';
-                return `Pathogenic: ${annotation.pathogenic ||
-                    'N/A'}, Penetrance: ${annotation.penetrance || 'N/A'}`;
-            },
-            sortBy: (d: Mutation[]) => {
-                const mutation = d ? d[0] : undefined;
-                if (!mutation) return [0];
-                const germlineData = this.props.germlineOncoKbData;
-                if (
-                    !germlineData ||
-                    !germlineData.result ||
-                    germlineData.result instanceof Error ||
-                    !germlineData.result.indicatorMap
-                )
-                    return [0];
-                const queryId = generateQueryVariantId(
-                    mutation.entrezGeneId,
-                    null,
-                    mutation.proteinChange,
-                    mutation.mutationType
-                );
-                const annotation = germlineData.result.indicatorMap[queryId];
-                if (!annotation) return [0];
-                // Sort by pathogenicity level
-                const pathogenicOrder: { [key: string]: number } = {
-                    Pathogenic: 4,
-                    'Likely Pathogenic': 3,
-                    VUS: 2,
-                    'Likely Benign': 1,
-                    Benign: 0,
-                };
-                return [pathogenicOrder[annotation.pathogenic] ?? 0];
-            },
-            visible: false,
         };
 
         this._columns[MutationTableColumnType.CUSTOM_DRIVER] = {

--- a/src/shared/components/mutationTable/column/GermlineOncoKbIcon.tsx
+++ b/src/shared/components/mutationTable/column/GermlineOncoKbIcon.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import { GermlineVariantAnnotation } from 'oncokb-ts-api-client';
+
+const PATHOGENIC_COLORS: { [key: string]: string } = {
+    Pathogenic: '#FF0000',
+    'Likely Pathogenic': '#FF6600',
+    VUS: '#696969',
+    'Likely Benign': '#33A02C',
+    Benign: '#33A02C',
+};
+
+const PATHOGENIC_ICONS: { [key: string]: string } = {
+    Pathogenic: 'fa-exclamation-circle',
+    'Likely Pathogenic': 'fa-exclamation-triangle',
+    VUS: 'fa-question-circle',
+    'Likely Benign': 'fa-check-circle',
+    Benign: 'fa-check-circle',
+};
+
+function GermlineTooltipContent(props: {
+    annotation: GermlineVariantAnnotation;
+}) {
+    const { annotation } = props;
+    return (
+        <div style={{ maxWidth: 300 }}>
+            <div style={{ marginBottom: 5 }}>
+                <strong>OncoKB Germline Annotation</strong>
+            </div>
+            <table className="table table-condensed table-borderless">
+                <tbody>
+                    <tr>
+                        <td>
+                            <strong>Pathogenicity:</strong>
+                        </td>
+                        <td>{annotation.pathogenic || 'N/A'}</td>
+                    </tr>
+                    {annotation.penetrance && (
+                        <tr>
+                            <td>
+                                <strong>Penetrance:</strong>
+                            </td>
+                            <td>{annotation.penetrance}</td>
+                        </tr>
+                    )}
+                    {annotation.geneSummary && (
+                        <tr>
+                            <td colSpan={2}>
+                                <strong>Gene Summary:</strong>
+                                <br />
+                                <span style={{ fontSize: '0.9em' }}>
+                                    {annotation.geneSummary}
+                                </span>
+                            </td>
+                        </tr>
+                    )}
+                    {annotation.variantSummary && (
+                        <tr>
+                            <td colSpan={2}>
+                                <strong>Variant Summary:</strong>
+                                <br />
+                                <span style={{ fontSize: '0.9em' }}>
+                                    {annotation.variantSummary}
+                                </span>
+                            </td>
+                        </tr>
+                    )}
+                    {annotation.genomicIndicators &&
+                        annotation.genomicIndicators.length > 0 && (
+                            <tr>
+                                <td colSpan={2}>
+                                    <strong>Genomic Indicators:</strong>
+                                    <br />
+                                    {annotation.genomicIndicators.map(
+                                        (gi, i) => (
+                                            <span
+                                                key={i}
+                                                style={{ fontSize: '0.9em' }}
+                                            >
+                                                {gi.name}
+                                                {gi.inheritanceMechanism &&
+                                                    ` (${gi.inheritanceMechanism
+                                                        .toLowerCase()
+                                                        .replace(/_/g, ' ')})`}
+                                                {gi.description && (
+                                                    <>: {gi.description}</>
+                                                )}
+                                                <br />
+                                            </span>
+                                        )
+                                    )}
+                                </td>
+                            </tr>
+                        )}
+                    {annotation.highestSensitiveLevel && (
+                        <tr>
+                            <td>
+                                <strong>Therapeutic Level:</strong>
+                            </td>
+                            <td>{annotation.highestSensitiveLevel}</td>
+                        </tr>
+                    )}
+                    {annotation.highestDiagnosticImplicationLevel && (
+                        <tr>
+                            <td>
+                                <strong>Diagnostic Level:</strong>
+                            </td>
+                            <td>
+                                {annotation.highestDiagnosticImplicationLevel}
+                            </td>
+                        </tr>
+                    )}
+                    {annotation.highestPrognosticImplicationLevel && (
+                        <tr>
+                            <td>
+                                <strong>Prognostic Level:</strong>
+                            </td>
+                            <td>
+                                {annotation.highestPrognosticImplicationLevel}
+                            </td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export default function GermlineOncoKbIcon(props: {
+    annotation: GermlineVariantAnnotation;
+}) {
+    const { annotation } = props;
+    const pathogenic = annotation.pathogenic || 'VUS';
+    const color = PATHOGENIC_COLORS[pathogenic] || '#696969';
+    const icon = PATHOGENIC_ICONS[pathogenic] || 'fa-question-circle';
+
+    return (
+        <DefaultTooltip
+            placement="right"
+            overlay={<GermlineTooltipContent annotation={annotation} />}
+        >
+            <span
+                style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    cursor: 'pointer',
+                }}
+            >
+                <i
+                    className={`fa ${icon}`}
+                    style={{
+                        color,
+                        fontSize: 14,
+                        marginRight: 3,
+                    }}
+                />
+                <span style={{ fontSize: 11, color }}>{pathogenic}</span>
+            </span>
+        </DefaultTooltip>
+    );
+}

--- a/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
+++ b/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
@@ -2,22 +2,6 @@ import * as React from 'react';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import { GermlineVariantAnnotation } from 'oncokb-ts-api-client';
 
-const PATHOGENIC_COLORS: { [key: string]: string } = {
-    Pathogenic: '#FF0000',
-    'Likely Pathogenic': '#FF6600',
-    VUS: '#696969',
-    'Likely Benign': '#33A02C',
-    Benign: '#33A02C',
-};
-
-const PATHOGENIC_ICONS: { [key: string]: string } = {
-    Pathogenic: 'fa-exclamation-circle',
-    'Likely Pathogenic': 'fa-exclamation-triangle',
-    VUS: 'fa-question-circle',
-    'Likely Benign': 'fa-check-circle',
-    Benign: 'fa-check-circle',
-};
-
 function GermlineTooltipContent(props: {
     annotation: GermlineVariantAnnotation;
 }) {
@@ -126,36 +110,21 @@ function GermlineTooltipContent(props: {
     );
 }
 
-export default function GermlineOncoKbIcon(props: {
+// Wraps the standard OncoKB Annotation column rendering for germline rows so
+// hovering anywhere in the cell surfaces a germline-specific tooltip
+// (pathogenicity, penetrance, genomic indicators, levels). The icon visual
+// is intentionally unchanged from somatic -- germline status is already
+// communicated by the indicator on the Protein Change column.
+export default function GermlineOncoKbTooltip(props: {
     annotation: GermlineVariantAnnotation;
+    children: React.ReactNode;
 }) {
-    const { annotation } = props;
-    const pathogenic = annotation.pathogenic || 'VUS';
-    const color = PATHOGENIC_COLORS[pathogenic] || '#696969';
-    const icon = PATHOGENIC_ICONS[pathogenic] || 'fa-question-circle';
-
     return (
         <DefaultTooltip
             placement="right"
-            overlay={<GermlineTooltipContent annotation={annotation} />}
+            overlay={<GermlineTooltipContent annotation={props.annotation} />}
         >
-            <span
-                style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    cursor: 'pointer',
-                }}
-            >
-                <i
-                    className={`fa ${icon}`}
-                    style={{
-                        color,
-                        fontSize: 14,
-                        marginRight: 3,
-                    }}
-                />
-                <span style={{ fontSize: 11, color }}>{pathogenic}</span>
-            </span>
+            <span style={{ display: 'inline-block' }}>{props.children}</span>
         </DefaultTooltip>
     );
 }

--- a/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
+++ b/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
@@ -165,6 +165,15 @@ export default function GermlineOncoKbTooltip(props: {
     annotation: GermlineVariantAnnotation;
     children: React.ReactNode;
 }) {
+    // Touch handler: on mobile, a tap fires both `mouseover`/`mouseenter`
+    // (synthesized) AND `click`. The inner OncoKB icon's own tooltip uses
+    // hover, so without intercepting the synthesized mouse events the user
+    // sees both our germline tooltip and the inner somatic tooltip stack
+    // briefly. Capturing pointerover/mouseover at the wrapper and stopping
+    // propagation keeps the inner hover tooltip from firing on touch.
+    const stopAll = (e: React.SyntheticEvent) => {
+        e.stopPropagation();
+    };
     return (
         <DefaultTooltip
             placement="right"
@@ -173,7 +182,11 @@ export default function GermlineOncoKbTooltip(props: {
         >
             <span
                 style={{ display: 'inline-block', cursor: 'pointer' }}
-                onClick={e => e.stopPropagation()}
+                onClick={stopAll}
+                onMouseOver={stopAll}
+                onMouseEnter={stopAll}
+                onTouchStart={stopAll}
+                onPointerOver={stopAll}
             >
                 {props.children}
             </span>

--- a/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
+++ b/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
@@ -1,120 +1,166 @@
 import * as React from 'react';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import { GermlineVariantAnnotation } from 'oncokb-ts-api-client';
+// Reuse the somatic OncoKbCard SCSS so the germline tooltip matches the
+// somatic tooltip's visual style (blue title, additional-info sections,
+// footer with the OncoKB logo).
+import oncoKbStyles from 'oncokb-frontend-commons/src/components/main.module.scss';
+import oncoKbLogoImgSrc from 'oncokb-styles/dist/images/logo/oncokb.svg';
 
-function GermlineTooltipContent(props: {
-    annotation: GermlineVariantAnnotation;
-}) {
+function germlineUrl(annotation: GermlineVariantAnnotation): string {
+    const hugo = annotation.query?.hugoSymbol;
+    if (!hugo) return 'https://www.oncokb.org';
+    const alteration = annotation.query?.alteration;
+    return alteration
+        ? `https://www.oncokb.org/gene/${hugo}/germline/${alteration}`
+        : `https://www.oncokb.org/gene/${hugo}/germline`;
+}
+
+function titleText(annotation: GermlineVariantAnnotation): string {
+    const parts: string[] = [];
+    const hugo = annotation.query?.hugoSymbol;
+    const alt = annotation.query?.alteration;
+    if (hugo) parts.push(hugo);
+    if (alt && (!hugo || !alt.includes(hugo))) parts.push(alt);
+    parts.push('(germline)');
+    return parts.join(' ');
+}
+
+function GermlineCard(props: { annotation: GermlineVariantAnnotation }) {
     const { annotation } = props;
+    const url = germlineUrl(annotation);
     return (
-        <div style={{ maxWidth: 300 }}>
-            <div style={{ marginBottom: 5 }}>
-                <strong>OncoKB Germline Annotation</strong>
+        <div
+            className={oncoKbStyles['oncokb-card']}
+            data-test="germline-oncokb-card"
+        >
+            <div className={oncoKbStyles['title']}>{titleText(annotation)}</div>
+
+            <div className={oncoKbStyles['additional-info']}>
+                <div>
+                    <strong>Pathogenicity: </strong>
+                    {annotation.pathogenic || 'N/A'}
+                </div>
+                {annotation.penetrance && (
+                    <div>
+                        <strong>Penetrance: </strong>
+                        {annotation.penetrance}
+                    </div>
+                )}
+                {annotation.clinVarId && (
+                    <div>
+                        <strong>ClinVar: </strong>
+                        <a
+                            href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${annotation.clinVarId}/`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {annotation.clinVarId}
+                        </a>
+                    </div>
+                )}
             </div>
-            <table className="table table-condensed table-borderless">
-                <tbody>
-                    <tr>
-                        <td>
-                            <strong>Pathogenicity:</strong>
-                        </td>
-                        <td>{annotation.pathogenic || 'N/A'}</td>
-                    </tr>
-                    {annotation.penetrance && (
-                        <tr>
-                            <td>
-                                <strong>Penetrance:</strong>
-                            </td>
-                            <td>{annotation.penetrance}</td>
-                        </tr>
-                    )}
+
+            {(annotation.geneSummary || annotation.variantSummary) && (
+                <div className={oncoKbStyles['additional-info']}>
                     {annotation.geneSummary && (
-                        <tr>
-                            <td colSpan={2}>
-                                <strong>Gene Summary:</strong>
-                                <br />
-                                <span style={{ fontSize: '0.9em' }}>
-                                    {annotation.geneSummary}
-                                </span>
-                            </td>
-                        </tr>
+                        <div>
+                            <strong>Gene Summary</strong>
+                            <div>{annotation.geneSummary}</div>
+                        </div>
                     )}
                     {annotation.variantSummary && (
-                        <tr>
-                            <td colSpan={2}>
-                                <strong>Variant Summary:</strong>
-                                <br />
-                                <span style={{ fontSize: '0.9em' }}>
-                                    {annotation.variantSummary}
-                                </span>
-                            </td>
-                        </tr>
+                        <div style={{ marginTop: 6 }}>
+                            <strong>Variant Summary</strong>
+                            <div>{annotation.variantSummary}</div>
+                        </div>
                     )}
-                    {annotation.genomicIndicators &&
-                        annotation.genomicIndicators.length > 0 && (
-                            <tr>
-                                <td colSpan={2}>
-                                    <strong>Genomic Indicators:</strong>
-                                    <br />
-                                    {annotation.genomicIndicators.map(
-                                        (gi, i) => (
-                                            <span
-                                                key={i}
-                                                style={{ fontSize: '0.9em' }}
-                                            >
-                                                {gi.name}
-                                                {gi.inheritanceMechanism &&
-                                                    ` (${gi.inheritanceMechanism
-                                                        .toLowerCase()
-                                                        .replace(/_/g, ' ')})`}
-                                                {gi.description && (
-                                                    <>: {gi.description}</>
-                                                )}
-                                                <br />
-                                            </span>
-                                        )
-                                    )}
-                                </td>
-                            </tr>
-                        )}
+                </div>
+            )}
+
+            {annotation.genomicIndicators &&
+                annotation.genomicIndicators.length > 0 && (
+                    <div className={oncoKbStyles['additional-info']}>
+                        <strong>Genomic Indicators</strong>
+                        {annotation.genomicIndicators.map((gi, i) => (
+                            <div key={i} style={{ marginTop: 4 }}>
+                                <strong>{gi.name}</strong>
+                                {gi.inheritanceMechanism && (
+                                    <span style={{ color: '#666' }}>
+                                        {' '}
+                                        ·{' '}
+                                        {gi.inheritanceMechanism
+                                            .toLowerCase()
+                                            .replace(/_/g, ' ')}
+                                    </span>
+                                )}
+                                {gi.description && (
+                                    <div style={{ fontSize: '0.95em' }}>
+                                        {gi.description}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+            {(annotation.highestSensitiveLevel ||
+                annotation.highestDiagnosticImplicationLevel ||
+                annotation.highestPrognosticImplicationLevel) && (
+                <div className={oncoKbStyles['additional-info']}>
+                    <strong>Highest Levels of Evidence</strong>
                     {annotation.highestSensitiveLevel && (
-                        <tr>
-                            <td>
-                                <strong>Therapeutic Level:</strong>
-                            </td>
-                            <td>{annotation.highestSensitiveLevel}</td>
-                        </tr>
+                        <div>
+                            Therapeutic: {annotation.highestSensitiveLevel}
+                        </div>
                     )}
                     {annotation.highestDiagnosticImplicationLevel && (
-                        <tr>
-                            <td>
-                                <strong>Diagnostic Level:</strong>
-                            </td>
-                            <td>
-                                {annotation.highestDiagnosticImplicationLevel}
-                            </td>
-                        </tr>
+                        <div>
+                            Diagnostic:{' '}
+                            {annotation.highestDiagnosticImplicationLevel}
+                        </div>
                     )}
                     {annotation.highestPrognosticImplicationLevel && (
-                        <tr>
-                            <td>
-                                <strong>Prognostic Level:</strong>
-                            </td>
-                            <td>
-                                {annotation.highestPrognosticImplicationLevel}
-                            </td>
-                        </tr>
+                        <div>
+                            Prognostic:{' '}
+                            {annotation.highestPrognosticImplicationLevel}
+                        </div>
                     )}
-                </tbody>
-            </table>
+                </div>
+            )}
+
+            <div className={oncoKbStyles['footer']}>
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={oncoKbStyles['oncokb-logo']}
+                >
+                    <img
+                        src={oncoKbLogoImgSrc}
+                        className={oncoKbStyles['oncokb-logo']}
+                        alt="OncoKB™"
+                    />
+                </a>
+            </div>
         </div>
     );
 }
 
 // Wraps the standard OncoKB Annotation column rendering for germline rows so
-// hovering anywhere in the cell surfaces a germline-specific tooltip
-// (pathogenicity, penetrance, genomic indicators, levels). The icon visual
-// is intentionally unchanged from somatic -- germline status is already
-// communicated by the indicator on the Protein Change column.
+// hovering / tapping the cell surfaces a germline-specific tooltip styled
+// to match the somatic OncoKbCard look. The icon visual is intentionally
+// unchanged from somatic -- germline status is communicated by the
+// indicator on the Protein Change column.
+//
+// Trigger is `click` only (no hover) on purpose:
+//   * On desktop, hover continues to open the inner OncoKB icon's own
+//     somatic tooltip; an explicit click reveals our germline tooltip.
+//   * On mobile, tap synthesizes both mouseenter and click. If we kept
+//     `hover` in our trigger list, every tap would open both our tooltip
+//     and the inner OncoKB hover tooltip on top of each other.
+// onClick stopPropagation is added so the same tap doesn't also fire any
+// click handler on the inner Annotation children.
 export default function GermlineOncoKbTooltip(props: {
     annotation: GermlineVariantAnnotation;
     children: React.ReactNode;
@@ -122,12 +168,15 @@ export default function GermlineOncoKbTooltip(props: {
     return (
         <DefaultTooltip
             placement="right"
-            // Include `click` so a tap on touch devices (where hover never
-            // fires) also opens the tooltip; keep `hover` for desktop.
-            trigger={['hover', 'click']}
-            overlay={<GermlineTooltipContent annotation={props.annotation} />}
+            trigger={['click']}
+            overlay={<GermlineCard annotation={props.annotation} />}
         >
-            <span style={{ display: 'inline-block' }}>{props.children}</span>
+            <span
+                style={{ display: 'inline-block', cursor: 'pointer' }}
+                onClick={e => e.stopPropagation()}
+            >
+                {props.children}
+            </span>
         </DefaultTooltip>
     );
 }

--- a/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
+++ b/src/shared/components/mutationTable/column/GermlineOncoKbTooltip.tsx
@@ -122,6 +122,9 @@ export default function GermlineOncoKbTooltip(props: {
     return (
         <DefaultTooltip
             placement="right"
+            // Include `click` so a tap on touch devices (where hover never
+            // fires) also opens the tooltip; keep `hover` for desktop.
+            trigger={['hover', 'click']}
             overlay={<GermlineTooltipContent annotation={props.annotation} />}
         >
             <span style={{ display: 'inline-block' }}>{props.children}</span>

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -959,6 +959,20 @@ export async function queryOncoKbData(
     return oncoKbData;
 }
 
+// Build the OncoKB-format genomicLocation key for a mutation, e.g.
+// "17,41246709,41246709,T,C". Used both as the OncoKB query id when
+// fetching germline annotations and as the lookup key in the indicator
+// map at render time, so producer and consumer must agree on the format.
+export function germlineOncoKbKeyForMutation(mutation: Mutation): string {
+    return [
+        mutation.chr,
+        mutation.startPosition,
+        mutation.endPosition,
+        mutation.referenceAllele,
+        mutation.variantAllele,
+    ].join(',');
+}
+
 export async function fetchGermlineOncoKbData(
     uniqueSampleKeyToTumorType: { [uniqueSampleKey: string]: string },
     annotatedGenes: { [entrezGeneId: number]: boolean } | Error,
@@ -979,59 +993,64 @@ export async function fetchGermlineOncoKbData(
 
     // Only query germline mutations for genes annotated by OncoKB
     const germlineMutations = mutationDataResult.filter(
-        m => !isNotGermlineMutation(m) && !!annotatedGenes[m.entrezGeneId]
+        m =>
+            !isNotGermlineMutation(m) &&
+            !!annotatedGenes[m.entrezGeneId] &&
+            // OncoKB byGenomicChange requires complete genomic coordinates;
+            // skip rows where the MAF is missing any of them.
+            !!m.chr &&
+            m.startPosition != null &&
+            m.endPosition != null &&
+            !!m.referenceAllele &&
+            !!m.variantAllele
     );
 
     if (germlineMutations.length === 0) {
         return GERMLINE_ONCOKB_DEFAULT;
     }
 
-    // Deduplicate by gene + alteration + tumor type
+    // Build one query per unique (genomicLocation, tumorType) pair. Tumor
+    // type is part of the key because OncoKB returns tumor-type-aware
+    // implication levels and we want the right one per sample.
     const uniqueQueries = _.uniqBy(
-        germlineMutations.map(mutation => ({
-            mutation,
-            id: generateQueryVariantId(
-                mutation.entrezGeneId,
+        germlineMutations.map(mutation => {
+            const tumorType =
                 cancerTypeForOncoKb(
                     mutation.uniqueSampleKey,
                     uniqueSampleKeyToTumorType
-                ),
-                mutation.proteinChange,
-                mutation.mutationType
-            ),
-        })),
-        q => q.id
+                ) || '';
+            const genomicLocation = germlineOncoKbKeyForMutation(mutation);
+            return {
+                evidenceTypes: [],
+                genomicLocation,
+                id: genomicLocation,
+                referenceGenome: 'GRCh37' as const,
+                tumorType,
+            };
+        }),
+        q => `${q.id}::${q.tumorType}`
     );
 
-    // Query each germline mutation individually via GET endpoint
-    const results = await Promise.all(
-        uniqueQueries.map(async ({ mutation, id }) => {
-            try {
-                const tumorType = cancerTypeForOncoKb(
-                    mutation.uniqueSampleKey,
-                    uniqueSampleKeyToTumorType
-                );
-                const annotation = await client.utilsVariantAnnotationGermlineGetUsingGET(
-                    {
-                        entrezGeneId: mutation.entrezGeneId,
-                        alteration: mutation.proteinChange,
-                        tumorType: tumorType || undefined,
-                    }
-                );
-                return { id, annotation };
-            } catch (e) {
-                // Silently skip mutations that fail
-                return null;
-            }
-        })
-    );
+    // OncoKB exposes batch annotation for germline only via the
+    // /annotate/germline/mutations/byGenomicChange POST endpoint. The
+    // /utils/variantAnnotation/germline single-variant GET endpoint
+    // requires a higher-tier token than cBioPortal's public token has.
+    let annotations: GermlineVariantAnnotation[];
+    try {
+        annotations = await client.annotateMutationsByGenomicChangeGermlinePostUsingPOST(
+            { body: uniqueQueries }
+        );
+    } catch (e) {
+        return new Error();
+    }
 
     const indicatorMap: {
         [id: string]: GermlineVariantAnnotation;
     } = {};
-    for (const result of results) {
-        if (result && result.annotation) {
-            indicatorMap[result.id] = result.annotation;
+    for (const annotation of annotations || []) {
+        const id = annotation.query?.id;
+        if (id) {
+            indicatorMap[id] = annotation;
         }
     }
 

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -47,6 +47,7 @@ import {
     chunkCalls,
     EvidenceType,
     IHotspotIndex,
+    IGermlineOncoKbData,
     IOncoKbData,
     isLinearClusterHotspot,
 } from 'cbioportal-utils';
@@ -74,6 +75,7 @@ import {
     AnnotateCopyNumberAlterationQuery,
     AnnotateStructuralVariantQuery,
     CancerGene,
+    GermlineVariantAnnotation,
     IndicatorQueryResp,
     OncoKbAPI,
     OncoKBInfo,
@@ -123,6 +125,10 @@ export const MolecularAlterationType_filenameSuffix: {
 };
 
 export const ONCOKB_DEFAULT: IOncoKbData = {
+    indicatorMap: {},
+};
+
+export const GERMLINE_ONCOKB_DEFAULT: IGermlineOncoKbData = {
     indicatorMap: {},
 };
 
@@ -951,6 +957,85 @@ export async function queryOncoKbData(
     };
 
     return oncoKbData;
+}
+
+export async function fetchGermlineOncoKbData(
+    uniqueSampleKeyToTumorType: { [uniqueSampleKey: string]: string },
+    annotatedGenes: { [entrezGeneId: number]: boolean } | Error,
+    mutationData: MobxPromise<Mutation[]>,
+    uncalledMutationData?: MobxPromise<Mutation[]>,
+    client: OncoKbAPI = oncokbClient
+): Promise<IGermlineOncoKbData | Error> {
+    const mutationDataResult = concatMutationData(
+        mutationData,
+        uncalledMutationData
+    );
+
+    if (annotatedGenes instanceof Error) {
+        return new Error();
+    } else if (mutationDataResult.length === 0) {
+        return GERMLINE_ONCOKB_DEFAULT;
+    }
+
+    // Only query germline mutations for genes annotated by OncoKB
+    const germlineMutations = mutationDataResult.filter(
+        m => !isNotGermlineMutation(m) && !!annotatedGenes[m.entrezGeneId]
+    );
+
+    if (germlineMutations.length === 0) {
+        return GERMLINE_ONCOKB_DEFAULT;
+    }
+
+    // Deduplicate by gene + alteration + tumor type
+    const uniqueQueries = _.uniqBy(
+        germlineMutations.map(mutation => ({
+            mutation,
+            id: generateQueryVariantId(
+                mutation.entrezGeneId,
+                cancerTypeForOncoKb(
+                    mutation.uniqueSampleKey,
+                    uniqueSampleKeyToTumorType
+                ),
+                mutation.proteinChange,
+                mutation.mutationType
+            ),
+        })),
+        q => q.id
+    );
+
+    // Query each germline mutation individually via GET endpoint
+    const results = await Promise.all(
+        uniqueQueries.map(async ({ mutation, id }) => {
+            try {
+                const tumorType = cancerTypeForOncoKb(
+                    mutation.uniqueSampleKey,
+                    uniqueSampleKeyToTumorType
+                );
+                const annotation = await client.utilsVariantAnnotationGermlineGetUsingGET(
+                    {
+                        entrezGeneId: mutation.entrezGeneId,
+                        alteration: mutation.proteinChange,
+                        tumorType: tumorType || undefined,
+                    }
+                );
+                return { id, annotation };
+            } catch (e) {
+                // Silently skip mutations that fail
+                return null;
+            }
+        })
+    );
+
+    const indicatorMap: {
+        [id: string]: GermlineVariantAnnotation;
+    } = {};
+    for (const result of results) {
+        if (result && result.annotation) {
+            indicatorMap[result.id] = result.annotation;
+        }
+    }
+
+    return { indicatorMap };
 }
 
 export async function queryOncoKbCopyNumberAlterationData(


### PR DESCRIPTION
## Summary

Prototype integration of OncoKB **germline** annotations into the patient view mutations table. Companion to the k8s switch that points `master.cbioportal.org` at `beta.oncokb.org` (only the beta OncoKB API exposes the germline endpoint at the moment).

Tracking issue: cBioPortal/cbioportal#12113

### What it does

- Extends `OncoKbAPI` client with `utilsVariantAnnotationGermlineGetUsingGET` and the `GermlineVariantAnnotation` / `GenomicIndicator` / `VariantAnnotationTumorType` types
- New `IGermlineOncoKbData` model + `GERMLINE_ONCOKB_DEFAULT`
- `fetchGermlineOncoKbData`: per-mutation GET against the germline endpoint, restricted to mutations where `!isNotGermlineMutation` and gene is OncoKB-annotated, deduplicated by query id
- New `germlineOncoKbData` `remoteData` on `PatientViewPageStore`, wired through `MutationTableWrapper` → `PatientViewMutationTable`
- New `GERMLINE_ONCOKB` column with render / download / sortBy
- New `GermlineOncoKbIcon` tooltip showing pathogenicity, penetrance, gene/variant summary, genomic indicators (name + inheritance + description), and highest sensitive/diagnostic/prognostic levels
- Column is gated on `show_oncokb`, hidden by default but selectable in column controls

### Preview

- https://deploy-preview-<PR#>.preview.cbioportal.org/patient?studyId=brca_tcga_pub&caseId=TCGA-A1-A0SK
  (any patient view in a study with germline-marked mutations should surface the column once enabled)

### Status

**Draft.** Open issues to address before marking ready:

- [ ] Schema-only follow-ups: `OncoKbAPI.ts` was hand-edited rather than regenerated from the beta swagger — the proper fix is to point `fetchOncoKbAPI` at `beta.oncokb.org` and re-run `pnpm run updateOncoKbAPI` once the beta API is publicly released
- [ ] N+1 GET calls — current implementation issues one GET per germline mutation. The germline OncoKB API only documents the GET endpoint, so this matches the available surface, but worth revisiting if a batch endpoint lands
- [ ] **Revert the first commit (`b11f24da3`) before merge** — it temporarily points `env/master.sh` at `master.cbioportal.org` so the deploy preview can talk to the backend that uses `beta.oncokb.org`. Once we're ready to ship, that line should go back to `https://www.cbioportal.org`
- [ ] End-to-end visual verification once Netlify preview is up

## Test plan

- [ ] Netlify deploy preview builds successfully
- [ ] Patient view loads without console errors
- [ ] Existing somatic OncoKB annotations still render (no regression)
- [ ] Germline OncoKB column renders for mutations marked germline in a study with such data
- [ ] Tooltip shows pathogenicity / penetrance / gene & variant summaries when present
- [x] **Investigate empty annotation for some germline variants** — example: ov_tcga_pub sample TCGA-04-1356-01, BRCA1 N723Ifs*13 (germline, genomicLocation 17,41245382,41245382,G,-) shows pathogenicity "NA" in the tooltip even though it is a known frameshift in BRCA1. Need to determine whether the cause is OncoKB returning no annotation for this specific frameshift via the byGenomicChange endpoint, a deletion-format mismatch ("-" vs explicit alt), or a key-mismatch in our indicatorMap lookup.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/cBioPortal/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->
