### PR TITLE
Address e2e flakery in remote e2e (playwright)

### DIFF
--- a/end-to-end-test-playwright/tests/helpers/results-screenshots.ts
+++ b/end-to-end-test-playwright/tests/helpers/results-screenshots.ts
@@ -219,7 +219,14 @@ export function runResultsTestSuite(
                 .click();
             await expect(
                 page.locator('div[data-test="ComparisonPageClinicalTabDiv"]')
-            ).toBeVisible();
+            ).toBeVisible({ timeout: 30000 });
+            // Kruskal-Wallis stats render asynchronously after the
+            // tab activates — snapshotting before the network is
+            // quiet captures an in-flight state and produces the
+            // ~17,902-pixel diff we see flaking in CI. Sibling
+            // 'comparison alterations sample mode' below already
+            // uses this pattern.
+            await waitForNetworkQuiet(page);
             await snapshot(
                 page,
                 'div[data-test="ComparisonTabDiv"]',

--- a/end-to-end-test-playwright/tests/quick-search.spec.ts
+++ b/end-to-end-test-playwright/tests/quick-search.spec.ts
@@ -59,6 +59,16 @@ test.describe('Quick Search', () => {
             .locator('strong', { hasText: 'AdCC11T' })
             .first()
             .click();
-        await expect(page.locator('a', { hasText: 'AdCC11T' })).toBeVisible();
+        // The patient page renders multiple anchors containing the
+        // sample id (header link, breadcrumb, sample table row, …),
+        // so a bare `locator('a', { hasText: 'AdCC11T' })` matches
+        // more than one element and fails Playwright's strict-mode
+        // visibility assertion. We just need to confirm the
+        // navigation landed; any matching anchor is fine. 60s
+        // timeout matches the sibling `shows gene results` test
+        // since the patient view loads from the live API.
+        await expect(
+            page.locator('a', { hasText: 'AdCC11T' }).first()
+        ).toBeVisible({ timeout: 60000 });
     });
 });

--- a/end-to-end-test-playwright/tests/studyview.spec.ts
+++ b/end-to-end-test-playwright/tests/studyview.spec.ts
@@ -136,6 +136,27 @@ test.describe('studyview tests', () => {
             page = await browser.newPage({
                 viewport: { width: 1600, height: 1000 },
             });
+            // The study-summary "raw data download" icon's visibility
+            // is gated on a fetch of study_list.json from
+            // datahub.assets.cbioportal.org. From CI's network path
+            // that fetch sometimes never lands; when it doesn't, the
+            // hasRawDataForDownload remoteData call falls back to
+            // false and the icon stays hidden — so the test fails
+            // even after waiting 30s. Stub the manifest at the page
+            // level with a known-good payload that includes
+            // laml_tcga, matching the JSON-array shape the real
+            // endpoint returns. Other tests in this block aren't
+            // affected because none of them assert on the icon.
+            await page.route('**/study_list.json', route =>
+                route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify([
+                        'laml_tcga',
+                        'laml_tcga_pan_can_atlas_2018',
+                    ]),
+                })
+            );
             await page.goto('/study?id=laml_tcga');
         });
         test.afterAll(async () => {
@@ -168,9 +189,22 @@ test.describe('studyview tests', () => {
 
         test('study should have the raw data available', async () => {
             await toStudyViewSummaryTab(page);
+            // The download icon's visibility is gated on the
+            // StudyViewPageStore.hasRawDataForDownload remoteData
+            // request, which fetches a separate study-list manifest
+            // via getStudyDownloadListUrl(). That request goes through
+            // `request(...)` (superagent), which is not tracked by
+            // window.ajaxQuiet — so waitForNetworkQuiet can return
+            // green while the manifest is still in flight, and the
+            // icon stays hidden. Belt and suspenders:
+            //   1) waitForNetworkQuiet for the main summary fetches.
+            //   2) WAIT_FOR_VISIBLE_TIMEOUT on toHaveCount to absorb
+            //      the trailing manifest request landing late on
+            //      cold-cache CI.
+            await waitForNetworkQuiet(page);
             await expect(
                 page.locator(STUDY_SUMMARY_RAW_DATA_DOWNLOAD)
-            ).toHaveCount(1);
+            ).toHaveCount(1, { timeout: WAIT_FOR_VISIBLE_TIMEOUT });
         });
 
         test('when quickly adding charts, each chart should get proper data.', async () => {


### PR DESCRIPTION
## Summary

Three minimal fixes for cross-run flaky tests surfaced by the `analyze_flakes` job (#5566). Each addresses a specific, identifiable root cause — no `waitForTimeout`, no arbitrary sleeps. Validated across 20 sequential `remote_e2e` pipelines on this branch; the final five (#17509–#17513) are all green with all three named tests passing. Each commit is scoped to one test file and is independently revertable.

## The three fixes

| Test | File | Root cause | Fix |
|---|---|---|---|
| `shows patient results` | `quick-search.spec.ts` | Patient page has multiple anchors matching the sample id (header link / breadcrumb / sample table row); strict-mode `toBeVisible` rejects >1 match | `.first()` + 60s timeout to match the sibling `shows gene results` test |
| `comparison clinical` | `helpers/results-screenshots.ts` | Kruskal-Wallis stats render asynchronously after the tab activates; the snapshot captures an in-flight state (~17,902-pixel diff) | `waitForNetworkQuiet(page)` before snapshot (same pattern as sibling `comparison alterations sample mode`) + 30s `toBeVisible` timeout |
| `study should have the raw data available` | `studyview.spec.ts` | Icon visibility is gated on a manifest fetch to `datahub.assets.cbioportal.org/study_list.json`. That fetch is unreachable from CI's network path often enough that the test fails ~half the time regardless of timeout — the remoteData call's `.catch` returns an empty body and the icon never renders | Stub the manifest at the page-route level before navigation with a known-good JSON array that includes `laml_tcga` |

## Not in this PR

- The remaining cross-run flakes (oncoprint screenshot race, PathwayMapper SVG layout drift, `studyview` filter-removal timeout, etc.) — those need a per-component "wait for stable" helper that's bigger than this PR's scope. Leaving for a follow-up batch.
- An earlier draft included an oncoprint fix that incorrectly used a `.oncoprintTrack` DOM selector (the tracks render to Canvas, not the DOM) — reverted before this PR was cleaned up.

## Test plan

- [x] Run `remote_e2e` on this branch. 5 consecutive greens on the final state (#17509–#17513).
- [ ] After merge, watch the next 5–10 PR pipelines and confirm none of the three named tests reappear in `flake-report.md`'s top-fail list.
- [ ] If any fix masks a real bug (e.g., `.first()` papering over a regression in the patient view), revert that single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
