### PR TITLE
Playwright e2e: caching MITM proxy with cross-shard merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,6 +361,14 @@ jobs:
       # Optional grep filter for targeted smoke runs. Empty by default →
       # whole suite runs. Set to e.g. 'patient-screenshot' to narrow.
       PLAYWRIGHT_GREP: ''
+      # Cache repeat requests to *.cbioportal.org through a local
+      # mitmdump backed by a SQLite file. restore_cache (below) seeds
+      # the file from a previous workflow run; the merge_playwright_cache
+      # job unions all 12 shards' contributions back into one for the
+      # next workflow. See end-to-end-test-playwright/proxy/cache_addon.py
+      # for the addon and proxy/merge_cache.py for the union step.
+      PW_CACHE_PROXY: '1'
+      PW_CACHE_DB: /tmp/pw-cache/cache.sqlite
     steps:
       - attach_workspace:
           at: /tmp/repo
@@ -390,6 +398,17 @@ jobs:
           # --frozen-lockfile: fail if pnpm-lock.yaml would change,
           # the pnpm equivalent of `npm ci`.
           command: pnpm install --frozen-lockfile --ignore-workspace
+      # Restore the response-cache SQLite file (if any prior workflow
+      # run produced one). The `keys:` list is tried in order; the
+      # first matching cache is used. We prefer branch-local caches
+      # because feature branches may hit different URLs than master,
+      # but fall back to master and finally to any v1 cache.
+      - restore_cache:
+          name: Restore playwright response cache
+          keys:
+            - playwright-cache-v1-{{ .Branch }}-
+            - playwright-cache-v1-master-
+            - playwright-cache-v1-
       - run:
           name: Start frontend dev server (pnpm serveDist) on localhost:3000
           background: true
@@ -429,6 +448,16 @@ jobs:
                 GREP_ARG="--grep=$PLAYWRIGHT_GREP"
                 echo "Filtering with --grep=$PLAYWRIGHT_GREP"
             fi
+            # When PW_CACHE_PROXY=1, route the playwright invocation
+            # through scripts/run-with-cache-proxy.sh, which spins up a
+            # local mitmdump that caches *.cbioportal.org responses for
+            # the lifetime of this shard. Cache is per-process — each
+            # shard is its own container and starts with an empty cache.
+            if [ "${PW_CACHE_PROXY:-0}" = "1" ]; then
+              PW_RUNNER=(./scripts/run-with-cache-proxy.sh)
+            else
+              PW_RUNNER=(pnpm exec playwright test)
+            fi
             set +e
             # --workers=3 on resource_class large (4 vCPU / 8 GB) leaves
             # one vCPU for the runner / serveDist while running 3 chromium
@@ -436,7 +465,7 @@ jobs:
             # (CPU-bound contention with serveDist + runner sharing the
             # 4th core). Only describes opted into mode: 'parallel'
             # actually use the extra workers; the rest still serialize.
-            pnpm exec playwright test --workers=3 \
+            "${PW_RUNNER[@]}" --workers=3 \
               --shard="${SHARD_NUM}/${CIRCLE_NODE_TOTAL}" \
               --reporter=list,junit,blob \
               $GREP_ARG
@@ -458,6 +487,26 @@ jobs:
               echo "playwright exit: 0 (this shard passed)"
             fi
             exit 0
+      # Persist this shard's cache.sqlite under a per-shard filename so
+      # the merge_playwright_cache job can union them all. The
+      # `exit 0` above means this step runs regardless of test
+      # pass/fail. cp is guarded in case the cache file is missing
+      # — e.g. when a shard crashes before producing any response.
+      - run:
+          name: Stage shard cache for workspace
+          command: |
+            mkdir -p /tmp/pw-cache-shards
+            if [ -f /tmp/pw-cache/cache.sqlite ]; then
+              cp /tmp/pw-cache/cache.sqlite \
+                 "/tmp/pw-cache-shards/cache-${CIRCLE_NODE_INDEX}.sqlite"
+              ls -la /tmp/pw-cache-shards/
+            else
+              echo "No /tmp/pw-cache/cache.sqlite to stage."
+            fi
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - pw-cache-shards
       - store_test_results:
           path: /tmp/repo/cbioportal-frontend/end-to-end-test-playwright/test-results
       - store_artifacts:
@@ -721,6 +770,50 @@ jobs:
           destination: test-results
       - store_test_results:
           path: /tmp/repo/cbioportal-frontend/end-to-end-test-playwright/test-results
+
+  # Unions the 12 per-shard cache.sqlite files produced by
+  # remote_e2e_shards into a single file and persists it via save_cache
+  # under a branch-scoped key. The shards job's restore_cache picks the
+  # most recent matching key on the next workflow run, so each run
+  # starts hot with the union of every shard's previous contributions.
+  #
+  # Wired with `requires: [remote_e2e_shards]` (not the API-polling
+  # pattern remote_e2e uses) on purpose: if any shard is red, the
+  # workflow's tests are broken and we don't want to expand the cache
+  # with potentially-wrong responses. The next green run will refresh
+  # it. Skipping cache updates on red runs is a feature.
+  merge_playwright_cache:
+    docker:
+      - image: ghcr.io/cbioportal/cbioportal-frontend-playwright-ci:v1.59.1-jammy
+    resource_class: small
+    working_directory: /tmp/repo
+    environment:
+      HOME: /tmp
+    steps:
+      # Source comes via the workspace persisted by build_frontend; the
+      # shards job adds pw-cache-shards/ to the same workspace tree.
+      - attach_workspace:
+          at: /tmp/repo
+      - run:
+          name: Merge per-shard cache.sqlite files
+          command: |
+            mkdir -p /tmp/pw-cache
+            python3 cbioportal-frontend/end-to-end-test-playwright/proxy/merge_cache.py \
+              /tmp/repo/pw-cache-shards \
+              /tmp/pw-cache/cache.sqlite
+            ls -la /tmp/pw-cache/
+      - save_cache:
+          name: Save merged playwright cache
+          # epoch in the key makes each run write a fresh entry rather
+          # than colliding with the existing key (which save_cache would
+          # silently no-op). restore_cache uses the prefix and picks
+          # the most recent, so older entries naturally age out.
+          key: playwright-cache-v1-{{ .Branch }}-{{ epoch }}
+          paths:
+            - /tmp/pw-cache/cache.sqlite
+      - store_artifacts:
+          path: /tmp/pw-cache/cache.sqlite
+          destination: cache.sqlite
 
   analyze_flakes:
     # Read-only post-step that surfaces tests whose pass/fail outcome
@@ -1593,6 +1686,16 @@ workflows:
       # uses CircleCI's public workflow API (no auth), so this works on
       # fork PRs too.
       - remote_e2e
+      # Unions all 12 shard caches into one file and save_caches it for
+      # the next workflow run. Requires green shards (see comment on
+      # the job for why).
+      - merge_playwright_cache:
+          requires:
+            # Need build_frontend so the workspace carries the source
+            # (merge_cache.py). And remote_e2e_shards for the per-shard
+            # cache.sqlite files.
+            - build_frontend
+            - remote_e2e_shards
       # Read-only post-step on remote_e2e: detects cross-run flakes
       # (pass in some PRs, fail in others) and writes a Claude-authored
       # analysis as a build artifact. Runs after remote_e2e so this

--- a/.circleci/images/playwright/Dockerfile
+++ b/.circleci/images/playwright/Dockerfile
@@ -19,10 +19,20 @@
 
 FROM mcr.microsoft.com/playwright:v1.59.1-jammy
 
-# Install jq (used by scripts/env_vars.sh to parse the GitHub API response when
-# resolving the PR's base branch).
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends jq \
+# Install jq (used by scripts/env_vars.sh to parse the GitHub API response
+# when resolving the PR's base branch) and mitmproxy via pip (used by
+# end-to-end-test-playwright/scripts/run-with-cache-proxy.sh to cache repeat
+# requests to *.cbioportal.org during a single test run; see that script's
+# header for the wiring).
+#
+# Why pip rather than apt: Ubuntu jammy ships mitmproxy 6.0.2, which has
+# unreliable HTTP/2 + addon-hook firing on modern Chromium TLS. The pip
+# release (11.x at time of writing) has a working request/response hook
+# pipeline. DEBIAN_FRONTEND=noninteractive prevents tzdata (pulled in
+# transitively by python3-pip) from blocking on its interactive prompt.
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq python3-pip \
+    && pip3 install --no-cache-dir 'mitmproxy>=11,<12' \
     && rm -rf /var/lib/apt/lists/*
 
 # Enable corepack so the `pnpm` shim is on PATH, then pre-fetch and activate

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -41,6 +41,18 @@ const updateSnapshots = process.env.PW_UPDATE_SNAPSHOTS as
 // 5+ minutes to slow shards. The localdb job opts in via PW_LOCAL=1.
 const includeLocalDb = process.env.PW_LOCAL === '1';
 
+// When scripts/run-with-cache-proxy.sh is in play, HTTPS_PROXY points
+// at a local mitmdump that caches *.cbioportal.org responses for the
+// duration of a single test run. Routing Playwright's browser through
+// it requires (a) the proxy server setting and (b) accepting the
+// proxy's self-signed CA — easier than installing the CA into Chromium.
+const proxyServer = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+const proxy = proxyServer ? { server: proxyServer } : undefined;
+if (proxy) {
+    // eslint-disable-next-line no-console
+    console.log(`[playwright.config] routing through proxy ${proxy.server}`);
+}
+
 export default defineConfig({
     testDir: './tests',
     testIgnore: includeLocalDb ? [] : ['**/local/**'],
@@ -80,7 +92,8 @@ export default defineConfig({
         video: 'retain-on-failure',
         actionTimeout: 15_000,
         navigationTimeout: 60_000,
-        ...(isLocaldev && { ignoreHTTPSErrors: true }),
+        ...((isLocaldev || proxy) && { ignoreHTTPSErrors: true }),
+        ...(proxy && { proxy }),
     },
 
     projects: [
@@ -106,6 +119,24 @@ export default defineConfig({
                         '--disable-font-subpixel-positioning',
                         '--disable-lcd-text',
                         '--font-render-hinting=none',
+                        // When routed through scripts/run-with-cache-proxy.sh,
+                        // mitmdump presents a self-signed cert generated on
+                        // first use. Chromium gates proxy/MITM certs *before*
+                        // Playwright's context-level ignoreHTTPSErrors gets a
+                        // chance to respond to the CDP request, so the only
+                        // reliable way to make TLS interception work is the
+                        // launch-level --ignore-certificate-errors flag.
+                        // We also pass --proxy-server here in addition to
+                        // use.proxy: in chromium-headless-shell builds the
+                        // CDP-level proxy setting (use.proxy) was observed to
+                        // silently no-op for HTTPS traffic, while the
+                        // launch-level switch is honoured reliably.
+                        ...(proxy
+                            ? [
+                                  '--ignore-certificate-errors',
+                                  `--proxy-server=${proxy.server}`,
+                              ]
+                            : []),
                         ...(isLocaldev
                             ? [
                                   // Private Network Access + the newer

--- a/end-to-end-test-playwright/proxy/.gitignore
+++ b/end-to-end-test-playwright/proxy/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/end-to-end-test-playwright/proxy/Dockerfile.overlay
+++ b/end-to-end-test-playwright/proxy/Dockerfile.overlay
@@ -1,0 +1,27 @@
+# Thin overlay used only for local development while the canonical CI
+# image (.circleci/images/playwright/Dockerfile) is being rebuilt with
+# mitmproxy baked in. Build once:
+#
+#   docker build --platform linux/amd64 \
+#     -f end-to-end-test-playwright/proxy/Dockerfile.overlay \
+#     -t cbioportal-frontend-playwright-ci:cache-local \
+#     end-to-end-test-playwright/proxy
+#
+# Then run the suite via:
+#
+#   PW_CACHE_PROXY=1 \
+#   PW_CACHE_IMAGE=cbioportal-frontend-playwright-ci:cache-local \
+#   ./scripts/docker-test.sh tests/your-spec.ts
+#
+# Once the GHCR image is republished, drop this overlay and the
+# PW_CACHE_IMAGE override.
+FROM ghcr.io/cbioportal/cbioportal-frontend-playwright-ci:v1.59.1-jammy
+USER root
+# Ubuntu jammy's apt mitmproxy is 6.0.2, which has known HTTP/2 +
+# addon-hook reliability issues. pip pulls a current release (11.x at
+# time of writing) with a working request/response hook pipeline. Pin
+# loosely so security backports flow in.
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-pip \
+    && pip3 install --no-cache-dir 'mitmproxy>=11,<12' \
+    && rm -rf /var/lib/apt/lists/*

--- a/end-to-end-test-playwright/proxy/cache_addon.py
+++ b/end-to-end-test-playwright/proxy/cache_addon.py
@@ -1,0 +1,238 @@
+"""
+mitmproxy addon: caching forward proxy for the Playwright e2e suite.
+
+Loaded by `mitmdump -s proxy/cache_addon.py` via scripts/run-with-cache-proxy.sh.
+Two cache tiers:
+
+  • L1 — in-process dict, populated on every response and consulted
+    first. Survives only for the lifetime of the mitmdump process
+    (i.e. one shard / one local run).
+  • L2 — optional SQLite file at PW_CACHE_DB. Consulted on L1 miss; new
+    entries are written through to disk. Multiple shards can each point
+    at the same restored copy of the file; the merge_playwright_cache
+    CircleCI job unions all shard outputs and re-saves the result so
+    the next workflow run starts with a populated cache.
+
+Configuration via env vars:
+  PW_CACHE_HOSTS      comma-separated host suffix allowlist
+                      (default: "cbioportal.org")
+  PW_CACHE_STATUSES   comma-separated cacheable status codes
+                      (default: "200,203,204,300,301,304,404")
+  PW_CACHE_LOG        "1" to log every hit/miss
+  PW_CACHE_DB         path to the SQLite cache file. Unset → L1 only.
+
+Design notes:
+  * Cache key is sha256(method + "\0" + url + "\0" + body). The body is
+    included so different POST /fetch payloads cache as separate entries.
+  * Set-Cookie is intentionally preserved on cached responses —
+    cbioportal's session (JSESSIONID) needs to survive cache replays.
+  * Content-Encoding / Content-Length / Transfer-Encoding are dropped
+    because we store flow.response.content (already decoded by
+    mitmproxy); leaving those headers would lie about the wire format.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import threading
+from typing import Dict, Optional, Tuple
+
+from mitmproxy import http
+
+# mitmproxy 11.x removed ctx.log in favour of stdlib logging. Configure a
+# named logger so [cache] lines are clearly attributable in the mitmdump
+# output (and survive any termlog filter).
+log = logging.getLogger("cache")
+log.setLevel(logging.INFO)
+
+
+def _env_list(name: str, default: str) -> list[str]:
+    # Treat an empty env var the same as an unset one — docker-test.sh
+    # forwards env vars as `-e NAME="${NAME:-}"`, which materialises as
+    # an empty string inside the container when the host left it unset.
+    raw = os.environ.get(name) or default
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+ALLOWED_HOST_SUFFIXES = tuple(_env_list("PW_CACHE_HOSTS", "cbioportal.org"))
+CACHEABLE_STATUSES = frozenset(
+    int(s) for s in _env_list("PW_CACHE_STATUSES", "200,203,204,300,301,304,404")
+)
+LOG_ENABLED = os.environ.get("PW_CACHE_LOG") == "1"
+DB_PATH = os.environ.get("PW_CACHE_DB") or None
+
+
+def _log(msg: str) -> None:
+    if LOG_ENABLED:
+        log.warning(f"[cache] {msg}")
+
+
+def _host_allowed(host: str) -> bool:
+    host = host.lower()
+    return any(
+        host == suffix or host.endswith("." + suffix)
+        for suffix in ALLOWED_HOST_SUFFIXES
+    )
+
+
+def _cache_key(flow: http.HTTPFlow) -> str:
+    req = flow.request
+    h = hashlib.sha256()
+    h.update(req.method.encode("utf-8"))
+    h.update(b"\0")
+    h.update(req.url.encode("utf-8"))
+    h.update(b"\0")
+    h.update(req.raw_content or b"")
+    return h.hexdigest()
+
+
+_HEADERS_TO_DROP = ("content-encoding", "content-length", "transfer-encoding")
+
+
+def _clean_headers(headers: http.Headers) -> http.Headers:
+    cleaned = headers.copy()
+    for name in _HEADERS_TO_DROP:
+        if name in cleaned:
+            del cleaned[name]
+    return cleaned
+
+
+# --- header (de)serialisation for the SQLite tier ---------------------
+# mitmproxy stores headers as a list of (bytes, bytes) tuples. We encode
+# them as a JSON list of [str, str] pairs using latin-1, which is a
+# lossless round-trip for any byte sequence and keeps the on-disk format
+# trivially diff-able if someone needs to inspect the cache file.
+
+def _headers_to_json(headers: http.Headers) -> str:
+    return json.dumps(
+        [[k.decode("latin-1"), v.decode("latin-1")] for k, v in headers.fields]
+    )
+
+
+def _headers_from_json(s: str) -> http.Headers:
+    return http.Headers(
+        [(k.encode("latin-1"), v.encode("latin-1")) for k, v in json.loads(s)]
+    )
+
+
+class ResponseCache:
+    def __init__(self) -> None:
+        self._store: Dict[str, Tuple[int, http.Headers, bytes]] = {}
+        self._lock = threading.Lock()
+        self._hits = 0
+        self._db_hits = 0
+        self._misses = 0
+        self._stored = 0
+        self._db: Optional[sqlite3.Connection] = None
+        if DB_PATH:
+            parent = os.path.dirname(DB_PATH)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            # check_same_thread=False because mitmproxy may dispatch
+            # hooks from worker threads in some flow types. isolation
+            # level=None puts SQLite in autocommit so each INSERT is
+            # durable without an explicit commit() — cheap insurance
+            # against losing entries if mitmdump is force-killed.
+            self._db = sqlite3.connect(
+                DB_PATH, check_same_thread=False, isolation_level=None
+            )
+            self._db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cache (
+                    key TEXT PRIMARY KEY,
+                    status INTEGER NOT NULL,
+                    headers TEXT NOT NULL,
+                    body BLOB NOT NULL
+                )
+                """
+            )
+            log.warning(f"[cache] SQLite backing enabled at {DB_PATH}")
+
+    def _db_get(
+        self, key: str
+    ) -> Optional[Tuple[int, http.Headers, bytes]]:
+        if self._db is None:
+            return None
+        row = self._db.execute(
+            "SELECT status, headers, body FROM cache WHERE key = ?", (key,)
+        ).fetchone()
+        if row is None:
+            return None
+        status, headers_json, body = row
+        return status, _headers_from_json(headers_json), body
+
+    def _db_put(
+        self, key: str, status: int, headers: http.Headers, body: bytes
+    ) -> None:
+        if self._db is None:
+            return
+        try:
+            self._db.execute(
+                "INSERT OR IGNORE INTO cache (key, status, headers, body) "
+                "VALUES (?, ?, ?, ?)",
+                (key, status, _headers_to_json(headers), body),
+            )
+        except sqlite3.Error as exc:
+            log.warning(f"[cache] sqlite write failed for {key[:12]}: {exc}")
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        if not _host_allowed(flow.request.host):
+            return
+        key = _cache_key(flow)
+        with self._lock:
+            entry = self._store.get(key)
+        if entry is not None:
+            self._hits += 1
+            _log(f"hit    {flow.request.method} {flow.request.url}")
+        else:
+            entry = self._db_get(key)
+            if entry is not None:
+                with self._lock:
+                    self._store[key] = entry
+                self._db_hits += 1
+                _log(f"db-hit {flow.request.method} {flow.request.url}")
+        if entry is None:
+            self._misses += 1
+            _log(f"miss   {flow.request.method} {flow.request.url}")
+            return
+        status, headers, body = entry
+        flow.response = http.Response.make(status, body, headers)
+
+    def response(self, flow: http.HTTPFlow) -> None:
+        if flow.response is None:
+            return
+        if not _host_allowed(flow.request.host):
+            return
+        if flow.response.status_code not in CACHEABLE_STATUSES:
+            return
+        key = _cache_key(flow)
+        with self._lock:
+            if key in self._store:
+                return  # already cached, don't overwrite with the replay
+            headers = _clean_headers(flow.response.headers)
+            body = flow.response.content or b""
+            self._store[key] = (flow.response.status_code, headers, body)
+            self._stored += 1
+        self._db_put(key, flow.response.status_code, headers, body)
+        _log(f"store  {flow.request.method} {flow.request.url}")
+
+    def done(self) -> None:
+        total = self._hits + self._db_hits + self._misses
+        log.warning(
+            f"[cache] summary: {self._hits} L1 hits / {self._db_hits} L2 hits / "
+            f"{self._misses} misses ({total} allowlisted requests), "
+            f"{self._stored} entries newly stored. "
+            f"allowlist={list(ALLOWED_HOST_SUFFIXES)} db={DB_PATH or '(none)'}"
+        )
+        if self._db is not None:
+            try:
+                self._db.close()
+            except sqlite3.Error:
+                pass
+
+
+addons = [ResponseCache()]

--- a/end-to-end-test-playwright/proxy/merge_cache.py
+++ b/end-to-end-test-playwright/proxy/merge_cache.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Merge per-shard SQLite caches produced by the Playwright shards into a
+single union file that the merge_playwright_cache CircleCI job hands
+back to save_cache. INSERT OR IGNORE keeps the first occurrence of each
+key — duplicates across shards (anything they all hit) cost nothing.
+
+Usage:  merge_cache.py <shards-dir> <output-path>
+
+The shards-dir is expected to contain one or more *.sqlite files
+(typically pw-cache-shards/cache-${CIRCLE_NODE_INDEX}.sqlite), each
+with the same schema as proxy/cache_addon.py creates. A missing or
+empty shards-dir is not an error — it just produces an empty merged
+file, which the next workflow run will populate from scratch.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sqlite3
+import sys
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS cache (
+    key TEXT PRIMARY KEY,
+    status INTEGER NOT NULL,
+    headers TEXT NOT NULL,
+    body BLOB NOT NULL
+)
+"""
+
+
+def main(shards_dir: str, output_path: str) -> int:
+    out_parent = os.path.dirname(output_path)
+    if out_parent:
+        os.makedirs(out_parent, exist_ok=True)
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    dst = sqlite3.connect(output_path)
+    dst.execute(SCHEMA)
+
+    # Exclude the output file in case it lives inside shards_dir (glob
+    # is happy to pick it up otherwise and SQLite then refuses to read
+    # it while we're writing to the same handle).
+    output_abs = os.path.abspath(output_path)
+    shard_files = sorted(
+        p for p in glob.glob(os.path.join(shards_dir, "*.sqlite"))
+        if os.path.abspath(p) != output_abs
+    )
+    if not shard_files:
+        print(f"[merge] no shard caches in {shards_dir}; writing empty file")
+        dst.commit()
+        dst.close()
+        return 0
+
+    total_rows = 0
+    for path in shard_files:
+        try:
+            src = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        except sqlite3.Error as exc:
+            print(f"[merge] skipping unreadable {path}: {exc}")
+            continue
+        try:
+            rows = src.execute(
+                "SELECT key, status, headers, body FROM cache"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            print(f"[merge] skipping {path} (no cache table?): {exc}")
+            src.close()
+            continue
+        src.close()
+        dst.executemany(
+            "INSERT OR IGNORE INTO cache (key, status, headers, body) "
+            "VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        print(f"[merge] {path}: {len(rows)} rows")
+        total_rows += len(rows)
+
+    dst.commit()
+    final_count = dst.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+    final_size = dst.execute(
+        "SELECT COALESCE(SUM(LENGTH(body)), 0) FROM cache"
+    ).fetchone()[0]
+    dst.close()
+
+    print(
+        f"[merge] merged {len(shard_files)} shard(s); "
+        f"{total_rows} rows in, {final_count} unique rows out "
+        f"({final_size / 1024 / 1024:.1f} MB body data)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <shards-dir> <output-path>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/end-to-end-test-playwright/scripts/docker-test.sh
+++ b/end-to-end-test-playwright/scripts/docker-test.sh
@@ -60,6 +60,22 @@ fi
 # Rosetta emulation. Passing --platform on amd64 hosts is harmless.
 PLATFORM_ARGS=(--platform linux/amd64)
 
+# When PW_CACHE_PROXY=1, route the inner command through the caching
+# mitmproxy wrapper (proxy/cache_addon.py). The wrapper script starts
+# mitmdump on 127.0.0.1:8888, exports HTTPS_PROXY, runs playwright,
+# and cleans up. The image must have mitmproxy installed
+# (.circleci/images/playwright/Dockerfile bakes it in); PW_CACHE_IMAGE
+# lets developers point at a local overlay tag while waiting for that
+# image to republish.
+PW_CACHE_PROXY="${PW_CACHE_PROXY:-0}"
+if [[ "${PW_CACHE_PROXY}" == "1" ]]; then
+    IMAGE="${PW_CACHE_IMAGE:-$IMAGE}"
+    INNER_CMD=(./scripts/run-with-cache-proxy.sh "$@")
+    echo "Caching proxy: enabled (image=${IMAGE}, hosts=${PW_CACHE_HOSTS:-cbioportal.org})"
+else
+    INNER_CMD=(pnpm exec playwright test "$@")
+fi
+
 exec docker run --rm -i \
     "${PLATFORM_ARGS[@]}" \
     --ipc=host \
@@ -73,6 +89,10 @@ exec docker run --rm -i \
     -e CI="${CI:-}" \
     -e LOCALDEV="${LOCALDEV}" \
     -e PW_LOCAL="${PW_LOCAL:-}" \
+    -e PW_CACHE_PROXY="${PW_CACHE_PROXY}" \
+    -e PW_CACHE_HOSTS="${PW_CACHE_HOSTS:-}" \
+    -e PW_CACHE_STATUSES="${PW_CACHE_STATUSES:-}" \
+    -e PW_CACHE_LOG="${PW_CACHE_LOG:-}" \
     ${LOCALDEV_ARGS[@]+"${LOCALDEV_ARGS[@]}"} \
     "${IMAGE}" \
-    pnpm exec playwright test "$@"
+    "${INNER_CMD[@]}"

--- a/end-to-end-test-playwright/scripts/run-with-cache-proxy.sh
+++ b/end-to-end-test-playwright/scripts/run-with-cache-proxy.sh
@@ -23,9 +23,26 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 if ! command -v mitmdump >/dev/null 2>&1; then
-    echo "error: mitmdump not on PATH inside container — rebuild the CI image" >&2
-    echo "       (.circleci/images/playwright/Dockerfile installs it via pip)" >&2
-    exit 1
+    # The canonical CI image installs mitmproxy at build time (see
+    # .circleci/images/playwright/Dockerfile). On a PR whose Dockerfile
+    # change hasn't reached GHCR yet — typically the first run of a
+    # branch from a fork, since the image-rebuild workflow only fires
+    # on the main repo — install at runtime so we can still exercise
+    # the cache wiring. Once the canonical image is rebuilt this whole
+    # block is skipped because mitmdump is already on PATH.
+    echo "[proxy] mitmdump not present; installing via pip (one-time-per-container)..."
+    if ! command -v pip3 >/dev/null 2>&1; then
+        DEBIAN_FRONTEND=noninteractive apt-get update -qq \
+            && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-pip
+    fi
+    pip3 install --quiet --no-cache-dir 'mitmproxy>=11,<12' || {
+        echo "error: pip install mitmproxy failed" >&2
+        exit 1
+    }
+    command -v mitmdump >/dev/null 2>&1 || {
+        echo "error: mitmdump still missing after pip install" >&2
+        exit 1
+    }
 fi
 
 PROXY_HOST="${PW_CACHE_PROXY_HOST:-127.0.0.1}"

--- a/end-to-end-test-playwright/scripts/run-with-cache-proxy.sh
+++ b/end-to-end-test-playwright/scripts/run-with-cache-proxy.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Inner entrypoint that runs `playwright test` behind a local caching
+# MITM proxy.
+#
+# Started by scripts/docker-test.sh (and by the CircleCI playwright_e2e
+# jobs) when PW_CACHE_PROXY=1. It:
+#   1. starts mitmdump with proxy/cache_addon.py on 127.0.0.1:8888,
+#   2. waits for the proxy to accept connections,
+#   3. exports HTTPS_PROXY / HTTP_PROXY so Chromium (launched by
+#      Playwright) routes through it,
+#   4. runs `pnpm exec playwright test "$@"`,
+#   5. always kills the proxy on exit so the container shutdown is clean.
+#
+# HTTPS_PROXY/HTTP_PROXY are the source of truth: playwright.config.ts
+# reads them to set `use.proxy.server` *and* Chromium's launch-level
+# `--proxy-server` flag. Keeping the env var as the toggle means the
+# proxy can be enabled/disabled per-run without touching the config.
+# The launch-level flag is required on top of `use.proxy` because
+# chromium-headless-shell was observed to silently no-op the CDP-level
+# proxy setting for HTTPS traffic (see the comment in playwright.config.ts).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v mitmdump >/dev/null 2>&1; then
+    echo "error: mitmdump not on PATH inside container — rebuild the CI image" >&2
+    echo "       (.circleci/images/playwright/Dockerfile installs it via pip)" >&2
+    exit 1
+fi
+
+PROXY_HOST="${PW_CACHE_PROXY_HOST:-127.0.0.1}"
+PROXY_PORT="${PW_CACHE_PROXY_PORT:-8888}"
+ADDON="$(pwd)/proxy/cache_addon.py"
+
+# mitmproxy stores its generated CA + config in confdir. Put it under
+# /tmp so it works for non-root users and disappears with the container.
+MITM_CONFDIR="${MITM_CONFDIR:-/tmp/mitm-ca}"
+mkdir -p "$MITM_CONFDIR"
+
+echo "[proxy] starting mitmdump on ${PROXY_HOST}:${PROXY_PORT}"
+echo "[proxy] allowlist=${PW_CACHE_HOSTS:-cbioportal.org}"
+
+mitmdump \
+    -s "$ADDON" \
+    --listen-host "$PROXY_HOST" \
+    --listen-port "$PROXY_PORT" \
+    --set confdir="$MITM_CONFDIR" \
+    --set flow_detail=0 \
+    > /tmp/mitmdump.log 2>&1 &
+PROXY_PID=$!
+
+stop_proxy() {
+    if kill -0 "$PROXY_PID" 2>/dev/null; then
+        kill "$PROXY_PID" 2>/dev/null || true
+        wait "$PROXY_PID" 2>/dev/null || true
+    fi
+}
+# Belt-and-braces: if the script dies between starting the proxy and
+# the explicit stop_proxy below, EXIT still kills it.
+trap stop_proxy EXIT INT TERM
+
+# Wait for the proxy to bind. mitmdump prints "HTTP(S) proxy listening
+# at ..." once ready; we poll the TCP port instead because that's
+# language-agnostic.
+for _ in $(seq 1 50); do
+    if (echo > "/dev/tcp/${PROXY_HOST}/${PROXY_PORT}") 2>/dev/null; then
+        echo "[proxy] up"
+        break
+    fi
+    sleep 0.2
+done
+
+if ! (echo > "/dev/tcp/${PROXY_HOST}/${PROXY_PORT}") 2>/dev/null; then
+    echo "[proxy] failed to bind ${PROXY_HOST}:${PROXY_PORT}; mitmdump log:" >&2
+    cat /tmp/mitmdump.log >&2 || true
+    exit 1
+fi
+
+export HTTP_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
+export HTTPS_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
+
+set +e
+pnpm exec playwright test "$@"
+TEST_EXIT=$?
+set -e
+
+# Shut the proxy down BEFORE tailing the log: mitmproxy 11 buffers
+# its addon log output and only flushes on shutdown, so reading the
+# file while mitmdump is still running shows nothing.
+stop_proxy
+
+echo "[proxy] mitmdump summary + addon log lines:"
+grep -E "\[cache\]|Loading|HTTP\(S\) proxy|error|Error" /tmp/mitmdump.log \
+    || tail -n 30 /tmp/mitmdump.log \
+    || true
+
+exit "$TEST_EXIT"


### PR DESCRIPTION
## Summary

Adds an opt-in caching forward proxy in front of the Playwright suite so repeat requests to `*.cbioportal.org` are served from a SQLite-backed cache instead of hitting the live portal. Each CircleCI shard contributes to its own cache file; a new `merge_playwright_cache` job unions all 12 and `save_cache`s the result, so the next workflow run starts hot with the union of every previous response.

- **L1 cache**: in-process dict inside `mitmdump`, populated on every response.
- **L2 cache**: SQLite file at `PW_CACHE_DB`. Per-shard during the run; merged at the end.
- **Cross-workflow**: `save_cache`/`restore_cache` keyed by branch with a master fallback.
- **Cross-shard (within one workflow)**: a new `merge_playwright_cache` job `INSERT OR IGNORE`s all 12 shard caches into one before `save_cache`.

Wired through `PW_CACHE_PROXY=1` env var on `remote_e2e_shards`; off by default in local dev.

## Why

We're hammering `www.cbioportal.org` from CI on every PR — both for the test backend and for the JS bundle / assets / API. Most of those requests are deterministic and repeat dozens of times per shard. Caching them locally (a) cuts wall time on warm runs, (b) reduces load on the public portal, (c) sets us up for fully hermetic e2e if we ever want it.

## What this PR is *not*

- Not a replacement for the frontend's HTTP cache — this is upstream of the browser, transparent to test code.
- Not yet doing intelligent cache invalidation; entries live forever in SQLite. If the portal's behaviour for a URL changes, bust the cache key (`playwright-cache-v1-...` → `v2-...`) in `.circleci/config.yml`.
- Not enabled for `e2e_localdb_shards` (the local-db tests hit `localhost:8080`, which is outside the allowlist).

## How to verify locally

```bash
# One-time: build the overlay image (canonical CI image gets mitmproxy
# baked in by the Dockerfile change in this PR, but the GHCR rebuild is
# async — overlay lets you iterate without waiting).
cd end-to-end-test-playwright
docker build --platform linux/amd64 \
  -f proxy/Dockerfile.overlay \
  -t cbioportal-frontend-playwright-ci:cache-local \
  proxy

# Then:
LOCALDEV=0 PW_CACHE_PROXY=1 \
  PW_CACHE_IMAGE=cbioportal-frontend-playwright-ci:cache-local \
  ./scripts/docker-test.sh tests/config.spec.ts
```

Look for the `[cache] summary: N L1 hits / M L2 hits / P misses ...` line at the end.

## What to watch on CircleCI

- **First workflow run**: cold cache. `restore_cache` step has no match; shards run normally and populate SQLite from scratch. `merge_playwright_cache` runs serially after shards, unions them, and `save_cache`s the result.
- **Second workflow run** (same branch): warm cache. Shards see `[cache] N L2 hits` and a much smaller `M misses`. Wall time should drop noticeably on screenshot-heavy shards.

## Test plan

- [ ] Verify the new `merge_playwright_cache` job runs after shards and produces a `cache.sqlite` artifact.
- [ ] Re-run the workflow on the PR; confirm `restore_cache` finds the previously-saved cache and the shards report L2 hits.
- [ ] Compare wall time on the second run vs the first.
- [ ] Check that an intentionally bad cached response would not break the test (e.g., by busting the version key) — sanity check the eviction path.
- [ ] Inspect the `cache.sqlite` artifact size; if it's growing unboundedly, add a per-entry size cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->