### PR TITLE
PoC: extract batched-fetch utility, migrate VariantCountCache

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -52,7 +52,7 @@ import {
     USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
 } from 'react-mutation-mapper';
 import { ClinicalInformationData } from 'shared/model/ClinicalInformation';
-import VariantCountCache from 'shared/cache/VariantCountCache';
+import { createVariantCountCache } from 'shared/cache/VariantCountCache';
 import CopyNumberCountCache from './CopyNumberCountCache';
 import CancerTypeCache from 'shared/cache/CancerTypeCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
@@ -2435,7 +2435,7 @@ export class PatientViewPageStore {
     }
 
     @cached @computed get variantCountCache() {
-        return new VariantCountCache(this.mutationMolecularProfileId.result);
+        return createVariantCountCache(this.mutationMolecularProfileId.result);
     }
 
     @cached @computed get discreteCNACache() {

--- a/src/shared/cache/VariantCountCache.ts
+++ b/src/shared/cache/VariantCountCache.ts
@@ -1,38 +1,38 @@
-import LazyMobXCache from 'shared/lib/LazyMobXCache';
 import client from 'shared/api/cbioportalInternalClientInstance';
 import { VariantCount, VariantCountIdentifier } from 'cbioportal-ts-api-client';
+import {
+    createBatchedReactiveFetch,
+    ReactiveFetchCache,
+} from 'shared/lib/batchedReactiveFetch';
+
+export type VariantCountCache = ReactiveFetchCache<
+    VariantCountIdentifier,
+    VariantCount
+>;
 
 function getKey<T extends { entrezGeneId: number; keyword?: string }>(
     obj: T
 ): string {
-    if (obj.keyword) {
-        return obj.entrezGeneId + '~' + obj.keyword;
-    } else {
-        return obj.entrezGeneId + '';
-    }
+    return obj.keyword
+        ? `${obj.entrezGeneId}~${obj.keyword}`
+        : `${obj.entrezGeneId}`;
 }
 
-function fetch(
-    queries: VariantCountIdentifier[],
+export function createVariantCountCache(
     mutationMolecularProfileId: string | undefined
-): Promise<VariantCount[]> {
-    if (!mutationMolecularProfileId) {
-        return Promise.reject('No mutation molecular profile id given');
-    } else if (queries.length > 0) {
-        return client.fetchVariantCountsUsingPOST({
-            molecularProfileId: mutationMolecularProfileId,
-            variantCountIdentifiers: queries,
-        });
-    } else {
-        return Promise.resolve([]);
-    }
-}
-
-export default class VariantCountCache extends LazyMobXCache<
-    VariantCount,
-    VariantCountIdentifier
-> {
-    constructor(mutationMolecularProfileId: string | undefined) {
-        super(getKey, getKey, fetch, mutationMolecularProfileId);
-    }
+): VariantCountCache {
+    return createBatchedReactiveFetch<VariantCountIdentifier, VariantCount>({
+        queryToKey: getKey,
+        dataToKey: getKey,
+        fetch: async queries => {
+            if (!mutationMolecularProfileId) {
+                throw new Error('No mutation molecular profile id given');
+            }
+            if (queries.length === 0) return [];
+            return client.fetchVariantCountsUsingPOST({
+                molecularProfileId: mutationMolecularProfileId,
+                variantCountIdentifiers: queries,
+            });
+        },
+    });
 }

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -36,7 +36,7 @@ import ExonColumnFormatter from './column/ExonColumnFormatter';
 import { IMutSigData } from 'shared/model/MutSig';
 import DiscreteCNACache from 'shared/cache/DiscreteCNACache';
 import MrnaExprRankCache from 'shared/cache/MrnaExprRankCache';
-import VariantCountCache from 'shared/cache/VariantCountCache';
+import { VariantCountCache } from 'shared/cache/VariantCountCache';
 import PubMedCache from 'shared/cache/PubMedCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';

--- a/src/shared/components/mutationTable/column/CohortColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CohortColumnFormatter.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import { Mutation } from 'cbioportal-ts-api-client';
-import VariantCountCache from 'shared/cache/VariantCountCache';
+import { VariantCountCache } from 'shared/cache/VariantCountCache';
 import FrequencyBar from 'shared/components/cohort/FrequencyBar';
 import { IMutSigData as MutSigData } from 'shared/model/MutSig';
 import { VariantCount } from 'cbioportal-ts-api-client';
-import { CacheData } from 'shared/lib/LazyMobXCache';
+import { ReactiveFetchEntry } from 'shared/lib/batchedReactiveFetch';
 import { getPercentage } from 'shared/lib/FormatUtils';
 import { If, Then } from 'react-if';
 import {
@@ -14,7 +14,7 @@ import {
 } from 'cbioportal-frontend-commons';
 import MutSigAnnotation from 'shared/components/annotation/MutSig';
 
-type AugVariantCountOutput = CacheData<VariantCount> & {
+type AugVariantCountOutput = ReactiveFetchEntry<VariantCount> & {
     hugoGeneSymbol: string;
 };
 

--- a/src/shared/lib/batchedReactiveFetch.spec.ts
+++ b/src/shared/lib/batchedReactiveFetch.spec.ts
@@ -1,0 +1,163 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { autorun } from 'mobx';
+import { createBatchedReactiveFetch } from './batchedReactiveFetch';
+
+type Query = { id: number };
+type Datum = { id: number; value: string };
+
+const queryToKey = (q: Query) => `${q.id}`;
+const dataToKey = (d: Datum) => `${d.id}`;
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('batchedReactiveFetch', () => {
+    it('collapses N .get() calls in one tick into a single fetch', async () => {
+        const fetch = sinon.spy(async (queries: Query[]): Promise<Datum[]> =>
+            queries.map(q => ({ id: q.id, value: `v${q.id}` }))
+        );
+        const cache = createBatchedReactiveFetch({
+            fetch,
+            queryToKey,
+            dataToKey,
+        });
+        for (let i = 0; i < 100; i++) cache.get({ id: i });
+        await tick();
+        assert.equal(fetch.callCount, 1);
+        assert.equal(fetch.args[0][0].length, 100);
+    });
+
+    it('first .get() returns null, subsequent reads after fetch return data', async () => {
+        const fetch = async (queries: Query[]) =>
+            queries.map(q => ({ id: q.id, value: `v${q.id}` }));
+        const cache = createBatchedReactiveFetch({
+            fetch,
+            queryToKey,
+            dataToKey,
+        });
+        assert.isNull(cache.get({ id: 1 }));
+        await tick();
+        assert.deepEqual(cache.get({ id: 1 }), {
+            status: 'complete',
+            data: { id: 1, value: 'v1' },
+        });
+    });
+
+    it('missing entries (queried but not returned) are marked complete with data:null', async () => {
+        const fetch = async (queries: Query[]) =>
+            queries
+                .filter(q => q.id !== 99)
+                .map(q => ({ id: q.id, value: 'x' }));
+        const cache = createBatchedReactiveFetch({
+            fetch,
+            queryToKey,
+            dataToKey,
+        });
+        cache.get({ id: 1 });
+        cache.get({ id: 99 });
+        await tick();
+        assert.deepEqual(cache.get({ id: 99 }), {
+            status: 'complete',
+            data: null,
+        });
+    });
+
+    it('errors mark entries as error and do not retry', async () => {
+        const fetch = sinon.spy(async () => {
+            throw new Error('boom');
+        });
+        const cache = createBatchedReactiveFetch({
+            fetch,
+            queryToKey,
+            dataToKey,
+        });
+        cache.get({ id: 1 });
+        await tick();
+        assert.deepEqual(cache.get({ id: 1 }), {
+            status: 'error',
+            data: null,
+        });
+        assert.equal(fetch.callCount, 1);
+        // Subsequent .get() of the errored key should not re-trigger fetch.
+        cache.get({ id: 1 });
+        await tick();
+        assert.equal(fetch.callCount, 1);
+    });
+
+    it('triggers a mobx reaction when fetch completes', async () => {
+        const fetch = async (queries: Query[]) =>
+            queries.map(q => ({ id: q.id, value: 'ok' }));
+        const cache = createBatchedReactiveFetch({
+            fetch,
+            queryToKey,
+            dataToKey,
+        });
+        const observed: (ReturnType<typeof cache.get> | null)[] = [];
+        const dispose = autorun(() => observed.push(cache.get({ id: 1 })));
+        assert.equal(observed.length, 1);
+        assert.isNull(observed[0]);
+        await tick();
+        assert.equal(observed.length, 2);
+        assert.deepEqual(observed[1], {
+            status: 'complete',
+            data: { id: 1, value: 'ok' },
+        });
+        dispose();
+    });
+
+    it('separate ticks → separate fetch calls', async () => {
+        const fetch = sinon.spy(async (queries: Query[]) =>
+            queries.map(q => ({ id: q.id, value: 'x' }))
+        );
+        const cache = createBatchedReactiveFetch({
+            fetch,
+            queryToKey,
+            dataToKey,
+        });
+        cache.get({ id: 1 });
+        cache.get({ id: 2 });
+        await tick();
+        cache.get({ id: 3 });
+        cache.get({ id: 4 });
+        await tick();
+        assert.equal(fetch.callCount, 2);
+        assert.deepEqual(
+            fetch.args[0][0].map((q: Query) => q.id),
+            [1, 2]
+        );
+        assert.deepEqual(
+            fetch.args[1][0].map((q: Query) => q.id),
+            [3, 4]
+        );
+    });
+
+    it('does not redundantly request keys already inflight', async () => {
+        let resolveFetch: (data: Datum[]) => void = () => {};
+        const fetch = sinon.spy(
+            (queries: Query[]) =>
+                new Promise<Datum[]>(resolve => {
+                    resolveFetch = resolve;
+                })
+        );
+        const cache = createBatchedReactiveFetch({
+            fetch,
+            queryToKey,
+            dataToKey,
+        });
+        cache.get({ id: 1 });
+        await tick(); // fires first fetch, still pending
+        cache.get({ id: 1 }); // should NOT enqueue again
+        cache.get({ id: 2 }); // new key, can enqueue
+        await tick();
+        assert.equal(
+            fetch.callCount,
+            2,
+            'second fetch only contains new key 2'
+        );
+        assert.deepEqual(
+            fetch.args[1][0].map((q: Query) => q.id),
+            [2]
+        );
+        resolveFetch([{ id: 1, value: 'v1' }, { id: 2, value: 'v2' }]);
+    });
+});

--- a/src/shared/lib/batchedReactiveFetch.ts
+++ b/src/shared/lib/batchedReactiveFetch.ts
@@ -1,0 +1,88 @@
+import { observable, runInAction } from 'mobx';
+
+// Captures the one piece of LazyMobXCache that's actually load-bearing:
+// per-render N→1 request collapsing for column formatters.
+//
+// The pattern: a column formatter calls `cache.get(query)` from inside each
+// row render. Returns null on first call, reactively fills in once the
+// debounced batched fetch resolves. All `.get(...)` calls within a single
+// microtask tick collapse into a single fetch invocation.
+//
+// Compared to LazyMobXCache, this drops: subclass scaffolding, .peek/.getPromise/
+// .addData/.cache surface, error retry tracking, MobxPromise integration,
+// and the `meta`-augmented data shape. Add them back when a concrete caller
+// needs them — most don't.
+
+// `.get()` returns null while the fetch is still in flight; once resolved the
+// entry is one of the two terminal shapes below.
+export type ReactiveFetchEntry<V> =
+    | { status: 'complete'; data: V | null }
+    | { status: 'error'; data: null };
+
+export interface ReactiveFetchCache<Q, V> {
+    get(query: Q): ReactiveFetchEntry<V> | null;
+}
+
+export function createBatchedReactiveFetch<Q, V>(args: {
+    fetch: (queries: Q[]) => Promise<V[]>;
+    queryToKey: (q: Q) => string;
+    dataToKey: (d: V) => string;
+}): ReactiveFetchCache<Q, V> {
+    const state = observable.box<{ [key: string]: ReactiveFetchEntry<V> }>(
+        {},
+        { deep: false }
+    );
+    const inflight = new Set<string>();
+    let queue = new Map<string, Q>();
+    let scheduled = false;
+
+    const flush = async () => {
+        scheduled = false;
+        if (queue.size === 0) return;
+        const batch = queue;
+        queue = new Map<string, Q>();
+        const keys = Array.from(batch.keys());
+        keys.forEach(k => inflight.add(k));
+        try {
+            const results = await args.fetch(Array.from(batch.values()));
+            const byKey = new Map(results.map(r => [args.dataToKey(r), r]));
+            runInAction(() => {
+                const next = { ...state.get() };
+                for (const k of keys) {
+                    const v = byKey.get(k);
+                    next[k] = {
+                        status: 'complete',
+                        data: v !== undefined ? v : null,
+                    };
+                }
+                state.set(next);
+            });
+        } catch {
+            runInAction(() => {
+                const next = { ...state.get() };
+                for (const k of keys) {
+                    next[k] = { status: 'error', data: null };
+                }
+                state.set(next);
+            });
+        } finally {
+            keys.forEach(k => inflight.delete(k));
+        }
+    };
+
+    return {
+        get(query: Q): ReactiveFetchEntry<V> | null {
+            const key = args.queryToKey(query);
+            const entry = state.get()[key];
+            if (entry) return entry;
+            if (!inflight.has(key) && !queue.has(key)) {
+                queue.set(key, query);
+                if (!scheduled) {
+                    scheduled = true;
+                    Promise.resolve().then(flush);
+                }
+            }
+            return null;
+        },
+    };
+}


### PR DESCRIPTION
## Proof of concept — not for merge as-is

This PR is a **design-review proposal**, not a complete migration. It introduces a small replacement utility for `LazyMobXCache` and migrates exactly one cache (`VariantCountCache`) as a worked example. Goal: surface the proposed API and migration pattern before committing to the long tail (~19 more subclasses, ~50+ call sites).

## Why

Profiling against production cBioPortal confirmed that the per-row column-formatter batching in `LazyMobXCache` is doing real work:

- Patient view (10 mutation rows visible) → **1** `variant-counts/fetch` request with **10** entries in body
- Results view (30 genes, MSK-IMPACT) → **1** `mutations/fetch` with all 30 genes batched, median batch sizes of 25–30 across other endpoints

So we can't simply delete the caches. But the rest of `LazyMobXCache`'s surface (`peek`, `getPromise`, `addData`, `cache` reactive read, error retry tracking, `meta`-augmented data, `MobxPromise` integration, ~20 thin subclass wrappers) is incidental — most call sites only use `.get()`.

This PR proposes: **keep the batching, drop the rest**.

## What's here

**New** — `src/shared/lib/batchedReactiveFetch.ts` (~50 lines):
```ts
export function createBatchedReactiveFetch<Q, V>(args: {
    fetch: (queries: Q[]) => Promise<V[]>;
    queryToKey: (q: Q) => string;
    dataToKey: (d: V) => string;
}): ReactiveFetchCache<Q, V>
```
A factory that returns `{ get(query) → ReactiveFetchEntry<V> | null }`. All `.get(...)` calls within a single microtask tick collapse into one fetch invocation. Internal state is a single `observable.box`, so mobx observers re-render when results land. 7 unit tests covering: N→1 collapse, reactive updates, in-flight dedup, error termination, cross-tick separation, missing-result handling.

**Migrated** — `VariantCountCache`: was a `LazyMobXCache` subclass, now a 30-line factory function. Same `.get({entrezGeneId, keyword})` shape at the call site. Three downstream files (`CohortColumnFormatter`, `MutationTable`, `PatientViewPageStore`) updated to consume the new type alias.

**Untouched** — `LazyMobXCache.ts`, the 18 other subclasses, `SampleGeneCache`, `SimpleCache`. They keep working as before. This PR adds the utility next to the old infra, doesn't replace it.

## Diff size
6 files, +285 / -34 lines. Most of that is the new utility and its test file.

## What I'd want from review
1. **Does the utility's API feel right?** Anything missing that would force the next migration to leak abstractions? The `meta`-augmented-data pattern (used by e.g. `MutationDataCache`) is a deliberate omission — I don't think it should bleed into the base utility, but worth confirming.
2. **`status: 'pending'` vs `null` on cache miss.** Old code returned `null` for both \"not yet requested\" and \"in flight\"; new code does the same. I dropped a `pending` variant from the type union since it was never observable — let me know if any caller wants to distinguish.
3. **Microtask-tick batching window** vs. the current `accumulatingDebounce` (delay 0). Behaviorally equivalent in practice (both fire on the next macrotask boundary), but if the timing nuance matters anywhere, flag it.

## Test plan
- [x] `pnpm typecheck` clean
- [x] 7 new unit tests in `batchedReactiveFetch.spec.ts` pass
- [x] Existing `LazyMobXCache.spec.ts` still passes (old infra unchanged)
- [x] `CohortColumnFormatter` specs (both variants) pass
- [ ] Live manual smoke test: open a patient view, confirm Cohort column still renders frequencies correctly (could not verify in CI; needs reviewer to click through)
- [ ] CI green

## If approved, follow-up PRs
Each migrating one or two caches at a time, in this rough order of leverage:
1. Other per-row hot paths: `MrnaExprRankCache`, `DiscreteCNACache`, `MutationCountCache`, `CopyNumberCountCache`
2. `getPromise`-using sites (oncoprint/plots): need a small `getPromise`-style helper or inlined `Promise.all`
3. Remaining incidental caches: most can be inlined directly

Once all subclasses are migrated, `LazyMobXCache.ts`, `SampleGeneCache.ts`, `SimpleCache.ts`, and the 19 wrapper subclass files can be deleted in a final cleanup PR. Estimated total: 1–2 weeks of focused work spread across ~10 reviewable PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->