### PR TITLE
PoC v2: layered primitives (batchify + memoize + reactive), migrate VariantCountCache

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -52,7 +52,7 @@ import {
     USE_DEFAULT_PUBLIC_INSTANCE_FOR_ONCOKB,
 } from 'react-mutation-mapper';
 import { ClinicalInformationData } from 'shared/model/ClinicalInformation';
-import VariantCountCache from 'shared/cache/VariantCountCache';
+import { createVariantCountCache } from 'shared/cache/VariantCountCache';
 import CopyNumberCountCache from './CopyNumberCountCache';
 import CancerTypeCache from 'shared/cache/CancerTypeCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
@@ -2435,7 +2435,7 @@ export class PatientViewPageStore {
     }
 
     @cached @computed get variantCountCache() {
-        return new VariantCountCache(this.mutationMolecularProfileId.result);
+        return createVariantCountCache(this.mutationMolecularProfileId.result);
     }
 
     @cached @computed get discreteCNACache() {

--- a/src/shared/cache/VariantCountCache.ts
+++ b/src/shared/cache/VariantCountCache.ts
@@ -1,38 +1,41 @@
-import LazyMobXCache from 'shared/lib/LazyMobXCache';
 import client from 'shared/api/cbioportalInternalClientInstance';
 import { VariantCount, VariantCountIdentifier } from 'cbioportal-ts-api-client';
+import {
+    batchify,
+    memoize,
+    reactive,
+    ReactiveCache,
+} from 'shared/lib/batchedFetch';
 
-function getKey<T extends { entrezGeneId: number; keyword?: string }>(
-    obj: T
-): string {
-    if (obj.keyword) {
-        return obj.entrezGeneId + '~' + obj.keyword;
-    } else {
-        return obj.entrezGeneId + '';
-    }
-}
+export type VariantCountCache = ReactiveCache<
+    VariantCountIdentifier,
+    VariantCount
+>;
 
-function fetch(
-    queries: VariantCountIdentifier[],
-    mutationMolecularProfileId: string | undefined
-): Promise<VariantCount[]> {
-    if (!mutationMolecularProfileId) {
-        return Promise.reject('No mutation molecular profile id given');
-    } else if (queries.length > 0) {
-        return client.fetchVariantCountsUsingPOST({
-            molecularProfileId: mutationMolecularProfileId,
-            variantCountIdentifiers: queries,
-        });
-    } else {
-        return Promise.resolve([]);
-    }
-}
+const keyOf = (x: { entrezGeneId: number; keyword?: string }) =>
+    x.keyword ? `${x.entrezGeneId}~${x.keyword}` : `${x.entrezGeneId}`;
 
-export default class VariantCountCache extends LazyMobXCache<
-    VariantCount,
-    VariantCountIdentifier
-> {
-    constructor(mutationMolecularProfileId: string | undefined) {
-        super(getKey, getKey, fetch, mutationMolecularProfileId);
-    }
+export function createVariantCountCache(
+    mutationMolecularProfileId: string | undefined,
+): VariantCountCache {
+    const fetchOne = memoize<VariantCountIdentifier, VariantCount | null>(
+        batchify<VariantCountIdentifier, VariantCount>(
+            qs => {
+                if (!mutationMolecularProfileId) {
+                    return Promise.reject(
+                        new Error('No mutation molecular profile id given'),
+                    );
+                }
+                if (qs.length === 0) return Promise.resolve([]);
+                return client.fetchVariantCountsUsingPOST({
+                    molecularProfileId: mutationMolecularProfileId,
+                    variantCountIdentifiers: qs,
+                });
+            },
+            keyOf,
+            keyOf,
+        ),
+        keyOf,
+    );
+    return reactive(fetchOne, keyOf);
 }

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -36,7 +36,7 @@ import ExonColumnFormatter from './column/ExonColumnFormatter';
 import { IMutSigData } from 'shared/model/MutSig';
 import DiscreteCNACache from 'shared/cache/DiscreteCNACache';
 import MrnaExprRankCache from 'shared/cache/MrnaExprRankCache';
-import VariantCountCache from 'shared/cache/VariantCountCache';
+import { VariantCountCache } from 'shared/cache/VariantCountCache';
 import PubMedCache from 'shared/cache/PubMedCache';
 import MutationCountCache from 'shared/cache/MutationCountCache';
 import GenomeNexusCache from 'shared/cache/GenomeNexusCache';

--- a/src/shared/components/mutationTable/column/CohortColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/CohortColumnFormatter.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import { Mutation } from 'cbioportal-ts-api-client';
-import VariantCountCache from 'shared/cache/VariantCountCache';
+import { VariantCountCache } from 'shared/cache/VariantCountCache';
 import FrequencyBar from 'shared/components/cohort/FrequencyBar';
 import { IMutSigData as MutSigData } from 'shared/model/MutSig';
 import { VariantCount } from 'cbioportal-ts-api-client';
-import { CacheData } from 'shared/lib/LazyMobXCache';
+import { ReactiveEntry } from 'shared/lib/batchedFetch';
 import { getPercentage } from 'shared/lib/FormatUtils';
 import { If, Then } from 'react-if';
 import {
@@ -14,7 +14,7 @@ import {
 } from 'cbioportal-frontend-commons';
 import MutSigAnnotation from 'shared/components/annotation/MutSig';
 
-type AugVariantCountOutput = CacheData<VariantCount> & {
+type AugVariantCountOutput = ReactiveEntry<VariantCount> & {
     hugoGeneSymbol: string;
 };
 

--- a/src/shared/lib/batchedFetch.spec.ts
+++ b/src/shared/lib/batchedFetch.spec.ts
@@ -1,0 +1,218 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { autorun } from 'mobx';
+import { batchify, memoize, reactive } from './batchedFetch';
+
+type Q = { id: number };
+type V = { id: number; v: string };
+
+const keyOf = (x: { id: number }) => `${x.id}`;
+const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('batchify', () => {
+    it('coalesces calls in the same tick into one bulkFetch', async () => {
+        const bulkFetch = sinon.spy(async (qs: Q[]): Promise<V[]> =>
+            qs.map(q => ({ id: q.id, v: `r${q.id}` })),
+        );
+        const fn = batchify<Q, V>(bulkFetch, keyOf, keyOf);
+        const promises = [1, 2, 3, 4].map(id => fn({ id }));
+        const results = await Promise.all(promises);
+        assert.equal(bulkFetch.callCount, 1);
+        assert.deepEqual(
+            results.map(r => r?.v),
+            ['r1', 'r2', 'r3', 'r4'],
+        );
+    });
+
+    it('different ticks → separate bulkFetch calls', async () => {
+        const bulkFetch = sinon.spy(async (qs: Q[]): Promise<V[]> =>
+            qs.map(q => ({ id: q.id, v: 'x' })),
+        );
+        const fn = batchify<Q, V>(bulkFetch, keyOf, keyOf);
+        await fn({ id: 1 });
+        await fn({ id: 2 });
+        assert.equal(bulkFetch.callCount, 2);
+    });
+
+    it('resolves to null if the bulk response is missing the key', async () => {
+        const bulkFetch = async (qs: Q[]): Promise<V[]> =>
+            qs.filter(q => q.id !== 99).map(q => ({ id: q.id, v: 'x' }));
+        const fn = batchify<Q, V>(bulkFetch, keyOf, keyOf);
+        assert.isNull(await fn({ id: 99 }));
+    });
+
+    it('rejects every queued promise when bulkFetch throws', async () => {
+        const fn = batchify<Q, V>(
+            async () => {
+                throw new Error('boom');
+            },
+            keyOf,
+            keyOf,
+        );
+        const results = await Promise.allSettled([fn({ id: 1 }), fn({ id: 2 })]);
+        assert.deepEqual(
+            results.map(r => r.status),
+            ['rejected', 'rejected'],
+        );
+    });
+});
+
+describe('memoize', () => {
+    it('returns the same Promise for concurrent calls with the same key', async () => {
+        const inner = sinon.spy(async (q: Q) => ({ id: q.id, v: 'x' }));
+        const fn = memoize(inner, keyOf);
+        const [a, b] = await Promise.all([fn({ id: 1 }), fn({ id: 1 })]);
+        assert.equal(inner.callCount, 1);
+        assert.strictEqual(a, b);
+    });
+
+    it('caches resolved values across ticks', async () => {
+        const inner = sinon.spy(async (q: Q) => ({ id: q.id, v: 'x' }));
+        const fn = memoize(inner, keyOf);
+        await fn({ id: 1 });
+        await fn({ id: 1 });
+        assert.equal(inner.callCount, 1);
+    });
+
+    it('evicts on rejection so the next call retries', async () => {
+        let shouldFail = true;
+        const inner = sinon.spy(async (q: Q) => {
+            if (shouldFail) throw new Error('fail');
+            return { id: q.id, v: 'ok' };
+        });
+        const fn = memoize<Q, V>(inner, keyOf);
+        await fn({ id: 1 }).catch(() => {});
+        shouldFail = false;
+        const result = await fn({ id: 1 });
+        assert.equal(result.v, 'ok');
+        assert.equal(inner.callCount, 2);
+    });
+
+    it('different keys are independent', async () => {
+        const inner = sinon.spy(async (q: Q) => ({ id: q.id, v: 'x' }));
+        const fn = memoize(inner, keyOf);
+        await Promise.all([fn({ id: 1 }), fn({ id: 2 })]);
+        assert.equal(inner.callCount, 2);
+    });
+});
+
+describe('reactive', () => {
+    it('returns null on first .get(), then the resolved entry', async () => {
+        const fn = async (q: Q) => ({ id: q.id, v: 'x' });
+        const cache = reactive(fn, keyOf);
+        assert.isNull(cache.get({ id: 1 }));
+        await tick();
+        assert.deepEqual(cache.get({ id: 1 }), {
+            status: 'complete',
+            data: { id: 1, v: 'x' },
+        });
+    });
+
+    it('flips an autorun observer when the fetch resolves', async () => {
+        const fn = async (q: Q) => ({ id: q.id, v: 'x' });
+        const cache = reactive(fn, keyOf);
+        const observed: any[] = [];
+        const dispose = autorun(() => observed.push(cache.get({ id: 1 })));
+        assert.equal(observed.length, 1);
+        assert.isNull(observed[0]);
+        await tick();
+        assert.equal(observed.length, 2);
+        assert.equal(observed[1].status, 'complete');
+        dispose();
+    });
+
+    it('errored entries are not retried', async () => {
+        const fn = sinon.spy(async (_: Q) => {
+            throw new Error('boom');
+        });
+        const cache = reactive(fn, keyOf);
+        cache.get({ id: 1 });
+        await tick();
+        assert.deepEqual(cache.get({ id: 1 }), {
+            status: 'error',
+            data: null,
+        });
+        cache.get({ id: 1 });
+        await tick();
+        assert.equal(fn.callCount, 1);
+    });
+
+    it('does not call fn twice while the first call is in flight', async () => {
+        let resolveInner: (v: V) => void = () => {};
+        const fn = sinon.spy(
+            (q: Q) =>
+                new Promise<V>(resolve => {
+                    resolveInner = () => resolve({ id: q.id, v: 'late' });
+                }),
+        );
+        const cache = reactive(fn, keyOf);
+        cache.get({ id: 1 });
+        cache.get({ id: 1 });
+        cache.get({ id: 1 });
+        assert.equal(fn.callCount, 1);
+        resolveInner({ id: 1, v: 'late' });
+        await tick();
+        assert.equal(cache.get({ id: 1 })?.status, 'complete');
+    });
+});
+
+describe('composition: batchify + memoize + reactive', () => {
+    // Stand-in for the migrated VariantCountCache pipeline.
+    function buildCache(bulkFetch: (qs: Q[]) => Promise<V[]>) {
+        return reactive<Q, V>(
+            memoize<Q, V | null>(
+                batchify<Q, V>(bulkFetch, keyOf, keyOf),
+                keyOf,
+            ),
+            keyOf,
+        );
+    }
+
+    it('500 .get() calls in one tick → 1 bulkFetch with 500 unique queries', async () => {
+        const bulkFetch = sinon.spy(async (qs: Q[]) =>
+            qs.map(q => ({ id: q.id, v: 'x' })),
+        );
+        const cache = buildCache(bulkFetch);
+        for (let i = 0; i < 500; i++) cache.get({ id: i });
+        await tick();
+        assert.equal(bulkFetch.callCount, 1);
+        assert.equal(bulkFetch.args[0][0].length, 500);
+    });
+
+    it('cache.get() across multiple frames re-uses memoized results', async () => {
+        const bulkFetch = sinon.spy(async (qs: Q[]) =>
+            qs.map(q => ({ id: q.id, v: 'x' })),
+        );
+        const cache = buildCache(bulkFetch);
+        cache.get({ id: 1 });
+        await tick();
+        // Re-render later asks for the same key: no new fetch.
+        cache.get({ id: 1 });
+        await tick();
+        assert.equal(bulkFetch.callCount, 1);
+    });
+
+    it('overlapping renders deduplicate keys but combine new ones', async () => {
+        const bulkFetch = sinon.spy(async (qs: Q[]) =>
+            qs.map(q => ({ id: q.id, v: 'x' })),
+        );
+        const cache = buildCache(bulkFetch);
+        // First render: ids 1..3
+        cache.get({ id: 1 });
+        cache.get({ id: 2 });
+        cache.get({ id: 3 });
+        await tick();
+        // Second render: ids 2..5 (some overlap)
+        cache.get({ id: 2 });
+        cache.get({ id: 3 });
+        cache.get({ id: 4 });
+        cache.get({ id: 5 });
+        await tick();
+        assert.equal(bulkFetch.callCount, 2);
+        // Second batch only includes the new keys (4, 5).
+        assert.deepEqual(
+            bulkFetch.args[1][0].map((q: Q) => q.id),
+            [4, 5],
+        );
+    });
+});

--- a/src/shared/lib/batchedFetch.ts
+++ b/src/shared/lib/batchedFetch.ts
@@ -1,0 +1,119 @@
+// Three independent primitives for composing fetch behavior.
+// Compose them when a caller needs more than one (see VariantCountCache).
+//
+// Why three pieces instead of one fused helper:
+// each addresses a distinct concern, and most callers in this codebase
+// only need one or two of them. Mixing them at use-site (rather than
+// pre-bundling) means cache classes don't have to inherit from anything.
+//
+//   batchify : turn a bulk endpoint into a single-item function that
+//              auto-coalesces concurrent calls within one microtask tick.
+//              No caching, no MobX. (DataLoader pattern.)
+//
+//   memoize  : promise-level dedup. Same key in flight or resolved →
+//              same Promise. Rejections evict so retries are possible.
+//
+//   reactive : wrap a Promise-returning fn so callers can read it
+//              synchronously during MobX render (returns null while
+//              fetching, observable.box flips when it resolves).
+
+import { observable, runInAction } from 'mobx';
+
+export function batchify<Q, V>(
+    bulkFetch: (queries: Q[]) => Promise<V[]>,
+    queryKey: (q: Q) => string,
+    resultKey: (v: V) => string,
+): (q: Q) => Promise<V | null> {
+    type Pending = {
+        query: Q;
+        resolve: (v: V | null) => void;
+        reject: (err: unknown) => void;
+    };
+    let queue: Pending[] = [];
+    let scheduled = false;
+
+    const flush = async () => {
+        scheduled = false;
+        const batch = queue;
+        queue = [];
+        try {
+            const results = await bulkFetch(batch.map(p => p.query));
+            const byKey = new Map(results.map(r => [resultKey(r), r]));
+            for (const p of batch) {
+                const v = byKey.get(queryKey(p.query));
+                p.resolve(v !== undefined ? v : null);
+            }
+        } catch (err) {
+            for (const p of batch) p.reject(err);
+        }
+    };
+
+    return query =>
+        new Promise<V | null>((resolve, reject) => {
+            queue.push({ query, resolve, reject });
+            if (!scheduled) {
+                scheduled = true;
+                Promise.resolve().then(flush);
+            }
+        });
+}
+
+export function memoize<Q, V>(
+    fn: (q: Q) => Promise<V>,
+    keyOf: (q: Q) => string,
+): (q: Q) => Promise<V> {
+    const cache = new Map<string, Promise<V>>();
+    return query => {
+        const key = keyOf(query);
+        let p = cache.get(key);
+        if (!p) {
+            p = fn(query).catch(err => {
+                cache.delete(key); // evict failures so callers can retry
+                throw err;
+            });
+            cache.set(key, p);
+        }
+        return p;
+    };
+}
+
+export type ReactiveEntry<V> =
+    | { status: 'complete'; data: V | null }
+    | { status: 'error'; data: null };
+
+export interface ReactiveCache<Q, V> {
+    get(query: Q): ReactiveEntry<V> | null;
+}
+
+export function reactive<Q, V>(
+    fn: (q: Q) => Promise<V | null>,
+    keyOf: (q: Q) => string,
+): ReactiveCache<Q, V> {
+    const state = observable.box<{ [key: string]: ReactiveEntry<V> }>(
+        {},
+        { deep: false },
+    );
+    const inflight = new Set<string>();
+
+    const settle = (key: string, entry: ReactiveEntry<V>) =>
+        runInAction(() => {
+            state.set({ ...state.get(), [key]: entry });
+            inflight.delete(key);
+        });
+
+    return {
+        get(query) {
+            const key = keyOf(query);
+            const existing = state.get()[key];
+            if (existing) return existing;
+            if (!inflight.has(key)) {
+                inflight.add(key);
+                fn(query).then(
+                    data => settle(key, { status: 'complete', data }),
+                    () => settle(key, { status: 'error', data: null }),
+                );
+            }
+            return null;
+        },
+    };
+}


### PR DESCRIPTION
## Replaces #5563

Same goal — propose a replacement for the \`LazyMobXCache\` hierarchy — but factored differently per review feedback. The previous PoC bundled batching, dedup, and MobX reactivity into one fused helper. This version splits them into three independent primitives so each cache only opts into the concerns it needs.

## Three primitives, ~120 lines total

\`\`\`ts
// src/shared/lib/batchedFetch.ts

batchify(bulkFetch, queryKey, resultKey)
  // Turns a bulk endpoint into a single-item function. Concurrent calls
  // within one microtask tick collapse into one bulkFetch call.
  // No caching, no MobX. (DataLoader pattern.)

memoize(fn, keyOf)
  // Promise-level dedup. Same key in flight or already resolved → same
  // Promise. Rejections evict so retries work.

reactive(fn, keyOf)
  // Wraps a Promise-returning fn in a MobX observable.box so callers can
  // read it synchronously during render. \`get(q)\` returns null while
  // fetching, then flips to {status, data} reactively when it resolves.
\`\`\`

Each cache then composes the layers it needs:

\`\`\`ts
// src/shared/cache/VariantCountCache.ts (post-migration)
const fetchOne = memoize(
    batchify(
        qs => client.fetchVariantCountsUsingPOST({ ... }),
        keyOf, keyOf,
    ),
    keyOf,
);
return reactive(fetchOne, keyOf);
\`\`\`

A cache that doesn't need batching skips \`batchify\`. A cache that doesn't need MobX skips \`reactive\` and uses the bare Promise-returning function. Etc.

## Why this is better than the v1 fused helper

| | v1 (#5563, closed) | v2 (this PR) |
|---|---|---|
| Primitives | 1 fused \`createBatchedReactiveFetch\` | 3 generic, named primitives |
| Pattern recognition | Custom thing | DataLoader + memoize + observable wrapper |
| Reactivity is replaceable | No, baked in | Yes, swap \`reactive\` for a different reactivity story |
| Each layer separately testable | No | Yes (4 tests per layer + 3 composition tests) |
| LOC for primitives | ~50 | ~120 (more, but each piece is smaller and self-contained) |
| LOC per migrated cache | ~30 | ~25 |

## Diff
+378 / -38 across 6 files. The bulk of the new lines are the three primitives plus 15 tests.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] 15 new unit tests in \`batchedFetch.spec.ts\` pass — 4 each for batchify/memoize/reactive plus 3 composition tests proving \`reactive(memoize(batchify(...)))\` collapses 500 in-tick calls into 1 fetch with full memoization across renders
- [x] Existing \`LazyMobXCache.spec.ts\` still passes (old infra unchanged)
- [x] Both \`CohortColumnFormatter\` specs pass (37 tests total in the relevant slice)
- [ ] Manual smoke: open a patient view, verify Cohort column still renders frequencies correctly (needs a reviewer with a working dev env)
- [ ] CI green

## What's intentionally NOT in this PR
- The other 18 LazyMobXCache subclasses
- \`LazyMobXCache.ts\`, \`SampleGeneCache.ts\`, \`SimpleCache.ts\` — untouched
- A cache-level helper that bundles all three primitives. If you find yourself writing the same 4-line \`reactive(memoize(batchify(...)))\` recipe in 18 places, that's the natural moment to add a convenience wrapper. We're not there yet.

## Review questions
1. **API shape.** \`batchify(bulkFetch, queryKey, resultKey)\` requires both a query key and a result key because results in the bulk response may have a different shape from queries. Reasonable, or worth simplifying for the common case where they're equal?
2. **Should \`memoize\` be unbounded?** It currently holds every resolved Promise forever. For caches that live for the lifetime of a page store this is fine; for caches with very wide query spaces it could leak. The current \`LazyMobXCache\` has the same behavior.
3. **Microtask-tick batching window** vs. \`accumulatingDebounce\` (delay 0). Behaviorally equivalent in practice — both fire on the next macrotask boundary — but worth flagging.

## If approved, follow-ups
Each migrating one or two caches:
1. Per-row hot paths: \`MrnaExprRankCache\`, \`DiscreteCNACache\`, \`MutationCountCache\`, \`CopyNumberCountCache\`
2. \`getPromise\`-using sites (oncoprint/plots): need a small \`getPromise\`-style helper or inlined \`Promise.all\`
3. Remaining incidental caches — most can probably skip \`batchify\` entirely

Once all subclasses are migrated, the LazyMobXCache hierarchy and ~20 wrapper files can be deleted in a final cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->