### PR TITLE
Playwright e2e: route shards through always-on caching proxy (smoke)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,10 @@ jobs:
       # of the standard HTTPS_PROXY: at job scope HTTPS_PROXY would also
       # apply to pnpm install, which times out trying to fetch the npm
       # registry through a proxy that only allowlists *.cbioportal.org.
-      PW_PROXY_SERVER: 'http://15.204.174.231:47821'
+      # Port 443 because OVH's upstream firewall silently drops packets
+      # to non-standard high ports — the previous 47821 endpoint was
+      # unreachable from CircleCI (all external probes timed out).
+      PW_PROXY_SERVER: 'http://15.204.174.231:443'
     steps:
       - attach_workspace:
           at: /tmp/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,14 +358,9 @@ jobs:
       BRANCH_ENV: master
       FRONTEND_TEST_USE_LOCAL_DIST: 'true'
       PLAYWRIGHT_JUNIT_OUTPUT_NAME: test-results/junit.xml
-      # *** TEMP for cache-proxy smoke: limit shards to two specs (config +
-      # patient-screenshot). Revert to '' to restore the full suite once
-      # we're confident the proxy wiring is sound. The regex is space-free
-      # because the existing shard step passes $GREP_ARG unquoted; bash
-      # would otherwise word-split a value like "(homepage config|...)"
-      # into 4 separate args and Playwright would see an unbalanced
-      # regex. .* covers the elided spaces.
-      PLAYWRIGHT_GREP: '(homepage.*config.*overrides|Patient.*cohort.*view)'
+      # Optional grep filter for targeted smoke runs. Empty by default →
+      # whole suite runs. Set to e.g. 'patient-screenshot' to narrow.
+      PLAYWRIGHT_GREP: ''
       # Route the browser through the always-on caching proxy (see
       # cbioportal-cache-proxy repo, now hosted on Fly.io). PW_WF_STAMP
       # is set in the Run Playwright shard step below because env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,8 +360,12 @@ jobs:
       PLAYWRIGHT_JUNIT_OUTPUT_NAME: test-results/junit.xml
       # *** TEMP for cache-proxy smoke: limit shards to two specs (config +
       # patient-screenshot). Revert to '' to restore the full suite once
-      # we're confident the proxy wiring is sound.
-      PLAYWRIGHT_GREP: '(homepage config overrides|Patient cohort)'
+      # we're confident the proxy wiring is sound. The regex is space-free
+      # because the existing shard step passes $GREP_ARG unquoted; bash
+      # would otherwise word-split a value like "(homepage config|...)"
+      # into 4 separate args and Playwright would see an unbalanced
+      # regex. .* covers the elided spaces.
+      PLAYWRIGHT_GREP: '(homepage.*config.*overrides|Patient.*cohort.*view)'
       # Route the browser through the always-on caching proxy (see
       # cbioportal-cache-proxy repo). PW_WF_STAMP is set in the Run
       # Playwright shard step below because env: blocks don't expand
@@ -443,7 +447,7 @@ jobs:
             # it and forwards as X-PW-Workflow-ID on every request so
             # the cache proxy gives this workflow its own namespace.
             export PW_WF_STAMP="$CIRCLE_WORKFLOW_ID"
-            echo "Cache-proxy stamp: $PW_WF_STAMP via $HTTPS_PROXY"
+            echo "Cache-proxy stamp: $PW_WF_STAMP via $PW_PROXY_SERVER"
             set +e
             # --workers=3 on resource_class large (4 vCPU / 8 GB) leaves
             # one vCPU for the runner / serveDist while running 3 chromium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,8 +365,11 @@ jobs:
       # Route the browser through the always-on caching proxy (see
       # cbioportal-cache-proxy repo). PW_WF_STAMP is set in the Run
       # Playwright shard step below because env: blocks don't expand
-      # CIRCLE_WORKFLOW_ID.
-      HTTPS_PROXY: 'http://15.204.174.231:47821'
+      # CIRCLE_WORKFLOW_ID. We deliberately use PW_PROXY_SERVER instead
+      # of the standard HTTPS_PROXY: at job scope HTTPS_PROXY would also
+      # apply to pnpm install, which times out trying to fetch the npm
+      # registry through a proxy that only allowlists *.cbioportal.org.
+      PW_PROXY_SERVER: 'http://15.204.174.231:47821'
     steps:
       - attach_workspace:
           at: /tmp/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,16 +367,18 @@ jobs:
       # regex. .* covers the elided spaces.
       PLAYWRIGHT_GREP: '(homepage.*config.*overrides|Patient.*cohort.*view)'
       # Route the browser through the always-on caching proxy (see
-      # cbioportal-cache-proxy repo). PW_WF_STAMP is set in the Run
-      # Playwright shard step below because env: blocks don't expand
-      # CIRCLE_WORKFLOW_ID. We deliberately use PW_PROXY_SERVER instead
-      # of the standard HTTPS_PROXY: at job scope HTTPS_PROXY would also
-      # apply to pnpm install, which times out trying to fetch the npm
-      # registry through a proxy that only allowlists *.cbioportal.org.
-      # Port 443 because OVH's upstream firewall silently drops packets
-      # to non-standard high ports — the previous 47821 endpoint was
-      # unreachable from CircleCI (all external probes timed out).
-      PW_PROXY_SERVER: 'http://15.204.174.231:443'
+      # cbioportal-cache-proxy repo, now hosted on Fly.io). PW_WF_STAMP
+      # is set in the Run Playwright shard step below because env:
+      # blocks don't expand CIRCLE_WORKFLOW_ID. We deliberately use
+      # PW_PROXY_SERVER instead of the standard HTTPS_PROXY: at job
+      # scope HTTPS_PROXY would also apply to pnpm install, which times
+      # out trying to fetch the npm registry through a proxy that only
+      # allowlists *.cbioportal.org. The previous OVH endpoint
+      # (15.204.174.231:443) was silently unreachable from CircleCI —
+      # no SYNs landed despite the box being open to other clients —
+      # so we moved to Fly's iad region, which sits near CircleCI's
+      # us-east runners on a different network path.
+      PW_PROXY_SERVER: 'http://cbioportal-cache-proxy.fly.dev:443'
     steps:
       - attach_workspace:
           at: /tmp/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,9 +358,15 @@ jobs:
       BRANCH_ENV: master
       FRONTEND_TEST_USE_LOCAL_DIST: 'true'
       PLAYWRIGHT_JUNIT_OUTPUT_NAME: test-results/junit.xml
-      # Optional grep filter for targeted smoke runs. Empty by default →
-      # whole suite runs. Set to e.g. 'patient-screenshot' to narrow.
-      PLAYWRIGHT_GREP: ''
+      # *** TEMP for cache-proxy smoke: limit shards to two specs (config +
+      # patient-screenshot). Revert to '' to restore the full suite once
+      # we're confident the proxy wiring is sound.
+      PLAYWRIGHT_GREP: '(homepage config overrides|Patient cohort)'
+      # Route the browser through the always-on caching proxy (see
+      # cbioportal-cache-proxy repo). PW_WF_STAMP is set in the Run
+      # Playwright shard step below because env: blocks don't expand
+      # CIRCLE_WORKFLOW_ID.
+      HTTPS_PROXY: 'http://15.204.174.231:47821'
     steps:
       - attach_workspace:
           at: /tmp/repo
@@ -429,6 +435,12 @@ jobs:
                 GREP_ARG="--grep=$PLAYWRIGHT_GREP"
                 echo "Filtering with --grep=$PLAYWRIGHT_GREP"
             fi
+            # CIRCLE_WORKFLOW_ID isn't expanded inside env: blocks, so
+            # PW_WF_STAMP has to be set here. playwright.config.ts reads
+            # it and forwards as X-PW-Workflow-ID on every request so
+            # the cache proxy gives this workflow its own namespace.
+            export PW_WF_STAMP="$CIRCLE_WORKFLOW_ID"
+            echo "Cache-proxy stamp: $PW_WF_STAMP via $HTTPS_PROXY"
             set +e
             # --workers=3 on resource_class large (4 vCPU / 8 GB) leaves
             # one vCPU for the runner / serveDist while running 3 chromium
@@ -1575,15 +1587,14 @@ workflows:
       #     requires:
       #       - pull_cbioportal_test_codebase
       #       - build_frontend
-      - e2e_localdb_shards:
-          requires:
-            - pull_cbioportal_test_codebase
-            - build_frontend
-      # Intentionally NOT requiring e2e_localdb_shards: same pattern as
-      # remote_e2e — this job polls the CircleCI API for the shards'
-      # terminal state and merges, so the merged HTML is produced even
-      # when shards are red.
-      - e2e_localdb_merge
+      # *** TEMP: localdb jobs commented out while we smoke-test the
+      # cache-proxy wiring on remote_e2e_shards. Re-enable before
+      # merging this branch.
+      # - e2e_localdb_shards:
+      #     requires:
+      #       - pull_cbioportal_test_codebase
+      #       - build_frontend
+      # - e2e_localdb_merge
       - remote_e2e_shards:
           requires:
             - build_frontend

--- a/end-to-end-test-playwright/fixtures.ts
+++ b/end-to-end-test-playwright/fixtures.ts
@@ -39,12 +39,39 @@ function withLocaldev(url: string): string {
 // double-patching is a no-op, but the symbol guard avoids stacking wrappers.
 const PATCHED = Symbol.for('cbio-localdev-patched');
 
+// Wait up to FONTS_READY_TIMEOUT_MS for document.fonts.ready to resolve.
+// goto() fires "load" before webfonts have finished — screenshots taken
+// immediately after see fallback-font glyph metrics, which shift text by
+// sub-pixels across the entire page and tank every screenshot diff.
+// Bounded so a stuck font fetch can't deadlock the test.
+const FONTS_READY_TIMEOUT_MS = 5000;
+async function awaitFontsSettled(page: Page): Promise<void> {
+    try {
+        await Promise.race([
+            page.evaluate(
+                () => (document as any).fonts && (document as any).fonts.ready
+            ),
+            new Promise(resolve =>
+                setTimeout(resolve, FONTS_READY_TIMEOUT_MS)
+            ),
+        ]);
+    } catch {
+        // page closed / nav races — never block the test on this
+    }
+}
+
 function patchPageGoto(page: Page): Page {
     if ((page as any)[PATCHED]) return page;
     (page as any)[PATCHED] = true;
     const originalGoto = page.goto.bind(page);
-    page.goto = ((url: string, options?: Parameters<typeof originalGoto>[1]) =>
-        originalGoto(withLocaldev(url), options)) as typeof page.goto;
+    page.goto = (async (
+        url: string,
+        options?: Parameters<typeof originalGoto>[1]
+    ) => {
+        const response = await originalGoto(withLocaldev(url), options);
+        await awaitFontsSettled(page);
+        return response;
+    }) as typeof page.goto;
     return page;
 }
 

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -42,11 +42,13 @@ const updateSnapshots = process.env.PW_UPDATE_SNAPSHOTS as
 const includeLocalDb = process.env.PW_LOCAL === '1';
 
 // Always-on caching forward proxy in front of *.cbioportal.org. When
-// HTTPS_PROXY is set, route the browser through it and stamp every
+// PW_PROXY_SERVER is set, route the browser through it and stamp every
 // request with PW_WF_STAMP so the proxy can key its cache per-workflow.
-// See https://github.com/cBioPortal/cbioportal-frontend-cache-proxy
-// (or wherever the service is hosted).
-const PROXY_SERVER = process.env.HTTPS_PROXY;
+// HTTPS_PROXY is honored as a fallback for local-dev convenience, but
+// CI must use PW_PROXY_SERVER: setting HTTPS_PROXY at job scope makes
+// pnpm install try to fetch the npm registry through the proxy too,
+// which times out (the proxy allowlists only *.cbioportal.org).
+const PROXY_SERVER = process.env.PW_PROXY_SERVER || process.env.HTTPS_PROXY;
 const WF_STAMP = process.env.PW_WF_STAMP || '';
 
 export default defineConfig({

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -89,7 +89,13 @@ export default defineConfig({
         screenshot: 'only-on-failure',
         video: 'retain-on-failure',
         actionTimeout: 15_000,
-        navigationTimeout: 60_000,
+        // First time a workflow runs, the proxy cache is empty and every
+        // request to cbioportal/3rd-parties goes upstream through
+        // mitmproxy's TLS-MITM hop. That adds enough latency (esp. at
+        // CI concurrency) that the standard 60s isn't always enough for
+        // a full SPA boot. Subsequent runs in the same workflow id (or
+        // retries within a run) hit the cache and complete much faster.
+        navigationTimeout: PROXY_SERVER ? 120_000 : 60_000,
         // ignoreHTTPSErrors is needed in localdev mode (to accept the
         // serveDist self-signed cert) and any time we route through
         // the cache proxy (to accept mitmproxy's generated CA).

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -41,6 +41,14 @@ const updateSnapshots = process.env.PW_UPDATE_SNAPSHOTS as
 // 5+ minutes to slow shards. The localdb job opts in via PW_LOCAL=1.
 const includeLocalDb = process.env.PW_LOCAL === '1';
 
+// Always-on caching forward proxy in front of *.cbioportal.org. When
+// HTTPS_PROXY is set, route the browser through it and stamp every
+// request with PW_WF_STAMP so the proxy can key its cache per-workflow.
+// See https://github.com/cBioPortal/cbioportal-frontend-cache-proxy
+// (or wherever the service is hosted).
+const PROXY_SERVER = process.env.HTTPS_PROXY;
+const WF_STAMP = process.env.PW_WF_STAMP || '';
+
 export default defineConfig({
     testDir: './tests',
     testIgnore: includeLocalDb ? [] : ['**/local/**'],
@@ -80,7 +88,19 @@ export default defineConfig({
         video: 'retain-on-failure',
         actionTimeout: 15_000,
         navigationTimeout: 60_000,
-        ...(isLocaldev && { ignoreHTTPSErrors: true }),
+        // ignoreHTTPSErrors is needed in localdev mode (to accept the
+        // serveDist self-signed cert) and any time we route through
+        // the cache proxy (to accept mitmproxy's generated CA).
+        ...((isLocaldev || PROXY_SERVER) && { ignoreHTTPSErrors: true }),
+        ...(PROXY_SERVER && {
+            proxy: { server: PROXY_SERVER },
+            extraHTTPHeaders: {
+                // The cache proxy keys entries by this header so each
+                // CI workflow run gets its own cache namespace. Locally
+                // unset is fine — the proxy treats blank as "default".
+                'X-PW-Workflow-ID': WF_STAMP,
+            },
+        }),
     },
 
     projects: [
@@ -106,6 +126,21 @@ export default defineConfig({
                         '--disable-font-subpixel-positioning',
                         '--disable-lcd-text',
                         '--font-render-hinting=none',
+                        // When routed through the cache proxy, mitmproxy
+                        // presents a self-signed cert. Chromium gates
+                        // proxy/MITM certs before the CDP-level
+                        // ignoreHTTPSErrors gets a chance, so launch-level
+                        // --ignore-certificate-errors is required. The
+                        // --proxy-server flag also has to be at launch
+                        // time: chromium-headless-shell was observed to
+                        // silently no-op the CDP-level proxy setting for
+                        // HTTPS traffic.
+                        ...(PROXY_SERVER
+                            ? [
+                                  '--ignore-certificate-errors',
+                                  `--proxy-server=${PROXY_SERVER}`,
+                              ]
+                            : []),
                         ...(isLocaldev
                             ? [
                                   // Private Network Access + the newer

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -141,6 +141,15 @@ export default defineConfig({
                             ? [
                                   '--ignore-certificate-errors',
                                   `--proxy-server=${PROXY_SERVER}`,
+                                  // Local frontend dev server traffic
+                                  // (localhost:3000 in LOCALDEV mode, or
+                                  // its --host-resolver-rules remap to
+                                  // host.docker.internal) must NOT go
+                                  // through the proxy — the proxy lives
+                                  // on a remote host and can't reach
+                                  // the test runner's loopback. Bypass
+                                  // covers both names plus 127.0.0.1.
+                                  '--proxy-bypass-list=localhost;127.0.0.1;host.docker.internal',
                               ]
                             : []),
                         ...(isLocaldev

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -150,6 +150,17 @@ export default defineConfig({
                         // rendering.
                         ...(PROXY_SERVER
                             ? [
+                                  // Chromium intermittently rejects the
+                                  // mitmproxy-generated cert even when
+                                  // ignoreHTTPSErrors: true is set at
+                                  // the CDP context level — the launch
+                                  // flag forces the always-accept path
+                                  // before CDP gets a chance. Re-added
+                                  // after fly logs showed periodic
+                                  // "ssl/tls alert certificate unknown"
+                                  // rejections from Chromium →
+                                  // ERR_EMPTY_RESPONSE on the test side.
+                                  '--ignore-certificate-errors',
                                   `--proxy-server=${PROXY_SERVER}`,
                                   // Only proxy cbioportal traffic; route
                                   // everything else direct. Reasons:

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -151,15 +151,51 @@ export default defineConfig({
                         ...(PROXY_SERVER
                             ? [
                                   `--proxy-server=${PROXY_SERVER}`,
-                                  // Local frontend dev server traffic
-                                  // (localhost:3000 in LOCALDEV mode, or
-                                  // its --host-resolver-rules remap to
-                                  // host.docker.internal) must NOT go
-                                  // through the proxy — the proxy lives
-                                  // on a remote host and can't reach
-                                  // the test runner's loopback. Bypass
-                                  // covers both names plus 127.0.0.1.
-                                  '--proxy-bypass-list=localhost;127.0.0.1;host.docker.internal',
+                                  // Only proxy cbioportal traffic; route
+                                  // everything else direct. Reasons:
+                                  //  1. loopback (localhost/127.0.0.1/
+                                  //     host.docker.internal) can't be
+                                  //     reached from the remote proxy.
+                                  //  2. 3rd-party static-asset hosts
+                                  //     (cdnjs font-awesome, googleapis,
+                                  //     gstatic) loaded font/icon
+                                  //     subresources through the proxy
+                                  //     unreliably — icons rendered as
+                                  //     glyph squares and screenshot
+                                  //     specs failed en masse.
+                                  //  3. Analytics endpoints (gtm, heap,
+                                  //     contentsquare) add nothing to
+                                  //     test correctness but add
+                                  //     proxy-MITM overhead.
+                                  //  4. docs.cbioportal.org renders an
+                                  //     embedded news iframe; it's not
+                                  //     part of the API surface we want
+                                  //     to cache, just let it through.
+                                  // Semicolons are chromium's bypass
+                                  // delimiter; wildcards match
+                                  // subdomains only (so we list each
+                                  // bare-host + *.host pair we care
+                                  // about).
+                                  '--proxy-bypass-list=' +
+                                      [
+                                          'localhost',
+                                          '127.0.0.1',
+                                          'host.docker.internal',
+                                          'cdnjs.cloudflare.com',
+                                          '*.cloudflare.com',
+                                          'googletagmanager.com',
+                                          '*.googletagmanager.com',
+                                          'heapanalytics.com',
+                                          '*.heapanalytics.com',
+                                          'contentsquare.net',
+                                          '*.contentsquare.net',
+                                          '*.netlify.app',
+                                          'docs.cbioportal.org',
+                                          '*.googleapis.com',
+                                          '*.gstatic.com',
+                                          '*.oncokb.org',
+                                          '*.genomenexus.org',
+                                      ].join(';'),
                               ]
                             : []),
                         ...(isLocaldev

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -95,21 +95,13 @@ export default defineConfig({
         // the cache proxy (to accept mitmproxy's generated CA).
         ...((isLocaldev || PROXY_SERVER) && { ignoreHTTPSErrors: true }),
         ...(PROXY_SERVER && {
-            proxy: {
-                server: PROXY_SERVER,
-                // Playwright's context-level proxy overrides the
-                // launch-level --proxy-bypass-list flag and starts
-                // with NO bypass — so without this, localhost:3000
-                // (the LOCALDEV dev-server) gets sent to the remote
-                // proxy, which obviously can't reach the runner's
-                // loopback. Matching syntax: comma-separated, no
-                // wildcards; Playwright matches by hostname.
-                bypass: 'localhost,127.0.0.1,host.docker.internal',
-            },
+            // Proxy is configured at launch level (--proxy-server /
+            // --proxy-bypass-list flags below) — NOT here. Setting
+            // both context-level `proxy` and launch-level flags
+            // produced ERR_EMPTY_RESPONSE for normal requests; the
+            // two configurations conflict inside chromium. We keep
+            // just the X-PW-Workflow-ID stamp header at this level.
             extraHTTPHeaders: {
-                // The cache proxy keys entries by this header so each
-                // CI workflow run gets its own cache namespace. Locally
-                // unset is fine — the proxy treats blank as "default".
                 'X-PW-Workflow-ID': WF_STAMP,
             },
         }),

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -128,18 +128,20 @@ export default defineConfig({
                         '--disable-font-subpixel-positioning',
                         '--disable-lcd-text',
                         '--font-render-hinting=none',
-                        // When routed through the cache proxy, mitmproxy
-                        // presents a self-signed cert. Chromium gates
-                        // proxy/MITM certs before the CDP-level
-                        // ignoreHTTPSErrors gets a chance, so launch-level
-                        // --ignore-certificate-errors is required. The
-                        // --proxy-server flag also has to be at launch
-                        // time: chromium-headless-shell was observed to
-                        // silently no-op the CDP-level proxy setting for
-                        // HTTPS traffic.
+                        // --proxy-server has to be at launch time:
+                        // chromium-headless-shell was observed to
+                        // silently no-op the CDP-level proxy setting
+                        // for HTTPS traffic. We rely on CDP-level
+                        // ignoreHTTPSErrors (set in use.ignoreHTTPSErrors
+                        // above) to handle both the proxy's MITM cert
+                        // and the localhost:3000 self-signed dev cert
+                        // — the launch-level --ignore-certificate-errors
+                        // tried earlier appeared to short-circuit the
+                        // CDP path for localhost, leaving the SPA bundle
+                        // unable to load and only the localdev banner
+                        // rendering.
                         ...(PROXY_SERVER
                             ? [
-                                  '--ignore-certificate-errors',
                                   `--proxy-server=${PROXY_SERVER}`,
                                   // Local frontend dev server traffic
                                   // (localhost:3000 in LOCALDEV mode, or

--- a/end-to-end-test-playwright/playwright.config.ts
+++ b/end-to-end-test-playwright/playwright.config.ts
@@ -95,7 +95,17 @@ export default defineConfig({
         // the cache proxy (to accept mitmproxy's generated CA).
         ...((isLocaldev || PROXY_SERVER) && { ignoreHTTPSErrors: true }),
         ...(PROXY_SERVER && {
-            proxy: { server: PROXY_SERVER },
+            proxy: {
+                server: PROXY_SERVER,
+                // Playwright's context-level proxy overrides the
+                // launch-level --proxy-bypass-list flag and starts
+                // with NO bypass — so without this, localhost:3000
+                // (the LOCALDEV dev-server) gets sent to the remote
+                // proxy, which obviously can't reach the runner's
+                // loopback. Matching syntax: comma-separated, no
+                // wildcards; Playwright matches by hostname.
+                bypass: 'localhost,127.0.0.1,host.docker.internal',
+            },
             extraHTTPHeaders: {
                 // The cache proxy keys entries by this header so each
                 // CI workflow run gets its own cache namespace. Locally

--- a/end-to-end-test-playwright/tests/helpers/common.ts
+++ b/end-to-end-test-playwright/tests/helpers/common.ts
@@ -16,6 +16,30 @@ export async function waitForNetworkQuiet(page: Page, timeoutMs = 30000) {
     });
 }
 
+/**
+ * Wait for all in-flight CSS-driven font loads to settle, bounded so a
+ * stuck @font-face fetch can't deadlock the test. ajaxQuiet only covers
+ * XHRs — font subresources (e.g. font-awesome from cdnjs, app webfonts
+ * from /reactapp/) aren't XHRs and finish independently. When the proxy
+ * makes cbioportal API responses cache-fast, ajaxQuiet flips before the
+ * icon font arrives, the screenshot snaps with system-font fallback
+ * glyphs, and every text/icon line diffs by sub-pixels against the
+ * reference. Calling this right before each snapshot eliminates that
+ * race regardless of proxy presence.
+ */
+export async function waitForFontsLoaded(page: Page, timeoutMs = 5000) {
+    try {
+        await Promise.race([
+            page.evaluate(
+                () => (document as any).fonts && (document as any).fonts.ready
+            ),
+            new Promise(resolve => setTimeout(resolve, timeoutMs)),
+        ]);
+    } catch {
+        // Page closed / nav race — never block a screenshot on this.
+    }
+}
+
 /** Convenience locator for elements tagged with a data-test attribute. */
 export function byTestHandle(page: Page, handle: string): Locator {
     return page.locator(`[data-test="${handle}"]`);
@@ -60,6 +84,7 @@ export async function expectElementScreenshot(
     }
     if (opts.pauseMs) await page.waitForTimeout(opts.pauseMs);
 
+    await waitForFontsLoaded(page);
     const mask = (opts.masks ?? ['.qtip']).map(s => page.locator(s));
     await expect(target).toHaveScreenshot(snapshotName, {
         mask,
@@ -92,6 +117,7 @@ export async function expectPageScreenshot(
     await page.mouse.move(0, 0);
     if (opts.pauseMs) await page.waitForTimeout(opts.pauseMs);
 
+    await waitForFontsLoaded(page);
     const mask = (opts.masks ?? ['.qtip']).map(s => page.locator(s));
     await expect(page).toHaveScreenshot(snapshotName, {
         mask,

--- a/end-to-end-test-playwright/tests/helpers/common.ts
+++ b/end-to-end-test-playwright/tests/helpers/common.ts
@@ -27,12 +27,29 @@ export async function waitForNetworkQuiet(page: Page, timeoutMs = 30000) {
  * reference. Calling this right before each snapshot eliminates that
  * race regardless of proxy presence.
  */
-export async function waitForFontsLoaded(page: Page, timeoutMs = 5000) {
+export async function waitForFontsLoaded(page: Page, timeoutMs = 8000) {
     try {
         await Promise.race([
-            page.evaluate(
-                () => (document as any).fonts && (document as any).fonts.ready
-            ),
+            page.evaluate(async () => {
+                const fonts = (document as any).fonts;
+                if (!fonts) return;
+                // document.fonts.ready only awaits fonts the browser
+                // has *already chosen to fetch*. Chromium fetches
+                // @font-face entries lazily — only when a glyph that
+                // resolves to that family is needed for rendering —
+                // so fonts.ready can resolve true before the icon
+                // font (FontAwesome) has even been requested, even if
+                // the page is already mid-render. Iterating and
+                // calling load() on each registered FontFace forces
+                // every declared @font-face to be fetched, after
+                // which fonts.ready actually waits for them.
+                const promises: Promise<unknown>[] = [];
+                for (const f of fonts) {
+                    promises.push(f.load().catch(() => {}));
+                }
+                await Promise.allSettled(promises);
+                await fonts.ready;
+            }),
             new Promise(resolve => setTimeout(resolve, timeoutMs)),
         ]);
     } catch {

--- a/end-to-end-test-playwright/tests/helpers/oncoprint.ts
+++ b/end-to-end-test-playwright/tests/helpers/oncoprint.ts
@@ -1,4 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
+import { waitForFontsLoaded } from './common';
 
 /**
  * Helpers ported from end-to-end-test/shared/specUtils_Async.js.
@@ -155,6 +156,7 @@ export async function expectOncoprintScreenshot(
     ];
     const mask = maskSelectors.map(s => page.locator(s));
 
+    await waitForFontsLoaded(page);
     await expect(target).toHaveScreenshot(snapshotName, { mask });
 }
 


### PR DESCRIPTION
## Summary

Routes the Playwright `remote_e2e_shards` job through a long-lived caching forward proxy. The proxy sits outside CircleCI on a VPS (currently `http://15.204.174.231:47821`), caches every `*.cbioportal.org` response keyed by `(workflow_id, method, url, body)`, and serves cache hits without touching the network. Each CircleCI workflow run gets its own cache namespace via `CIRCLE_WORKFLOW_ID` injected as the `X-PW-Workflow-ID` request header, so:

- Workflow run N, shard 0, first request to URL X → live network, response stored under stamp N.
- Workflow run N, any other shard, same request → served from the cache, no backend hit.
- Workflow run N+1 → cold cache; backend timing variance is back on the table.

The goal is to take backend response timing out of the screenshot-flakiness equation across the 12 shards of a single workflow.

## What this PR is — and isn't

- **TEMP scope**: `PLAYWRIGHT_GREP` restricts shards to `config.spec.ts` + `patient-screenshot.spec.ts` (5 tests) so this first CI run is cheap and fast. Once we see one green run + one warm-cache run, lift the grep.
- **TEMP also**: `e2e_localdb_shards` and `e2e_localdb_merge` are commented out of the `tests` workflow so they don't compete during the smoke. Re-enable before merging.
- **Not changing snapshots**: the canonical `__snapshots__/` baselines stay untouched. The proxy serves responses byte-identical to what the backend gave on the first request; the screenshots should match what they already do.
- **No secrets**: the proxy is on a non-standard port (47821), no auth, fronted by nginx with per-IP `limit_conn 10`. Cbioportal data is public, so the worst case is bandwidth abuse, not data leakage.

## Validated locally (Docker, chromium-headless-shell)

| Pass | Tests | Pass/Fail | Wall |
|---|---|---|---|
| 1 — cold workflow (`--update-snapshots`) | 20 across 6 specs | 19/1 | 3.0 min |
| 2 — warm, same workflow stamp | 20 | **20/0** | 2.1 min |
| 3 — warm, same stamp | 20 | **20/0** | 2.1 min |

Passes 2 and 3 produced byte-identical screenshots. The one failure in pass 1 (`patient-screenshot.spec.ts`) was the usual screenshot drift on the recording pass — the proxy can't help with the initial capture, only with replays of cached responses.

## What to watch on CircleCI

- `remote_e2e_shards` should run only 5 tests (4 config + 1 patient-screenshot) across 12 shards. Most shards will have 0 tests assigned (Playwright's sharder distributes by file).
- Each shard's log should print:
  ```
  Cache-proxy stamp: <workflow-id> via http://15.204.174.231:47821
  ```
- If the proxy is reachable and the wiring is right, all 5 tests pass.
- Re-running the workflow on the same PR should be byte-identical (warm cache).

## Test plan

- [ ] First CI run completes — 5 tests pass via the proxy
- [ ] Re-run the workflow on this PR — confirm the proxy logs show cache hits (I'll check `cache.sqlite` on the VPS)
- [ ] Lift `PLAYWRIGHT_GREP` and re-enable localdb in a follow-up commit; rerun
- [ ] Compare full-suite wall time and pass rate vs a recent master CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->