### PR TITLE
nightly: run Playwright remote_e2e in place of legacy WDIO e2e_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1074,10 +1074,14 @@ workflows:
           requires:
             - pull_cbioportal_test_codebase
             - build_frontend
-      - e2e_tests:
+      # Playwright remote e2e replaces the legacy WDIO `e2e_tests` job in
+      # the nightly workflow. `remote_e2e` polls the CircleCI API for the
+      # shards' terminal state and merges the report, so it intentionally
+      # does NOT `require` remote_e2e_shards.
+      - remote_e2e_shards:
           requires:
-            - pull_cbioportal_test_codebase
             - build_frontend
+      - remote_e2e
       # - e2e_tests_against_master:
       #     requires:
       #       - pull_cbioportal_test_codebase


### PR DESCRIPTION
## Summary

- Swap the daily nightly cron from the legacy WDIO `e2e_tests` job to the new Playwright `remote_e2e[_shards]` job.
- After this merges, the 22:11 UTC master cron will produce the same `test-results/results.json` + merged HTML report that PR builds already produce, so the e2e dashboard (https://github.com/cBioPortal/e2e-report) will start showing nightly columns alongside PR runs.
- No change to the WDIO suite itself or to other workflows. PR-trigger pipelines were already on `remote_e2e`; this lines the cron up with that.

## Test plan

- [ ] Verify the swap was tested off-master on `nightly-playwright-e2e` and produced a green `remote_e2e` run plus the expected artifacts (`playwright-report/index.html`, `test-results/results.json`, `test-results/junit.xml`).
- [ ] After merge, watch tomorrow's 22:11 UTC nightly pipeline and confirm `remote_e2e` shows up in the workflow (and not `e2e_tests`).
- [ ] Confirm the e2e-report dashboard picks up the new nightly column on its next refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->