### PR TITLE
Improve resources feature v1

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -6,6 +6,7 @@ import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls
 import {
     DefaultTooltip,
     toggleColumnVisibility,
+    pluralize,
 } from 'cbioportal-frontend-commons';
 import {
     PatientViewPageStore,
@@ -480,15 +481,19 @@ export class PatientViewPageInner extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
+                    const displayName =
+                        data.length > 1
+                            ? pluralize(def.displayName, data.length)
+                            : def.displayName;
                     list.push(
                         <MSKTab
                             key={getPatientViewResourceTabId(def.resourceId)}
                             id={getPatientViewResourceTabId(def.resourceId)}
-                            linkText={def.displayName}
+                            linkText={displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
-                                resourceDisplayName={def.displayName}
+                                resourceDisplayName={displayName}
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
                             />

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -481,19 +481,15 @@ export class PatientViewPageInner extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
-                    const displayName =
-                        data.length > 1
-                            ? pluralize(def.displayName, data.length)
-                            : def.displayName;
                     list.push(
                         <MSKTab
                             key={getPatientViewResourceTabId(def.resourceId)}
                             id={getPatientViewResourceTabId(def.resourceId)}
-                            linkText={displayName}
+                            linkText={def.displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
-                                resourceDisplayName={displayName}
+                                resourceDisplayName={def.displayName}
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
                             />

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -488,6 +488,7 @@ export class PatientViewPageInner extends React.Component<
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
+                                resourceDisplayName={def.displayName}
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
                             />

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -175,7 +175,7 @@ export class PatientViewPageInner extends React.Component<
         this.patientViewMutationDataStore = new PatientViewMutationsDataStore(
             () => {
                 return this.pageStore.mergedMutationDataIncludingUncalledFilteredByGene.filter(
-                    (mutationArray) => {
+                    mutationArray => {
                         return !isFusion(mutationArray[0]);
                     }
                 );
@@ -191,8 +191,7 @@ export class PatientViewPageInner extends React.Component<
 
         this.setOpenResourceTabs();
 
-        this.mergeMutationTableOncoKbIcons =
-            getOncoKbIconStyleFromLocalStorage().mergeIcons;
+        this.mergeMutationTableOncoKbIcons = getOncoKbIconStyleFromLocalStorage().mergeIcons;
     }
 
     setOpenResourceTabs() {
@@ -247,7 +246,7 @@ export class PatientViewPageInner extends React.Component<
     @computed get showWholeSlideViewerTab() {
         return (
             this.pageStore.clinicalDataForSamples.isComplete &&
-            _.some(this.pageStore.clinicalDataForSamples.result, (s) => {
+            _.some(this.pageStore.clinicalDataForSamples.result, s => {
                 return s.clinicalAttributeId === 'MSK_SLIDE_ID';
             })
         );
@@ -287,7 +286,7 @@ export class PatientViewPageInner extends React.Component<
         if (this.pageStore.resourceIdToResourceData.isComplete) {
             return _.some(
                 this.pageStore.resourceIdToResourceData.result,
-                (data) => data.length > 0
+                data => data.length > 0
             );
         } else {
             return false;
@@ -361,7 +360,7 @@ export class PatientViewPageInner extends React.Component<
         const entrezGeneIds: number[] = _.uniq(
             _.map(
                 this.pageStore.mergedMutationDataIncludingUncalled,
-                (mutations) => mutations[0].entrezGeneId
+                mutations => mutations[0].entrezGeneId
             )
         );
         return (
@@ -379,7 +378,7 @@ export class PatientViewPageInner extends React.Component<
         const entrezGeneIds: number[] = _.uniq(
             _.map(
                 this.pageStore.mergedDiscreteCNAData,
-                (alterations) => alterations[0].entrezGeneId
+                alterations => alterations[0].entrezGeneId
             )
         );
         return (
@@ -471,13 +470,12 @@ export class PatientViewPageInner extends React.Component<
             this.pageStore.resourceIdToResourceData,
         ],
         render: () => {
-            const openDefinitions =
-                this.pageStore.resourceDefinitions.result!.filter((d) =>
-                    this.pageStore.isResourceTabOpen(d.resourceId)
-                );
-            const sorted = _.sortBy(openDefinitions, (d) => d.priority);
-            const resourceDataById =
-                this.pageStore.resourceIdToResourceData.result!;
+            const openDefinitions = this.pageStore.resourceDefinitions.result!.filter(
+                d => this.pageStore.isResourceTabOpen(d.resourceId)
+            );
+            const sorted = _.sortBy(openDefinitions, d => d.priority);
+            const resourceDataById = this.pageStore.resourceIdToResourceData
+                .result!;
 
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
@@ -569,17 +567,15 @@ export class PatientViewPageInner extends React.Component<
 
     @action.bound
     private handleReturnToStudyView() {
-        const patientIdentifiers = this.pageStore.patientIdsInCohort.map(
-            (p) => {
-                const patientIdParts = p.split(':');
-                return {
-                    patientId: patientIdParts[1],
-                    studyId: patientIdParts[0],
-                };
-            }
-        );
+        const patientIdentifiers = this.pageStore.patientIdsInCohort.map(p => {
+            const patientIdParts = p.split(':');
+            return {
+                patientId: patientIdParts[1],
+                studyId: patientIdParts[0],
+            };
+        });
         const queriedStudies: Set<string> = new Set(
-            patientIdentifiers.map((p) => p.studyId)
+            patientIdentifiers.map(p => p.studyId)
         );
 
         // We need to do this because of url length limits. We post the data to the new window once it is opened.
@@ -605,7 +601,7 @@ export class PatientViewPageInner extends React.Component<
                 ? deleteAtIndex - 1
                 : deleteAtIndex;
 
-        let navCaseIds = newCohortIdList.map((p) => {
+        let navCaseIds = newCohortIdList.map(p => {
             const patientIdParts = p.split(':');
             return {
                 patientId: patientIdParts[1],
@@ -708,7 +704,7 @@ export class PatientViewPageInner extends React.Component<
                                 ]
                             )
                         }
-                        onChangeCurrentPage={(newPage) => {
+                        onChangeCurrentPage={newPage => {
                             if (
                                 newPage > 0 &&
                                 newPage <=

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -6,7 +6,6 @@ import { IColumnVisibilityDef } from 'shared/components/columnVisibilityControls
 import {
     DefaultTooltip,
     toggleColumnVisibility,
-    pluralize,
 } from 'cbioportal-frontend-commons';
 import {
     PatientViewPageStore,
@@ -176,7 +175,7 @@ export class PatientViewPageInner extends React.Component<
         this.patientViewMutationDataStore = new PatientViewMutationsDataStore(
             () => {
                 return this.pageStore.mergedMutationDataIncludingUncalledFilteredByGene.filter(
-                    mutationArray => {
+                    (mutationArray) => {
                         return !isFusion(mutationArray[0]);
                     }
                 );
@@ -192,7 +191,8 @@ export class PatientViewPageInner extends React.Component<
 
         this.setOpenResourceTabs();
 
-        this.mergeMutationTableOncoKbIcons = getOncoKbIconStyleFromLocalStorage().mergeIcons;
+        this.mergeMutationTableOncoKbIcons =
+            getOncoKbIconStyleFromLocalStorage().mergeIcons;
     }
 
     setOpenResourceTabs() {
@@ -247,7 +247,7 @@ export class PatientViewPageInner extends React.Component<
     @computed get showWholeSlideViewerTab() {
         return (
             this.pageStore.clinicalDataForSamples.isComplete &&
-            _.some(this.pageStore.clinicalDataForSamples.result, s => {
+            _.some(this.pageStore.clinicalDataForSamples.result, (s) => {
                 return s.clinicalAttributeId === 'MSK_SLIDE_ID';
             })
         );
@@ -287,7 +287,7 @@ export class PatientViewPageInner extends React.Component<
         if (this.pageStore.resourceIdToResourceData.isComplete) {
             return _.some(
                 this.pageStore.resourceIdToResourceData.result,
-                data => data.length > 0
+                (data) => data.length > 0
             );
         } else {
             return false;
@@ -361,7 +361,7 @@ export class PatientViewPageInner extends React.Component<
         const entrezGeneIds: number[] = _.uniq(
             _.map(
                 this.pageStore.mergedMutationDataIncludingUncalled,
-                mutations => mutations[0].entrezGeneId
+                (mutations) => mutations[0].entrezGeneId
             )
         );
         return (
@@ -379,7 +379,7 @@ export class PatientViewPageInner extends React.Component<
         const entrezGeneIds: number[] = _.uniq(
             _.map(
                 this.pageStore.mergedDiscreteCNAData,
-                alterations => alterations[0].entrezGeneId
+                (alterations) => alterations[0].entrezGeneId
             )
         );
         return (
@@ -471,12 +471,13 @@ export class PatientViewPageInner extends React.Component<
             this.pageStore.resourceIdToResourceData,
         ],
         render: () => {
-            const openDefinitions = this.pageStore.resourceDefinitions.result!.filter(
-                d => this.pageStore.isResourceTabOpen(d.resourceId)
-            );
-            const sorted = _.sortBy(openDefinitions, d => d.priority);
-            const resourceDataById = this.pageStore.resourceIdToResourceData
-                .result!;
+            const openDefinitions =
+                this.pageStore.resourceDefinitions.result!.filter((d) =>
+                    this.pageStore.isResourceTabOpen(d.resourceId)
+                );
+            const sorted = _.sortBy(openDefinitions, (d) => d.priority);
+            const resourceDataById =
+                this.pageStore.resourceIdToResourceData.result!;
 
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
@@ -568,15 +569,17 @@ export class PatientViewPageInner extends React.Component<
 
     @action.bound
     private handleReturnToStudyView() {
-        const patientIdentifiers = this.pageStore.patientIdsInCohort.map(p => {
-            const patientIdParts = p.split(':');
-            return {
-                patientId: patientIdParts[1],
-                studyId: patientIdParts[0],
-            };
-        });
+        const patientIdentifiers = this.pageStore.patientIdsInCohort.map(
+            (p) => {
+                const patientIdParts = p.split(':');
+                return {
+                    patientId: patientIdParts[1],
+                    studyId: patientIdParts[0],
+                };
+            }
+        );
         const queriedStudies: Set<string> = new Set(
-            patientIdentifiers.map(p => p.studyId)
+            patientIdentifiers.map((p) => p.studyId)
         );
 
         // We need to do this because of url length limits. We post the data to the new window once it is opened.
@@ -602,7 +605,7 @@ export class PatientViewPageInner extends React.Component<
                 ? deleteAtIndex - 1
                 : deleteAtIndex;
 
-        let navCaseIds = newCohortIdList.map(p => {
+        let navCaseIds = newCohortIdList.map((p) => {
             const patientIdParts = p.split(':');
             return {
                 patientId: patientIdParts[1],
@@ -705,7 +708,7 @@ export class PatientViewPageInner extends React.Component<
                                 ]
                             )
                         }
-                        onChangeCurrentPage={newPage => {
+                        onChangeCurrentPage={(newPage) => {
                             if (
                                 newPage > 0 &&
                                 newPage <=

--- a/src/pages/patientView/resources/ResourcesTab.tsx
+++ b/src/pages/patientView/resources/ResourcesTab.tsx
@@ -55,7 +55,6 @@ export default class ResourcesTab extends React.Component<
                         <SampleResourcesTable
                             data={this.sampleRows.result!}
                             sampleManager={this.props.sampleManager!}
-                            isTabOpen={this.props.store.isResourceTabOpen}
                             openResource={this.props.openResource}
                         />
                     </div>
@@ -79,7 +78,6 @@ export default class ResourcesTab extends React.Component<
                             resources={
                                 this.props.store.patientResourceData.result!
                             }
-                            isTabOpen={this.props.store.isResourceTabOpen}
                             openResource={this.props.openResource}
                         />
                     </div>
@@ -107,7 +105,6 @@ export default class ResourcesTab extends React.Component<
                             resources={
                                 this.props.store.studyResourceData.result!
                             }
-                            isTabOpen={this.props.store.isResourceTabOpen}
                             openResource={this.props.openResource}
                         />
                     </div>
@@ -141,7 +138,6 @@ export default class ResourcesTab extends React.Component<
                             resources={
                                 this.props.store.studyResourceData.result!
                             }
-                            isTabOpen={this.props.store.isResourceTabOpen}
                             openResource={this.props.openResource}
                         />
                     </div>

--- a/src/pages/patientView/resources/ResourcesTab.tsx
+++ b/src/pages/patientView/resources/ResourcesTab.tsx
@@ -122,7 +122,7 @@ export default class ResourcesTab extends React.Component<
                 if (this.props.store.resourceIdToResourceData.isComplete) {
                     return !_.some(
                         this.props.store.resourceIdToResourceData.result,
-                        data => data.length > 0
+                        (data) => data.length > 0
                     );
                 }
                 return true;

--- a/src/pages/patientView/resources/ResourcesTab.tsx
+++ b/src/pages/patientView/resources/ResourcesTab.tsx
@@ -122,7 +122,7 @@ export default class ResourcesTab extends React.Component<
                 if (this.props.store.resourceIdToResourceData.isComplete) {
                     return !_.some(
                         this.props.store.resourceIdToResourceData.result,
-                        (data) => data.length > 0
+                        data => data.length > 0
                     );
                 }
                 return true;

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -62,7 +62,7 @@ import ResourceTab from '../../shared/components/resources/ResourceTab';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
 import ResourcesTab, { RESOURCES_TAB_NAME } from './resources/ResourcesTab';
 import { ResourceData } from 'cbioportal-ts-api-client';
-import { getResourceConfig } from 'shared/lib/ResourceUtils';
+import { getResourceConfig } from 'shared/lib/ResourceConfig';
 import $ from 'jquery';
 import { StudyViewComparisonGroup } from 'pages/groupComparison/GroupComparisonUtils';
 import { parse } from 'query-string';

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -551,6 +551,7 @@ export default class StudyViewPage extends React.Component<
                             <ResourceTab
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
+                                resourceDisplayName={def.displayName}
                             />
                         </MSKTab>
                     );
@@ -742,6 +743,16 @@ export default class StudyViewPage extends React.Component<
                                     >
                                         <div>
                                             <ResourcesTab
+                                                resourceDisplayName={
+                                                    this.store
+                                                        .resourceDefinitions
+                                                        .result?.length == 1
+                                                        ? this.store
+                                                              .resourceDefinitions
+                                                              .result[0]
+                                                              .displayName
+                                                        : RESOURCES_TAB_NAME
+                                                }
                                                 store={this.store}
                                                 openResource={this.openResource}
                                             />

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -62,6 +62,7 @@ import ResourceTab from '../../shared/components/resources/ResourceTab';
 import StudyViewURLWrapper from './StudyViewURLWrapper';
 import ResourcesTab, { RESOURCES_TAB_NAME } from './resources/ResourcesTab';
 import { ResourceData } from 'cbioportal-ts-api-client';
+import { getResourceConfig } from 'shared/lib/ResourceUtils';
 import $ from 'jquery';
 import { StudyViewComparisonGroup } from 'pages/groupComparison/GroupComparisonUtils';
 import { parse } from 'query-string';
@@ -545,21 +546,25 @@ export default class StudyViewPage extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
-                    const displayName =
+                    const config = getResourceConfig(def);
+                    const originalDisplayName =
                         data.length > 1
                             ? pluralize(def.displayName, data.length)
                             : def.displayName;
+                    const customDisplayName =
+                        config.customizedDisplayName || originalDisplayName;
+
                     list.push(
                         <MSKTab
                             key={getStudyViewResourceTabId(def.resourceId)}
                             id={getStudyViewResourceTabId(def.resourceId)}
-                            linkText={displayName}
+                            linkText={originalDisplayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
-                                resourceDisplayName={displayName}
+                                resourceDisplayName={customDisplayName}
                             />
                         </MSKTab>
                     );

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -21,6 +21,7 @@ import {
     getBrowserWindow,
     onMobxPromise,
     remoteData,
+    pluralize,
 } from 'cbioportal-frontend-commons';
 import { PageLayout } from '../../shared/components/PageLayout/PageLayout';
 import IFrameLoader from '../../shared/components/iframeLoader/IFrameLoader';
@@ -379,7 +380,10 @@ export default class StudyViewPage extends React.Component<
     }
 
     @computed get shouldShowResources() {
-        if (this.store.resourceDefinitions.isComplete) {
+        if (
+            this.store.resourceDefinitions.isComplete &&
+            this.store.resourceIdToResourceData.isComplete
+        ) {
             return this.store.resourceDefinitions.result.length > 0;
         } else {
             return false;
@@ -541,17 +545,21 @@ export default class StudyViewPage extends React.Component<
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
+                    const displayName =
+                        data.length > 1
+                            ? pluralize(def.displayName, data.length)
+                            : def.displayName;
                     list.push(
                         <MSKTab
                             key={getStudyViewResourceTabId(def.resourceId)}
                             id={getStudyViewResourceTabId(def.resourceId)}
-                            linkText={def.displayName}
+                            linkText={displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
                                 resourceData={resourceDataById[def.resourceId]}
                                 urlWrapper={this.urlWrapper}
-                                resourceDisplayName={def.displayName}
+                                resourceDisplayName={displayName}
                             />
                         </MSKTab>
                     );
@@ -735,8 +743,13 @@ export default class StudyViewPage extends React.Component<
                                         linkText={
                                             this.store.resourceDefinitions
                                                 .result?.length == 1
-                                                ? this.store.resourceDefinitions
-                                                      .result[0].displayName
+                                                ? pluralize(
+                                                      this.store
+                                                          .resourceDefinitions
+                                                          .result[0]
+                                                          .displayName,
+                                                      2
+                                                  )
                                                 : RESOURCES_TAB_NAME
                                         }
                                         hide={!this.shouldShowResources}
@@ -747,10 +760,13 @@ export default class StudyViewPage extends React.Component<
                                                     this.store
                                                         .resourceDefinitions
                                                         .result?.length == 1
-                                                        ? this.store
-                                                              .resourceDefinitions
-                                                              .result[0]
-                                                              .displayName
+                                                        ? pluralize(
+                                                              this.store
+                                                                  .resourceDefinitions
+                                                                  .result[0]
+                                                                  .displayName,
+                                                              2
+                                                          )
                                                         : RESOURCES_TAB_NAME
                                                 }
                                                 store={this.store}

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -21,7 +21,6 @@ import {
     getBrowserWindow,
     onMobxPromise,
     remoteData,
-    pluralize,
 } from 'cbioportal-frontend-commons';
 import { PageLayout } from '../../shared/components/PageLayout/PageLayout';
 import IFrameLoader from '../../shared/components/iframeLoader/IFrameLoader';
@@ -743,7 +742,7 @@ export default class StudyViewPage extends React.Component<
                                         }
                                         linkText={
                                             this.store.resourceDefinitions
-                                                .result?.length == 1
+                                                .result?.length === 1
                                                 ? this.store.resourceDefinitions
                                                       .result[0].displayName
                                                 : RESOURCES_TAB_NAME
@@ -752,16 +751,6 @@ export default class StudyViewPage extends React.Component<
                                     >
                                         <div>
                                             <ResourcesTab
-                                                resourceDisplayName={
-                                                    this.store
-                                                        .resourceDefinitions
-                                                        .result?.length == 1
-                                                        ? this.store
-                                                              .resourceDefinitions
-                                                              .result[0]
-                                                              .displayName
-                                                        : RESOURCES_TAB_NAME
-                                                }
                                                 store={this.store}
                                                 openResource={this.openResource}
                                             />

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -547,18 +547,14 @@ export default class StudyViewPage extends React.Component<
                 const data = resourceDataById[def.resourceId];
                 if (data && data.length > 0) {
                     const config = getResourceConfig(def);
-                    const originalDisplayName =
-                        data.length > 1
-                            ? pluralize(def.displayName, data.length)
-                            : def.displayName;
                     const customDisplayName =
-                        config.customizedDisplayName || originalDisplayName;
+                        config.customizedDisplayName || def.displayName;
 
                     list.push(
                         <MSKTab
                             key={getStudyViewResourceTabId(def.resourceId)}
                             id={getStudyViewResourceTabId(def.resourceId)}
-                            linkText={originalDisplayName}
+                            linkText={def.displayName}
                             onClickClose={this.closeResourceTab}
                         >
                             <ResourceTab
@@ -748,13 +744,8 @@ export default class StudyViewPage extends React.Component<
                                         linkText={
                                             this.store.resourceDefinitions
                                                 .result?.length == 1
-                                                ? pluralize(
-                                                      this.store
-                                                          .resourceDefinitions
-                                                          .result[0]
-                                                          .displayName,
-                                                      2
-                                                  )
+                                                ? this.store.resourceDefinitions
+                                                      .result[0].displayName
                                                 : RESOURCES_TAB_NAME
                                         }
                                         hide={!this.shouldShowResources}
@@ -765,13 +756,10 @@ export default class StudyViewPage extends React.Component<
                                                     this.store
                                                         .resourceDefinitions
                                                         .result?.length == 1
-                                                        ? pluralize(
-                                                              this.store
-                                                                  .resourceDefinitions
-                                                                  .result[0]
-                                                                  .displayName,
-                                                              2
-                                                          )
+                                                        ? this.store
+                                                              .resourceDefinitions
+                                                              .result[0]
+                                                              .displayName
                                                         : RESOURCES_TAB_NAME
                                                 }
                                                 store={this.store}

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -226,7 +226,7 @@ export default class StudyViewPage extends React.Component<
                     parameters: {
                         studies:
                             this.store.queriedPhysicalStudies.result
-                                .map((s) => s.studyId)
+                                .map(s => s.studyId)
                                 .join(',') + ',',
                     },
                 });
@@ -317,14 +317,15 @@ export default class StudyViewPage extends React.Component<
     private sharedGroups: StudyViewComparisonGroup[] = [];
 
     @observable shareCustomDataLinkModal = false;
-    private getShareCustomChartBookmarkUrl: Promise<any> =
-        Promise.resolve(null);
+    private getShareCustomChartBookmarkUrl: Promise<any> = Promise.resolve(
+        null
+    );
 
     @action.bound
     openShareUrlModal(groups: StudyViewComparisonGroup[]) {
         this.shareLinkModal = true;
         this.sharedGroups = groups;
-        const groupIds = groups.map((group) => group.uid);
+        const groupIds = groups.map(group => group.uid);
         this.getShareBookmarkUrl = Promise.resolve({
             bitlyUrl: undefined,
             fullUrl: `${window.location.protocol}//${window.location.host}${
@@ -485,8 +486,9 @@ export default class StudyViewPage extends React.Component<
                     placement="bottomLeft"
                     destroyTooltipOnHide={true}
                     onPopupAlign={(tooltipEl: any) => {
-                        const arrowEl =
-                            tooltipEl.querySelector('.rc-tooltip-arrow');
+                        const arrowEl = tooltipEl.querySelector(
+                            '.rc-tooltip-arrow'
+                        );
                         arrowEl.style.right = '10px';
                     }}
                     getTooltipContainer={() =>
@@ -533,13 +535,12 @@ export default class StudyViewPage extends React.Component<
             this.store.resourceIdToResourceData,
         ],
         render: () => {
-            const openDefinitions =
-                this.store.resourceDefinitions.result!.filter((d) =>
-                    this.store.isResourceTabOpen(d.resourceId)
-                );
-            const sorted = _.sortBy(openDefinitions, (d) => d.priority);
-            const resourceDataById =
-                this.store.resourceIdToResourceData.result!;
+            const openDefinitions = this.store.resourceDefinitions.result!.filter(
+                d => this.store.isResourceTabOpen(d.resourceId)
+            );
+            const sorted = _.sortBy(openDefinitions, d => d.priority);
+            const resourceDataById = this.store.resourceIdToResourceData
+                .result!;
 
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
@@ -874,11 +875,8 @@ export default class StudyViewPage extends React.Component<
                                                     }
                                                     trigger={['click']}
                                                     placement={'bottomLeft'}
-                                                    onVisibleChange={(
-                                                        visible
-                                                    ) =>
-                                                        (this.showCustomSelectTooltip =
-                                                            !!visible)
+                                                    onVisibleChange={visible =>
+                                                        (this.showCustomSelectTooltip = !!visible)
                                                     }
                                                     destroyTooltipOnHide={true}
                                                     overlay={() => (
@@ -893,23 +891,17 @@ export default class StudyViewPage extends React.Component<
                                                                         .samples
                                                                         .result
                                                                 }
-                                                                contentNormalizer={(
-                                                                    content
-                                                                ) => {
+                                                                contentNormalizer={content => {
                                                                     return content
                                                                         .split(
                                                                             /[, ]+/
                                                                         ) // Split the content by either commas or spaces
                                                                         .map(
-                                                                            (
-                                                                                line
-                                                                            ) =>
+                                                                            line =>
                                                                                 line.trim()
                                                                         ) // Remove extra spaces around each line
                                                                         .filter(
-                                                                            (
-                                                                                line
-                                                                            ) =>
+                                                                            line =>
                                                                                 line.length >
                                                                                 0
                                                                         ) // Remove empty lines
@@ -933,8 +925,7 @@ export default class StudyViewPage extends React.Component<
                                                                 onSubmit={(
                                                                     chart: CustomChartData
                                                                 ) => {
-                                                                    this.showCustomSelectTooltip =
-                                                                        false;
+                                                                    this.showCustomSelectTooltip = false;
                                                                     this.store.updateCustomSelect(
                                                                         chart
                                                                     );
@@ -1001,9 +992,8 @@ export default class StudyViewPage extends React.Component<
                                                     this
                                                         .showAlterationFilterTooltip
                                                 }
-                                                onVisibleChange={(visible) => {
-                                                    this.showAlterationFilterTooltip =
-                                                        !!visible;
+                                                onVisibleChange={visible => {
+                                                    this.showAlterationFilterTooltip = !!visible;
                                                 }}
                                             >
                                                 <button
@@ -1054,8 +1044,7 @@ export default class StudyViewPage extends React.Component<
                                                     StudyViewPageTabKeyEnum.CLINICAL_DATA
                                                 }
                                                 showResetPopup={() => {
-                                                    this.showReturnToDefaultChartListModal =
-                                                        true;
+                                                    this.showReturnToDefaultChartListModal = true;
                                                 }}
                                                 openShareCustomDataUrlModal={
                                                     this
@@ -1075,8 +1064,7 @@ export default class StudyViewPage extends React.Component<
                                                     .showReturnToDefaultChartListModal
                                             }
                                             onHide={() => {
-                                                this.showReturnToDefaultChartListModal =
-                                                    false;
+                                                this.showReturnToDefaultChartListModal = false;
                                             }}
                                             keyboard
                                         >
@@ -1102,8 +1090,7 @@ export default class StudyViewPage extends React.Component<
                                                     }}
                                                     onClick={() => {
                                                         this.store.resetToDefaultChartSettings();
-                                                        this.showReturnToDefaultChartListModal =
-                                                            false;
+                                                        this.showReturnToDefaultChartListModal = false;
                                                     }}
                                                 >
                                                     Confirm
@@ -1115,8 +1102,7 @@ export default class StudyViewPage extends React.Component<
                                                         marginBottom: '0',
                                                     }}
                                                     onClick={() => {
-                                                        this.showReturnToDefaultChartListModal =
-                                                            false;
+                                                        this.showReturnToDefaultChartListModal = false;
                                                     }}
                                                 >
                                                     Cancel

--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -226,7 +226,7 @@ export default class StudyViewPage extends React.Component<
                     parameters: {
                         studies:
                             this.store.queriedPhysicalStudies.result
-                                .map(s => s.studyId)
+                                .map((s) => s.studyId)
                                 .join(',') + ',',
                     },
                 });
@@ -317,15 +317,14 @@ export default class StudyViewPage extends React.Component<
     private sharedGroups: StudyViewComparisonGroup[] = [];
 
     @observable shareCustomDataLinkModal = false;
-    private getShareCustomChartBookmarkUrl: Promise<any> = Promise.resolve(
-        null
-    );
+    private getShareCustomChartBookmarkUrl: Promise<any> =
+        Promise.resolve(null);
 
     @action.bound
     openShareUrlModal(groups: StudyViewComparisonGroup[]) {
         this.shareLinkModal = true;
         this.sharedGroups = groups;
-        const groupIds = groups.map(group => group.uid);
+        const groupIds = groups.map((group) => group.uid);
         this.getShareBookmarkUrl = Promise.resolve({
             bitlyUrl: undefined,
             fullUrl: `${window.location.protocol}//${window.location.host}${
@@ -486,9 +485,8 @@ export default class StudyViewPage extends React.Component<
                     placement="bottomLeft"
                     destroyTooltipOnHide={true}
                     onPopupAlign={(tooltipEl: any) => {
-                        const arrowEl = tooltipEl.querySelector(
-                            '.rc-tooltip-arrow'
-                        );
+                        const arrowEl =
+                            tooltipEl.querySelector('.rc-tooltip-arrow');
                         arrowEl.style.right = '10px';
                     }}
                     getTooltipContainer={() =>
@@ -535,12 +533,13 @@ export default class StudyViewPage extends React.Component<
             this.store.resourceIdToResourceData,
         ],
         render: () => {
-            const openDefinitions = this.store.resourceDefinitions.result!.filter(
-                d => this.store.isResourceTabOpen(d.resourceId)
-            );
-            const sorted = _.sortBy(openDefinitions, d => d.priority);
-            const resourceDataById = this.store.resourceIdToResourceData
-                .result!;
+            const openDefinitions =
+                this.store.resourceDefinitions.result!.filter((d) =>
+                    this.store.isResourceTabOpen(d.resourceId)
+                );
+            const sorted = _.sortBy(openDefinitions, (d) => d.priority);
+            const resourceDataById =
+                this.store.resourceIdToResourceData.result!;
 
             const tabs: JSX.Element[] = sorted.reduce((list, def) => {
                 const data = resourceDataById[def.resourceId];
@@ -875,8 +874,11 @@ export default class StudyViewPage extends React.Component<
                                                     }
                                                     trigger={['click']}
                                                     placement={'bottomLeft'}
-                                                    onVisibleChange={visible =>
-                                                        (this.showCustomSelectTooltip = !!visible)
+                                                    onVisibleChange={(
+                                                        visible
+                                                    ) =>
+                                                        (this.showCustomSelectTooltip =
+                                                            !!visible)
                                                     }
                                                     destroyTooltipOnHide={true}
                                                     overlay={() => (
@@ -891,17 +893,23 @@ export default class StudyViewPage extends React.Component<
                                                                         .samples
                                                                         .result
                                                                 }
-                                                                contentNormalizer={content => {
+                                                                contentNormalizer={(
+                                                                    content
+                                                                ) => {
                                                                     return content
                                                                         .split(
                                                                             /[, ]+/
                                                                         ) // Split the content by either commas or spaces
                                                                         .map(
-                                                                            line =>
+                                                                            (
+                                                                                line
+                                                                            ) =>
                                                                                 line.trim()
                                                                         ) // Remove extra spaces around each line
                                                                         .filter(
-                                                                            line =>
+                                                                            (
+                                                                                line
+                                                                            ) =>
                                                                                 line.length >
                                                                                 0
                                                                         ) // Remove empty lines
@@ -925,7 +933,8 @@ export default class StudyViewPage extends React.Component<
                                                                 onSubmit={(
                                                                     chart: CustomChartData
                                                                 ) => {
-                                                                    this.showCustomSelectTooltip = false;
+                                                                    this.showCustomSelectTooltip =
+                                                                        false;
                                                                     this.store.updateCustomSelect(
                                                                         chart
                                                                     );
@@ -992,8 +1001,9 @@ export default class StudyViewPage extends React.Component<
                                                     this
                                                         .showAlterationFilterTooltip
                                                 }
-                                                onVisibleChange={visible => {
-                                                    this.showAlterationFilterTooltip = !!visible;
+                                                onVisibleChange={(visible) => {
+                                                    this.showAlterationFilterTooltip =
+                                                        !!visible;
                                                 }}
                                             >
                                                 <button
@@ -1044,7 +1054,8 @@ export default class StudyViewPage extends React.Component<
                                                     StudyViewPageTabKeyEnum.CLINICAL_DATA
                                                 }
                                                 showResetPopup={() => {
-                                                    this.showReturnToDefaultChartListModal = true;
+                                                    this.showReturnToDefaultChartListModal =
+                                                        true;
                                                 }}
                                                 openShareCustomDataUrlModal={
                                                     this
@@ -1064,7 +1075,8 @@ export default class StudyViewPage extends React.Component<
                                                     .showReturnToDefaultChartListModal
                                             }
                                             onHide={() => {
-                                                this.showReturnToDefaultChartListModal = false;
+                                                this.showReturnToDefaultChartListModal =
+                                                    false;
                                             }}
                                             keyboard
                                         >
@@ -1090,7 +1102,8 @@ export default class StudyViewPage extends React.Component<
                                                     }}
                                                     onClick={() => {
                                                         this.store.resetToDefaultChartSettings();
-                                                        this.showReturnToDefaultChartListModal = false;
+                                                        this.showReturnToDefaultChartListModal =
+                                                            false;
                                                     }}
                                                 >
                                                     Confirm
@@ -1102,7 +1115,8 @@ export default class StudyViewPage extends React.Component<
                                                         marginBottom: '0',
                                                     }}
                                                     onClick={() => {
-                                                        this.showReturnToDefaultChartListModal = false;
+                                                        this.showReturnToDefaultChartListModal =
+                                                            false;
                                                     }}
                                                 >
                                                     Cancel

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -21,7 +21,8 @@ import {
     ClinicalData,
     StudyViewFilter,
 } from 'cbioportal-ts-api-client';
-import { getResourceConfig } from 'shared/lib/ResourceUtils';
+import { getResourceConfig } from 'shared/lib/ResourceConfig';
+import { hasNonEmptyDescriptionInDefinitions } from 'shared/lib/ResourceUtils';
 
 export interface IFilesLinksTable {
     resourceDisplayName: string;
@@ -384,12 +385,19 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
             });
         }
 
-        defaultColumns.push({
-            ...this.getDefaultColumnConfig('description', 'Description'),
-            render: (data: { [id: string]: string }) => {
-                return <div>{data.description}</div>;
-            },
-        });
+        // Only show Description column if at least one resource definition has a non-empty description
+        if (
+            hasNonEmptyDescriptionInDefinitions(
+                this.props.store.resourceDefinitions.result
+            )
+        ) {
+            defaultColumns.push({
+                ...this.getDefaultColumnConfig('description', 'Description'),
+                render: (data: { [id: string]: string }) => {
+                    return <div>{data.description}</div>;
+                },
+            });
+        }
 
         // Conditionally add the last column if not hidden
         if (!shouldHideResourcesPerPatientColumn) {

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -301,7 +301,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
             },
 
             {
-                ...this.getDefaultColumnConfig('resourceUrl', 'Resource URL'),
+                ...this.getDefaultColumnConfig('url', 'Resource URL'),
                 render: (data: { [id: string]: string }) => {
                     return (
                         <div>
@@ -377,7 +377,10 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                 showColumnVisibility={false}
                                 showCountHeader={false}
                                 showFilterClearButton={false}
-                                showCopyDownload={false}
+                                showCopyDownload={true}
+                                copyDownloadProps={{
+                                    showCopy: false,
+                                }}
                                 initialSortColumn={'resourcesPerPatient'}
                                 initialSortDirection={'desc'}
                             />

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -241,6 +241,23 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
     });
 
     @computed get columns() {
+        // Determine if there's only one unique resource type
+        const uniqueResourceTypes =
+            this.resourceData.result && this.resourceData.result.data
+                ? _.uniq(
+                      this.resourceData.result.data.map(
+                          item => item.typeOfResource as string
+                      )
+                  )
+                : [];
+        const resourcesPerPatientColumnName =
+            uniqueResourceTypes.length === 1 && uniqueResourceTypes[0]
+                ? `${pluralize(
+                      uniqueResourceTypes[0] as string,
+                      2
+                  )} per Patient`
+                : 'Resources per Patient';
+
         let defaultColumns: Column<{ [id: string]: any }>[] = [
             {
                 ...this.getDefaultColumnConfig('patientId', 'Patient ID'),
@@ -293,7 +310,16 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                     path,
                                     data.patientId
                                 )}
+                                style={{ fontSize: 10 }}
                             >
+                                <i
+                                    className={`fa fa-user fa-sm`}
+                                    style={{
+                                        marginRight: 5,
+                                        color: 'black',
+                                    }}
+                                    title="Open in Patient View"
+                                />
                                 {data.typeOfResource}
                             </a>
                         </div>
@@ -335,7 +361,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
             {
                 ...this.getDefaultColumnConfig(
                     'resourcesPerPatient',
-                    'Resources per Patient',
+                    resourcesPerPatientColumnName,
                     true
                 ),
                 render: (data: { [id: string]: number }) => {
@@ -369,11 +395,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                                 this.resourceData.result
                                                     ?.totalItems
                                             }{' '}
-                                            {pluralize(
-                                                this.props.resourceDisplayName,
-                                                this.resourceData.result
-                                                    ?.totalItems || 1
-                                            )}
+                                            {this.props.resourceDisplayName}
                                         </strong>
                                     </div>
                                 }

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -15,7 +15,7 @@ import {
     getPatientViewUrlWithPathname,
 } from 'shared/api/urls';
 import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
-import { isUrl, remoteData } from 'cbioportal-frontend-commons';
+import { isUrl, pluralize, remoteData } from 'cbioportal-frontend-commons';
 import { makeObservable, observable, computed } from 'mobx';
 import {
     ResourceData,
@@ -24,6 +24,7 @@ import {
 } from 'cbioportal-ts-api-client';
 
 export interface IFilesLinksTable {
+    resourceDisplayName: string;
     store: StudyViewPageStore;
 }
 
@@ -368,7 +369,11 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                                                 this.resourceData.result
                                                     ?.totalItems
                                             }{' '}
-                                            resources
+                                            {pluralize(
+                                                this.props.resourceDisplayName,
+                                                this.resourceData.result
+                                                    ?.totalItems || 1
+                                            )}
                                         </strong>
                                     </div>
                                 }

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -16,16 +16,14 @@ import {
 import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
 import { isUrl, pluralize, remoteData } from 'cbioportal-frontend-commons';
 import { makeObservable, observable, computed } from 'mobx';
+import { ResourceData, StudyViewFilter } from 'cbioportal-ts-api-client';
 import {
-    ResourceData,
-    ClinicalData,
-    StudyViewFilter,
-} from 'cbioportal-ts-api-client';
-import { getResourceConfig } from 'shared/lib/ResourceConfig';
+    getResourceConfig,
+    ResourceCustomConfig,
+} from 'shared/lib/ResourceConfig';
 import { hasNonEmptyDescriptionInDefinitions } from 'shared/lib/ResourceUtils';
 
 export interface IFilesLinksTable {
-    resourceDisplayName: string;
     store: StudyViewPageStore;
 }
 
@@ -47,30 +45,6 @@ function getResourceDataOfEntireStudy(studyIds: string[]) {
     return Promise.all(allResources).then(allResources =>
         _(allResources)
             .flatMap()
-            .value()
-    );
-}
-
-function getResourceDataOfPatients(studyClinicalData: {
-    [uniqueSampleKey: string]: ClinicalData[];
-}) {
-    const resourcesPerPatient = _(studyClinicalData)
-        .flatMap(clinicaldataItems => clinicaldataItems)
-        .uniqBy('patientId')
-        .map(resource =>
-            internalClient.getAllResourceDataOfPatientInStudyUsingGET({
-                studyId: resource.studyId,
-                patientId: resource.patientId,
-                projection: 'DETAILED',
-            })
-        )
-        .flatten()
-        .value();
-
-    return Promise.all(resourcesPerPatient).then(resourcesPerPatient =>
-        _(resourcesPerPatient)
-            .flatMap()
-            .groupBy('patientId')
             .value()
     );
 }
@@ -217,6 +191,35 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
 
     @observable searchTerm: string | undefined = undefined;
 
+    @computed get uniqueResourceTypes(): string[] {
+        if (!this.resourceData.result?.data) return [];
+        return _.uniq(
+            this.resourceData.result.data.map(
+                item => item.typeOfResource as string
+            )
+        );
+    }
+
+    @computed get singleTypeConfig(): {
+        config: ResourceCustomConfig;
+        typeName: string;
+    } | null {
+        if (
+            this.uniqueResourceTypes.length !== 1 ||
+            !this.uniqueResourceTypes[0]
+        ) {
+            return null;
+        }
+        const typeName = this.uniqueResourceTypes[0];
+        const def = this.props.store.resourceDefinitions.result?.find(
+            d => d.displayName === typeName
+        );
+        const config = def
+            ? getResourceConfig(def)
+            : ({} as ResourceCustomConfig);
+        return { config, typeName };
+    }
+
     readonly resourceData = remoteData({
         await: () => [
             this.props.store.selectedSamples,
@@ -242,47 +245,15 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
     });
 
     @computed get columns() {
-        // Determine if there's only one unique resource type
-        const uniqueResourceTypes =
-            this.resourceData.result && this.resourceData.result.data
-                ? _.uniq(
-                      this.resourceData.result.data.map(
-                          item => item.typeOfResource as string
-                      )
-                  )
-                : [];
-        let resourcesPerPatientColumnName = 'Resources per Patient';
-        let shouldHideResourcesPerPatientColumn = false;
+        const { singleTypeConfig } = this;
+        const config = singleTypeConfig?.config ?? {};
 
-        // Get config for single resource type (if applicable)
-        let config: any = {};
-        if (uniqueResourceTypes.length === 1 && uniqueResourceTypes[0]) {
-            const def = this.props.store.resourceDefinitions.result?.find(
-                d => d.displayName === uniqueResourceTypes[0]
-            );
-
-            if (def) {
-                config = getResourceConfig(def);
-                // Set default column name for single resource type
-                resourcesPerPatientColumnName = `${pluralize(
-                    uniqueResourceTypes[0] as string,
-                    2
-                )} per Patient`;
-
-                if (config.hidePerPatientColumn) {
-                    shouldHideResourcesPerPatientColumn = true;
-                }
-            } else {
-                resourcesPerPatientColumnName = `${pluralize(
-                    uniqueResourceTypes[0] as string,
-                    2
-                )} per Patient`;
-            }
-        }
-
-        // Apply customizations (only active for single resource type with config)
+        const resourcesPerPatientColumnName = singleTypeConfig
+            ? `${pluralize(singleTypeConfig.typeName, 2)} per Patient`
+            : 'Resources per Patient';
+        const shouldHideResourcesPerPatientColumn = !!config.hidePerPatientColumn;
         const typeOfResourceColumnName =
-            config.columnNameMapping?.['Type Of Resource'] ||
+            config.columnNameMapping?.['Type Of Resource'] ??
             'Type Of Resource';
         const hideUrlColumn = !!config.hideUrlColumn;
         const openInNewTab = !!config.openInNewTab;
@@ -430,52 +401,16 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                     <Else>
                         <FilesLinksTableComponent
                             initialItemsPerPage={20}
-                            headerComponent={(() => {
-                                // Determine if there's only one unique resource type
-                                const uniqueResourceTypes =
-                                    this.resourceData.result &&
-                                    this.resourceData.result.data
-                                        ? _.uniq(
-                                              this.resourceData.result.data.map(
-                                                  item =>
-                                                      item.typeOfResource as string
-                                              )
-                                          )
-                                        : [];
-                                let def;
-                                if (
-                                    uniqueResourceTypes.length === 1 &&
-                                    uniqueResourceTypes[0]
-                                ) {
-                                    def = this.props.store.resourceDefinitions.result?.find(
-                                        d =>
-                                            d.displayName ===
-                                            uniqueResourceTypes[0]
-                                    );
-                                }
-                                let customName = '';
-                                if (def) {
-                                    const config = getResourceConfig(def);
-                                    if (config.customizedDisplayName) {
-                                        customName =
-                                            config.customizedDisplayName;
-                                    }
-                                }
-
-                                return (
-                                    <div className={'positionAbsolute'}>
-                                        <strong>
-                                            {
-                                                this.resourceData.result
-                                                    ?.totalItems
-                                            }{' '}
-                                            {customName
-                                                ? customName
-                                                : 'resources'}
-                                        </strong>
-                                    </div>
-                                );
-                            })()}
+                            headerComponent={
+                                <div className={'positionAbsolute'}>
+                                    <strong>
+                                        {this.resourceData.result?.totalItems}{' '}
+                                        {this.singleTypeConfig?.config
+                                            .customizedDisplayName ||
+                                            'resources'}
+                                    </strong>
+                                </div>
+                            }
                             data={this.resourceData.result?.data || []}
                             columns={this.columns}
                             showColumnVisibility={false}

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -35,15 +35,17 @@ const RECORD_LIMIT = 500;
 
 function getResourceDataOfEntireStudy(studyIds: string[]) {
     // Fetch resource data for each studyId, then return combined results
-    const allResources = studyIds.map((studyId) =>
+    const allResources = studyIds.map(studyId =>
         internalClient.getAllStudyResourceDataInStudyPatientSampleUsingGET({
             studyId: studyId,
             projection: 'DETAILED',
         })
     );
 
-    return Promise.all(allResources).then((allResources) =>
-        _(allResources).flatMap().value()
+    return Promise.all(allResources).then(allResources =>
+        _(allResources)
+            .flatMap()
+            .value()
     );
 }
 
@@ -67,8 +69,8 @@ function buildItemsAndResources(resourceData: {
     );
 
     const items: { [attributeId: string]: string | number }[] = _(resourceData)
-        .flatMap((data) =>
-            data.map((resource) => ({
+        .flatMap(data =>
+            data.map(resource => ({
                 studyId: resource.studyId,
                 patientId: resource.patientId,
                 sampleId: resource.sampleId,
@@ -93,17 +95,13 @@ async function fetchFilesLinksData(
     recordLimit: number
 ) {
     const selectedStudyIds = [
-        ...new Set(selectedSamples.map((item) => item.studyId)),
+        ...new Set(selectedSamples.map(item => item.studyId)),
     ];
 
     // sampleIds (+patientIds) for the selectedSamples
     const selectedIds = new Map([
-        ...selectedSamples.map(
-            (item) => [item.sampleId, item.studyId] as const
-        ),
-        ...selectedSamples.map(
-            (item) => [item.patientId, item.studyId] as const
-        ),
+        ...selectedSamples.map(item => [item.sampleId, item.studyId] as const),
+        ...selectedSamples.map(item => [item.patientId, item.studyId] as const),
     ]);
 
     // Fetch resources for entire study
@@ -114,10 +112,10 @@ async function fetchFilesLinksData(
     // Filter the resources to consist of only studyView selected samples
     // Also keep patient level resources (e.g. Those don't have a sampleId)
     const resourcesForPatientsAndSamples = _(resourcesForEntireStudy)
-        .filter((resource) =>
+        .filter(resource =>
             selectedIds.has(resource.sampleId || resource.patientId)
         )
-        .groupBy((r) => r.patientId)
+        .groupBy(r => r.patientId)
         .value();
 
     // we create objects with the necessary properties for each resource
@@ -127,7 +125,7 @@ async function fetchFilesLinksData(
     );
 
     // set the number of resources available per patient.
-    _.forEach(items, (item) => {
+    _.forEach(items, item => {
         item.resourcesPerPatient = resourcesPerPatient[item.patientId];
     });
 
@@ -197,7 +195,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         if (!this.resourceData.result?.data) return [];
         return _.uniq(
             this.resourceData.result.data.map(
-                (item) => item.typeOfResource as string
+                item => item.typeOfResource as string
             )
         );
     }
@@ -214,7 +212,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         }
         const typeName = this.uniqueResourceTypes[0];
         const def = this.props.store.resourceDefinitions.result?.find(
-            (d) => d.displayName === typeName
+            d => d.displayName === typeName
         );
         const config = def
             ? getResourceConfig(def)
@@ -256,8 +254,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         const { singleTypeConfig } = this;
         const config = singleTypeConfig?.config ?? {};
 
-        const shouldHideResourcesPerPatientColumn =
-            !!config.hidePerPatientColumn;
+        const shouldHideResourcesPerPatientColumn = !!config.hidePerPatientColumn;
         const typeOfResourceColumnName =
             config.columnNameMapping?.['Type Of Resource'] ??
             'Type Of Resource';
@@ -430,7 +427,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                             }}
                             initialSortColumn={
                                 this.columns.some(
-                                    (column) =>
+                                    column =>
                                         column.name ===
                                         this.resourcesPerPatientColumnName
                                 )

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -425,7 +425,15 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                             copyDownloadProps={{
                                 showCopy: false,
                             }}
-                            initialSortColumn={'resourcesPerPatient'}
+                            initialSortColumn={
+                                this.columns.some(
+                                    column =>
+                                        column.name ===
+                                        resourcesPerPatientColumnName
+                                )
+                                    ? resourcesPerPatientColumnName
+                                    : this.columns[0]?.name
+                            }
                             initialSortDirection={'desc'}
                         />
                     </Else>

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -22,6 +22,8 @@ import {
     ResourceCustomConfig,
 } from 'shared/lib/ResourceConfig';
 import { hasNonEmptyDescriptionInDefinitions } from 'shared/lib/ResourceUtils';
+import { getServerConfig } from 'config/config';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
 
 export interface IFilesLinksTable {
     store: StudyViewPageStore;
@@ -421,7 +423,11 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                             // when header component is null, we might want to also ensure no extra spacing or issues occur.
                             // but LazyMobXTable should handle null headerComponent gracefully.
                             showFilterClearButton={false}
-                            showCopyDownload={true}
+                            showCopyDownload={
+                                getServerConfig()
+                                    .skin_hide_download_controls ===
+                                DownloadControlOption.SHOW_ALL
+                            }
                             copyDownloadProps={{
                                 showCopy: false,
                             }}

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -222,6 +222,12 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         return { config, typeName };
     }
 
+    @computed get resourcesPerPatientColumnName(): string {
+        return this.singleTypeConfig
+            ? `${pluralize(this.singleTypeConfig.typeName, 2)} per Patient`
+            : 'Resources per Patient';
+    }
+
     readonly resourceData = remoteData({
         await: () => [
             this.props.store.selectedSamples,
@@ -250,9 +256,6 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         const { singleTypeConfig } = this;
         const config = singleTypeConfig?.config ?? {};
 
-        const resourcesPerPatientColumnName = singleTypeConfig
-            ? `${pluralize(singleTypeConfig.typeName, 2)} per Patient`
-            : 'Resources per Patient';
         const shouldHideResourcesPerPatientColumn =
             !!config.hidePerPatientColumn;
         const typeOfResourceColumnName =
@@ -378,7 +381,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
             defaultColumns.push({
                 ...this.getDefaultColumnConfig(
                     'resourcesPerPatient',
-                    resourcesPerPatientColumnName,
+                    this.resourcesPerPatientColumnName,
                     true
                 ),
                 render: (data: { [id: string]: number }) => {
@@ -427,11 +430,11 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                             }}
                             initialSortColumn={
                                 this.columns.some(
-                                    column =>
+                                    (column) =>
                                         column.name ===
-                                        resourcesPerPatientColumnName
+                                        this.resourcesPerPatientColumnName
                                 )
-                                    ? resourcesPerPatientColumnName
+                                    ? this.resourcesPerPatientColumnName
                                     : this.columns[0]?.name
                             }
                             initialSortDirection={'desc'}

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -35,17 +35,15 @@ const RECORD_LIMIT = 500;
 
 function getResourceDataOfEntireStudy(studyIds: string[]) {
     // Fetch resource data for each studyId, then return combined results
-    const allResources = studyIds.map(studyId =>
+    const allResources = studyIds.map((studyId) =>
         internalClient.getAllStudyResourceDataInStudyPatientSampleUsingGET({
             studyId: studyId,
             projection: 'DETAILED',
         })
     );
 
-    return Promise.all(allResources).then(allResources =>
-        _(allResources)
-            .flatMap()
-            .value()
+    return Promise.all(allResources).then((allResources) =>
+        _(allResources).flatMap().value()
     );
 }
 
@@ -69,8 +67,8 @@ function buildItemsAndResources(resourceData: {
     );
 
     const items: { [attributeId: string]: string | number }[] = _(resourceData)
-        .flatMap(data =>
-            data.map(resource => ({
+        .flatMap((data) =>
+            data.map((resource) => ({
                 studyId: resource.studyId,
                 patientId: resource.patientId,
                 sampleId: resource.sampleId,
@@ -95,13 +93,17 @@ async function fetchFilesLinksData(
     recordLimit: number
 ) {
     const selectedStudyIds = [
-        ...new Set(selectedSamples.map(item => item.studyId)),
+        ...new Set(selectedSamples.map((item) => item.studyId)),
     ];
 
     // sampleIds (+patientIds) for the selectedSamples
     const selectedIds = new Map([
-        ...selectedSamples.map(item => [item.sampleId, item.studyId] as const),
-        ...selectedSamples.map(item => [item.patientId, item.studyId] as const),
+        ...selectedSamples.map(
+            (item) => [item.sampleId, item.studyId] as const
+        ),
+        ...selectedSamples.map(
+            (item) => [item.patientId, item.studyId] as const
+        ),
     ]);
 
     // Fetch resources for entire study
@@ -112,10 +114,10 @@ async function fetchFilesLinksData(
     // Filter the resources to consist of only studyView selected samples
     // Also keep patient level resources (e.g. Those don't have a sampleId)
     const resourcesForPatientsAndSamples = _(resourcesForEntireStudy)
-        .filter(resource =>
+        .filter((resource) =>
             selectedIds.has(resource.sampleId || resource.patientId)
         )
-        .groupBy(r => r.patientId)
+        .groupBy((r) => r.patientId)
         .value();
 
     // we create objects with the necessary properties for each resource
@@ -125,7 +127,7 @@ async function fetchFilesLinksData(
     );
 
     // set the number of resources available per patient.
-    _.forEach(items, item => {
+    _.forEach(items, (item) => {
         item.resourcesPerPatient = resourcesPerPatient[item.patientId];
     });
 
@@ -195,7 +197,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         if (!this.resourceData.result?.data) return [];
         return _.uniq(
             this.resourceData.result.data.map(
-                item => item.typeOfResource as string
+                (item) => item.typeOfResource as string
             )
         );
     }
@@ -212,7 +214,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         }
         const typeName = this.uniqueResourceTypes[0];
         const def = this.props.store.resourceDefinitions.result?.find(
-            d => d.displayName === typeName
+            (d) => d.displayName === typeName
         );
         const config = def
             ? getResourceConfig(def)
@@ -251,7 +253,8 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
         const resourcesPerPatientColumnName = singleTypeConfig
             ? `${pluralize(singleTypeConfig.typeName, 2)} per Patient`
             : 'Resources per Patient';
-        const shouldHideResourcesPerPatientColumn = !!config.hidePerPatientColumn;
+        const shouldHideResourcesPerPatientColumn =
+            !!config.hidePerPatientColumn;
         const typeOfResourceColumnName =
             config.columnNameMapping?.['Type Of Resource'] ??
             'Type Of Resource';

--- a/src/pages/studyView/resources/ResourcesTab.tsx
+++ b/src/pages/studyView/resources/ResourcesTab.tsx
@@ -10,6 +10,7 @@ import ResourceTable from 'shared/components/resources/ResourceTable';
 import { FilesAndLinks } from './FilesAndLinks';
 
 export interface IResourcesTabProps {
+    resourceDisplayName: string;
     store: StudyViewPageStore;
     openResource: (resource: ResourceData) => void;
 }
@@ -68,9 +69,12 @@ export default class ResourcesTab extends React.Component<
                 <div className="resourcesTab">
                     <div className="resourcesSection">
                         <h4 className="blackHeader">
-                            Patient and Sample Resources
+                            Patient and Sample {this.props.resourceDisplayName}
                         </h4>
-                        <FilesAndLinks store={this.props.store}></FilesAndLinks>
+                        <FilesAndLinks
+                            resourceDisplayName={this.props.resourceDisplayName}
+                            store={this.props.store}
+                        ></FilesAndLinks>
                     </div>
                 </div>
             </div>

--- a/src/pages/studyView/resources/ResourcesTab.tsx
+++ b/src/pages/studyView/resources/ResourcesTab.tsx
@@ -68,9 +68,6 @@ export default class ResourcesTab extends React.Component<
                 </div>
                 <div className="resourcesTab">
                     <div className="resourcesSection">
-                        <h4 className="blackHeader">
-                            Patient and Sample {this.props.resourceDisplayName}
-                        </h4>
                         <FilesAndLinks
                             resourceDisplayName={this.props.resourceDisplayName}
                             store={this.props.store}

--- a/src/pages/studyView/resources/ResourcesTab.tsx
+++ b/src/pages/studyView/resources/ResourcesTab.tsx
@@ -10,7 +10,6 @@ import ResourceTable from 'shared/components/resources/ResourceTable';
 import { FilesAndLinks } from './FilesAndLinks';
 
 export interface IResourcesTabProps {
-    resourceDisplayName: string;
     store: StudyViewPageStore;
     openResource: (resource: ResourceData) => void;
 }
@@ -42,7 +41,6 @@ export default class ResourcesTab extends React.Component<
                             resources={
                                 this.props.store.studyResourceData.result!
                             }
-                            isTabOpen={this.props.store.isResourceTabOpen}
                             openResource={this.props.openResource}
                         />
                     </div>
@@ -68,10 +66,7 @@ export default class ResourcesTab extends React.Component<
                 </div>
                 <div className="resourcesTab">
                     <div className="resourcesSection">
-                        <FilesAndLinks
-                            resourceDisplayName={this.props.resourceDisplayName}
-                            store={this.props.store}
-                        ></FilesAndLinks>
+                        <FilesAndLinks store={this.props.store}></FilesAndLinks>
                     </div>
                 </div>
             </div>

--- a/src/pages/studyView/styles.scss
+++ b/src/pages/studyView/styles.scss
@@ -98,7 +98,6 @@ iframe.mdacc-heatmap-iframe {
 
 .resourcesTab {
     .resourcesSection {
-        @include dashed-border-section;
         margin-bottom: 30px;
 
         &:last-child {

--- a/src/shared/components/resources/ResourceTab.spec.tsx
+++ b/src/shared/components/resources/ResourceTab.spec.tsx
@@ -1,0 +1,114 @@
+jest.mock('shared/components/iframeLoader/IFrameLoader', () => {
+    const React = require('react');
+
+    return function MockIFrameLoader() {
+        return <div data-testid="iframe-loader" />;
+    };
+});
+
+jest.mock('shared/components/loadingIndicator/LoadingIndicator', () => {
+    const React = require('react');
+
+    return function MockLoadingIndicator(props: { isLoading: boolean }) {
+        return props.isLoading ? <div data-testid="loading-indicator" /> : null;
+    };
+});
+
+const mockReload = jest.fn();
+
+jest.mock('cbioportal-frontend-commons', () => ({
+    WindowWrapper: class WindowWrapper {
+        size = { height: 900, width: 1200 };
+    },
+    getBrowserWindow: () => ({
+        location: {
+            protocol: 'https:',
+            reload: mockReload,
+        },
+    }),
+}));
+
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ResourceData, ResourceDefinition } from 'cbioportal-ts-api-client';
+import ResourceTab, { IResourceTabProps } from './ResourceTab';
+
+const VPN_WARNING_MESSAGE =
+    'This resource requires VPN access. Please connect to VPN and refresh the page.';
+
+function makeDefinition(
+    overrides: Partial<ResourceDefinition> = {}
+): ResourceDefinition {
+    return {
+        customMetaData: '',
+        description: '',
+        displayName: 'H&E Slide',
+        openByDefault: false,
+        priority: '1',
+        resourceId: 'MSK_HNE',
+        resourceType: 'PATIENT',
+        studyId: 'study1',
+        ...overrides,
+    };
+}
+
+function makeResourceData(overrides: Partial<ResourceData> = {}): ResourceData {
+    return {
+        patientId: 'PATIENT_1',
+        resourceDefinition: makeDefinition(),
+        resourceId: 'MSK_HNE',
+        sampleId: 'SAMPLE_1',
+        studyId: 'study1',
+        uniquePatientKey: 'PATIENT_1',
+        uniqueSampleKey: 'SAMPLE_1',
+        url: 'https://example.org/resource.png',
+        ...overrides,
+    };
+}
+
+function makeProps(
+    overrides: Partial<IResourceTabProps> = {}
+): IResourceTabProps {
+    return {
+        resourceDisplayName: 'H&E Slide',
+        resourceData: [makeResourceData()],
+        urlWrapper: {
+            setResourceUrl: jest.fn(),
+            query: {},
+        },
+        ...overrides,
+    };
+}
+
+describe('ResourceTab', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.clearAllMocks();
+    });
+
+    it('renders the iframe when the accessibility check succeeds', async () => {
+        global.fetch = jest.fn().mockResolvedValue({}) as typeof fetch;
+
+        render(<ResourceTab {...makeProps()} />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId('iframe-loader')).toBeTruthy()
+        );
+        expect(screen.queryByText(VPN_WARNING_MESSAGE)).toBeNull();
+    });
+
+    it('shows the configured warning when the accessibility check fails', async () => {
+        global.fetch = jest
+            .fn()
+            .mockRejectedValue(new Error('VPN blocked')) as typeof fetch;
+
+        render(<ResourceTab {...makeProps()} />);
+
+        await waitFor(() =>
+            expect(screen.getByText(VPN_WARNING_MESSAGE)).toBeTruthy()
+        );
+        expect(screen.queryByTestId('iframe-loader')).toBeNull();
+    });
+});

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -13,6 +13,7 @@ import { getServerConfig } from 'config/config';
 import { CUSTOM_URL_TRANSFORMERS } from 'shared/components/resources/customResourceHelpers';
 
 export interface IResourceTabProps {
+    resourceDisplayName: string;
     resourceData: ResourceData[];
     urlWrapper: {
         setResourceUrl: (resourceUrl: string) => void;

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -118,10 +118,7 @@ export default class ResourceTab extends React.Component<
             <div>
                 <div style={{ display: 'flex', alignItems: 'flex-end' }}>
                     <FeatureTitle
-                        title={
-                            this.currentResourceDatum.resourceDefinition
-                                .displayName
-                        }
+                        title={this.props.resourceDisplayName}
                         isLoading={false}
                         className="pull-left"
                         style={{ marginBottom: 10 }}
@@ -130,9 +127,10 @@ export default class ResourceTab extends React.Component<
                         {this.currentResourceDatum.sampleId
                             ? this.currentResourceDatum.sampleId
                             : this.currentResourceDatum.patientId}
-                        {this.currentResourceDatum.resourceDefinition
-                            .description &&
-                            ` | ${this.currentResourceDatum.resourceDefinition.description}`}
+                        {` | ${this.props.resourceDisplayName}`}
+                        {` | ${this.currentResourceIndex + 1} of ${
+                            this.props.resourceData.length
+                        }`}
                     </p>
                 </div>
                 <div

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -40,7 +40,7 @@ export default class ResourceTab extends React.Component<
             return 0;
         } else {
             const index = this.props.resourceData.findIndex(
-                d => d.url === this.props.urlWrapper.query.resourceUrl
+                (d) => d.url === this.props.urlWrapper.query.resourceUrl
             );
             if (index === -1) {
                 return 0;
@@ -98,7 +98,7 @@ export default class ResourceTab extends React.Component<
 
         try {
             // apply instance specific transformation on url (e.g. to keep state)
-            CUSTOM_URL_TRANSFORMERS.forEach(config => {
+            CUSTOM_URL_TRANSFORMERS.forEach((config) => {
                 if (config.test(this.currentResourceDatum) === true) {
                     url = config.transformer(this.currentResourceDatum);
                 }

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -2,15 +2,13 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import FeatureTitle from '../featureTitle/FeatureTitle';
 import WindowStore from '../window/WindowStore';
-import { action, computed, makeObservable, observable } from 'mobx';
+import { action, computed, makeObservable } from 'mobx';
 import styles from './styles.module.scss';
 import classNames from 'classnames';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { ResourceData } from 'cbioportal-ts-api-client';
 import { buildPDFUrl, getFileExtension } from './ResourcesTableUtils';
 import IFrameLoader from 'shared/components/iframeLoader/IFrameLoader';
-import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
-import { getServerConfig } from 'config/config';
 import { CUSTOM_URL_TRANSFORMERS } from 'shared/components/resources/customResourceHelpers';
 import { getResourceConfig } from 'shared/lib/ResourceConfig';
 
@@ -31,34 +29,6 @@ export default class ResourceTab extends React.Component<
     constructor(props: any) {
         super(props);
         makeObservable(this);
-    }
-
-    @observable private urlCheckComplete = false;
-    @observable private urlIsAccessible = true;
-
-    componentDidMount() {
-        // Check URL accessibility if there's an error message configured
-        if (this.iframeErrorMessage && this.currentResourceDatum.url) {
-            this.checkUrlAccessibility();
-        }
-    }
-
-    @action.bound
-    private async checkUrlAccessibility() {
-        try {
-            // Try to fetch the URL with HEAD request (lightweight)
-            await fetch(this.currentResourceDatum.url, {
-                method: 'HEAD',
-                mode: 'no-cors', // Avoid CORS issues
-            });
-            // With no-cors, we can't read the status, but if it doesn't throw, assume it's accessible
-            this.urlIsAccessible = true;
-        } catch (error) {
-            // If fetch fails, URL is not accessible
-            this.urlIsAccessible = false;
-        } finally {
-            this.urlCheckComplete = true;
-        }
     }
 
     @computed get iframeHeight() {
@@ -143,30 +113,12 @@ export default class ResourceTab extends React.Component<
     }
 
     @computed get iframeErrorMessage() {
-        // Get the resource definition for the current resource
         const resourceDef = this.currentResourceDatum.resourceDefinition;
         if (resourceDef) {
             const config = getResourceConfig(resourceDef);
             return config.iframeErrorMessage;
         }
         return undefined;
-    }
-
-    @computed get shouldShowWarning() {
-        // Only show warning if:
-        // 1. There's an error message configured
-        // 2. URL check is complete
-        // 3. URL is NOT accessible
-        return (
-            this.iframeErrorMessage &&
-            this.urlCheckComplete &&
-            !this.urlIsAccessible
-        );
-    }
-
-    @computed get isCheckingUrlAccessibility() {
-        // Show loading indicator while checking URL accessibility
-        return this.iframeErrorMessage && !this.urlCheckComplete;
     }
 
     render() {
@@ -185,7 +137,9 @@ export default class ResourceTab extends React.Component<
                         {this.currentResourceDatum.sampleId
                             ? this.currentResourceDatum.sampleId
                             : this.currentResourceDatum.patientId}
-                        {` | ${this.props.resourceDisplayName}`}
+                        {this.currentResourceDatum.resourceDefinition
+                            ?.description &&
+                            ` | ${this.currentResourceDatum.resourceDefinition.description}`}
                         {` | ${this.currentResourceIndex + 1} of ${
                             this.props.resourceData.length
                         }`}
@@ -223,51 +177,31 @@ export default class ResourceTab extends React.Component<
                                 {this.currentResourceDatum.url}
                             </a>
                         </div>
-                    ) : (
-                        <div
-                            style={{
-                                width: '100%',
-                                display: 'flex',
-                                alignItems: 'center',
-                                minHeight: this.iframeHeight,
-                            }}
-                        >
-                            {this.isCheckingUrlAccessibility ? (
-                                // Show loading while checking URL accessibility
-                                <LoadingIndicator
-                                    isLoading={true}
-                                    center={true}
-                                    size="big"
+                    ) : this.iframeErrorMessage ? (
+                        <div className={styles.warningBanner}>
+                            <div className={styles.warningIcon}>
+                                <i className="fa fa-exclamation-triangle" />
+                            </div>
+                            <div className={styles.warningText}>
+                                {this.iframeErrorMessage}
+                            </div>
+                            <button
+                                className={styles.refreshButton}
+                                onClick={() => window.location.reload()}
+                            >
+                                <i
+                                    className="fa fa-refresh"
+                                    style={{ marginRight: 6 }}
                                 />
-                            ) : this.shouldShowWarning ? (
-                                // Show warning if URL is not accessible
-                                <div className={styles.warningBanner}>
-                                    <div className={styles.warningIcon}>
-                                        <i className="fa fa-exclamation-triangle" />
-                                    </div>
-                                    <div className={styles.warningText}>
-                                        {this.iframeErrorMessage}
-                                    </div>
-                                    <button
-                                        className={styles.refreshButton}
-                                        onClick={() => window.location.reload()}
-                                    >
-                                        <i
-                                            className="fa fa-refresh"
-                                            style={{ marginRight: 6 }}
-                                        />
-                                        Refresh Page
-                                    </button>
-                                </div>
-                            ) : (
-                                // Show iframe if no error message or URL is accessible
-                                <IFrameLoader
-                                    url={this.iframeUrl}
-                                    height={this.iframeHeight}
-                                    width={'100%'}
-                                />
-                            )}
+                                Refresh Page
+                            </button>
                         </div>
+                    ) : (
+                        <IFrameLoader
+                            url={this.iframeUrl}
+                            height={this.iframeHeight}
+                            width={'100%'}
+                        />
                     )}
                     {multipleData && (
                         <div

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -2,13 +2,20 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import FeatureTitle from '../featureTitle/FeatureTitle';
 import WindowStore from '../window/WindowStore';
-import { action, computed, makeObservable } from 'mobx';
+import {
+    action,
+    computed,
+    makeObservable,
+    observable,
+    runInAction,
+} from 'mobx';
 import styles from './styles.module.scss';
 import classNames from 'classnames';
 import { getBrowserWindow } from 'cbioportal-frontend-commons';
 import { ResourceData } from 'cbioportal-ts-api-client';
 import { buildPDFUrl, getFileExtension } from './ResourcesTableUtils';
 import IFrameLoader from 'shared/components/iframeLoader/IFrameLoader';
+import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import { CUSTOM_URL_TRANSFORMERS } from 'shared/components/resources/customResourceHelpers';
 import { getResourceConfig } from 'shared/lib/ResourceConfig';
 
@@ -31,6 +38,78 @@ export default class ResourceTab extends React.Component<
         makeObservable(this);
     }
 
+    @observable private urlCheckComplete = false;
+    @observable private urlIsAccessible = true;
+    private latestUrlCheckRequestId = 0;
+
+    componentDidMount() {
+        this.startUrlAccessibilityCheck();
+    }
+
+    componentDidUpdate(prevProps: IResourceTabProps) {
+        if (
+            this.getCurrentResourceUrl(prevProps) !==
+            this.getCurrentResourceUrl()
+        ) {
+            this.startUrlAccessibilityCheck();
+        }
+    }
+
+    componentWillUnmount() {
+        this.latestUrlCheckRequestId += 1;
+    }
+
+    private getCurrentResourceUrl(props: IResourceTabProps = this.props) {
+        const selectedResourceUrl = props.urlWrapper.query.resourceUrl;
+        if (!selectedResourceUrl) {
+            return props.resourceData[0]?.url;
+        }
+
+        return (
+            props.resourceData.find(d => d.url === selectedResourceUrl)?.url ??
+            props.resourceData[0]?.url
+        );
+    }
+
+    @action.bound
+    private startUrlAccessibilityCheck() {
+        const currentResourceUrl = this.currentResourceDatum?.url;
+
+        if (!this.iframeErrorMessage || !currentResourceUrl) {
+            this.urlIsAccessible = true;
+            this.urlCheckComplete = true;
+            return;
+        }
+
+        const requestId = this.latestUrlCheckRequestId + 1;
+        this.latestUrlCheckRequestId = requestId;
+        this.urlIsAccessible = true;
+        this.urlCheckComplete = false;
+        void this.checkUrlAccessibility(currentResourceUrl, requestId);
+    }
+
+    private async checkUrlAccessibility(url: string, requestId: number) {
+        let urlIsAccessible = true;
+
+        try {
+            await fetch(url, {
+                method: 'HEAD',
+                mode: 'no-cors',
+            });
+        } catch (error) {
+            urlIsAccessible = false;
+        }
+
+        if (requestId !== this.latestUrlCheckRequestId) {
+            return;
+        }
+
+        runInAction(() => {
+            this.urlIsAccessible = urlIsAccessible;
+            this.urlCheckComplete = true;
+        });
+    }
+
     @computed get iframeHeight() {
         return WindowStore.size.height - 275;
     }
@@ -40,7 +119,7 @@ export default class ResourceTab extends React.Component<
             return 0;
         } else {
             const index = this.props.resourceData.findIndex(
-                (d) => d.url === this.props.urlWrapper.query.resourceUrl
+                d => d.url === this.props.urlWrapper.query.resourceUrl
             );
             if (index === -1) {
                 return 0;
@@ -98,7 +177,7 @@ export default class ResourceTab extends React.Component<
 
         try {
             // apply instance specific transformation on url (e.g. to keep state)
-            CUSTOM_URL_TRANSFORMERS.forEach((config) => {
+            CUSTOM_URL_TRANSFORMERS.forEach(config => {
                 if (config.test(this.currentResourceDatum) === true) {
                     url = config.transformer(this.currentResourceDatum);
                 }
@@ -119,6 +198,18 @@ export default class ResourceTab extends React.Component<
             return config.iframeErrorMessage;
         }
         return undefined;
+    }
+
+    @computed get shouldShowWarning() {
+        return (
+            !!this.iframeErrorMessage &&
+            this.urlCheckComplete &&
+            !this.urlIsAccessible
+        );
+    }
+
+    @computed get isCheckingUrlAccessibility() {
+        return !!this.iframeErrorMessage && !this.urlCheckComplete;
     }
 
     render() {
@@ -177,31 +268,50 @@ export default class ResourceTab extends React.Component<
                                 {this.currentResourceDatum.url}
                             </a>
                         </div>
-                    ) : this.iframeErrorMessage ? (
-                        <div className={styles.warningBanner}>
-                            <div className={styles.warningIcon}>
-                                <i className="fa fa-exclamation-triangle" />
-                            </div>
-                            <div className={styles.warningText}>
-                                {this.iframeErrorMessage}
-                            </div>
-                            <button
-                                className={styles.refreshButton}
-                                onClick={() => getBrowserWindow().location.reload()}
-                            >
-                                <i
-                                    className="fa fa-refresh"
-                                    style={{ marginRight: 6 }}
-                                />
-                                Refresh Page
-                            </button>
-                        </div>
                     ) : (
-                        <IFrameLoader
-                            url={this.iframeUrl}
-                            height={this.iframeHeight}
-                            width={'100%'}
-                        />
+                        <div
+                            style={{
+                                width: '100%',
+                                display: 'flex',
+                                alignItems: 'center',
+                                minHeight: this.iframeHeight,
+                            }}
+                        >
+                            {this.isCheckingUrlAccessibility ? (
+                                <LoadingIndicator
+                                    isLoading={true}
+                                    center={true}
+                                    size="big"
+                                />
+                            ) : this.shouldShowWarning ? (
+                                <div className={styles.warningBanner}>
+                                    <div className={styles.warningIcon}>
+                                        <i className="fa fa-exclamation-triangle" />
+                                    </div>
+                                    <div className={styles.warningText}>
+                                        {this.iframeErrorMessage}
+                                    </div>
+                                    <button
+                                        className={styles.refreshButton}
+                                        onClick={() =>
+                                            getBrowserWindow().location.reload()
+                                        }
+                                    >
+                                        <i
+                                            className="fa fa-refresh"
+                                            style={{ marginRight: 6 }}
+                                        />
+                                        Refresh Page
+                                    </button>
+                                </div>
+                            ) : (
+                                <IFrameLoader
+                                    url={this.iframeUrl}
+                                    height={this.iframeHeight}
+                                    width={'100%'}
+                                />
+                            )}
+                        </div>
                     )}
                     {multipleData && (
                         <div

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -187,7 +187,7 @@ export default class ResourceTab extends React.Component<
                             </div>
                             <button
                                 className={styles.refreshButton}
-                                onClick={() => window.location.reload()}
+                                onClick={() => getBrowserWindow().location.reload()}
                             >
                                 <i
                                     className="fa fa-refresh"

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -7,6 +7,7 @@ import LazyMobXTable, {
     Column,
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
 import _ from 'lodash';
+import { hasNonEmptyDescriptionInResources } from 'shared/lib/ResourceUtils';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
@@ -162,8 +163,12 @@ const ResourceTable = observer(
                 sortBy: row => row.url,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.url.toUpperCase().includes(filterStringUpper ?? ''),
-            },
-            {
+            }
+        );
+
+        // Only show Description column if at least one resource has a non-empty description
+        if (hasNonEmptyDescriptionInResources(resources)) {
+            columns.push({
                 name: 'Description',
                 headerRender: () => (
                     <span data-test={'Description'}>{'Description'}</span>
@@ -175,8 +180,8 @@ const ResourceTable = observer(
                     (row.description ?? '')
                         .toUpperCase()
                         .includes(filterStringUpper ?? ''),
-            }
-        );
+            });
+        }
 
         return (
             <ResourceMobXTable

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -6,6 +6,7 @@ import { useLocalObservable } from 'mobx-react-lite';
 import LazyMobXTable, {
     Column,
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
+import _ from 'lodash';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
@@ -102,11 +103,18 @@ const ResourceTable = observer(
             });
         }
 
+        // Determine if there's only one unique resource type
+        const uniqueResourceNames = _.uniq(state.data.map(d => d.resourceName));
+        const resourceColumnName =
+            uniqueResourceNames.length === 1 && uniqueResourceNames[0]
+                ? uniqueResourceNames[0]
+                : 'Resource';
+
         columns.push(
             {
-                name: 'Resource',
+                name: resourceColumnName,
                 headerRender: () => (
-                    <span data-test={'Resource'}>{'Resource'}</span>
+                    <span data-test={'Resource'}>{resourceColumnName}</span>
                 ),
                 render: row => (
                     <a onClick={() => openResource(row.resource)}>
@@ -123,8 +131,10 @@ const ResourceTable = observer(
                         .includes(filterStringUpper ?? ''),
             },
             {
-                name: '',
-                headerRender: () => <span></span>,
+                name: 'Resource URL',
+                headerRender: () => (
+                    <span data-test={'Resource URL'}>{'Resource URL'}</span>
+                ),
                 render: row => (
                     <a
                         href={row.url}
@@ -148,11 +158,11 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Description'}>{'Description'}</span>
                 ),
-                render: row => <span>{row.description}</span>,
-                download: row => row.description || '',
-                sortBy: row => row.description || '',
+                render: row => <span>{row.description ?? ''}</span>,
+                download: row => row.description ?? '',
+                sortBy: row => row.description ?? '',
                 filter: (row, _filterString, filterStringUpper) =>
-                    (row.description || '')
+                    (row.description ?? '')
                         .toUpperCase()
                         .includes(filterStringUpper ?? ''),
             }

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { getFileExtension } from './ResourcesTableUtils';
 import { ResourceData } from 'cbioportal-ts-api-client';
-import _ from 'lodash';
 import { useLocalObservable } from 'mobx-react-lite';
+import LazyMobXTable, {
+    Column,
+} from 'shared/components/lazyMobXTable/LazyMobXTable';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
@@ -45,68 +47,131 @@ function icon(resource: ResourceData) {
     }
 }
 
+class ResourceMobXTable extends LazyMobXTable<{
+    resource: ResourceData;
+    resourceName: string;
+    url: string;
+    description?: string;
+    priority: string | number;
+    sampleId?: React.ReactNode;
+}> {}
+
 const ResourceTable = observer(
     ({ resources, isTabOpen, openResource, sampleId }: IResourceTableProps) => {
-        const resourceTable = useLocalObservable(() => ({
+        const state = useLocalObservable(() => ({
             get data() {
-                return _.sortBy(resources, r => r.resourceDefinition.priority);
+                // Map incoming resources into row data for the MobX table
+                return resources.map(r => ({
+                    resource: r,
+                    resourceName: r.resourceDefinition?.displayName ?? r.url,
+                    url: r.url,
+                    description: r.resourceDefinition?.description,
+                    priority: r.resourceDefinition?.priority ?? 0,
+                    sampleId,
+                }));
             },
         }));
 
-        return resourceTable.data.length === 0 ? (
-            <p>There are no resources for this sample.</p>
-        ) : (
-            <table className="simple-table table table-striped table-border-top">
-                <thead>
-                    <tr>
-                        {sampleId && <th>Sample ID</th>}
-                        <th>Resource</th>
-                        <th></th>
-                        {resourceTable.data.length > 0 && <th>Description</th>}
-                    </tr>
-                </thead>
-                <tbody>
-                    {resourceTable.data.length === 0 ? (
-                        <tr>
-                            <td colSpan={3} style={{ textAlign: 'center' }}>
-                                There are no results
-                            </td>
-                        </tr>
-                    ) : (
-                        resourceTable.data.map(resource => (
-                            <tr>
-                                {sampleId && <td>{sampleId}</td>}
-                                <td>
-                                    <a onClick={() => openResource(resource)}>
-                                        {icon(resource)}
-                                        {resource.resourceDefinition
-                                            .displayName || resource.url}
-                                    </a>
-                                </td>
-                                <td>
-                                    <a
-                                        href={resource.url}
-                                        style={{ fontSize: 10 }}
-                                        target={'_blank'}
-                                    >
-                                        <i
-                                            className={`fa fa-external-link fa-sm`}
-                                            style={{
-                                                marginRight: 5,
-                                                color: 'black',
-                                            }}
-                                        />
-                                        Open in new window
-                                    </a>
-                                </td>
-                                <td>
-                                    {resource.resourceDefinition.description}
-                                </td>
-                            </tr>
-                        ))
-                    )}
-                </tbody>
-            </table>
+        if (state.data.length === 0) {
+            return <p>There are no resources for this sample.</p>;
+        }
+
+        const columns: Column<{
+            resource: ResourceData;
+            resourceName: string;
+            url: string;
+            description?: string;
+            priority: string | number;
+            sampleId?: React.ReactNode;
+        }>[] = [];
+
+        if (sampleId) {
+            columns.push({
+                name: 'Sample ID',
+                headerRender: () => (
+                    <span data-test={'Sample ID'}>{'Sample ID'}</span>
+                ),
+                render: row => <span>{row.sampleId}</span>,
+                download: row => `${row.resource.sampleId ?? ''}`,
+                sortBy: row => `${row.resource.sampleId ?? ''}`,
+                filter: (row, _filterString, filterStringUpper) => {
+                    const value = `${row.resource.sampleId ??
+                        ''}`.toUpperCase();
+                    return value.includes(filterStringUpper ?? '');
+                },
+            });
+        }
+
+        columns.push(
+            {
+                name: 'Resource',
+                headerRender: () => (
+                    <span data-test={'Resource'}>{'Resource'}</span>
+                ),
+                render: row => (
+                    <a onClick={() => openResource(row.resource)}>
+                        {icon(row.resource)}
+                        {row.resourceName}
+                    </a>
+                ),
+                download: row => row.resourceName,
+                // Sort by priority to mirror previous initial ordering
+                sortBy: row => row.priority,
+                filter: (row, _filterString, filterStringUpper) =>
+                    row.resourceName
+                        .toUpperCase()
+                        .includes(filterStringUpper ?? ''),
+            },
+            {
+                name: '',
+                headerRender: () => <span></span>,
+                render: row => (
+                    <a
+                        href={row.url}
+                        style={{ fontSize: 10 }}
+                        target={'_blank'}
+                    >
+                        <i
+                            className={`fa fa-external-link fa-sm`}
+                            style={{ marginRight: 5, color: 'black' }}
+                        />
+                        Open in new window
+                    </a>
+                ),
+                download: row => row.url,
+                sortBy: row => row.url,
+                filter: (row, _filterString, filterStringUpper) =>
+                    row.url.toUpperCase().includes(filterStringUpper ?? ''),
+            },
+            {
+                name: 'Description',
+                headerRender: () => (
+                    <span data-test={'Description'}>{'Description'}</span>
+                ),
+                render: row => <span>{row.description}</span>,
+                download: row => row.description || '',
+                sortBy: row => row.description || '',
+                filter: (row, _filterString, filterStringUpper) =>
+                    (row.description || '')
+                        .toUpperCase()
+                        .includes(filterStringUpper ?? ''),
+            }
+        );
+
+        return (
+            <ResourceMobXTable
+                initialItemsPerPage={20}
+                data={state.data}
+                columns={columns}
+                showColumnVisibility={false}
+                showCountHeader={false}
+                showFilterClearButton={false}
+                showCopyDownload={true}
+                copyDownloadProps={{ showCopy: false }}
+                // Use the 'Resource' column which sorts by priority via sortBy
+                initialSortColumn={'Resource'}
+                initialSortDirection={'asc'}
+            />
         );
     }
 );

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -117,8 +117,18 @@ const ResourceTable = observer(
                     <span data-test={'Resource'}>{resourceColumnName}</span>
                 ),
                 render: row => (
-                    <a onClick={() => openResource(row.resource)}>
-                        {icon(row.resource)}
+                    <a
+                        onClick={() => openResource(row.resource)}
+                        style={{ fontSize: 10 }}
+                    >
+                        <i
+                            className={`fa fa-user fa-sm`}
+                            style={{
+                                marginRight: 5,
+                                color: 'black',
+                            }}
+                            title="Open in Patient View"
+                        />
                         {row.resourceName}
                     </a>
                 ),

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -102,8 +102,8 @@ const ResourceTable = observer(
                     </a>
                 ),
                 download: (row) => row.resourceName,
-                // Sort by the displayed resource name so column sorting matches the UI
-                sortBy: (row) => row.resourceName,
+                // Sort by priority so the initial ordering reflects resource priority
+                sortBy: (row) => row.priority,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.resourceName
                         .toUpperCase()

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -7,6 +7,8 @@ import LazyMobXTable, {
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
 import _ from 'lodash';
 import { hasNonEmptyDescriptionInResources } from 'shared/lib/ResourceUtils';
+import { getServerConfig } from 'config/config';
+import { DownloadControlOption } from 'cbioportal-frontend-commons';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
@@ -28,7 +30,7 @@ const ResourceTable = observer(
         const state = useLocalObservable(() => ({
             get data() {
                 // Map incoming resources into row data for the MobX table
-                return resources.map((r) => ({
+                return resources.map(r => ({
                     resource: r,
                     resourceName: r.resourceDefinition?.displayName ?? r.url,
                     url: r.url,
@@ -58,22 +60,19 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Sample ID'}>{'Sample ID'}</span>
                 ),
-                render: (row) => <span>{row.sampleId}</span>,
-                download: (row) => `${row.resource.sampleId ?? ''}`,
-                sortBy: (row) => `${row.resource.sampleId ?? ''}`,
+                render: row => <span>{row.sampleId}</span>,
+                download: row => `${row.resource.sampleId ?? ''}`,
+                sortBy: row => `${row.resource.sampleId ?? ''}`,
                 filter: (row, _filterString, filterStringUpper) => {
-                    const value = `${
-                        row.resource.sampleId ?? ''
-                    }`.toUpperCase();
+                    const value = `${row.resource.sampleId ??
+                        ''}`.toUpperCase();
                     return value.includes(filterStringUpper ?? '');
                 },
             });
         }
 
         // Determine if there's only one unique resource type
-        const uniqueResourceNames = _.uniq(
-            state.data.map((d) => d.resourceName)
-        );
+        const uniqueResourceNames = _.uniq(state.data.map(d => d.resourceName));
         const resourceColumnHeader =
             uniqueResourceNames.length === 1 && uniqueResourceNames[0]
                 ? uniqueResourceNames[0]
@@ -85,7 +84,7 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Resource'}>{resourceColumnHeader}</span>
                 ),
-                render: (row) => (
+                render: row => (
                     <a
                         onClick={() => openResource(row.resource)}
                         style={{ fontSize: 10 }}
@@ -101,9 +100,9 @@ const ResourceTable = observer(
                         {row.resourceName}
                     </a>
                 ),
-                download: (row) => row.resourceName,
+                download: row => row.resourceName,
                 // Sort by priority so the initial ordering reflects resource priority
-                sortBy: (row) => row.priority,
+                sortBy: row => row.priority,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.resourceName
                         .toUpperCase()
@@ -114,7 +113,7 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Resource URL'}>{'Resource URL'}</span>
                 ),
-                render: (row) => (
+                render: row => (
                     <a
                         href={row.url}
                         style={{ fontSize: 10 }}
@@ -128,8 +127,8 @@ const ResourceTable = observer(
                         Open in new window
                     </a>
                 ),
-                download: (row) => row.url,
-                sortBy: (row) => row.url,
+                download: row => row.url,
+                sortBy: row => row.url,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.url.toUpperCase().includes(filterStringUpper ?? ''),
             }
@@ -142,9 +141,9 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Description'}>{'Description'}</span>
                 ),
-                render: (row) => <span>{row.description ?? ''}</span>,
-                download: (row) => row.description ?? '',
-                sortBy: (row) => row.description ?? '',
+                render: row => <span>{row.description ?? ''}</span>,
+                download: row => row.description ?? '',
+                sortBy: row => row.description ?? '',
                 filter: (row, _filterString, filterStringUpper) =>
                     (row.description ?? '')
                         .toUpperCase()
@@ -160,7 +159,10 @@ const ResourceTable = observer(
                 showColumnVisibility={false}
                 showCountHeader={false}
                 showFilterClearButton={false}
-                showCopyDownload={true}
+                showCopyDownload={
+                    getServerConfig().skin_hide_download_controls ===
+                    DownloadControlOption.SHOW_ALL
+                }
                 copyDownloadProps={{ showCopy: false }}
                 initialSortColumn={'Resource'}
                 initialSortDirection={'asc'}

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -74,16 +74,16 @@ const ResourceTable = observer(
         const uniqueResourceNames = _.uniq(
             state.data.map((d) => d.resourceName)
         );
-        const resourceColumnName =
+        const resourceColumnHeader =
             uniqueResourceNames.length === 1 && uniqueResourceNames[0]
                 ? uniqueResourceNames[0]
                 : 'Resource';
 
         columns.push(
             {
-                name: resourceColumnName,
+                name: 'Resource',
                 headerRender: () => (
-                    <span data-test={'Resource'}>{resourceColumnName}</span>
+                    <span data-test={'Resource'}>{resourceColumnHeader}</span>
                 ),
                 render: (row) => (
                     <a
@@ -119,6 +119,7 @@ const ResourceTable = observer(
                         href={row.url}
                         style={{ fontSize: 10 }}
                         target={'_blank'}
+                        rel="noopener noreferrer"
                     >
                         <i
                             className={`fa fa-external-link fa-sm`}

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { getFileExtension } from './ResourcesTableUtils';
 import { ResourceData } from 'cbioportal-ts-api-client';
 import { useLocalObservable } from 'mobx-react-lite';
 import LazyMobXTable, {
@@ -11,42 +10,8 @@ import { hasNonEmptyDescriptionInResources } from 'shared/lib/ResourceUtils';
 
 export interface IResourceTableProps {
     resources: ResourceData[];
-    isTabOpen: (resourceId: string) => boolean;
     openResource: (resource: ResourceData) => void;
     sampleId?: React.ReactNode;
-}
-
-function icon(resource: ResourceData) {
-    let className = '';
-    const fileExtension = getFileExtension(resource.url);
-    switch (fileExtension) {
-        case 'pdf':
-            className = 'fa fa-file-pdf-o';
-            break;
-        case 'png':
-        case 'jpeg':
-        case 'jpg':
-        case 'gif':
-            className = 'fa fa-file-image-o';
-            break;
-        case 'm4a':
-        case 'flac':
-        case 'mp3':
-        case 'mp4':
-        case 'wav':
-            className = 'fa fa-file-audio-o';
-            break;
-    }
-    if (className) {
-        return (
-            <i
-                className={`${className} fa-sm`}
-                style={{ marginRight: 5, color: 'black' }}
-            />
-        );
-    } else {
-        return null;
-    }
 }
 
 class ResourceMobXTable extends LazyMobXTable<{
@@ -54,12 +19,12 @@ class ResourceMobXTable extends LazyMobXTable<{
     resourceName: string;
     url: string;
     description?: string;
-    priority: string | number;
+    priority: string;
     sampleId?: React.ReactNode;
 }> {}
 
 const ResourceTable = observer(
-    ({ resources, isTabOpen, openResource, sampleId }: IResourceTableProps) => {
+    ({ resources, openResource, sampleId }: IResourceTableProps) => {
         const state = useLocalObservable(() => ({
             get data() {
                 // Map incoming resources into row data for the MobX table
@@ -68,7 +33,7 @@ const ResourceTable = observer(
                     resourceName: r.resourceDefinition?.displayName ?? r.url,
                     url: r.url,
                     description: r.resourceDefinition?.description,
-                    priority: r.resourceDefinition?.priority ?? 0,
+                    priority: r.resourceDefinition?.priority ?? '',
                     sampleId,
                 }));
             },
@@ -83,7 +48,7 @@ const ResourceTable = observer(
             resourceName: string;
             url: string;
             description?: string;
-            priority: string | number;
+            priority: string;
             sampleId?: React.ReactNode;
         }>[] = [];
 
@@ -193,8 +158,7 @@ const ResourceTable = observer(
                 showFilterClearButton={false}
                 showCopyDownload={true}
                 copyDownloadProps={{ showCopy: false }}
-                // Use the 'Resource' column which sorts by priority via sortBy
-                initialSortColumn={'Resource'}
+                initialSortColumn={resourceColumnName}
                 initialSortDirection={'asc'}
             />
         );

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -102,8 +102,8 @@ const ResourceTable = observer(
                     </a>
                 ),
                 download: (row) => row.resourceName,
-                // Sort by priority to mirror previous initial ordering
-                sortBy: (row) => row.priority,
+                // Sort by the displayed resource name so column sorting matches the UI
+                sortBy: (row) => row.resourceName,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.resourceName
                         .toUpperCase()

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -28,7 +28,7 @@ const ResourceTable = observer(
         const state = useLocalObservable(() => ({
             get data() {
                 // Map incoming resources into row data for the MobX table
-                return resources.map(r => ({
+                return resources.map((r) => ({
                     resource: r,
                     resourceName: r.resourceDefinition?.displayName ?? r.url,
                     url: r.url,
@@ -58,19 +58,22 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Sample ID'}>{'Sample ID'}</span>
                 ),
-                render: row => <span>{row.sampleId}</span>,
-                download: row => `${row.resource.sampleId ?? ''}`,
-                sortBy: row => `${row.resource.sampleId ?? ''}`,
+                render: (row) => <span>{row.sampleId}</span>,
+                download: (row) => `${row.resource.sampleId ?? ''}`,
+                sortBy: (row) => `${row.resource.sampleId ?? ''}`,
                 filter: (row, _filterString, filterStringUpper) => {
-                    const value = `${row.resource.sampleId ??
-                        ''}`.toUpperCase();
+                    const value = `${
+                        row.resource.sampleId ?? ''
+                    }`.toUpperCase();
                     return value.includes(filterStringUpper ?? '');
                 },
             });
         }
 
         // Determine if there's only one unique resource type
-        const uniqueResourceNames = _.uniq(state.data.map(d => d.resourceName));
+        const uniqueResourceNames = _.uniq(
+            state.data.map((d) => d.resourceName)
+        );
         const resourceColumnName =
             uniqueResourceNames.length === 1 && uniqueResourceNames[0]
                 ? uniqueResourceNames[0]
@@ -82,7 +85,7 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Resource'}>{resourceColumnName}</span>
                 ),
-                render: row => (
+                render: (row) => (
                     <a
                         onClick={() => openResource(row.resource)}
                         style={{ fontSize: 10 }}
@@ -98,9 +101,9 @@ const ResourceTable = observer(
                         {row.resourceName}
                     </a>
                 ),
-                download: row => row.resourceName,
+                download: (row) => row.resourceName,
                 // Sort by priority to mirror previous initial ordering
-                sortBy: row => row.priority,
+                sortBy: (row) => row.priority,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.resourceName
                         .toUpperCase()
@@ -111,7 +114,7 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Resource URL'}>{'Resource URL'}</span>
                 ),
-                render: row => (
+                render: (row) => (
                     <a
                         href={row.url}
                         style={{ fontSize: 10 }}
@@ -124,8 +127,8 @@ const ResourceTable = observer(
                         Open in new window
                     </a>
                 ),
-                download: row => row.url,
-                sortBy: row => row.url,
+                download: (row) => row.url,
+                sortBy: (row) => row.url,
                 filter: (row, _filterString, filterStringUpper) =>
                     row.url.toUpperCase().includes(filterStringUpper ?? ''),
             }
@@ -138,9 +141,9 @@ const ResourceTable = observer(
                 headerRender: () => (
                     <span data-test={'Description'}>{'Description'}</span>
                 ),
-                render: row => <span>{row.description ?? ''}</span>,
-                download: row => row.description ?? '',
-                sortBy: row => row.description ?? '',
+                render: (row) => <span>{row.description ?? ''}</span>,
+                download: (row) => row.description ?? '',
+                sortBy: (row) => row.description ?? '',
                 filter: (row, _filterString, filterStringUpper) =>
                     (row.description ?? '')
                         .toUpperCase()

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -162,7 +162,7 @@ const ResourceTable = observer(
                 showFilterClearButton={false}
                 showCopyDownload={true}
                 copyDownloadProps={{ showCopy: false }}
-                initialSortColumn={resourceColumnName}
+                initialSortColumn={'Resource'}
                 initialSortDirection={'asc'}
             />
         );

--- a/src/shared/components/resources/SampleResourcesTable.tsx
+++ b/src/shared/components/resources/SampleResourcesTable.tsx
@@ -29,7 +29,7 @@ export default class SampleResourcesTable extends React.Component<
         );
         return _.sortBy(
             this.props.data,
-            (rowData) => sampleIndex[rowData.sample.sampleId]
+            rowData => sampleIndex[rowData.sample.sampleId]
         );
     }
 

--- a/src/shared/components/resources/SampleResourcesTable.tsx
+++ b/src/shared/components/resources/SampleResourcesTable.tsx
@@ -11,7 +11,6 @@ import ResourceTable from './ResourceTable';
 export interface ISampleResourcesTableProps {
     data: ResourcesTableRowData[];
     sampleManager: SampleManager;
-    isTabOpen: (resourceId: string) => boolean;
     openResource: (resource: ResourceData) => void;
 }
 
@@ -50,7 +49,6 @@ export default class SampleResourcesTable extends React.Component<
                         <>
                             <ResourceTable
                                 resources={datum.resources}
-                                isTabOpen={this.props.isTabOpen}
                                 openResource={this.props.openResource}
                                 sampleId={sampleId}
                             />

--- a/src/shared/components/resources/SampleResourcesTable.tsx
+++ b/src/shared/components/resources/SampleResourcesTable.tsx
@@ -29,7 +29,7 @@ export default class SampleResourcesTable extends React.Component<
         );
         return _.sortBy(
             this.props.data,
-            rowData => sampleIndex[rowData.sample.sampleId]
+            (rowData) => sampleIndex[rowData.sample.sampleId]
         );
     }
 

--- a/src/shared/components/resources/styles.module.scss
+++ b/src/shared/components/resources/styles.module.scss
@@ -14,3 +14,56 @@
         }
     }
 }
+
+.warningBanner {
+    padding: 20px 30px;
+    background-color: #fff3cd;
+    border: 2px solid #ffc107;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    max-width: 450px;
+    margin: 0 auto;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.warningIcon {
+    color: #856404;
+    font-size: 36px;
+    margin-bottom: 12px;
+}
+
+.warningText {
+    color: #856404;
+    font-size: 14px;
+    line-height: 1.5;
+    font-weight: 500;
+    margin-bottom: 16px;
+}
+
+.refreshButton {
+    padding: 8px 16px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+        opacity: 0.9;
+        transform: translateY(-1px);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    &:active {
+        opacity: 0.8;
+        transform: translateY(0);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/src/shared/components/resources/styles.module.scss.d.ts
+++ b/src/shared/components/resources/styles.module.scss.d.ts
@@ -1,6 +1,10 @@
 declare const styles: {
   readonly "active": string;
   readonly "carouselButton": string;
+  readonly "refreshButton": string;
+  readonly "warningBanner": string;
+  readonly "warningIcon": string;
+  readonly "warningText": string;
 };
 export = styles;
 

--- a/src/shared/lib/ResourceConfig.spec.ts
+++ b/src/shared/lib/ResourceConfig.spec.ts
@@ -1,0 +1,129 @@
+import { assert } from 'chai';
+import {
+    getResourceConfig,
+    RESOURCE_CUSTOM_CONFIGS,
+    ResourceCustomConfig,
+} from './ResourceConfig';
+import { ResourceDefinition } from 'cbioportal-ts-api-client';
+
+function makeDefinition(
+    overrides: Partial<ResourceDefinition> = {}
+): ResourceDefinition {
+    return {
+        resourceId: 'TEST_RESOURCE',
+        displayName: 'Test Resource',
+        description: '',
+        priority: '1',
+        customMetaData: '',
+        resourceType: 'PATIENT',
+        studyId: 'study1',
+        ...overrides,
+    };
+}
+
+describe('getResourceConfig', () => {
+    it('returns empty config for unknown resourceId', () => {
+        const config = getResourceConfig(
+            makeDefinition({ resourceId: 'UNKNOWN' })
+        );
+        assert.deepEqual(config, {});
+    });
+
+    it('returns empty config when resourceId is empty string', () => {
+        const config = getResourceConfig(makeDefinition({ resourceId: '' }));
+        assert.deepEqual(config, {});
+    });
+
+    describe('MSK_HNE', () => {
+        it('returns the full MSK_HNE config', () => {
+            const config = getResourceConfig(
+                makeDefinition({ resourceId: 'MSK_HNE' })
+            );
+            assert.deepEqual(config, RESOURCE_CUSTOM_CONFIGS['MSK_HNE']);
+        });
+
+        it('has all expected fields set', () => {
+            const config = getResourceConfig(
+                makeDefinition({ resourceId: 'MSK_HNE' })
+            );
+            assert.equal(
+                config.customizedDisplayName,
+                'Samples with H&E Slides'
+            );
+            assert.isTrue(config.hidePerPatientColumn);
+            assert.isTrue(config.hideUrlColumn);
+            assert.isTrue(config.openInNewTab);
+            assert.equal(
+                config.columnNameMapping?.['Type Of Resource'],
+                'View'
+            );
+            assert.isString(config.iframeErrorMessage);
+            assert.isNotEmpty(config.iframeErrorMessage);
+        });
+
+        it('does not mutate the RESOURCE_CUSTOM_CONFIGS entry', () => {
+            const original = { ...RESOURCE_CUSTOM_CONFIGS['MSK_HNE'] };
+            const config = getResourceConfig(
+                makeDefinition({ resourceId: 'MSK_HNE' })
+            );
+            config.customizedDisplayName = 'mutated';
+            assert.deepEqual(
+                RESOURCE_CUSTOM_CONFIGS['MSK_HNE'],
+                original,
+                'RESOURCE_CUSTOM_CONFIGS entry should not be mutated'
+            );
+        });
+
+        it('customMetaData overrides customizedDisplayName while preserving other fields', () => {
+            const config = getResourceConfig(
+                makeDefinition({
+                    resourceId: 'MSK_HNE',
+                    customMetaData: JSON.stringify({
+                        customizedDisplayName: 'Override Name',
+                    }),
+                })
+            );
+            assert.equal(config.customizedDisplayName, 'Override Name');
+            // Other MSK_HNE fields should still be present
+            assert.isTrue(config.hidePerPatientColumn);
+            assert.isTrue(config.hideUrlColumn);
+            assert.isTrue(config.openInNewTab);
+        });
+
+        it('customMetaData can override iframeErrorMessage', () => {
+            const config = getResourceConfig(
+                makeDefinition({
+                    resourceId: 'MSK_HNE',
+                    customMetaData: JSON.stringify({
+                        iframeErrorMessage: 'Custom VPN message',
+                    }),
+                })
+            );
+            assert.equal(config.iframeErrorMessage, 'Custom VPN message');
+        });
+
+        it('ignores invalid JSON in customMetaData and falls back to base MSK_HNE config', () => {
+            const config = getResourceConfig(
+                makeDefinition({
+                    resourceId: 'MSK_HNE',
+                    customMetaData: '{invalid json',
+                })
+            );
+            assert.deepEqual(config, RESOURCE_CUSTOM_CONFIGS['MSK_HNE']);
+        });
+    });
+
+    it('applies customMetaData on top of empty base config for unknown resourceId', () => {
+        const config = getResourceConfig(
+            makeDefinition({
+                resourceId: 'UNKNOWN',
+                customMetaData: JSON.stringify({
+                    customizedDisplayName: 'From MetaData',
+                    hidePerPatientColumn: true,
+                }),
+            })
+        );
+        assert.equal(config.customizedDisplayName, 'From MetaData');
+        assert.isTrue(config.hidePerPatientColumn);
+    });
+});

--- a/src/shared/lib/ResourceConfig.spec.ts
+++ b/src/shared/lib/ResourceConfig.spec.ts
@@ -17,6 +17,7 @@ function makeDefinition(
         customMetaData: '',
         resourceType: 'PATIENT',
         studyId: 'study1',
+        openByDefault: false,
         ...overrides,
     };
 }
@@ -58,7 +59,7 @@ describe('getResourceConfig', () => {
                 'View'
             );
             assert.isString(config.iframeErrorMessage);
-            assert.isNotEmpty(config.iframeErrorMessage);
+            assert.notEqual(config.iframeErrorMessage, '');
         });
 
         it('does not mutate the RESOURCE_CUSTOM_CONFIGS entry', () => {

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -1,0 +1,82 @@
+import { ResourceDefinition } from 'cbioportal-ts-api-client';
+
+/**
+ * Configuration options for customizing resource display and behavior.
+ */
+export interface ResourceCustomConfig {
+    /**
+     * Custom display name for the resource (e.g., "Samples with H&E Slides")
+     * Used in: Study View (tab name and count header)
+     */
+    customizedDisplayName?: string;
+
+    /**
+     * Whether to hide the "Resources per Patient" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hidePerPatientColumn?: boolean;
+
+    /**
+     * Mapping to rename column headers (e.g., { 'Type Of Resource': 'View' })
+     * Used in: Study View (Files & Links tab)
+     */
+    columnNameMapping?: Record<string, string>;
+
+    /**
+     * Whether to hide the "Resource URL" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hideUrlColumn?: boolean;
+
+    /**
+     * Whether resource links should open in a new tab
+     * Used in: Study View (Files & Links tab)
+     */
+    openInNewTab?: boolean;
+}
+
+export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
+    HE: {
+        customizedDisplayName: 'Samples with H&E Slides',
+        hidePerPatientColumn: true,
+        columnNameMapping: { 'Type Of Resource': 'View' },
+        hideUrlColumn: true,
+        openInNewTab: true,
+    },
+};
+
+// Type for ResourceDefinition with optional customMetaData field
+type ExtendedResourceDefinition = ResourceDefinition & {
+    customMetaData?: string;
+};
+
+export function getResourceConfig(
+    def: ResourceDefinition
+): ResourceCustomConfig {
+    let config: ResourceCustomConfig = {};
+    const extendedDef = def as ExtendedResourceDefinition;
+
+    // 1. Load from local dictionary
+    if (def.resourceId && RESOURCE_CUSTOM_CONFIGS[def.resourceId]) {
+        config = { ...RESOURCE_CUSTOM_CONFIGS[def.resourceId] };
+    }
+
+    // 2. Override with customMetaData
+    if (extendedDef.customMetaData) {
+        try {
+            const customConfig = JSON.parse(
+                extendedDef.customMetaData
+            ) as Partial<ResourceCustomConfig>;
+            // Merge all properties from customConfig into config
+            // This automatically handles all current and future properties
+            Object.assign(config, customConfig);
+        } catch (e) {
+            console.warn(
+                `Failed to parse customMetaData for resource ${def.resourceId}`,
+                e
+            );
+        }
+    }
+
+    return config;
+}

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -33,6 +33,12 @@ export interface ResourceCustomConfig {
      * Used in: Study View (Files & Links tab)
      */
     openInNewTab?: boolean;
+
+    /**
+     * Custom error message to show when iframe fails to load
+     * Used in: Patient View (resource iframe)
+     */
+    iframeErrorMessage?: string;
 }
 
 export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
@@ -42,6 +48,8 @@ export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
         columnNameMapping: { 'Type Of Resource': 'View' },
         hideUrlColumn: true,
         openInNewTab: true,
+        iframeErrorMessage:
+            'This resource requires VPN access. Please connect to VPN and refresh the page.',
     },
 };
 

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -42,7 +42,7 @@ export interface ResourceCustomConfig {
 }
 
 export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
-    HE: {
+    MSK_HNE: {
         customizedDisplayName: 'Samples with H&E Slides',
         hidePerPatientColumn: true,
         columnNameMapping: { 'Type Of Resource': 'View' },

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -53,16 +53,10 @@ export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
     },
 };
 
-// Type for ResourceDefinition with optional customMetaData field
-type ExtendedResourceDefinition = ResourceDefinition & {
-    customMetaData?: string;
-};
-
 export function getResourceConfig(
     def: ResourceDefinition
 ): ResourceCustomConfig {
     let config: ResourceCustomConfig = {};
-    const extendedDef = def as ExtendedResourceDefinition;
 
     // 1. Load from local dictionary
     if (def.resourceId && RESOURCE_CUSTOM_CONFIGS[def.resourceId]) {
@@ -70,13 +64,11 @@ export function getResourceConfig(
     }
 
     // 2. Override with customMetaData
-    if (extendedDef.customMetaData) {
+    if (def.customMetaData) {
         try {
-            const customConfig = JSON.parse(
-                extendedDef.customMetaData
-            ) as Partial<ResourceCustomConfig>;
-            // Merge all properties from customConfig into config
-            // This automatically handles all current and future properties
+            const customConfig = JSON.parse(def.customMetaData) as Partial<
+                ResourceCustomConfig
+            >;
             Object.assign(config, customConfig);
         } catch (e) {
             console.warn(

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -66,9 +66,9 @@ export function getResourceConfig(
     // 2. Override with customMetaData
     if (def.customMetaData) {
         try {
-            const customConfig = JSON.parse(
-                def.customMetaData
-            ) as Partial<ResourceCustomConfig>;
+            const customConfig = JSON.parse(def.customMetaData) as Partial<
+                ResourceCustomConfig
+            >;
             Object.assign(config, customConfig);
         } catch (e) {
             console.warn(

--- a/src/shared/lib/ResourceConfig.ts
+++ b/src/shared/lib/ResourceConfig.ts
@@ -66,9 +66,9 @@ export function getResourceConfig(
     // 2. Override with customMetaData
     if (def.customMetaData) {
         try {
-            const customConfig = JSON.parse(def.customMetaData) as Partial<
-                ResourceCustomConfig
-            >;
+            const customConfig = JSON.parse(
+                def.customMetaData
+            ) as Partial<ResourceCustomConfig>;
             Object.assign(config, customConfig);
         } catch (e) {
             console.warn(

--- a/src/shared/lib/ResourceUtils.spec.ts
+++ b/src/shared/lib/ResourceUtils.spec.ts
@@ -18,7 +18,9 @@ function makeDef(description: string | undefined): ResourceDefinition {
     };
 }
 
-function makeResourceData(description: string | undefined): {
+function makeResourceData(
+    description: string | undefined
+): {
     resourceDefinition?: ResourceDefinition;
 } {
     return { resourceDefinition: makeDef(description) };

--- a/src/shared/lib/ResourceUtils.spec.ts
+++ b/src/shared/lib/ResourceUtils.spec.ts
@@ -1,0 +1,108 @@
+import { assert } from 'chai';
+import {
+    hasNonEmptyDescriptionInDefinitions,
+    hasNonEmptyDescriptionInResources,
+} from './ResourceUtils';
+import { ResourceDefinition } from 'cbioportal-ts-api-client';
+
+function makeDef(description: string | undefined): ResourceDefinition {
+    return {
+        resourceId: 'R1',
+        displayName: 'Resource',
+        description: description as string,
+        priority: '1',
+        customMetaData: '',
+        resourceType: 'PATIENT',
+        studyId: 'study1',
+    };
+}
+
+function makeResourceData(
+    description: string | undefined
+): { resourceDefinition?: ResourceDefinition } {
+    return { resourceDefinition: makeDef(description) };
+}
+
+describe('hasNonEmptyDescriptionInDefinitions', () => {
+    it('returns false for undefined input', () => {
+        assert.isFalse(hasNonEmptyDescriptionInDefinitions(undefined));
+    });
+
+    it('returns false for empty array', () => {
+        assert.isFalse(hasNonEmptyDescriptionInDefinitions([]));
+    });
+
+    it('returns false when all descriptions are empty strings', () => {
+        assert.isFalse(
+            hasNonEmptyDescriptionInDefinitions([makeDef(''), makeDef('')])
+        );
+    });
+
+    it('returns false when all descriptions are undefined', () => {
+        assert.isFalse(
+            hasNonEmptyDescriptionInDefinitions([
+                makeDef(undefined),
+                makeDef(undefined),
+            ])
+        );
+    });
+
+    it('returns true when at least one description is non-empty', () => {
+        assert.isTrue(
+            hasNonEmptyDescriptionInDefinitions([
+                makeDef(''),
+                makeDef('Some description'),
+            ])
+        );
+    });
+
+    it('returns true when all descriptions are non-empty', () => {
+        assert.isTrue(
+            hasNonEmptyDescriptionInDefinitions([
+                makeDef('Desc A'),
+                makeDef('Desc B'),
+            ])
+        );
+    });
+});
+
+describe('hasNonEmptyDescriptionInResources', () => {
+    it('returns false for empty array', () => {
+        assert.isFalse(hasNonEmptyDescriptionInResources([]));
+    });
+
+    it('returns false when all descriptions are empty', () => {
+        assert.isFalse(
+            hasNonEmptyDescriptionInResources([
+                makeResourceData(''),
+                makeResourceData(''),
+            ])
+        );
+    });
+
+    it('returns false when resourceDefinition is absent', () => {
+        assert.isFalse(
+            hasNonEmptyDescriptionInResources([
+                { resourceDefinition: undefined },
+            ])
+        );
+    });
+
+    it('returns true when at least one resource has a non-empty description', () => {
+        assert.isTrue(
+            hasNonEmptyDescriptionInResources([
+                makeResourceData(''),
+                makeResourceData('Has a description'),
+            ])
+        );
+    });
+
+    it('returns true when all resources have non-empty descriptions', () => {
+        assert.isTrue(
+            hasNonEmptyDescriptionInResources([
+                makeResourceData('Desc A'),
+                makeResourceData('Desc B'),
+            ])
+        );
+    });
+});

--- a/src/shared/lib/ResourceUtils.spec.ts
+++ b/src/shared/lib/ResourceUtils.spec.ts
@@ -14,12 +14,13 @@ function makeDef(description: string | undefined): ResourceDefinition {
         customMetaData: '',
         resourceType: 'PATIENT',
         studyId: 'study1',
+        openByDefault: false,
     };
 }
 
-function makeResourceData(
-    description: string | undefined
-): { resourceDefinition?: ResourceDefinition } {
+function makeResourceData(description: string | undefined): {
+    resourceDefinition?: ResourceDefinition;
+} {
     return { resourceDefinition: makeDef(description) };
 }
 

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -1,16 +1,47 @@
 import { ResourceDefinition } from 'cbioportal-ts-api-client';
 
+/**
+ * Configuration options for customizing resource display and behavior.
+ */
 export interface ResourceCustomConfig {
+    /**
+     * Custom display name for the resource (e.g., "Samples with H&E Slides")
+     * Used in: Study View (tab name and count header)
+     */
     customizedDisplayName?: string;
-    columnHeader?: string;
-    hideResourcesPerPatientColumn?: boolean;
+
+    /**
+     * Whether to hide the "Resources per Patient" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hidePerPatientColumn?: boolean;
+
+    /**
+     * Mapping to rename column headers (e.g., { 'Type Of Resource': 'View' })
+     * Used in: Study View (Files & Links tab)
+     */
+    columnNameMapping?: Record<string, string>;
+
+    /**
+     * Whether to hide the "Resource URL" column
+     * Used in: Study View (Files & Links tab)
+     */
+    hideUrlColumn?: boolean;
+
+    /**
+     * Whether resource links should open in a new tab
+     * Used in: Study View (Files & Links tab)
+     */
+    openInNewTab?: boolean;
 }
 
 export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
     HE: {
-        customizedDisplayName: 'H&E Samples with Slides',
-        columnHeader: 'H&E Slides per Sample',
-        hideResourcesPerPatientColumn: true,
+        customizedDisplayName: 'Samples with H&E Slides',
+        hidePerPatientColumn: true,
+        columnNameMapping: { 'Type Of Resource': 'View' },
+        hideUrlColumn: true,
+        openInNewTab: true,
     },
 };
 
@@ -33,21 +64,12 @@ export function getResourceConfig(
     // 2. Override with customMetaData
     if (extendedDef.customMetaData) {
         try {
-            const customConfig = JSON.parse(extendedDef.customMetaData);
-            if (customConfig.customizedDisplayName) {
-                config.customizedDisplayName =
-                    customConfig.customizedDisplayName;
-            } else if (customConfig.tabLabel) {
-                // Fallback for backward compatibility
-                config.customizedDisplayName = customConfig.tabLabel;
-            }
-            if (customConfig.columnHeader) {
-                config.columnHeader = customConfig.columnHeader;
-            }
-            if (customConfig.hideResourcesPerPatientColumn !== undefined) {
-                config.hideResourcesPerPatientColumn =
-                    customConfig.hideResourcesPerPatientColumn;
-            }
+            const customConfig = JSON.parse(
+                extendedDef.customMetaData
+            ) as Partial<ResourceCustomConfig>;
+            // Merge all properties from customConfig into config
+            // This automatically handles all current and future properties
+            Object.assign(config, customConfig);
         } catch (e) {
             console.warn(
                 `Failed to parse customMetaData for resource ${def.resourceId}`,

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -1,82 +1,33 @@
 import { ResourceDefinition } from 'cbioportal-ts-api-client';
+import _ from 'lodash';
 
 /**
- * Configuration options for customizing resource display and behavior.
+ * Helper function to check if a string is non-empty
  */
-export interface ResourceCustomConfig {
-    /**
-     * Custom display name for the resource (e.g., "Samples with H&E Slides")
-     * Used in: Study View (tab name and count header)
-     */
-    customizedDisplayName?: string;
-
-    /**
-     * Whether to hide the "Resources per Patient" column
-     * Used in: Study View (Files & Links tab)
-     */
-    hidePerPatientColumn?: boolean;
-
-    /**
-     * Mapping to rename column headers (e.g., { 'Type Of Resource': 'View' })
-     * Used in: Study View (Files & Links tab)
-     */
-    columnNameMapping?: Record<string, string>;
-
-    /**
-     * Whether to hide the "Resource URL" column
-     * Used in: Study View (Files & Links tab)
-     */
-    hideUrlColumn?: boolean;
-
-    /**
-     * Whether resource links should open in a new tab
-     * Used in: Study View (Files & Links tab)
-     */
-    openInNewTab?: boolean;
+function isNonEmptyString(value: string | undefined): boolean {
+    return !_.isEmpty(value);
 }
 
-export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
-    HE: {
-        customizedDisplayName: 'Samples with H&E Slides',
-        hidePerPatientColumn: true,
-        columnNameMapping: { 'Type Of Resource': 'View' },
-        hideUrlColumn: true,
-        openInNewTab: true,
-    },
-};
-
-// Extend ResourceDefinition to include customMetaData if it's missing in the types
-interface ExtendedResourceDefinition extends ResourceDefinition {
-    customMetaData?: string;
+/**
+ * Checks if any resource definition has a non-empty description.
+ * @param definitions Array of resource definitions to check
+ * @returns true if at least one definition has a non-empty description
+ */
+export function hasNonEmptyDescriptionInDefinitions(
+    definitions: ResourceDefinition[] | undefined
+): boolean {
+    return definitions?.some(def => isNonEmptyString(def.description)) ?? false;
 }
 
-export function getResourceConfig(
-    def: ResourceDefinition
-): ResourceCustomConfig {
-    let config: ResourceCustomConfig = {};
-    const extendedDef = def as ExtendedResourceDefinition;
-
-    // 1. Load from local dictionary
-    if (def.resourceId && RESOURCE_CUSTOM_CONFIGS[def.resourceId]) {
-        config = { ...RESOURCE_CUSTOM_CONFIGS[def.resourceId] };
-    }
-
-    // 2. Override with customMetaData
-    if (extendedDef.customMetaData) {
-        try {
-            const customConfig = JSON.parse(
-                extendedDef.customMetaData
-            ) as Partial<ResourceCustomConfig>;
-            // Merge all properties from customConfig into config
-            // This automatically handles all current and future properties
-            Object.assign(config, customConfig);
-        } catch (e) {
-            console.warn(
-                `Failed to parse customMetaData for resource ${def.resourceId}`,
-                e
-            );
-        }
-    }
-
-    return config;
+/**
+ * Checks if any resource has a non-empty description in its resource definition.
+ * @param resources Array of resource data to check
+ * @returns true if at least one resource has a non-empty description
+ */
+export function hasNonEmptyDescriptionInResources(
+    resources: { resourceDefinition?: ResourceDefinition }[]
+): boolean {
+    return resources.some(r =>
+        isNonEmptyString(r.resourceDefinition?.description)
+    );
 }

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -1,0 +1,60 @@
+import { ResourceDefinition } from 'cbioportal-ts-api-client';
+
+export interface ResourceCustomConfig {
+    customizedDisplayName?: string;
+    columnHeader?: string;
+    hideResourcesPerPatientColumn?: boolean;
+}
+
+export const RESOURCE_CUSTOM_CONFIGS: Record<string, ResourceCustomConfig> = {
+    HE: {
+        customizedDisplayName: 'H&E Samples with Slides',
+        columnHeader: 'H&E Slides per Sample',
+        hideResourcesPerPatientColumn: true,
+    },
+};
+
+// Extend ResourceDefinition to include customMetaData if it's missing in the types
+interface ExtendedResourceDefinition extends ResourceDefinition {
+    customMetaData?: string;
+}
+
+export function getResourceConfig(
+    def: ResourceDefinition
+): ResourceCustomConfig {
+    let config: ResourceCustomConfig = {};
+    const extendedDef = def as ExtendedResourceDefinition;
+
+    // 1. Load from local dictionary
+    if (def.resourceId && RESOURCE_CUSTOM_CONFIGS[def.resourceId]) {
+        config = { ...RESOURCE_CUSTOM_CONFIGS[def.resourceId] };
+    }
+
+    // 2. Override with customMetaData
+    if (extendedDef.customMetaData) {
+        try {
+            const customConfig = JSON.parse(extendedDef.customMetaData);
+            if (customConfig.customizedDisplayName) {
+                config.customizedDisplayName =
+                    customConfig.customizedDisplayName;
+            } else if (customConfig.tabLabel) {
+                // Fallback for backward compatibility
+                config.customizedDisplayName = customConfig.tabLabel;
+            }
+            if (customConfig.columnHeader) {
+                config.columnHeader = customConfig.columnHeader;
+            }
+            if (customConfig.hideResourcesPerPatientColumn !== undefined) {
+                config.hideResourcesPerPatientColumn =
+                    customConfig.hideResourcesPerPatientColumn;
+            }
+        } catch (e) {
+            console.warn(
+                `Failed to parse customMetaData for resource ${def.resourceId}`,
+                e
+            );
+        }
+    }
+
+    return config;
+}

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -16,7 +16,9 @@ function isNonEmptyString(value: string | undefined): boolean {
 export function hasNonEmptyDescriptionInDefinitions(
     definitions: ResourceDefinition[] | undefined
 ): boolean {
-    return definitions?.some(def => isNonEmptyString(def.description)) ?? false;
+    return (
+        definitions?.some((def) => isNonEmptyString(def.description)) ?? false
+    );
 }
 
 /**
@@ -27,7 +29,7 @@ export function hasNonEmptyDescriptionInDefinitions(
 export function hasNonEmptyDescriptionInResources(
     resources: { resourceDefinition?: ResourceDefinition }[]
 ): boolean {
-    return resources.some(r =>
+    return resources.some((r) =>
         isNonEmptyString(r.resourceDefinition?.description)
     );
 }

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -15,9 +15,7 @@ function isNonEmptyString(value: string | null | undefined): boolean {
 export function hasNonEmptyDescriptionInDefinitions(
     definitions: ResourceDefinition[] | undefined
 ): boolean {
-    return (
-        definitions?.some((def) => isNonEmptyString(def.description)) ?? false
-    );
+    return definitions?.some(def => isNonEmptyString(def.description)) ?? false;
 }
 
 /**
@@ -28,7 +26,7 @@ export function hasNonEmptyDescriptionInDefinitions(
 export function hasNonEmptyDescriptionInResources(
     resources: { resourceDefinition?: ResourceDefinition }[]
 ): boolean {
-    return resources.some((r) =>
+    return resources.some(r =>
         isNonEmptyString(r.resourceDefinition?.description)
     );
 }

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -1,5 +1,4 @@
 import { ResourceDefinition } from 'cbioportal-ts-api-client';
-import _ from 'lodash';
 
 /**
  * Helper function to check if a string is non-empty

--- a/src/shared/lib/ResourceUtils.ts
+++ b/src/shared/lib/ResourceUtils.ts
@@ -4,8 +4,8 @@ import _ from 'lodash';
 /**
  * Helper function to check if a string is non-empty
  */
-function isNonEmptyString(value: string | undefined): boolean {
-    return !_.isEmpty(value);
+function isNonEmptyString(value: string | null | undefined): boolean {
+    return (value?.trim().length ?? 0) > 0;
 }
 
 /**


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11682

### How to test:
- Please set `localStorage.netlify = "deploy-preview-5552--cbioportalfrontend"` in the browser console first and refresh the page
- [Study view page](https://triage.cbioportal.mskcc.org/study/filesAndLinks?id=coad_msk_2025)
- Patient view page

### Changes Made

**This is a frontend-only Resources / Files & Links enhancement PR**
  - No backend API contract changes are introduced in this patch
  - The main work is in shared resources components plus Study View / Patient View wiring
  - Overall scope is: table UX improvements, per-resource customization, and resource viewer behavior changes

- **Shared `ResourceTable` is substantially refactored**
  - The old custom HTML table is replaced with `LazyMobXTable`
  - This adds built-in:
    - search/filtering
    - CSV download
    - standardized sorting/pagination behavior
  - Rows are normalized into a table data model containing:
    - `resource`
    - `resourceName`
    - `url`
    - `description`
    - `priority`
    - optional `sampleId`

- **`ResourceTable` column behavior changes**
  - Optional **Sample ID** column remains supported
  - The main resource column is clickable and opens the in-app resource tab
  - A separate **Resource URL** column opens the raw URL in a new tab
  - The **Description** column is now conditional:
    - shown only if at least one resource has a non-empty description
    - hidden entirely when all descriptions are empty / missing

- **`ResourceTable` now uses dynamic naming**
  - If all resources in the table are the same type, the generic **Resource** header is replaced with that specific resource name
  - Otherwise it stays **Resource**
  - Initial sort is tied to that dynamic column name and uses resource priority for ordering

- **Study View `FilesAndLinks` gets the largest product-facing update**
  - The table remains derived from study-wide resource data filtered to selected samples/patients
  - It now supports a single-resource-type mode:
    - detects when all rows share one resource type
    - resolves config for that type
    - applies UI customizations based on that config

- **Study View config-driven customizations**
  - Can rename the **Type Of Resource** column
  - Can hide the **Resource URL** column
  - Can hide the **Resources per Patient** column
  - Can change the count/header label text
  - Can force resource links to open in a new tab
  - Example in this PR: `MSK_HNE`

- **Study View copy and layout are simplified**
  - Removes the extra **Patient and Sample Resources** subheading
  - Removes dashed-border section styling around the resources section
  - Count header now uses:
    - `customizedDisplayName` when configured
    - otherwise generic `resources`

- **Study View resource navigation links are made more explicit**
  - The resource-type column link gets a user icon and routes into the patient resource view
  - If config says `openInNewTab`, the patient resource route opens in a new tab
  - URL column still represents the raw external destination when shown

- **A new resource customization layer is introduced**
  - New file: `src/shared/lib/ResourceConfig.ts`
  - Adds `ResourceCustomConfig` with fields for:
    - `customizedDisplayName`
    - `hidePerPatientColumn`
    - `columnNameMapping`
    - `hideUrlColumn`
    - `openInNewTab`
    - `iframeErrorMessage`
  - Config is built in two layers:
    - hardcoded dictionary by `resourceId`
    - JSON override from backend `customMetaData`

- **Hardcoded built-in config in this PR**
  - Adds `MSK_HNE` defaults
  - That config:
    - renames the display to **Samples with H&E Slides**
    - hides per-patient counts
    - renames **Type Of Resource** to **View**
    - hides the URL column
    - opens links in a new tab
    - provides a VPN-related iframe warning message

- **New helper utilities are added**
  - `ResourceUtils.ts` contains pure helpers that detect non-empty descriptions
  - These helpers are used to decide whether Description columns should render at all
  - This avoids empty Description columns in both shared resource tables and Study View files/links tables

- **`ResourceTab` viewer behavior changes**
  - `ResourceTab` now accepts `resourceDisplayName` instead of always reading `resourceDefinition.displayName`
  - The title area now shows:
    - passed display name
    - sample or patient identifier
    - optional description
    - a counter like `1 of N`
  - This improves multi-resource navigation context inside the viewer

- **New warning-banner flow in the resource viewer**
  - If a resource config provides `iframeErrorMessage`, the tab renders a yellow warning banner
  - The banner includes:
    - warning icon
    - warning message text
    - refresh button
  - New SCSS module styles support this banner

- **Study View and Patient View wiring changes**
  - `StudyViewPage.tsx`
    - resolves config with `getResourceConfig(def)`
    - passes `customizedDisplayName || def.displayName` into `ResourceTab`
    - tightens resource visibility logic to wait for both definitions and resource data
  - `PatientViewPage.tsx`
    - passes `resourceDisplayName={def.displayName}` into `ResourceTab`
    - otherwise mostly formatting / low-signal cleanup
  - `ResourcesTab.tsx` in both views removes now-unused `isTabOpen` plumbing

- **Test coverage is added for the new abstractions**
  - `ResourceConfig.spec.ts`
    - covers known vs unknown resource IDs
    - covers metadata override behavior
    - covers invalid JSON fallback
    - confirms base config objects are not mutated
  - `ResourceUtils.spec.ts`
    - covers empty vs non-empty descriptions
    - covers both definition-level and resource-row-level inputs

## Review focus

- **Most important files to review**
  - `src/shared/components/resources/ResourceTable.tsx`
  - `src/pages/studyView/resources/FilesAndLinks.tsx`
  - `src/shared/components/resources/ResourceTab.tsx`
  - `src/shared/lib/ResourceConfig.ts`

- **Main conceptual buckets**
  - shared table infrastructure upgrade
  - resource-specific customization framework
  - Study View presentation changes
  - Patient/Study resource viewer behavior changes

- **Notable review concerns**
  - `MSK_HNE` is a hardcoded institution-specific config in shared frontend code
  - `iframeErrorMessage` currently causes the warning banner to render instead of the iframe, so product intent should be confirmed
  - The PR mixes generic UX improvements with product-specific customization, which may deserve separate scrutiny during review
