### PR TITLE
Fix Netlify deploy preview white page (restore CBIOPORTAL_URL substitution)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   DISABLE_TYPECHECK="true"
 
 [build]
-  command = "rm -rf node_modules && corepack enable && pnpm install --frozen-lockfile --force && pnpm run buildModules && pnpm run typecheck && pnpm run buildMain"
+  command = "rm -rf node_modules && corepack enable && pnpm install --frozen-lockfile --force && pnpm run buildModules && pnpm run typecheck && eval \"$(./scripts/env_vars.sh)\" && pnpm run buildMain"
 
 [[headers]]
 for = "/*.otf"


### PR DESCRIPTION
## Summary

Every PR's Netlify deploy preview (`deploy-preview-<N>.preview.cbioportal.org`) currently renders a blank page. The Netlify build succeeds and the bundle ships, but the app crashes on boot before rendering.

## Root cause

#5549 (commit 181d35700) changed the Netlify build command from:

```
pnpm run build
```

to:

```
pnpm run buildModules && pnpm run typecheck && pnpm run buildMain
```

to gate deploy previews on the new typecheck step. The replaced `build` script chained `./scripts/env_vars.sh && eval "$(./scripts/env_vars.sh)" && pnpm run buildAll`, which exports `CBIOPORTAL_URL` and `GENOME_NEXUS_URL` based on the PR's **target** branch (e.g. `env/master.sh` → `https://www.cbioportal.org`). Calling `buildMain` directly skips that env setup.

Without those env vars, `rspack.config.js` falls back to its placeholder defaults (`rspack.config.js:193`):

```js
ENV_CBIOPORTAL_URL: process.env.CBIOPORTAL_URL
    ? JSON.stringify(cleanAndValidateUrl(process.env.CBIOPORTAL_URL))
    : '"replace_me_env_cbioportal_url"',
```

So the literal string `replace_me_env_cbioportal_url` ends up baked into the bundle.

## Runtime symptom

At boot the app issues `GET /replace_me_env_cbioportal_url/config_service`. Netlify's SPA catch-all (`from = "/*", to = "/index.html", status = 200`) serves `index.html` for that path. jQuery tries to parse the HTML as JSON, throws a `parsererror`, and the app boot aborts before React renders — `<div id="reactRoot"></div>` stays empty.

Captured via headless Chromium against `https://deploy-preview-5580.preview.cbioportal.org`:

```json
{
  "message": "Uncaught [object Object]",
  "filename": ".../reactapp/common.bundle.js",
  "errorJSON": "{\"readyState\":4,\"status\":200,\"statusText\":\"parsererror\",\"responseText\":\"<!doctype html>...<div id=\\\"reactRoot\\\"></div>...\"}"
}
```

with the offending request:

```
GET https://deploy-preview-5580.preview.cbioportal.org/replace_me_env_cbioportal_url/config_service
```

## Fix

Restore the `env_vars.sh` eval immediately before `buildMain` in `netlify.toml`. This keeps the typecheck-as-gate intent of #5549 and the branch-aware URL selection (e.g. PRs targeting `release-X` still pick up `env/release-X.sh`).

```diff
-  command = "rm -rf node_modules && corepack enable && pnpm install --frozen-lockfile --force && pnpm run buildModules && pnpm run typecheck && pnpm run buildMain"
+  command = "rm -rf node_modules && corepack enable && pnpm install --frozen-lockfile --force && pnpm run buildModules && pnpm run typecheck && eval \"$(./scripts/env_vars.sh)\" && pnpm run buildMain"
```

## Reproduction

- Production (broken — affects all open PRs): https://deploy-preview-5580.preview.cbioportal.org
- Deploy preview (fixed): https://deploy-preview-5581.preview.cbioportal.org

## Test plan

- [ ] Netlify deploy preview for this PR renders the cBioPortal homepage (not blank)
- [ ] Network tab shows requests going to `https://www.cbioportal.org/...` not `/replace_me_env_cbioportal_url/...`
- [ ] No `parsererror` in the console at page load
- [ ] Typecheck step still runs (regression check on #5549's intent)
- [ ] Spot-check on a PR targeting a `release-*` branch picks up the right env script (branch-aware behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)