### PR TITLE
Route chat sidebar through Vercel AI Gateway; let users switch models with per-call pricing

### DIFF
--- a/packages/chat-sidebar-server/api/chat/highlights.ts
+++ b/packages/chat-sidebar-server/api/chat/highlights.ts
@@ -15,13 +15,13 @@ export default async function handler(
         res.status(405).json({ error: 'Method not allowed' });
         return;
     }
-    const { studyId, inventory } = (req.body ?? {}) as any;
+    const { studyId, inventory, model } = (req.body ?? {}) as any;
     if (!studyId || typeof studyId !== 'string') {
         res.status(400).json({ error: 'studyId (string) required' });
         return;
     }
     try {
-        const result = await runHighlights({ studyId, inventory });
+        const result = await runHighlights({ studyId, inventory, model });
         res.json(result);
     } catch (err: any) {
         console.error('highlights failed:', err);

--- a/packages/chat-sidebar-server/api/chat/models.ts
+++ b/packages/chat-sidebar-server/api/chat/models.ts
@@ -1,0 +1,27 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getShortlistedModels } from '../../src/pricing.js';
+import { applyCors } from '../../src/cors.js';
+
+export const config = {
+    maxDuration: 30,
+};
+
+export default async function handler(
+    req: VercelRequest,
+    res: VercelResponse
+) {
+    if (applyCors(req, res)) return;
+    if (req.method !== 'GET') {
+        res.status(405).json({ error: 'Method not allowed' });
+        return;
+    }
+    try {
+        const models = await getShortlistedModels();
+        res.json({ models });
+    } catch (err: any) {
+        console.error('models failed:', err);
+        res.status(500).json({
+            error: err?.message ?? 'Could not fetch model catalog',
+        });
+    }
+}

--- a/packages/chat-sidebar-server/api/chat/suggest.ts
+++ b/packages/chat-sidebar-server/api/chat/suggest.ts
@@ -15,8 +15,8 @@ export default async function handler(
         res.status(405).json({ error: 'Method not allowed' });
         return;
     }
-    const { studyId, genes, tab, preset, userPrompt, screenshot } = (req.body ??
-        {}) as any;
+    const { studyId, genes, tab, preset, userPrompt, screenshot, model } =
+        (req.body ?? {}) as any;
     if (!studyId || typeof studyId !== 'string') {
         res.status(400).json({ error: 'studyId (string) required' });
         return;
@@ -29,6 +29,7 @@ export default async function handler(
             preset,
             userPrompt,
             screenshot,
+            model,
         });
         res.json(result);
     } catch (err: any) {

--- a/packages/chat-sidebar-server/package.json
+++ b/packages/chat-sidebar-server/package.json
@@ -11,10 +11,11 @@
         "vercel-build": "cd ../.. && pnpm --filter chat-sidebar build && rm -rf packages/chat-sidebar-server/public && mkdir -p packages/chat-sidebar-server/public && cp -R packages/chat-sidebar/dist/. packages/chat-sidebar-server/public/"
     },
     "dependencies": {
-        "@anthropic-ai/sdk": "^0.88.0",
+        "ai": "^6.0.188",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "zod": "4.4.3"
     },
     "devDependencies": {
         "@types/cors": "^2.8.17",

--- a/packages/chat-sidebar-server/src/core.ts
+++ b/packages/chat-sidebar-server/src/core.ts
@@ -1,20 +1,34 @@
 // Shared chat-sidebar logic. Both the Express server (src/server.ts) and the
 // Vercel serverless functions (api/chat/*.ts) call into runSuggest() and
 // runHighlights() here so the two stacks never drift.
+//
+// LLM calls route through the Vercel AI Gateway via `ai@^6` (plain
+// "provider/model" slugs auto-route). Auth is the VERCEL_OIDC_TOKEN env var
+// locally (refresh with `vercel env pull .env.local --yes`) and the
+// platform-injected OIDC token on deploy.
 
-import Anthropic from '@anthropic-ai/sdk';
+import {
+    generateText,
+    generateObject,
+    type ModelMessage,
+    type UserContent,
+} from 'ai';
+import { z } from 'zod';
 import { fetchPaperForStudy, PaperContext } from './paper.js';
 
-export const SUGGEST_MODEL = 'claude-opus-4-7';
-export const HIGHLIGHTS_MODEL = 'claude-sonnet-4-6';
+// Gateway slugs use dots for versions (anthropic/claude-opus-4.7), not
+// hyphens. Verified against gateway.getAvailableModels() during the refactor.
+export const SUGGEST_MODEL = 'anthropic/claude-opus-4.7';
+export const HIGHLIGHTS_MODEL = 'anthropic/claude-sonnet-4.6';
 // Kept for the /health endpoint and the iframe banner.
 export const MODEL = SUGGEST_MODEL;
 
 // Per-1M-token base prices in USD. Cache write is 1.25x input (5-min TTL) or
 // 2x (1-hour TTL); cache read is 0.1x input — same multipliers across models.
+// AI Gateway is zero-markup so these are the underlying Anthropic prices.
 const PRICES: Record<string, { input: number; output: number }> = {
-    'claude-opus-4-7': { input: 5.0, output: 25.0 },
-    'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
+    'anthropic/claude-opus-4.7': { input: 5.0, output: 25.0 },
+    'anthropic/claude-sonnet-4.6': { input: 3.0, output: 15.0 },
 };
 
 export function computeCost(usage: any, model: string = SUGGEST_MODEL) {
@@ -54,15 +68,11 @@ export function computeCost(usage: any, model: string = SUGGEST_MODEL) {
     };
 }
 
-// Anthropic client is lazy so we don't crash at import time on Vercel cold
-// starts when ANTHROPIC_API_KEY hasn't been resolved yet.
-let _anthropic: Anthropic | null = null;
-function client(): Anthropic {
-    if (!process.env.ANTHROPIC_API_KEY) {
-        throw new Error('ANTHROPIC_API_KEY is not set');
-    }
-    if (!_anthropic) _anthropic = new Anthropic();
-    return _anthropic;
+// The Anthropic-native usage shape we feed to computeCost is nested under
+// providerMetadata.anthropic.usage by the AI SDK. Pull it out defensively so
+// computeCost keeps working even if the shape shifts.
+function extractAnthropicUsage(providerMetadata: any): any {
+    return providerMetadata?.anthropic?.usage ?? {};
 }
 
 // Per-process paper cache. Persistent on the Express server; per-warm-Lambda
@@ -158,29 +168,17 @@ function buildSuggestUserText(ctx: {
     return lines.join('\n');
 }
 
-function buildSuggestUserMessage(
-    ctx: SuggestInput
-): Anthropic.MessageParam['content'] {
+// Build the user-message content for runSuggest. When a screenshot is
+// provided we send a multi-part content array (image + text); otherwise a
+// plain string keeps the wire format minimal. The AI SDK accepts a data URL
+// directly as the image source — mediaType is parsed from the URL.
+function buildSuggestUserContent(ctx: SuggestInput): UserContent {
     const text = buildSuggestUserText(ctx);
     const shot = ctx.screenshot;
     if (!shot) return text;
-    // Strip "data:image/png;base64," prefix; Anthropic wants the raw base64.
-    const match = /^data:(image\/(?:png|jpeg|webp|gif));base64,(.+)$/.exec(shot);
-    if (!match) return text;
-    const [, mediaType, data] = match;
+    if (!/^data:image\/(?:png|jpeg|webp|gif);base64,/.test(shot)) return text;
     return [
-        {
-            type: 'image',
-            source: {
-                type: 'base64',
-                media_type: mediaType as
-                    | 'image/png'
-                    | 'image/jpeg'
-                    | 'image/webp'
-                    | 'image/gif',
-                data,
-            },
-        },
+        { type: 'image', image: shot },
         { type: 'text', text },
     ];
 }
@@ -216,66 +214,50 @@ const TAB_HINTS = [
     'pathways',
 ] as const;
 
-const HIGHLIGHT_SCHEMA = {
-    type: 'object',
-    properties: {
-        highlights: {
-            type: 'array',
-            items: {
-                type: 'object',
-                properties: {
-                    type: {
-                        type: 'string',
-                        enum: ['alteration', 'gene', 'tab'],
-                        description:
-                            'alteration = beacon on an oncoprint legend label; gene = beacon on an oncoprint gene track title; tab = beacon on a results-view tab.',
-                    },
-                    alterationType: {
-                        type: 'string',
-                        enum: ALTERATION_TYPES as unknown as string[],
-                        description:
-                            'Required when type=alteration. Canonical oncoprint legend bucket.',
-                    },
-                    gene: {
-                        type: 'string',
-                        description:
-                            'Required when type=gene. HUGO symbol, e.g. TP53.',
-                    },
-                    genes: {
-                        type: 'array',
-                        items: { type: 'string' },
-                        description:
-                            'Optional when type=alteration. Genes the paper ties to this alteration type.',
-                    },
-                    tabHint: {
-                        type: 'string',
-                        enum: TAB_HINTS as unknown as string[],
-                        description:
-                            'Required when type=tab. Which results-view tab the paper has pertinent content for.',
-                    },
-                    note: {
-                        type: 'string',
-                        description:
-                            'One-sentence paper-grounded observation, <= 220 chars. No filler.',
-                    },
-                    quote: {
-                        type: 'string',
-                        description:
-                            'Verbatim substring from the paper that grounds the note. <= 320 chars.',
-                    },
-                    importance: {
-                        type: 'string',
-                        enum: ['high', 'medium', 'low'],
-                    },
-                },
-                required: ['type', 'note', 'quote', 'importance'],
-                additionalProperties: false,
-            },
-        },
-    },
-    required: ['highlights'],
-    additionalProperties: false,
-} as const;
+const HighlightSchema = z.object({
+    type: z
+        .enum(['alteration', 'gene', 'tab'])
+        .describe(
+            'alteration = beacon on an oncoprint legend label; gene = beacon on an oncoprint gene track title; tab = beacon on a results-view tab.'
+        ),
+    alterationType: z
+        .enum(ALTERATION_TYPES)
+        .optional()
+        .describe(
+            'Required when type=alteration. Canonical oncoprint legend bucket.'
+        ),
+    gene: z
+        .string()
+        .optional()
+        .describe('Required when type=gene. HUGO symbol, e.g. TP53.'),
+    genes: z
+        .array(z.string())
+        .optional()
+        .describe(
+            'Optional when type=alteration. Genes the paper ties to this alteration type.'
+        ),
+    tabHint: z
+        .enum(TAB_HINTS)
+        .optional()
+        .describe(
+            'Required when type=tab. Which results-view tab the paper has pertinent content for.'
+        ),
+    note: z
+        .string()
+        .describe(
+            'One-sentence paper-grounded observation, <= 220 chars. No filler.'
+        ),
+    quote: z
+        .string()
+        .describe(
+            'Verbatim substring from the paper that grounds the note. <= 320 chars.'
+        ),
+    importance: z.enum(['high', 'medium', 'low']),
+});
+
+const HighlightsResponseSchema = z.object({
+    highlights: z.array(HighlightSchema),
+});
 
 function buildHighlightSystemPrompt(paper: PaperContext): string {
     return [
@@ -369,6 +351,26 @@ function paperInfo(paper: PaperContext): PaperInfo {
     };
 }
 
+// Build the `messages` array with the big paper-grounded system prompt
+// marked as an Anthropic 1h cache breakpoint. Putting the system message in
+// the messages array (rather than as a top-level `system:` option) is what
+// lets us attach providerOptions.anthropic.cacheControl to it.
+function buildMessages(
+    systemText: string,
+    userContent: UserContent
+): ModelMessage[] {
+    return [
+        {
+            role: 'system',
+            content: systemText,
+            providerOptions: {
+                anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+            },
+        },
+        { role: 'user', content: userContent },
+    ];
+}
+
 export interface SuggestInput {
     studyId: string;
     genes?: string[];
@@ -391,33 +393,26 @@ export async function runSuggest(
     input: SuggestInput
 ): Promise<SuggestResult> {
     const paper = await getPaperContext(input.studyId);
-    const stream = client().messages.stream({
+    const result = await generateText({
         model: SUGGEST_MODEL,
-        max_tokens: 1024,
-        system: [
-            {
-                type: 'text',
-                text: buildSuggestSystemPrompt(paper),
-                cache_control: { type: 'ephemeral', ttl: '1h' },
-            },
-        ],
-        messages: [
-            {
-                role: 'user',
-                content: buildSuggestUserMessage(input),
-            },
-        ],
+        maxOutputTokens: 1024,
+        // The system role lives inside messages so we can attach a
+        // providerOptions.anthropic.cacheControl breakpoint to it — the
+        // top-level `system` option doesn't accept per-message options.
+        // Our system content is internally constructed (never user-derived),
+        // so the SDK's prompt-injection warning is not a real concern here.
+        allowSystemInMessages: true,
+        messages: buildMessages(
+            buildSuggestSystemPrompt(paper),
+            buildSuggestUserContent(input)
+        ),
     });
-    const finalMessage = await stream.finalMessage();
-    const suggestion = finalMessage.content
-        .filter((b): b is Anthropic.TextBlock => b.type === 'text')
-        .map(b => b.text)
-        .join('');
+    const usage = extractAnthropicUsage(result.providerMetadata);
     return {
-        suggestion,
+        suggestion: result.text,
         paper: paperInfo(paper),
-        usage: finalMessage.usage,
-        cost: computeCost(finalMessage.usage, SUGGEST_MODEL),
+        usage,
+        cost: computeCost(usage, SUGGEST_MODEL),
     };
 }
 
@@ -445,44 +440,21 @@ export async function runHighlights(
     input: HighlightsInput
 ): Promise<HighlightsResult> {
     const paper = await getPaperContext(input.studyId);
-    const response = await client().messages.create({
+    const result = await generateObject({
         model: HIGHLIGHTS_MODEL,
-        max_tokens: 4096,
-        output_config: {
-            format: {
-                type: 'json_schema',
-                schema: HIGHLIGHT_SCHEMA,
-            },
-        },
-        system: [
-            {
-                type: 'text',
-                text: buildHighlightSystemPrompt(paper),
-                cache_control: { type: 'ephemeral', ttl: '1h' },
-            },
-        ],
-        messages: [
-            {
-                role: 'user',
-                content: buildHighlightsUserText(input.inventory),
-            },
-        ],
+        maxOutputTokens: 4096,
+        schema: HighlightsResponseSchema,
+        allowSystemInMessages: true,
+        messages: buildMessages(
+            buildHighlightSystemPrompt(paper),
+            buildHighlightsUserText(input.inventory)
+        ),
     });
-    const textBlock = response.content.find(
-        (b): b is Anthropic.TextBlock => b.type === 'text'
-    );
-    let parsed: any = { highlights: [] };
-    if (textBlock) {
-        try {
-            parsed = JSON.parse(textBlock.text);
-        } catch {
-            /* fall through with empty list */
-        }
-    }
+    const usage = extractAnthropicUsage(result.providerMetadata);
     return {
-        highlights: parsed.highlights ?? [],
+        highlights: result.object.highlights,
         paper: paperInfo(paper),
-        usage: response.usage,
-        cost: computeCost(response.usage, HIGHLIGHTS_MODEL),
+        usage,
+        cost: computeCost(usage, HIGHLIGHTS_MODEL),
     };
 }

--- a/packages/chat-sidebar-server/src/core.ts
+++ b/packages/chat-sidebar-server/src/core.ts
@@ -15,65 +15,17 @@ import {
 } from 'ai';
 import { z } from 'zod';
 import { fetchPaperForStudy, PaperContext } from './paper.js';
+import {
+    computeCostFromUsage,
+    type CostBreakdown,
+} from './pricing.js';
 
-// Gateway slugs use dots for versions (anthropic/claude-opus-4.7), not
-// hyphens. Verified against gateway.getAvailableModels() during the refactor.
+// Default Gateway slugs (dots, not hyphens — verified against
+// gateway.getAvailableModels()). Callers may override the model per request.
 export const SUGGEST_MODEL = 'anthropic/claude-opus-4.7';
 export const HIGHLIGHTS_MODEL = 'anthropic/claude-sonnet-4.6';
 // Kept for the /health endpoint and the iframe banner.
 export const MODEL = SUGGEST_MODEL;
-
-// Per-1M-token base prices in USD. Cache write is 1.25x input (5-min TTL) or
-// 2x (1-hour TTL); cache read is 0.1x input — same multipliers across models.
-// AI Gateway is zero-markup so these are the underlying Anthropic prices.
-const PRICES: Record<string, { input: number; output: number }> = {
-    'anthropic/claude-opus-4.7': { input: 5.0, output: 25.0 },
-    'anthropic/claude-sonnet-4.6': { input: 3.0, output: 15.0 },
-};
-
-export function computeCost(usage: any, model: string = SUGGEST_MODEL) {
-    const price = PRICES[model] ?? PRICES[SUGGEST_MODEL];
-    const inputTok = usage?.input_tokens ?? 0;
-    const cacheRead = usage?.cache_read_input_tokens ?? 0;
-    const outputTok = usage?.output_tokens ?? 0;
-    const cacheWrite5m =
-        usage?.cache_creation?.ephemeral_5m_input_tokens ?? 0;
-    const cacheWrite1h =
-        usage?.cache_creation?.ephemeral_1h_input_tokens ?? 0;
-    const cacheWriteTotal =
-        usage?.cache_creation_input_tokens ?? cacheWrite5m + cacheWrite1h;
-
-    const inputCost = (inputTok * price.input) / 1_000_000;
-    const cacheWriteCost =
-        (cacheWrite5m * price.input * 1.25 + cacheWrite1h * price.input * 2.0) /
-        1_000_000;
-    const cacheReadCost = (cacheRead * price.input * 0.1) / 1_000_000;
-    const outputCost = (outputTok * price.output) / 1_000_000;
-    return {
-        total: inputCost + cacheWriteCost + cacheReadCost + outputCost,
-        inputCost,
-        cacheWriteCost,
-        cacheReadCost,
-        outputCost,
-        tokens: {
-            input: inputTok,
-            cacheWrite: cacheWriteTotal,
-            cacheWrite5m,
-            cacheWrite1h,
-            cacheRead,
-            output: outputTok,
-        },
-        currency: 'USD',
-        model,
-    };
-}
-
-// The Anthropic-native usage shape we feed to computeCost is nested under
-// providerMetadata.anthropic.usage by the AI SDK. Pull it out defensively so
-// computeCost keeps working even if the shape shifts.
-function extractAnthropicUsage(providerMetadata: any): any {
-    return providerMetadata?.anthropic?.usage ?? {};
-}
 
 // Per-process paper cache. Persistent on the Express server; per-warm-Lambda
 // on Vercel (each warm function reuses; cold starts fetch fresh from PMC).
@@ -380,39 +332,44 @@ export interface SuggestInput {
     userPrompt?: string;
     // base64 PNG data URL of the current viewport, captured client-side.
     screenshot?: string;
+    // Optional Gateway slug override (e.g. "openai/gpt-5.4"). Falls back to
+    // SUGGEST_MODEL when absent.
+    model?: string;
 }
 
 export interface SuggestResult {
     suggestion: string;
     paper: PaperInfo;
     usage: any;
-    cost: ReturnType<typeof computeCost>;
+    cost: CostBreakdown;
 }
 
 export async function runSuggest(
     input: SuggestInput
 ): Promise<SuggestResult> {
     const paper = await getPaperContext(input.studyId);
+    const model = input.model ?? SUGGEST_MODEL;
     const result = await generateText({
-        model: SUGGEST_MODEL,
+        model,
         maxOutputTokens: 1024,
         // The system role lives inside messages so we can attach a
         // providerOptions.anthropic.cacheControl breakpoint to it — the
         // top-level `system` option doesn't accept per-message options.
         // Our system content is internally constructed (never user-derived),
         // so the SDK's prompt-injection warning is not a real concern here.
+        // The Anthropic-namespaced providerOptions are silently ignored by
+        // non-Anthropic providers, so this is safe to send unconditionally.
         allowSystemInMessages: true,
         messages: buildMessages(
             buildSuggestSystemPrompt(paper),
             buildSuggestUserContent(input)
         ),
     });
-    const usage = extractAnthropicUsage(result.providerMetadata);
     return {
         suggestion: result.text,
         paper: paperInfo(paper),
-        usage,
-        cost: computeCost(usage, SUGGEST_MODEL),
+        usage: result.usage,
+        cost: await computeCostFromUsage(result.usage, model),
     };
 }
 
@@ -427,21 +384,24 @@ export interface HighlightsInput {
         genes?: string[];
         tabs?: string[];
     };
+    // Optional Gateway slug override; falls back to HIGHLIGHTS_MODEL.
+    model?: string;
 }
 
 export interface HighlightsResult {
     highlights: any[];
     paper: PaperInfo;
     usage: any;
-    cost: ReturnType<typeof computeCost>;
+    cost: CostBreakdown;
 }
 
 export async function runHighlights(
     input: HighlightsInput
 ): Promise<HighlightsResult> {
     const paper = await getPaperContext(input.studyId);
+    const model = input.model ?? HIGHLIGHTS_MODEL;
     const result = await generateObject({
-        model: HIGHLIGHTS_MODEL,
+        model,
         maxOutputTokens: 4096,
         schema: HighlightsResponseSchema,
         allowSystemInMessages: true,
@@ -450,11 +410,10 @@ export async function runHighlights(
             buildHighlightsUserText(input.inventory)
         ),
     });
-    const usage = extractAnthropicUsage(result.providerMetadata);
     return {
         highlights: result.object.highlights,
         paper: paperInfo(paper),
-        usage,
-        cost: computeCost(usage, HIGHLIGHTS_MODEL),
+        usage: result.usage,
+        cost: await computeCostFromUsage(result.usage, model),
     };
 }

--- a/packages/chat-sidebar-server/src/pricing.ts
+++ b/packages/chat-sidebar-server/src/pricing.ts
@@ -1,0 +1,161 @@
+// Per-token pricing for any model the Vercel AI Gateway routes us to.
+//
+// We pull the pricing table from gateway.getAvailableModels() once on first
+// use rather than hand-maintaining a PRICES record — that catalog is the
+// authoritative source and updates automatically when providers reprice.
+//
+// One caveat for Anthropic 1h-TTL caches: the Gateway lists a single
+// `cacheCreationInputTokens` rate which is Anthropic's 5m-TTL price (1.25x
+// input). The 1h-TTL write is actually 2x input, so first-call cache-write
+// cost on a long paper is under-reported by ~30%. Subsequent cache reads
+// (the common case) are correct. Acceptable for an MVP cost display.
+//
+// We also accept the curated shortlist that the iframe surfaces in its
+// model dropdown — see MODEL_SHORTLIST below. The list controls what the
+// user can pick; the pricing comes from the Gateway.
+
+import { gateway } from 'ai';
+
+export interface ModelPricing {
+    // Per-token, in USD. Strings in the Gateway response; we parse to Number.
+    input: number;
+    output: number;
+    cachedInput: number;
+    cacheCreation: number;
+}
+
+export interface ModelInfo {
+    id: string;
+    name: string;
+    description: string;
+    pricing: ModelPricing;
+}
+
+// Curated subset of `provider/model` slugs that we expose in the sidebar
+// dropdown. Pulled from the user's selections during this branch's setup.
+// Order here is the display order in the dropdown.
+export const MODEL_SHORTLIST: readonly string[] = [
+    'anthropic/claude-opus-4.7',
+    'anthropic/claude-sonnet-4.6',
+    'anthropic/claude-haiku-4.5',
+    'openai/gpt-5.4',
+    'openai/gpt-5.4-mini',
+    'google/gemini-3-pro-preview',
+    'xai/grok-4.1-fast-reasoning',
+    'deepseek/deepseek-v4-pro',
+];
+
+let modelCache: Map<string, ModelInfo> | null = null;
+let modelCachePromise: Promise<Map<string, ModelInfo>> | null = null;
+
+async function loadModels(): Promise<Map<string, ModelInfo>> {
+    if (modelCache) return modelCache;
+    if (!modelCachePromise) {
+        modelCachePromise = (async () => {
+            const { models } = await gateway.getAvailableModels();
+            const m = new Map<string, ModelInfo>();
+            for (const x of models as any[]) {
+                if (!x.pricing) continue;
+                m.set(x.id, {
+                    id: x.id,
+                    name: x.name ?? x.id,
+                    description: x.description ?? '',
+                    pricing: {
+                        input: Number(x.pricing.input),
+                        output: Number(x.pricing.output),
+                        cachedInput: Number(x.pricing.cachedInputTokens ?? 0),
+                        cacheCreation: Number(
+                            x.pricing.cacheCreationInputTokens ?? 0
+                        ),
+                    },
+                });
+            }
+            modelCache = m;
+            return m;
+        })();
+    }
+    return modelCachePromise;
+}
+
+export async function getPricing(
+    modelId: string
+): Promise<ModelPricing | null> {
+    const m = await loadModels();
+    return m.get(modelId)?.pricing ?? null;
+}
+
+// Return the shortlist with name + pricing populated, for the iframe to
+// render in its dropdown. Drops any entries the Gateway doesn't know about
+// (e.g. a slug got renamed between releases) so the UI never shows a model
+// the backend can't actually route to.
+export async function getShortlistedModels(): Promise<ModelInfo[]> {
+    const m = await loadModels();
+    return MODEL_SHORTLIST.map(id => m.get(id)).filter(
+        (x): x is ModelInfo => x !== undefined
+    );
+}
+
+export interface CostBreakdown {
+    total: number;
+    inputCost: number;
+    cacheWriteCost: number;
+    cacheReadCost: number;
+    outputCost: number;
+    tokens: {
+        input: number;
+        cacheWrite: number;
+        cacheRead: number;
+        output: number;
+    };
+    currency: 'USD';
+    model: string;
+}
+
+// AI-SDK-normalized usage shape (result.usage from generateText/Object).
+// We accept `any` to stay tolerant of shape drift across providers.
+export async function computeCostFromUsage(
+    usage: any,
+    modelId: string
+): Promise<CostBreakdown> {
+    const pricing = (await getPricing(modelId)) ?? {
+        input: 0,
+        output: 0,
+        cachedInput: 0,
+        cacheCreation: 0,
+    };
+
+    // result.usage shape from AI SDK v6:
+    //   inputTokens: total input incl. cached
+    //   outputTokens: total output
+    //   cachedInputTokens: subset of inputTokens that hit the cache
+    //   inputTokenDetails: { noCacheTokens, cacheReadTokens, cacheWriteTokens }
+    const totalInput = usage?.inputTokens ?? 0;
+    const cacheRead =
+        usage?.inputTokenDetails?.cacheReadTokens ??
+        usage?.cachedInputTokens ??
+        0;
+    const cacheWrite = usage?.inputTokenDetails?.cacheWriteTokens ?? 0;
+    const uncachedInput = Math.max(0, totalInput - cacheRead - cacheWrite);
+    const outputTok = usage?.outputTokens ?? 0;
+
+    const inputCost = uncachedInput * pricing.input;
+    const cacheReadCost = cacheRead * pricing.cachedInput;
+    const cacheWriteCost = cacheWrite * pricing.cacheCreation;
+    const outputCost = outputTok * pricing.output;
+
+    return {
+        total: inputCost + cacheReadCost + cacheWriteCost + outputCost,
+        inputCost,
+        cacheWriteCost,
+        cacheReadCost,
+        outputCost,
+        tokens: {
+            input: uncachedInput,
+            cacheWrite,
+            cacheRead,
+            output: outputTok,
+        },
+        currency: 'USD',
+        model: modelId,
+    };
+}

--- a/packages/chat-sidebar-server/src/server.ts
+++ b/packages/chat-sidebar-server/src/server.ts
@@ -1,14 +1,22 @@
 // Express dev server — wraps the shared logic in core.ts so that
 // `pnpm dev` here mirrors what the Vercel functions in api/chat/* do.
-import 'dotenv/config';
+import { config as loadEnv } from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import { MODEL, runSuggest, runHighlights } from './core.js';
 
+// Load .env then layer .env.local on top — VERCEL_OIDC_TOKEN lands in
+// .env.local via `vercel env pull`, so the local order has to match what
+// Vercel does in deployed envs.
+loadEnv();
+loadEnv({ path: '.env.local', override: true });
+
 const PORT = Number(process.env.PORT || 4000);
 
-if (!process.env.ANTHROPIC_API_KEY) {
-    console.error('ANTHROPIC_API_KEY is not set. Add it to .env.');
+if (!process.env.VERCEL_OIDC_TOKEN && !process.env.AI_GATEWAY_API_KEY) {
+    console.error(
+        'No AI Gateway credentials found. Run `vercel env pull .env.local --yes` to provision VERCEL_OIDC_TOKEN, or set AI_GATEWAY_API_KEY.'
+    );
     process.exit(1);
 }
 

--- a/packages/chat-sidebar-server/src/server.ts
+++ b/packages/chat-sidebar-server/src/server.ts
@@ -4,6 +4,7 @@ import { config as loadEnv } from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import { MODEL, runSuggest, runHighlights } from './core.js';
+import { getShortlistedModels } from './pricing.js';
 
 // Load .env then layer .env.local on top — VERCEL_OIDC_TOKEN lands in
 // .env.local via `vercel env pull`, so the local order has to match what
@@ -28,8 +29,20 @@ app.get('/api/chat/health', (_req, res) => {
     res.json({ ok: true, model: MODEL });
 });
 
+app.get('/api/chat/models', async (_req, res) => {
+    try {
+        const models = await getShortlistedModels();
+        res.json({ models });
+    } catch (err: any) {
+        console.error('models failed:', err);
+        res.status(500).json({
+            error: err?.message ?? 'Could not fetch model catalog',
+        });
+    }
+});
+
 app.post('/api/chat/suggest', async (req, res) => {
-    const { studyId, genes, tab, preset, userPrompt, screenshot } =
+    const { studyId, genes, tab, preset, userPrompt, screenshot, model } =
         req.body ?? {};
     if (!studyId || typeof studyId !== 'string') {
         res.status(400).json({ error: 'studyId (string) required' });
@@ -43,6 +56,7 @@ app.post('/api/chat/suggest', async (req, res) => {
             preset,
             userPrompt,
             screenshot,
+            model,
         });
         res.json(result);
     } catch (err: any) {
@@ -54,13 +68,13 @@ app.post('/api/chat/suggest', async (req, res) => {
 });
 
 app.post('/api/chat/highlights', async (req, res) => {
-    const { studyId, inventory } = req.body ?? {};
+    const { studyId, inventory, model } = req.body ?? {};
     if (!studyId || typeof studyId !== 'string') {
         res.status(400).json({ error: 'studyId (string) required' });
         return;
     }
     try {
-        const result = await runHighlights({ studyId, inventory });
+        const result = await runHighlights({ studyId, inventory, model });
         res.json(result);
     } catch (err: any) {
         console.error('highlights failed:', err);

--- a/packages/chat-sidebar/src/App.tsx
+++ b/packages/chat-sidebar/src/App.tsx
@@ -32,6 +32,18 @@ interface SuggestResponse {
     cost?: Cost;
 }
 
+interface ModelInfo {
+    id: string;
+    name: string;
+    description: string;
+    pricing: {
+        input: number;
+        output: number;
+        cachedInput: number;
+        cacheCreation: number;
+    };
+}
+
 type Preset = 'keyFinding' | 'cohort' | 'limitations';
 
 const PRESETS: { id: Preset; label: string }[] = [
@@ -39,6 +51,15 @@ const PRESETS: { id: Preset; label: string }[] = [
     { id: 'cohort', label: 'Cohort' },
     { id: 'limitations', label: 'Limitations' },
 ];
+
+const MODEL_STORAGE_KEY = 'chat-sidebar:selectedModel';
+
+// $X/M-tokens display for the dropdown tooltip. Pricing comes through as
+// per-token dollars, so multiply by 1M for the human-readable form.
+function formatPerMillion(perToken: number): string {
+    const perMillion = perToken * 1_000_000;
+    return `$${perMillion.toFixed(2)}/M`;
+}
 
 function formatCost(n: number): string {
     // Sub-cent precision so a $0.0023 call doesn't read as "$0.00".
@@ -105,8 +126,52 @@ export function App() {
     const [lastScreenshot, setLastScreenshot] = useState<string | null>(null);
     const [showScreenshot, setShowScreenshot] = useState(false);
     const [input, setInput] = useState('');
+    const [models, setModels] = useState<ModelInfo[]>([]);
+    const [selectedModel, setSelectedModel] = useState<string | null>(() => {
+        try {
+            return localStorage.getItem(MODEL_STORAGE_KEY);
+        } catch {
+            return null;
+        }
+    });
     const autoRunRef = useRef(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    // Fetch the curated model catalog once on mount. If localStorage already
+    // had a selection, keep it; otherwise default to the first model the
+    // backend returns (currently anthropic/claude-opus-4.7).
+    useEffect(() => {
+        let cancelled = false;
+        fetch('/api/chat/models')
+            .then(r => r.json())
+            .then((data: { models: ModelInfo[] }) => {
+                if (cancelled) return;
+                setModels(data.models);
+                if (
+                    !selectedModel ||
+                    !data.models.some(m => m.id === selectedModel)
+                ) {
+                    setSelectedModel(data.models[0]?.id ?? null);
+                }
+            })
+            .catch(() => {
+                /* dropdown will fall back to "(default)" */
+            });
+        return () => {
+            cancelled = true;
+        };
+        // Run once — selectedModel is read but not a dep on purpose.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const onSelectModel = (id: string) => {
+        setSelectedModel(id);
+        try {
+            localStorage.setItem(MODEL_STORAGE_KEY, id);
+        } catch {
+            /* private mode etc — selection just doesn't persist */
+        }
+    };
 
     useEffect(() => {
         if (!studyId || autoRunRef.current) return;
@@ -156,6 +221,7 @@ export function App() {
                     preset: opts.preset,
                     userPrompt: opts.userPrompt,
                     screenshot,
+                    model: selectedModel ?? undefined,
                 }),
             });
             if (!r.ok) {
@@ -182,7 +248,39 @@ export function App() {
     return (
         <div className="chat-shell">
             <header className="chat-header">
-                <div className="chat-title">Study Chat</div>
+                <div className="chat-header-row">
+                    <div className="chat-title">Study Chat</div>
+                    {models.length > 0 && (
+                        <select
+                            className="model-select"
+                            value={selectedModel ?? ''}
+                            onChange={e => onSelectModel(e.target.value)}
+                            disabled={loading}
+                            title={
+                                selectedModel
+                                    ? (models.find(
+                                          m => m.id === selectedModel
+                                      )?.description ?? '')
+                                    : ''
+                            }
+                            aria-label="Model"
+                        >
+                            {models.map(m => (
+                                <option
+                                    key={m.id}
+                                    value={m.id}
+                                    title={`in ${formatPerMillion(m.pricing.input)} · out ${formatPerMillion(m.pricing.output)}${
+                                        m.pricing.cachedInput > 0
+                                            ? ` · cached ${formatPerMillion(m.pricing.cachedInput)}`
+                                            : ''
+                                    }`}
+                                >
+                                    {m.name}
+                                </option>
+                            ))}
+                        </select>
+                    )}
+                </div>
                 {study && (
                     <div className="chat-subtitle" title={study.description}>
                         {suggestion?.paper?.paperUrl ? (

--- a/packages/chat-sidebar/src/styles.css
+++ b/packages/chat-sidebar/src/styles.css
@@ -43,9 +43,31 @@ body,
     background: var(--bg-alt);
 }
 
+.chat-header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
 .chat-title {
     font-weight: 600;
     font-size: 14px;
+}
+
+.model-select {
+    font: inherit;
+    font-size: 11px;
+    padding: 2px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text);
+    max-width: 180px;
+}
+
+.model-select:disabled {
+    opacity: 0.6;
 }
 
 .chat-subtitle {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,9 +950,9 @@ importers:
 
   packages/chat-sidebar-server:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.88.0
-        version: 0.88.0(zod@3.25.76)
+      ai:
+        specifier: ^6.0.188
+        version: 6.0.188(zod@4.4.3)
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -962,6 +962,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.1
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
@@ -1192,14 +1195,21 @@ packages:
     resolution: {integrity: sha512-stbHw2c2T12bABmFyBrhJL4tufw+hUjvhmJthOxAxKVDwAtAZSI17Kue8VNxaHewf5oRydPo6W62BlWrbrNa6Q==}
     engines: {node: '>=16.16.0', npm: '>=8.11'}
 
-  '@anthropic-ai/sdk@0.88.0':
-    resolution: {integrity: sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==}
-    hasBin: true
+  '@ai-sdk/gateway@3.0.118':
+    resolution: {integrity: sha512-XYPbVoDo1TDMVLe5Eg42gIjdOyxaizh9H0kiSSnTXr+AdrqZvutk/ypLOiqBXPV3D1K3+BSm/sbFeomZJlM64A==}
+    engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2913,6 +2923,10 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@peculiar/asn1-cms@2.6.1':
     resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
 
@@ -3276,6 +3290,9 @@ packages:
     deprecated: |-
       Deprecated: no longer maintained and no longer used by Sinon packages. See
         https://github.com/sinonjs/nise/issues/243 for replacement details.
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@testing-library/dom@8.20.1':
     resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
@@ -4070,6 +4087,10 @@ packages:
   '@vercel/node@5.0.4':
     resolution: {integrity: sha512-AXpTFDzomabvi/FmxDDTwmnuqRBDfy2i0nzjKwVPM3ch94EucPbiAk3+18iZOX/A+o2mBO4jKc1DmB0ifQF2Rw==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vercel/python@4.7.1':
     resolution: {integrity: sha512-H4g/5e8unII4oQ+KN5IUvTZSzHmj+lLYDkAK15QGYgAxBtE/mHUvEZpPPo7DPUDIyfq8ybWB1bmk7H5kEahubQ==}
 
@@ -4288,6 +4309,12 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ai@6.0.188:
+    resolution: {integrity: sha512-kNwIl1MM4ESzeOPDYuN+FidJ2QY5kGWHLtTMru6HHPW/JJ6nPuvHRhJ8tMX/Y2Tijx9DCiv2W7y5IBouuB712g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   airbnb-prop-types@2.16.0:
     resolution: {integrity: sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==}
@@ -6890,6 +6917,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -8649,10 +8680,6 @@ packages:
 
   json-schema-to-ts@1.6.4:
     resolution: {integrity: sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==}
-
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -12528,9 +12555,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-jest@27.1.5:
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -13617,6 +13641,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -13629,11 +13656,23 @@ snapshots:
       pako: 2.1.0
       upng-js: 2.1.0
 
-  '@anthropic-ai/sdk@0.88.0(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.118(zod@4.4.3)':
     dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -15650,6 +15689,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@peculiar/asn1-cms@2.6.1':
     dependencies:
       '@peculiar/asn1-schema': 2.6.0
@@ -16040,6 +16081,8 @@ snapshots:
       lodash: 4.18.1
 
   '@sinonjs/text-encoding@0.7.3': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@8.20.1':
     dependencies:
@@ -17483,6 +17526,8 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vercel/python@4.7.1': {}
 
   '@vercel/redwood@2.1.13(encoding@0.1.13)(rollup@4.60.4)':
@@ -17737,6 +17782,14 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ai@6.0.188(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.118(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
 
   airbnb-prop-types@2.16.0(react@16.14.0):
     dependencies:
@@ -21117,6 +21170,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.8: {}
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -23364,11 +23419,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ts-toolbelt: 6.15.5
-
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -28471,8 +28521,6 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-algebra@2.0.0: {}
-
   ts-jest@27.1.5(@babel/core@7.4.4)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.4.4))(jest@27.5.1(ts-node@10.9.2(@types/node@22.19.19)(typescript@4.9.5)))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
@@ -29860,5 +29908,7 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Replace direct `@anthropic-ai/sdk` usage in `packages/chat-sidebar-server/` with `ai@^6` + `zod`. LLM calls now route through the **Vercel AI Gateway** using gateway slugs (`anthropic/claude-opus-4.7`, etc.) authenticated via `VERCEL_OIDC_TOKEN`. Anthropic prompt caching survives the Gateway — verified end-to-end that the 1h cache breakpoint on the paper-text system prompt produces the same `cache_creation_input_tokens` / `cache_read_input_tokens` shape and gives a ~9× cost reduction on repeat calls.
- Add a **model dropdown** in the sidebar header. Selection persists in `localStorage` and ships with each suggest call. Curated shortlist: 3 Anthropic models (Opus 4.7 / Sonnet 4.6 / Haiku 4.5), 2 OpenAI (GPT-5.4 / 5.4 Mini), Gemini 3 Pro Preview, Grok 4.1 Fast Reasoning, DeepSeek V4 Pro.
- **Cost is computed from authoritative Gateway pricing** (`gateway.getAvailableModels()`), not a hand-maintained table — works for any provider the Gateway routes us to. Per-call cost shown in the chat UI; per-token in/out/cached rates surfaced in the dropdown option tooltips.

## Why
Unified observability and spend tracking in one Vercel dashboard, provider-agnostic so we can A/B different models by changing a string, and a way to compare grounding quality across vendors on the actual paper-reading workload. The model picker also lets us cheap out on Haiku for high-volume runs.

## Mechanics worth flagging
- `runHighlights` swaps the hand-built JSON Schema + `JSON.parse` path for `generateObject` with a Zod schema — cleaner contract, same cache breakpoint.
- System prompt must go inside `messages` (not the top-level `system:` option) for `providerOptions.anthropic.cacheControl` to attach; `allowSystemInMessages: true` silences the SDK's prompt-injection warning since our system content is internally constructed.
- Cost calc uses the AI-SDK-normalized `result.usage` shape so it works cross-provider. One known under-count: Gateway lists Anthropic's 5m-TTL write rate (1.25× input); our 1h-TTL writes actually bill at 2×. Cache writes are one-time per session, so the display delta is small; documented inline in `src/pricing.ts`.
- New `GET /api/chat/models` endpoint (Express + Vercel function) returns the shortlist with name + per-token pricing for the dropdown.
- Server startup now requires `VERCEL_OIDC_TOKEN` (or `AI_GATEWAY_API_KEY`) instead of `ANTHROPIC_API_KEY`. `.env.local` is layered on top of `.env` to match Vercel's deployed env order.

## Test plan
- [x] Verified `gateway.getAvailableModels()` returns valid slugs for all 8 shortlisted models with non-zero pricing.
- [x] Two consecutive `runSuggest` calls against `glioma_msk_2018` — call 2 read all of call 1's cache tokens through the Gateway (Anthropic models).
- [x] Two consecutive `runHighlights` calls — Zod-schema parsing succeeds, valid highlights returned, caching path confirmed.
- [x] Cross-provider smoke test (Haiku / GPT-5.4-mini / Gemini-3-Pro-Preview) — all return non-empty grounded responses with sensible cost numbers (.009 to .035 per call).
- [x] `pnpm exec tsc --noEmit` clean in both `packages/chat-sidebar-server` and `packages/chat-sidebar`.
- [ ] In-browser sanity check: model dropdown renders, selection persists across reload, cost line updates per call, switching providers visibly changes per-call cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781971149&installation_id=126502837&pr_number=5591&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5591&signature=ff85bbe369a5da89e632f1c651016a7910b2a9df18962162e517abd726b90707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->