### PR TITLE
Add generic assay frequency table to Study View

### DIFF
--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -590,7 +590,9 @@ export type GenericAssayDataCount = {
 
 };
 export type GenericAssayDataCountFilter = {
-    'genericAssayDataFilters': Array < GenericAssayDataFilter >
+    'genericAssayDataFilters'?: Array < GenericAssayDataFilter >
+
+        'profileType'?: string
 
         'studyViewFilter': StudyViewFilter
 

--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -611,6 +611,21 @@ export type GenericAssayDataFilter = {
         'values': Array < DataFilterValue >
 
 };
+export type GenericAssaySelectionValue = {
+    'stableId': string
+
+        'value': string
+
+};
+export type GenericAssaySelectionFilter = {
+    'patientLevel': boolean
+
+        'profileType': string
+
+        'values': Array < Array < GenericAssaySelectionValue >
+        >
+
+};
 export type GenericAssayEnrichment = {
     'genericEntityMetaProperties': {}
 
@@ -1554,6 +1569,8 @@ export type StudyViewFilter = {
         'geneFilters': Array < GeneFilter >
 
         'genericAssayDataFilters': Array < GenericAssayDataFilter >
+
+        'genericAssaySelectionFilters': Array < GenericAssaySelectionFilter >
 
         'genomicDataFilters': Array < GenomicDataFilter >
 

--- a/packages/cbioportal-ts-api-client/src/index.tsx
+++ b/packages/cbioportal-ts-api-client/src/index.tsx
@@ -64,6 +64,8 @@ export {
     GenericAssayDataCountFilter,
     GenericAssayDataCountItem,
     GenericAssayDataFilter,
+    GenericAssaySelectionFilter,
+    GenericAssaySelectionValue,
     GenericAssayEnrichment,
     Geneset,
     GenesetCorrelation,

--- a/src/pages/studyView/StudyViewComparisonUtils.ts
+++ b/src/pages/studyView/StudyViewComparisonUtils.ts
@@ -210,6 +210,10 @@ export function getComparisonParamsForTable(
             return {
                 namespaceAttributeValues: selectedRowsKeys.slice(),
             };
+        case ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE:
+            return {
+                genericAssayRowKeys: selectedRowsKeys.slice(),
+            };
         default:
             return {};
     }

--- a/src/pages/studyView/StudyViewConfig.ts
+++ b/src/pages/studyView/StudyViewConfig.ts
@@ -66,6 +66,7 @@ export enum ChartTypeEnum {
     BAR_CHART = 'BAR_CHART',
     SURVIVAL = 'SURVIVAL',
     TABLE = 'TABLE',
+    GENERIC_ASSAY_FREQUENCY_TABLE = 'GENERIC_ASSAY_FREQUENCY_TABLE',
     SCATTER = 'SCATTER',
     VIOLIN_PLOT_TABLE = 'VIOLIN_PLOT_TABLE',
     VARIANT_ANNOTATIONS_TABLE = 'VARIANT_ANNOTATIONS_TABLE',
@@ -91,6 +92,7 @@ export enum ChartTypeNameEnum {
     BAR_CHART = 'bar chart',
     SURVIVAL = 'survival plot',
     TABLE = 'table',
+    GENERIC_ASSAY_FREQUENCY_TABLE = 'table',
     SCATTER = 'density plot',
     VIOLIN_PLOT_TABLE = 'table',
     MUTATED_GENES_TABLE = 'table',
@@ -199,6 +201,11 @@ const studyViewFrontEnd = {
                 minW: 2,
             },
             [ChartTypeEnum.TABLE]: {
+                w: 2,
+                h: 2,
+                minW: 2,
+            },
+            [ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE]: {
                 w: 2,
                 h: 2,
                 minW: 2,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -5620,21 +5620,14 @@ export class StudyViewPageStore
                             [],
                         meta => meta.stableId
                     );
-                    const entityStableIds = _.keys(entityMetaByStableId);
-                    if (_.isEmpty(entityStableIds)) {
+                    if (_.isEmpty(entityMetaByStableId)) {
                         return [];
                     }
 
                     const result = await this.internalClient.fetchGenericAssayDataCountsUsingPOST(
                         {
                             genericAssayDataCountFilter: {
-                                genericAssayDataFilters: entityStableIds.map(
-                                    stableId =>
-                                        ({
-                                            stableId,
-                                            profileType: chartInfo.profileType,
-                                        }) as GenericAssayDataFilter
-                                ),
+                                profileType: chartInfo.profileType,
                                 studyViewFilter: this.filters,
                             } as GenericAssayDataCountFilter,
                         }

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -708,6 +708,33 @@ export class StudyViewPageStore
 
         this.reactionDisposers.push(
             reaction(
+                () => [
+                    this.genericAssayProfiles.isComplete,
+                    this.genericAssayProfiles.result.length,
+                    this.genericAssayProfileOptionsByType.isComplete,
+                    _.keys(this.genericAssayProfileOptionsByType.result || {}).sort(),
+                ],
+                ([
+                    genericAssayProfilesReady,
+                    genericAssayProfileCount,
+                    genericAssayProfileOptionsReady,
+                ]) => {
+                    if (
+                        genericAssayProfilesReady &&
+                        genericAssayProfileCount > 0 &&
+                        genericAssayProfileOptionsReady
+                    ) {
+                        this.registerGenericAssayFrequencyTableCharts();
+                    }
+                },
+                {
+                    equals: comparer.structural,
+                }
+            )
+        );
+
+        this.reactionDisposers.push(
+            reaction(
                 () => [this.filtersProxy, this.hesitateUpdate],
                 () => {
                     if (!this.hesitateUpdate || this.filters === undefined) {
@@ -7807,6 +7834,7 @@ export class StudyViewPageStore
             this.defaultVisibleAttributes.isPending ||
             this.chartClinicalAttributes.isPending ||
             this.clinicalAttributes.isPending ||
+            this.genericAssayProfiles.isPending ||
             this.mutationProfiles.isPending ||
             this.cnaProfiles.isPending ||
             this.structuralVariantProfiles.isPending ||
@@ -7839,8 +7867,8 @@ export class StudyViewPageStore
             pending = pending || this.molecularProfileOptions.isPending;
         }
         if (
-            !_.isEmpty(this.initialFilters.genericAssayDataFilters) ||
-            !_.isEmpty(this.initialFilters.genericAssaySelectionFilters)
+            !this.genericAssayProfiles.isPending &&
+            !_.isEmpty(this.genericAssayProfiles.result)
         ) {
             pending =
                 pending || this.genericAssayProfileOptionsByType.isPending;

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -138,6 +138,7 @@ import {
     getFilteredSampleIdentifiers,
     getFilteredStudiesWithSamples,
     getGenericAssayChartUniqueKey,
+    getGenericAssayChartDisplayName,
     buildGenericAssayFrequencyTableDataFilters,
     flattenGenericAssayFrequencyTableRows,
     GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
@@ -4817,6 +4818,47 @@ export class StudyViewPageStore
         return this._genericAssayDataFilterSet.has(uniqueKey)
             ? this._genericAssayDataFilterSet.get(uniqueKey)!.values
             : [];
+    }
+
+    public getGenericAssayFilterDisplayName(
+        stableId: string,
+        profileType: string
+    ): string {
+        const uniqueKey = getGenericAssayChartUniqueKey(stableId, profileType);
+        const chartMeta = this._genericAssayCharts.get(uniqueKey);
+        if (chartMeta) {
+            return chartMeta.displayName;
+        }
+
+        let genericAssayType = '';
+        let profileLabel = profileType;
+
+        for (const [type, options] of Object.entries(
+            this.genericAssayProfileOptionsByType.result || {}
+        )) {
+            const profileOption = options.find(
+                option => option.value === profileType
+            );
+            if (profileOption) {
+                genericAssayType = type;
+                profileLabel = profileOption.label;
+                break;
+            }
+        }
+
+        const entityMetaByStableId = _.keyBy(
+            this.genericAssayEntitiesGroupedByProfileIdSuffix.result?.[
+                profileType
+            ] || [],
+            meta => meta.stableId
+        );
+
+        return getGenericAssayChartDisplayName(
+            stableId,
+            profileLabel,
+            genericAssayType,
+            entityMetaByStableId
+        );
     }
 
     @autobind

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8156,6 +8156,20 @@ export class StudyViewPageStore
         return map;
     }
 
+    @computed get _defaultGenericAssayChartMap() {
+        return _.reduce(
+            this._defaultVisibleChartIds,
+            (acc, chartUniqueKey) => {
+                const chart = this._genericAssayChartMap.get(chartUniqueKey);
+                if (chart) {
+                    acc[chartUniqueKey] = chart;
+                }
+                return acc;
+            },
+            {} as { [uniqueKey: string]: GenericAssayChart }
+        );
+    }
+
     @action.bound
     public resetToDefaultChartSettings(): void {
         this.clearPageChartSettings();
@@ -8203,7 +8217,7 @@ export class StudyViewPageStore
             _.fromPairs(this._defaultChartsDimension.toJSON()),
             _.fromPairs(this._defaultChartsType.toJSON()),
             {},
-            {},
+            this._defaultGenericAssayChartMap,
             this._defaultXvsYChartMap,
             {},
             _.fromPairs(this._defaultClinicalDataBinFilterSet.toJSON())

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -138,6 +138,12 @@ import {
     getFilteredSampleIdentifiers,
     getFilteredStudiesWithSamples,
     getGenericAssayChartUniqueKey,
+    buildGenericAssayFrequencyTableDataFilters,
+    flattenGenericAssayFrequencyTableRows,
+    GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+    GenericAssayFrequencyTableRow,
+    getGenericAssayFrequencyTableSelectedRowKeys,
+    getGenericAssayFrequencyTableUniqueKey,
     getGenericAssayDataAsClinicalData,
     getGenomicChartUniqueKey,
     getGenomicDataAsClinicalData,
@@ -457,6 +463,7 @@ export type GenericAssayChart = {
     genericAssayType: string;
     genericAssayEntityId: string;
     patientLevel?: boolean;
+    chartKind?: 'ENTITY' | 'PROFILE_FREQUENCY_TABLE';
 };
 
 export const DataBinMethodConstants: { [key: string]: 'DYNAMIC' | 'STATIC' } = {
@@ -541,7 +548,7 @@ export class StudyViewPageStore
     chartsBinsGeneratorConfigs = observable.map<string, BinsGeneratorConfig>();
 
     private getDataBinFilterSet(uniqueKey: string) {
-        if (this.isGenericAssayChart(uniqueKey)) {
+        if (this.isGenericAssayEntityChart(uniqueKey)) {
             return this._genericAssayDataBinFilterSet;
         } else if (this.isGeneSpecificChart(uniqueKey)) {
             return this._genomicDataBinFilterSet;
@@ -1405,7 +1412,7 @@ export class StudyViewPageStore
         const promises: any = [this.selectedSamples];
         if (this.isGeneSpecificChart(chartMeta.uniqueKey)) {
             promises.push(this.genomicChartPromises[chartMeta.uniqueKey]);
-        } else if (this.isGenericAssayChart(chartMeta.uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(chartMeta.uniqueKey)) {
             promises.push(this.genericAssayChartPromises[chartMeta.uniqueKey]);
         } else if (
             this.isUserDefinedCustomDataChart(chartMeta.uniqueKey) &&
@@ -1430,7 +1437,9 @@ export class StudyViewPageStore
                             this.molecularProfileMapByType,
                             selectedSamples
                         );
-                    } else if (this.isGenericAssayChart(chartMeta.uniqueKey)) {
+                    } else if (
+                        this.isGenericAssayEntityChart(chartMeta.uniqueKey)
+                    ) {
                         const chartInfo = this._genericAssayChartMap.get(
                             chartMeta.uniqueKey
                         )!;
@@ -1903,7 +1912,7 @@ export class StudyViewPageStore
         const promises: any = [this.selectedSamples];
         if (chartMeta.uniqueKey === SpecialChartsUniqueKeyEnum.CANCER_STUDIES) {
             promises.push(this.cancerStudyAsClinicalData);
-        } else if (this.isGenericAssayChart(chartMeta.uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(chartMeta.uniqueKey)) {
             promises.push(this.genericAssayProfiles);
         }
 
@@ -1950,7 +1959,9 @@ export class StudyViewPageStore
                                     undefined
                             );
                         }
-                    } else if (this.isGenericAssayChart(chartMeta.uniqueKey)) {
+                    } else if (
+                        this.isGenericAssayEntityChart(chartMeta.uniqueKey)
+                    ) {
                         // get generic assay data for the given attribute
                         // patientAttribute and genericAssayChart are always exist
                         const isPatientAttribute = chartMeta.patientAttribute;
@@ -2728,6 +2739,9 @@ export class StudyViewPageStore
 
     public genericAssayDataCountPromises: {
         [id: string]: MobxPromise<ClinicalDataCountSummary[]>;
+    } = {};
+    public genericAssayFrequencyTablePromises: {
+        [id: string]: MobxPromise<GenericAssayFrequencyTableRow[]>;
     } = {};
 
     private _chartSampleIdentifiersFilterSet = observable.map<
@@ -3602,6 +3616,49 @@ export class StudyViewPageStore
     }
 
     @action.bound
+    setGenericAssayFrequencyTableFilters(
+        uniqueKey: string,
+        selectedRowKeys: string[]
+    ): void {
+        const chart = this._genericAssayChartMap.get(uniqueKey);
+        if (chart?.chartKind !== 'PROFILE_FREQUENCY_TABLE') {
+            return;
+        }
+
+        _.forEach(Array.from(this._genericAssayDataFilterSet.keys()), key => {
+            const genericAssayDataFilter = this._genericAssayDataFilterSet.get(key);
+            if (genericAssayDataFilter?.profileType === chart.profileType) {
+                this._genericAssayDataFilterSet.delete(key);
+            }
+        });
+
+        const rows =
+            this.getGenericAssayFrequencyTableData({
+                uniqueKey,
+            } as ChartMeta).result || [];
+        if (_.isEmpty(rows) || _.isEmpty(selectedRowKeys)) {
+            return;
+        }
+
+        buildGenericAssayFrequencyTableDataFilters(rows, selectedRowKeys).forEach(
+            genericAssayDataFilter => {
+                this._genericAssayDataFilterSet.set(
+                    getGenericAssayChartUniqueKey(
+                        genericAssayDataFilter.stableId,
+                        genericAssayDataFilter.profileType
+                    ),
+                    genericAssayDataFilter
+                );
+            }
+        );
+    }
+
+    @action.bound
+    resetGenericAssayFrequencyTableFilters(uniqueKey: string): void {
+        this.setGenericAssayFrequencyTableFilters(uniqueKey, []);
+    }
+
+    @action.bound
     updateScatterPlotFilterByValues(
         chartUniqueKey: string,
         bounds?: RectangleBounds
@@ -3973,6 +4030,20 @@ export class StudyViewPageStore
         return this._genericAssayChartMap.has(uniqueKey);
     }
 
+    public isGenericAssayFrequencyTableChart(uniqueKey: string): boolean {
+        return (
+            this._genericAssayChartMap.get(uniqueKey)?.chartKind ===
+            'PROFILE_FREQUENCY_TABLE'
+        );
+    }
+
+    public isGenericAssayEntityChart(uniqueKey: string): boolean {
+        return (
+            this._genericAssayChartMap.has(uniqueKey) &&
+            !this.isGenericAssayFrequencyTableChart(uniqueKey)
+        );
+    }
+
     public getMolecularChartDataType(uniqueKey: string): string {
         if (this.isGeneSpecificChart(uniqueKey)) {
             return this._geneSpecificChartMap.get(uniqueKey)!.dataType!;
@@ -4013,6 +4084,9 @@ export class StudyViewPageStore
     ): void {
         if (!visible) {
             switch (this.chartsType.get(chartUniqueKey)) {
+                case ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE:
+                    this.resetGenericAssayFrequencyTableFilters(chartUniqueKey);
+                    break;
                 case ChartTypeEnum.PIE_CHART:
                 case ChartTypeEnum.TABLE:
                     if (this.isUserDefinedCustomDataChart(chartUniqueKey)) {
@@ -4020,7 +4094,7 @@ export class StudyViewPageStore
                             chartUniqueKey,
                             []
                         );
-                    } else if (this.isGenericAssayChart(chartUniqueKey)) {
+                    } else if (this.isGenericAssayEntityChart(chartUniqueKey)) {
                         this.updateGenericAssayDataFilters(chartUniqueKey, []);
                     } else if (this.isGeneSpecificChart(chartUniqueKey)) {
                         this.updateCategoricalGenomicDataFilters(
@@ -4040,7 +4114,7 @@ export class StudyViewPageStore
                             chartUniqueKey,
                             []
                         );
-                    } else if (this.isGenericAssayChart(chartUniqueKey)) {
+                    } else if (this.isGenericAssayEntityChart(chartUniqueKey)) {
                         this.updateGenericAssayDataFilters(chartUniqueKey, []);
                     } else if (
                         this.isUserDefinedCustomDataChart(chartUniqueKey)
@@ -4118,6 +4192,12 @@ export class StudyViewPageStore
 
     private isChartFiltered(chartUniqueKey: string): boolean {
         switch (this.chartsType.get(chartUniqueKey)) {
+            case ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE:
+                return (
+                    this.getGenericAssayFrequencyTableSelectedRowKeys(
+                        chartUniqueKey
+                    ).length > 0
+                );
             case ChartTypeEnum.PIE_CHART:
             case ChartTypeEnum.TABLE:
                 if (this.isGeneSpecificChart(chartUniqueKey)) {
@@ -4127,7 +4207,7 @@ export class StudyViewPageStore
                         this._customDataFilterSet.has(chartUniqueKey) ||
                         this.preDefinedCustomChartFilterSet.has(chartUniqueKey)
                     );
-                } else if (this.isGenericAssayChart(chartUniqueKey)) {
+                } else if (this.isGenericAssayEntityChart(chartUniqueKey)) {
                     return this._genericAssayDataFilterSet.has(chartUniqueKey);
                 } else {
                     return this._clinicalDataFilterSet.has(chartUniqueKey);
@@ -4209,7 +4289,7 @@ export class StudyViewPageStore
             // the genomicDataBinFilter is guaranteed for bar chart.
             let ref = this._genomicDataBinFilterSet.get(uniqueKey);
             ref!.disableLogScale = !ref!.disableLogScale;
-        } else if (this.isGenericAssayChart(uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(uniqueKey)) {
             // reset filters before toggling
             this.updateGenericAssayDataFilters(uniqueKey, []);
 
@@ -4254,7 +4334,7 @@ export class StudyViewPageStore
                         .disableLogScale) ||
                 isLogScaleByDataBins(dataBins)
             );
-        } else if (this.isGenericAssayChart(uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(uniqueKey)) {
             return (
                 (this._genericAssayDataBinFilterSet.get(uniqueKey) !==
                     undefined &&
@@ -4285,7 +4365,7 @@ export class StudyViewPageStore
                 this._genomicDataBinFilterSet.get(uniqueKey) !== undefined &&
                 !this._genomicDataBinFilterSet.get(uniqueKey)!.disableLogScale
             );
-        } else if (this.isGenericAssayChart(uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(uniqueKey)) {
             return (
                 this._genericAssayDataBinFilterSet.get(uniqueKey) !==
                     undefined &&
@@ -4346,7 +4426,7 @@ export class StudyViewPageStore
             newFilter.binMethod = binMethod;
             newFilter.binsGeneratorConfig = binsGeneratorConfig;
             this._genomicDataBinFilterSet.set(uniqueKey, newFilter);
-        } else if (this.isGenericAssayChart(uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(uniqueKey)) {
             let newFilter = _.clone(
                 this._genericAssayDataBinFilterSet.get(uniqueKey)
             )!;
@@ -4384,7 +4464,7 @@ export class StudyViewPageStore
             return getNonZeroUniqueBins(
                 this.getGenomicChartDataBin(chartMeta).result!
             );
-        } else if (this.isGenericAssayChart(chartMeta.uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(chartMeta.uniqueKey)) {
             return getNonZeroUniqueBins(
                 this.getGenericAssayChartDataBin(chartMeta).result!
             );
@@ -4737,6 +4817,21 @@ export class StudyViewPageStore
         return this._genericAssayDataFilterSet.has(uniqueKey)
             ? this._genericAssayDataFilterSet.get(uniqueKey)!.values
             : [];
+    }
+
+    @autobind
+    public getGenericAssayFrequencyTableSelectedRowKeys(
+        uniqueKey: string
+    ): string[] {
+        const chart = this._genericAssayChartMap.get(uniqueKey);
+        if (chart?.chartKind !== 'PROFILE_FREQUENCY_TABLE') {
+            return [];
+        }
+
+        return getGenericAssayFrequencyTableSelectedRowKeys(
+            this.genericAssayDataFilters,
+            chart.profileType
+        );
     }
 
     @computed
@@ -5393,54 +5488,134 @@ export class StudyViewPageStore
                     const chartInfo = this._genericAssayChartMap.get(
                         chartMeta.uniqueKey
                     );
-                    if (chartInfo) {
-                        let result: GenericAssayDataCountItem[] = [];
-
-                        result = await this.internalClient.fetchGenericAssayDataCountsUsingPOST(
-                            {
-                                genericAssayDataCountFilter: {
-                                    genericAssayDataFilters: [
-                                        {
-                                            stableId:
-                                                chartInfo.genericAssayEntityId,
-                                            profileType: chartInfo.profileType,
-                                        } as GenericAssayDataFilter,
-                                    ],
-                                    studyViewFilter: this.filters,
-                                } as GenericAssayDataCountFilter,
-                            }
-                        );
-
-                        if (_.isEmpty(result)) {
-                            return res;
-                        }
-
-                        let data = result.find(
-                            d => d.stableId === chartInfo.genericAssayEntityId
-                        );
-                        let counts: ClinicalDataCount[] = [];
-                        let stableId: string = '';
-                        if (data !== undefined) {
-                            counts = data.counts.map(c => {
-                                return {
-                                    count: c.count,
-                                    value: c.value,
-                                } as ClinicalDataCount;
-                            });
-                            stableId = data.stableId;
-                            if (!this.chartToUsedColors.has(stableId)) {
-                                this.chartToUsedColors.set(stableId, new Set());
-                            }
-                        }
-
-                        return this.addColorToCategories(counts, stableId);
+                    if (
+                        chartInfo === undefined ||
+                        chartInfo.chartKind === 'PROFILE_FREQUENCY_TABLE'
+                    ) {
+                        return res;
                     }
-                    return res;
+
+                    const entityChartInfo = chartInfo;
+                    let result: GenericAssayDataCountItem[] = [];
+
+                    result = await this.internalClient.fetchGenericAssayDataCountsUsingPOST(
+                        {
+                            genericAssayDataCountFilter: {
+                                genericAssayDataFilters: [
+                                    {
+                                        stableId:
+                                            entityChartInfo.genericAssayEntityId,
+                                        profileType:
+                                            entityChartInfo.profileType,
+                                    } as GenericAssayDataFilter,
+                                ],
+                                studyViewFilter: this.filters,
+                            } as GenericAssayDataCountFilter,
+                        }
+                    );
+
+                    if (_.isEmpty(result)) {
+                        return res;
+                    }
+
+                    let data = result.find(
+                        d => d.stableId === entityChartInfo.genericAssayEntityId
+                    );
+                    let counts: ClinicalDataCount[] = [];
+                    let stableId: string = '';
+                    if (data !== undefined) {
+                        counts = data.counts.map(c => {
+                            return {
+                                count: c.count,
+                                value: c.value,
+                            } as ClinicalDataCount;
+                        });
+                        stableId = data.stableId;
+                        if (!this.chartToUsedColors.has(stableId)) {
+                            this.chartToUsedColors.set(stableId, new Set());
+                        }
+                    }
+
+                    return this.addColorToCategories(counts, stableId);
                 },
                 default: [],
             });
         }
         return this.genericAssayDataCountPromises[chartMeta.uniqueKey];
+    }
+
+    public getGenericAssayFrequencyTableData(
+        chartMeta: ChartMeta
+    ): MobxPromise<GenericAssayFrequencyTableRow[]> {
+        if (
+            !this.genericAssayFrequencyTablePromises.hasOwnProperty(
+                chartMeta.uniqueKey
+            )
+        ) {
+            this.genericAssayFrequencyTablePromises[
+                chartMeta.uniqueKey
+            ] = remoteData<GenericAssayFrequencyTableRow[]>({
+                await: () => [
+                    this.selectedSamples,
+                    this.genericAssayEntitiesGroupedByProfileIdSuffix,
+                ],
+                invoke: async () => {
+                    const chartInfo = this._genericAssayChartMap.get(
+                        chartMeta.uniqueKey
+                    );
+                    if (
+                        chartInfo?.chartKind !== 'PROFILE_FREQUENCY_TABLE' ||
+                        !this.hasFilteredSamples
+                    ) {
+                        return [];
+                    }
+
+                    const entityMetaByProfileIdSuffix =
+                        this.genericAssayEntitiesGroupedByProfileIdSuffix
+                            .result || {};
+                    const entityMetaByStableId = _.keyBy(
+                        entityMetaByProfileIdSuffix[chartInfo.profileType] ||
+                            [],
+                        meta => meta.stableId
+                    );
+                    const entityStableIds = _.keys(entityMetaByStableId);
+                    if (_.isEmpty(entityStableIds)) {
+                        return [];
+                    }
+
+                    const result = await this.internalClient.fetchGenericAssayDataCountsUsingPOST(
+                        {
+                            genericAssayDataCountFilter: {
+                                genericAssayDataFilters: entityStableIds.map(
+                                    stableId =>
+                                        ({
+                                            stableId,
+                                            profileType: chartInfo.profileType,
+                                        }) as GenericAssayDataFilter
+                                ),
+                                studyViewFilter: this.filters,
+                            } as GenericAssayDataCountFilter,
+                        }
+                    );
+
+                    const totalCount = chartInfo.patientLevel
+                        ? this.selectedPatients.length
+                        : this.selectedSamples.result.length;
+
+                    return flattenGenericAssayFrequencyTableRows(
+                        result,
+                        chartInfo.dataType!,
+                        chartInfo.profileType,
+                        chartInfo.genericAssayType,
+                        totalCount,
+                        entityMetaByStableId
+                    );
+                },
+                default: [],
+            });
+        }
+
+        return this.genericAssayFrequencyTablePromises[chartMeta.uniqueKey];
     }
 
     public getGenomicChartDataCount(
@@ -5728,31 +5903,35 @@ export class StudyViewPageStore
                     );
                     const attribute = this._genericAssayDataBinFilterSet.get(
                         chartMeta.uniqueKey
-                    )!;
-                    if (chartInfo) {
-                        const gaDataBins = await this.internalClient.fetchGenericAssayDataBinCountsUsingPOST(
-                            {
-                                dataBinMethod: DataBinMethodConstants.STATIC,
-                                genericAssayDataBinCountFilter: {
-                                    genericAssayDataBinFilters: [
-                                        {
-                                            stableId:
-                                                chartInfo.genericAssayEntityId,
-                                            profileType: chartInfo.profileType,
-                                            customBins: attribute.customBins,
-                                            disableLogScale:
-                                                attribute.disableLogScale,
-                                        },
-                                    ] as any,
-                                    studyViewFilter: this.filters,
-                                },
-                            }
-                        );
-                        return convertGenericAssayDataBinsToDataBins(
-                            gaDataBins
-                        );
+                    );
+                    if (
+                        chartInfo === undefined ||
+                        chartInfo.chartKind === 'PROFILE_FREQUENCY_TABLE' ||
+                        !attribute
+                    ) {
+                        return [];
                     }
-                    return [];
+
+                    const entityChartInfo = chartInfo;
+                    const gaDataBins = await this.internalClient.fetchGenericAssayDataBinCountsUsingPOST(
+                        {
+                            dataBinMethod: DataBinMethodConstants.STATIC,
+                            genericAssayDataBinCountFilter: {
+                                genericAssayDataBinFilters: [
+                                    {
+                                        stableId:
+                                            entityChartInfo.genericAssayEntityId,
+                                        profileType: entityChartInfo.profileType,
+                                        customBins: attribute.customBins,
+                                        disableLogScale:
+                                            attribute.disableLogScale,
+                                    },
+                                ] as any,
+                                studyViewFilter: this.filters,
+                            },
+                        }
+                    );
+                    return convertGenericAssayDataBinsToDataBins(gaDataBins);
                 },
                 default: [],
             });
@@ -6979,7 +7158,10 @@ export class StudyViewPageStore
 
                 this._genericAssayCharts.set(uniqueKey, chartMeta);
 
-                this._genericAssayChartMap.set(uniqueKey, newChart);
+                this._genericAssayChartMap.set(uniqueKey, {
+                    ...newChart,
+                    chartKind: newChart.chartKind || 'ENTITY',
+                });
                 this.changeChartVisibility(uniqueKey, true);
                 this.chartsType.set(uniqueKey, ChartTypeEnum.BAR_CHART);
                 this.chartsDimension.set(uniqueKey, { w: 2, h: 1 });
@@ -7031,7 +7213,10 @@ export class StudyViewPageStore
 
                 this._genericAssayCharts.set(uniqueKey, chartMeta);
 
-                this._genericAssayChartMap.set(uniqueKey, newChart);
+                this._genericAssayChartMap.set(uniqueKey, {
+                    ...newChart,
+                    chartKind: newChart.chartKind || 'ENTITY',
+                });
                 this.changeChartVisibility(uniqueKey, true);
                 this.chartsType.set(uniqueKey, ChartTypeEnum.PIE_CHART);
                 this.chartsDimension.set(
@@ -7044,6 +7229,98 @@ export class StudyViewPageStore
                 this.newlyAddedCharts.push(uniqueKey);
             }
         });
+    }
+
+    @action.bound
+    addGenericAssayFrequencyTableCharts(
+        newCharts: GenericAssayChart[],
+        visible: boolean,
+        loadedfromUserSettings: boolean = false
+    ): void {
+        if (!loadedfromUserSettings && visible) {
+            this.newlyAddedCharts.clear();
+        }
+
+        newCharts.forEach(newChart => {
+            const uniqueKey = getGenericAssayFrequencyTableUniqueKey(
+                newChart.profileType
+            );
+
+            if (!this._genericAssayChartMap.has(uniqueKey)) {
+                const newChartName = newChart.name
+                    ? newChart.name
+                    : this.getDefaultCustomChartName();
+                const chartMeta: ChartMeta = {
+                    uniqueKey,
+                    displayName: newChartName,
+                    description: newChart.description || newChartName,
+                    dataType: ChartMetaDataTypeEnum.GENERIC_ASSAY,
+                    patientAttribute: newChart.patientLevel || false,
+                    renderWhenDataChange: false,
+                    priority: 0,
+                    genericAssayType: newChart.genericAssayType,
+                };
+
+                this._genericAssayCharts.set(uniqueKey, chartMeta);
+                this._genericAssayChartMap.set(uniqueKey, {
+                    ...newChart,
+                    chartKind: 'PROFILE_FREQUENCY_TABLE',
+                    genericAssayEntityId:
+                        GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                });
+                this.chartsType.set(
+                    uniqueKey,
+                    ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE
+                );
+                this.chartsDimension.set(
+                    uniqueKey,
+                    STUDY_VIEW_CONFIG.layout.dimensions[
+                        ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE
+                    ]
+                );
+            }
+
+            if (visible) {
+                this.changeChartVisibility(uniqueKey, true);
+                if (!loadedfromUserSettings) {
+                    this.newlyAddedCharts.push(uniqueKey);
+                }
+            }
+        });
+    }
+
+    @action.bound
+    registerGenericAssayFrequencyTableCharts(): void {
+        _.forEach(
+            this.genericAssayProfileOptionsByType.result,
+            (options, genericAssayType) => {
+                const frequencyTableCharts = options
+                    .filter(
+                        option =>
+                            option.dataType === DataTypeConstants.BINARY ||
+                            option.dataType === DataTypeConstants.CATEGORICAL
+                    )
+                    .map(option => ({
+                        name: `${option.label} Frequency Table`,
+                        description: option.description,
+                        profileType: option.value,
+                        genericAssayType,
+                        genericAssayEntityId:
+                            GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                        dataType: option.dataType,
+                        patientLevel: option.patientLevel,
+                        chartKind: 'PROFILE_FREQUENCY_TABLE' as const,
+                    }));
+
+                if (!_.isEmpty(frequencyTableCharts)) {
+                    this.addGenericAssayFrequencyTableCharts(
+                        frequencyTableCharts,
+                        false,
+                        true
+                    );
+                }
+            }
+        );
     }
 
     @action.bound
@@ -7658,25 +7935,51 @@ export class StudyViewPageStore
                     true
                 );
             }
-            if (
-                chartUserSettings.genericAssayEntityId &&
-                chartUserSettings.profileType
-            ) {
-                this.addGenericAssayContinuousCharts(
-                    [
-                        {
-                            name: chartUserSettings.name,
-                            description: chartUserSettings.description,
-                            profileType: chartUserSettings.profileType,
-                            genericAssayType: chartUserSettings.genericAssayType!,
-                            genericAssayEntityId:
-                                chartUserSettings.genericAssayEntityId,
-                            dataType: chartUserSettings.dataType,
-                            patientLevel: chartUserSettings.patientLevelProfile,
-                        },
-                    ],
-                    true
-                );
+            if (chartUserSettings.profileType && chartUserSettings.genericAssayType) {
+                if (
+                    chartUserSettings.chartType ===
+                        ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE ||
+                    chartUserSettings.genericAssayEntityId ===
+                        GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID
+                ) {
+                    this.addGenericAssayFrequencyTableCharts(
+                        [
+                            {
+                                name: chartUserSettings.name,
+                                description: chartUserSettings.description,
+                                profileType: chartUserSettings.profileType,
+                                genericAssayType:
+                                    chartUserSettings.genericAssayType,
+                                genericAssayEntityId:
+                                    GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                                dataType: chartUserSettings.dataType,
+                                patientLevel:
+                                    chartUserSettings.patientLevelProfile,
+                                chartKind: 'PROFILE_FREQUENCY_TABLE',
+                            },
+                        ],
+                        true,
+                        true
+                    );
+                } else if (chartUserSettings.genericAssayEntityId) {
+                    this.addGenericAssayContinuousCharts(
+                        [
+                            {
+                                name: chartUserSettings.name,
+                                description: chartUserSettings.description,
+                                profileType: chartUserSettings.profileType,
+                                genericAssayType:
+                                    chartUserSettings.genericAssayType,
+                                genericAssayEntityId:
+                                    chartUserSettings.genericAssayEntityId,
+                                dataType: chartUserSettings.dataType,
+                                patientLevel:
+                                    chartUserSettings.patientLevelProfile,
+                            },
+                        ],
+                        true
+                    );
+                }
             }
             if (chartUserSettings.chartType === ChartTypeEnum.SCATTER) {
                 this.addXvsYScatterChart(
@@ -8170,7 +8473,7 @@ export class StudyViewPageStore
                 data = this.cancerStudiesData;
             } else if (this.isUserDefinedCustomDataChart(attr.uniqueKey)) {
                 data = this.getCustomDataCount(attr);
-            } else if (this.isGenericAssayChart(attr.uniqueKey)) {
+            } else if (this.isGenericAssayEntityChart(attr.uniqueKey)) {
                 data = this.getGenericAssayChartDataCount(attr);
             } else if (this.isGeneSpecificChart(attr.uniqueKey)) {
                 data = this.getGenomicChartDataCount(attr);
@@ -8417,6 +8720,7 @@ export class StudyViewPageStore
 
     @action
     initializeGenericAssayCharts(): void {
+        this.registerGenericAssayFrequencyTableCharts();
         // initialize generic assay continuous data chart
         if (!_.isEmpty(this.initialFilters.genericAssayDataFilters)) {
             _.map(
@@ -9304,7 +9608,7 @@ export class StudyViewPageStore
                 chartMeta,
                 this.getCustomDataCount(chartMeta).result!
             );
-        } else if (this.isGenericAssayChart(chartMeta.uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(chartMeta.uniqueKey)) {
             return this.getClinicalDataCountSummary(
                 chartMeta,
                 this.getGenericAssayChartDataCount(chartMeta).result!
@@ -9378,7 +9682,7 @@ export class StudyViewPageStore
                     this.selectedSamples.result
                 );
             }
-        } else if (this.isGenericAssayChart(chartMeta.uniqueKey)) {
+        } else if (this.isGenericAssayEntityChart(chartMeta.uniqueKey)) {
             clinicalDataList = await getGenericAssayDataAsClinicalData(
                 this._genericAssayChartMap.get(chartMeta.uniqueKey)!,
                 this.molecularProfileMapByType,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -9,6 +9,7 @@ import {
     makeObservable,
     observable,
     reaction,
+    runInAction,
     toJS,
 } from 'mobx';
 import {
@@ -139,12 +140,12 @@ import {
     getFilteredStudiesWithSamples,
     getGenericAssayChartUniqueKey,
     getGenericAssayChartDisplayName,
-    buildGenericAssayFrequencyTableDataFilters,
+    getGenericAssayEntityLabel,
     flattenGenericAssayFrequencyTableRows,
     GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
     GenericAssayFrequencyTableRow,
-    getGenericAssayFrequencyTableSelectedRowKeys,
     getGenericAssayFrequencyTableUniqueKey,
+    splitGenericAssayFrequencyTableRowUniqueKey,
     getGenericAssayDataAsClinicalData,
     getGenomicChartUniqueKey,
     getGenomicDataAsClinicalData,
@@ -2123,6 +2124,122 @@ export class StudyViewPageStore
         });
     }
 
+    private createGenericAssayFrequencyTableComparisonSession(
+        chartMeta: ChartMeta,
+        genericAssayRowKeys: string[],
+        statusCallback: (phase: LoadingPhase) => void
+    ): Promise<string> {
+        statusCallback(LoadingPhase.DOWNLOADING_GROUPS);
+
+        return new Promise<string>(resolve => {
+            onMobxPromise<any>(
+                [this.selectedSamples, this.genericAssayProfiles],
+                async (selectedSamples: Sample[]) => {
+                    const chart = this._genericAssayChartMap.get(
+                        chartMeta.uniqueKey
+                    );
+                    if (
+                        !chart ||
+                        chart.chartKind !== 'PROFILE_FREQUENCY_TABLE' ||
+                        selectedSamples.length === 0
+                    ) {
+                        return;
+                    }
+
+                    const profileByStudyId =
+                        this.getGenericAssayFrequencyTableProfileMap(chart);
+                    const filteredSamples = selectedSamples.filter(
+                        sample => profileByStudyId[sample.studyId] !== undefined
+                    );
+                    const stableIds = _.uniq(
+                        genericAssayRowKeys.map(
+                            rowKey =>
+                                splitGenericAssayFrequencyTableRowUniqueKey(
+                                    rowKey
+                                ).stableId
+                        )
+                    );
+                    const sampleMolecularIdentifiers = filteredSamples.map(
+                        sample => ({
+                            sampleId: sample.sampleId,
+                            molecularProfileId:
+                                profileByStudyId[sample.studyId]
+                                    .molecularProfileId,
+                        })
+                    );
+                    const data = await getClient().fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
+                        {
+                            projection: 'DETAILED',
+                            genericAssayDataMultipleStudyFilter: {
+                                genericAssayStableIds: stableIds,
+                                sampleMolecularIdentifiers,
+                            } as GenericAssayDataMultipleStudyFilter,
+                        } as any
+                    );
+                    const dataByStableIdAndCaseKey = _.groupBy(
+                        data,
+                        datum =>
+                            `${datum.stableId}::${
+                                chart.patientLevel
+                                    ? datum.uniquePatientKey
+                                    : datum.uniqueSampleKey
+                            }`
+                    );
+
+                    const groups: SessionGroupData[] = _.chain(
+                        genericAssayRowKeys
+                    )
+                        .map(rowKey => {
+                            const { stableId, value } =
+                                splitGenericAssayFrequencyTableRowUniqueKey(
+                                    rowKey
+                                );
+                            const sampleIdentifiers = getFilteredSampleIdentifiers(
+                                filteredSamples.filter(sample => {
+                                    const caseKey = chart.patientLevel
+                                        ? sample.uniquePatientKey
+                                        : sample.uniqueSampleKey;
+                                    return (
+                                        dataByStableIdAndCaseKey[
+                                            `${stableId}::${caseKey}`
+                                        ]?.some(
+                                            datum => datum.value === value
+                                        ) || false
+                                    );
+                                })
+                            );
+
+                            if (sampleIdentifiers.length === 0) {
+                                return null;
+                            }
+
+                            return getGroupParameters(
+                                this.getGenericAssayFrequencyTableFilterDisplayName(
+                                    chartMeta.uniqueKey,
+                                    rowKey
+                                ),
+                                sampleIdentifiers,
+                                this.studyIds
+                            );
+                        })
+                        .compact()
+                        .slice(0, MAX_GROUPS_IN_SESSION)
+                        .value();
+
+                    statusCallback(LoadingPhase.CREATING_SESSION);
+
+                    const { id } = await comparisonClient.addComparisonSession({
+                        groups,
+                        clinicalAttributeName: chartMeta.displayName,
+                        origin: this.studyIds,
+                    });
+
+                    resolve(id);
+                }
+            );
+        });
+    }
+
     @autobind
     public async openComparisonPage(
         chartMeta: ChartMeta,
@@ -2137,6 +2254,8 @@ export class StudyViewPageStore
             namespaceAttributeValues?: string[];
             // for treatments tables
             treatmentUniqueKeys?: string[];
+            // for generic assay frequency tables
+            genericAssayRowKeys?: string[];
         }
     ): Promise<void> {
         // open window before the first `await` call - this makes it a synchronous window.open,
@@ -2235,6 +2354,13 @@ export class StudyViewPageStore
                 comparisonId = await this.createVariantAnnotationComparisonSession(
                     chartMeta,
                     params.namespaceAttributeValues!,
+                    statusCallback
+                );
+                break;
+            case ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE:
+                comparisonId = await this.createGenericAssayFrequencyTableComparisonSession(
+                    chartMeta,
+                    params.genericAssayRowKeys!,
                     statusCallback
                 );
                 break;
@@ -2749,6 +2875,10 @@ export class StudyViewPageStore
         ChartUniqueKey,
         SampleIdentifier[]
     >({}, { deep: false });
+    private _genericAssayFrequencyTableFilterSet = observable.map<
+        ChartUniqueKey,
+        string[][]
+    >({}, { deep: false });
 
     public preDefinedCustomChartFilterSet = observable.map<
         ChartUniqueKey,
@@ -3102,6 +3232,7 @@ export class StudyViewPageStore
         this._namespaceDataFilterSet.clear();
         this._genericAssayDataFilterSet.clear();
         this._chartSampleIdentifiersFilterSet.clear();
+        this._genericAssayFrequencyTableFilterSet.clear();
         this.preDefinedCustomChartFilterSet.clear();
         this.numberOfSelectedSamplesInCustomSelection = 0;
         this.removeComparisonGroupSelectionFilter();
@@ -3617,46 +3748,209 @@ export class StudyViewPageStore
     }
 
     @action.bound
-    setGenericAssayFrequencyTableFilters(
+    async setGenericAssayFrequencyTableFilters(
         uniqueKey: string,
-        selectedRowKeys: string[]
-    ): void {
+        selectedRowKeysGroups: string[][]
+    ): Promise<void> {
+        trackStudyViewFilterEvent('genericAssayCategoricalData', this);
+        await this.updateGenericAssayFrequencyTableSelection(
+            uniqueKey,
+            selectedRowKeysGroups,
+            true
+        );
+    }
+
+    private getFiltersExcludingChartSampleIdentifierFilter(
+        chartKey: string
+    ): StudyViewFilter {
+        const filters = _.cloneDeep(this.filters);
+        const sampleIdentifiersFilterSets = Array.from(
+            this._chartSampleIdentifiersFilterSet.entries()
+        )
+            .filter(([key]) => key !== chartKey)
+            .map(([, sampleIdentifiers]) => sampleIdentifiers);
+
+        if (!_.isEmpty(sampleIdentifiersFilterSets)) {
+            filters.sampleIdentifiers = intersect<SampleIdentifier>(
+                sampleIdentifiersFilterSets,
+                (sampleIdentifier: any) => {
+                    return (
+                        (sampleIdentifier as SampleIdentifier).sampleId +
+                        (sampleIdentifier as SampleIdentifier).studyId
+                    );
+                }
+            );
+        } else if (_.isEmpty(this.queriedSampleIdentifiers.result)) {
+            filters.studyIds = this.queriedPhysicalStudyIds.result;
+            filters.sampleIdentifiers = [];
+        } else {
+            filters.sampleIdentifiers = this.queriedSampleIdentifiers.result;
+            filters.studyIds = [];
+        }
+
+        return filters;
+    }
+
+    private async getFilteredSamplesExcludingChartSelection(
+        chartKey: string
+    ): Promise<Sample[]> {
+        return this.internalClient.fetchFilteredSamplesUsingPOST({
+            studyViewFilter:
+                this.getFiltersExcludingChartSampleIdentifierFilter(chartKey),
+        });
+    }
+
+    private getGenericAssayFrequencyTableProfileMap(
+        chart: GenericAssayChart
+    ): { [studyId: string]: MolecularProfile } {
+        return _.chain(this.genericAssayProfiles.result)
+            .filter(
+                profile =>
+                    profile.genericAssayType === chart.genericAssayType &&
+                    getSuffixOfMolecularProfile(profile) === chart.profileType
+            )
+            .keyBy(profile => profile.studyId)
+            .value();
+    }
+
+    private async updateGenericAssayFrequencyTableSelection(
+        uniqueKey: string,
+        selectedRowKeysGroups: string[][],
+        append: boolean
+    ): Promise<void> {
         const chart = this._genericAssayChartMap.get(uniqueKey);
         if (chart?.chartKind !== 'PROFILE_FREQUENCY_TABLE') {
             return;
         }
 
-        _.forEach(Array.from(this._genericAssayDataFilterSet.keys()), key => {
-            const genericAssayDataFilter = this._genericAssayDataFilterSet.get(key);
-            if (genericAssayDataFilter?.profileType === chart.profileType) {
-                this._genericAssayDataFilterSet.delete(key);
-            }
-        });
+        const normalizedGroups = _.chain(selectedRowKeysGroups)
+            .map(group => _.uniq(group))
+            .filter(group => group.length > 0)
+            .value();
+        const nextGroups = append
+            ? (this._genericAssayFrequencyTableFilterSet.get(uniqueKey) || []).concat(
+                  normalizedGroups
+              )
+            : normalizedGroups;
 
-        const rows =
-            this.getGenericAssayFrequencyTableData({
-                uniqueKey,
-            } as ChartMeta).result || [];
-        if (_.isEmpty(rows) || _.isEmpty(selectedRowKeys)) {
+        if (_.isEmpty(nextGroups)) {
+            runInAction(() => {
+                this._genericAssayFrequencyTableFilterSet.delete(uniqueKey);
+                this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
+            });
             return;
         }
 
-        buildGenericAssayFrequencyTableDataFilters(rows, selectedRowKeys).forEach(
-            genericAssayDataFilter => {
-                this._genericAssayDataFilterSet.set(
-                    getGenericAssayChartUniqueKey(
-                        genericAssayDataFilter.stableId,
-                        genericAssayDataFilter.profileType
-                    ),
-                    genericAssayDataFilter
+        const profileByStudyId =
+            this.getGenericAssayFrequencyTableProfileMap(chart);
+        const baseSamples = await this.getFilteredSamplesExcludingChartSelection(
+            uniqueKey
+        );
+        const filteredSamples = baseSamples.filter(
+            sample => profileByStudyId[sample.studyId] !== undefined
+        );
+
+        if (_.isEmpty(filteredSamples)) {
+            runInAction(() => {
+                this._genericAssayFrequencyTableFilterSet.delete(uniqueKey);
+                this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
+            });
+            return;
+        }
+
+        const stableIds = _.uniq(
+            _.flatMap(nextGroups, group =>
+                group.map(
+                    rowKey =>
+                        splitGenericAssayFrequencyTableRowUniqueKey(rowKey)
+                            .stableId
+                )
+            )
+        );
+        const sampleMolecularIdentifiers = filteredSamples.map(sample => ({
+            sampleId: sample.sampleId,
+            molecularProfileId: profileByStudyId[sample.studyId]
+                .molecularProfileId,
+        }));
+        const data = await getClient().fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
+            {
+                projection: 'DETAILED',
+                genericAssayDataMultipleStudyFilter: {
+                    genericAssayStableIds: stableIds,
+                    sampleMolecularIdentifiers,
+                } as GenericAssayDataMultipleStudyFilter,
+            } as any
+        );
+
+        const dataByStableIdAndCaseKey = _.groupBy(
+            data,
+            datum =>
+                `${datum.stableId}::${
+                    chart.patientLevel ? datum.uniquePatientKey : datum.uniqueSampleKey
+                }`
+        );
+        const groupedCases = nextGroups.map(group => {
+            const groupCases = filteredSamples.filter(sample =>
+                group.some(rowKey => {
+                    const { stableId, value } =
+                        splitGenericAssayFrequencyTableRowUniqueKey(rowKey);
+                    const caseKey = chart.patientLevel
+                        ? sample.uniquePatientKey
+                        : sample.uniqueSampleKey;
+                    return (
+                        dataByStableIdAndCaseKey[`${stableId}::${caseKey}`]?.some(
+                            datum => datum.value === value
+                        ) || false
+                    );
+                })
+            );
+            return getFilteredSampleIdentifiers(groupCases);
+        });
+        const selectedCases = intersect<SampleIdentifier>(
+            groupedCases,
+            (sampleIdentifier: any) => {
+                return (
+                    (sampleIdentifier as SampleIdentifier).sampleId +
+                    (sampleIdentifier as SampleIdentifier).studyId
                 );
             }
         );
+
+        runInAction(() => {
+            this._genericAssayFrequencyTableFilterSet.set(uniqueKey, nextGroups);
+            if (_.isEmpty(selectedCases)) {
+                this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
+            } else {
+                this._chartSampleIdentifiersFilterSet.set(
+                    uniqueKey,
+                    selectedCases
+                );
+            }
+        });
     }
 
     @action.bound
     resetGenericAssayFrequencyTableFilters(uniqueKey: string): void {
-        this.setGenericAssayFrequencyTableFilters(uniqueKey, []);
+        this._genericAssayFrequencyTableFilterSet.delete(uniqueKey);
+        this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
+    }
+
+    @action.bound
+    async removeGenericAssayFrequencyTableFilter(
+        uniqueKey: string,
+        rowKey: string
+    ): Promise<void> {
+        const nextGroups = (this._genericAssayFrequencyTableFilterSet.get(
+            uniqueKey
+        ) || [])
+            .map(group => group.filter(key => key !== rowKey))
+            .filter(group => group.length > 0);
+
+        await this.updateGenericAssayFrequencyTableSelection(
+            uniqueKey,
+            nextGroups,
+            false
+        );
     }
 
     @action.bound
@@ -3999,6 +4293,12 @@ export class StudyViewPageStore
         chartKey: string
     ): SampleIdentifier[] {
         return this._chartSampleIdentifiersFilterSet.get(chartKey) || [];
+    }
+
+    public getGenericAssayFrequencyTableSelections(): Array<
+        [string, string[][]]
+    > {
+        return Array.from(this._genericAssayFrequencyTableFilterSet.entries());
     }
 
     public isPreDefinedCustomChart(uniqueKey: string): boolean {
@@ -4864,16 +5164,41 @@ export class StudyViewPageStore
     @autobind
     public getGenericAssayFrequencyTableSelectedRowKeys(
         uniqueKey: string
-    ): string[] {
+    ): string[][] {
         const chart = this._genericAssayChartMap.get(uniqueKey);
         if (chart?.chartKind !== 'PROFILE_FREQUENCY_TABLE') {
             return [];
         }
 
-        return getGenericAssayFrequencyTableSelectedRowKeys(
-            this.genericAssayDataFilters,
-            chart.profileType
+        return this._genericAssayFrequencyTableFilterSet.get(uniqueKey) || [];
+    }
+
+    public getGenericAssayFrequencyTableFilterDisplayName(
+        uniqueKey: string,
+        rowKey: string
+    ): string {
+        const chart = this._genericAssayChartMap.get(uniqueKey);
+        if (!chart) {
+            return rowKey;
+        }
+
+        const { stableId, value } =
+            splitGenericAssayFrequencyTableRowUniqueKey(rowKey);
+        const entityMetaByProfileIdSuffix =
+            this.genericAssayEntitiesGroupedByProfileIdSuffix.result || {};
+        const entityMetaByStableId = _.keyBy(
+            entityMetaByProfileIdSuffix[chart.profileType] || [],
+            meta => meta.stableId
         );
+        const entityLabel = getGenericAssayEntityLabel(
+            stableId,
+            chart.genericAssayType,
+            entityMetaByStableId
+        );
+
+        return chart.dataType === 'BINARY'
+            ? entityLabel
+            : `${entityLabel}: ${value}`;
     }
 
     @computed

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -7866,13 +7866,6 @@ export class StudyViewPageStore
         if (!_.isEmpty(this.initialFilters.mutationDataFilters)) {
             pending = pending || this.molecularProfileOptions.isPending;
         }
-        if (
-            !this.genericAssayProfiles.isPending &&
-            !_.isEmpty(this.genericAssayProfiles.result)
-        ) {
-            pending =
-                pending || this.genericAssayProfileOptionsByType.isPending;
-        }
         if (!_.isEmpty(this.initialFilters.caseLists)) {
             pending = pending || this.caseListSampleCounts.isPending;
         }

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -7606,6 +7606,39 @@ export class StudyViewPageStore
 
     @action.bound
     registerGenericAssayFrequencyTableCharts(): void {
+        const frequencyTableCharts = _.flatMap(
+            _.toPairs(this.genericAssayProfileOptionsByType.result),
+            ([genericAssayType, options]) =>
+                options
+                    .filter(
+                        option =>
+                            option.dataType === DataTypeConstants.BINARY ||
+                            option.dataType === DataTypeConstants.CATEGORICAL
+                    )
+                    .map(option => ({
+                        name: `${option.label} Frequency Table`,
+                        description: option.description,
+                        profileType: option.value,
+                        genericAssayType,
+                        genericAssayEntityId:
+                            GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                        dataType: option.dataType,
+                        patientLevel: option.patientLevel,
+                        chartKind: 'PROFILE_FREQUENCY_TABLE' as const,
+                    }))
+        );
+
+        if (!_.isEmpty(frequencyTableCharts)) {
+            this.addGenericAssayFrequencyTableCharts(
+                frequencyTableCharts,
+                false,
+                true
+            );
+        }
+    }
+
+    @action.bound
+    showDefaultGenericAssayFrequencyTableCharts(): void {
         _.forEach(
             this.genericAssayProfileOptionsByType.result,
             (options, genericAssayType) => {
@@ -7630,7 +7663,7 @@ export class StudyViewPageStore
                 if (!_.isEmpty(frequencyTableCharts)) {
                     this.addGenericAssayFrequencyTableCharts(
                         frequencyTableCharts,
-                        false,
+                        true,
                         true
                     );
                 }
@@ -7865,6 +7898,14 @@ export class StudyViewPageStore
         }
         if (!_.isEmpty(this.initialFilters.mutationDataFilters)) {
             pending = pending || this.molecularProfileOptions.isPending;
+        }
+        if (
+            this.isInitiallLoad &&
+            !this.genericAssayProfiles.isPending &&
+            !_.isEmpty(this.genericAssayProfiles.result)
+        ) {
+            pending =
+                pending || this.genericAssayProfileOptionsByType.isPending;
         }
         if (!_.isEmpty(this.initialFilters.caseLists)) {
             pending = pending || this.caseListSampleCounts.isPending;
@@ -9033,6 +9074,7 @@ export class StudyViewPageStore
     @action
     initializeGenericAssayCharts(): void {
         this.registerGenericAssayFrequencyTableCharts();
+        this.showDefaultGenericAssayFrequencyTableCharts();
         if (!_.isEmpty(this.initialFilters.genericAssaySelectionFilters)) {
             _.each(
                 this.initialFilters.genericAssaySelectionFilters,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -141,9 +141,12 @@ import {
     getGenericAssayChartUniqueKey,
     getGenericAssayChartDisplayName,
     getGenericAssayEntityLabel,
+    buildGenericAssaySelectionFilter,
     flattenGenericAssayFrequencyTableRows,
     GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+    GenericAssayFrequencyTableSelectionFilter,
     GenericAssayFrequencyTableRow,
+    getGenericAssayFrequencyTableSelectedRowKeyGroups,
     getGenericAssayFrequencyTableUniqueKey,
     splitGenericAssayFrequencyTableRowUniqueKey,
     getGenericAssayDataAsClinicalData,
@@ -2411,7 +2414,11 @@ export class StudyViewPageStore
     }
     // < / comparison groups code>
 
-    @observable private initialFiltersQuery: Partial<StudyViewFilter> = {};
+    @observable private initialFiltersQuery: Partial<
+        StudyViewFilter & {
+            genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+        }
+    > = {};
 
     @observable studyIds: string[] = [];
 
@@ -2536,7 +2543,13 @@ export class StudyViewPageStore
     }
 
     @action
-    updateStoreByFilters(filters: Partial<StudyViewFilter>): void {
+    updateStoreByFilters(
+        filters: Partial<
+            StudyViewFilter & {
+                genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+            }
+        >
+    ): void {
         // fixes filters in place to ensure backward compatiblity
         // as filter specification changes
         ensureBackwardCompatibilityOfFilters(filters);
@@ -2715,7 +2728,9 @@ export class StudyViewPageStore
     }
 
     @computed
-    get initialFilters(): StudyViewFilter {
+    get initialFilters(): StudyViewFilter & {
+        genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+    } {
         let initialFilter = {} as StudyViewFilter;
         if (_.isEmpty(this.queriedSampleIdentifiers.result)) {
             initialFilter.studyIds = this.queriedPhysicalStudyIds.result;
@@ -2723,7 +2738,9 @@ export class StudyViewPageStore
             initialFilter.sampleIdentifiers = this.queriedSampleIdentifiers.result;
         }
 
-        const studyViewFilter: StudyViewFilter = Object.assign(
+        const studyViewFilter: StudyViewFilter & {
+            genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+        } = Object.assign(
             {},
             toJS(this.initialFiltersQuery),
             initialFilter
@@ -3760,46 +3777,6 @@ export class StudyViewPageStore
         );
     }
 
-    private getFiltersExcludingChartSampleIdentifierFilter(
-        chartKey: string
-    ): StudyViewFilter {
-        const filters = _.cloneDeep(this.filters);
-        const sampleIdentifiersFilterSets = Array.from(
-            this._chartSampleIdentifiersFilterSet.entries()
-        )
-            .filter(([key]) => key !== chartKey)
-            .map(([, sampleIdentifiers]) => sampleIdentifiers);
-
-        if (!_.isEmpty(sampleIdentifiersFilterSets)) {
-            filters.sampleIdentifiers = intersect<SampleIdentifier>(
-                sampleIdentifiersFilterSets,
-                (sampleIdentifier: any) => {
-                    return (
-                        (sampleIdentifier as SampleIdentifier).sampleId +
-                        (sampleIdentifier as SampleIdentifier).studyId
-                    );
-                }
-            );
-        } else if (_.isEmpty(this.queriedSampleIdentifiers.result)) {
-            filters.studyIds = this.queriedPhysicalStudyIds.result;
-            filters.sampleIdentifiers = [];
-        } else {
-            filters.sampleIdentifiers = this.queriedSampleIdentifiers.result;
-            filters.studyIds = [];
-        }
-
-        return filters;
-    }
-
-    private async getFilteredSamplesExcludingChartSelection(
-        chartKey: string
-    ): Promise<Sample[]> {
-        return this.internalClient.fetchFilteredSamplesUsingPOST({
-            studyViewFilter:
-                this.getFiltersExcludingChartSampleIdentifierFilter(chartKey),
-        });
-    }
-
     private getGenericAssayFrequencyTableProfileMap(
         chart: GenericAssayChart
     ): { [studyId: string]: MolecularProfile } {
@@ -3833,97 +3810,13 @@ export class StudyViewPageStore
               )
             : normalizedGroups;
 
-        if (_.isEmpty(nextGroups)) {
-            runInAction(() => {
-                this._genericAssayFrequencyTableFilterSet.delete(uniqueKey);
-                this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
-            });
-            return;
-        }
-
-        const profileByStudyId =
-            this.getGenericAssayFrequencyTableProfileMap(chart);
-        const baseSamples = await this.getFilteredSamplesExcludingChartSelection(
-            uniqueKey
-        );
-        const filteredSamples = baseSamples.filter(
-            sample => profileByStudyId[sample.studyId] !== undefined
-        );
-
-        if (_.isEmpty(filteredSamples)) {
-            runInAction(() => {
-                this._genericAssayFrequencyTableFilterSet.delete(uniqueKey);
-                this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
-            });
-            return;
-        }
-
-        const stableIds = _.uniq(
-            _.flatMap(nextGroups, group =>
-                group.map(
-                    rowKey =>
-                        splitGenericAssayFrequencyTableRowUniqueKey(rowKey)
-                            .stableId
-                )
-            )
-        );
-        const sampleMolecularIdentifiers = filteredSamples.map(sample => ({
-            sampleId: sample.sampleId,
-            molecularProfileId: profileByStudyId[sample.studyId]
-                .molecularProfileId,
-        }));
-        const data = await getClient().fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
-            {
-                projection: 'DETAILED',
-                genericAssayDataMultipleStudyFilter: {
-                    genericAssayStableIds: stableIds,
-                    sampleMolecularIdentifiers,
-                } as GenericAssayDataMultipleStudyFilter,
-            } as any
-        );
-
-        const dataByStableIdAndCaseKey = _.groupBy(
-            data,
-            datum =>
-                `${datum.stableId}::${
-                    chart.patientLevel ? datum.uniquePatientKey : datum.uniqueSampleKey
-                }`
-        );
-        const groupedCases = nextGroups.map(group => {
-            const groupCases = filteredSamples.filter(sample =>
-                group.some(rowKey => {
-                    const { stableId, value } =
-                        splitGenericAssayFrequencyTableRowUniqueKey(rowKey);
-                    const caseKey = chart.patientLevel
-                        ? sample.uniquePatientKey
-                        : sample.uniqueSampleKey;
-                    return (
-                        dataByStableIdAndCaseKey[`${stableId}::${caseKey}`]?.some(
-                            datum => datum.value === value
-                        ) || false
-                    );
-                })
-            );
-            return getFilteredSampleIdentifiers(groupCases);
-        });
-        const selectedCases = intersect<SampleIdentifier>(
-            groupedCases,
-            (sampleIdentifier: any) => {
-                return (
-                    (sampleIdentifier as SampleIdentifier).sampleId +
-                    (sampleIdentifier as SampleIdentifier).studyId
-                );
-            }
-        );
-
         runInAction(() => {
-            this._genericAssayFrequencyTableFilterSet.set(uniqueKey, nextGroups);
-            if (_.isEmpty(selectedCases)) {
-                this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
+            if (_.isEmpty(nextGroups)) {
+                this._genericAssayFrequencyTableFilterSet.delete(uniqueKey);
             } else {
-                this._chartSampleIdentifiersFilterSet.set(
+                this._genericAssayFrequencyTableFilterSet.set(
                     uniqueKey,
-                    selectedCases
+                    nextGroups
                 );
             }
         });
@@ -3932,7 +3825,6 @@ export class StudyViewPageStore
     @action.bound
     resetGenericAssayFrequencyTableFilters(uniqueKey: string): void {
         this._genericAssayFrequencyTableFilterSet.delete(uniqueKey);
-        this._chartSampleIdentifiersFilterSet.delete(uniqueKey);
     }
 
     @action.bound
@@ -4847,14 +4739,45 @@ export class StudyViewPageStore
         return Array.from(this._genericAssayDataFilterSet.values());
     }
 
-    @observable filters!: StudyViewFilter;
+    @computed
+    get genericAssaySelectionFilters(): GenericAssayFrequencyTableSelectionFilter[] {
+        return Array.from(this._genericAssayFrequencyTableFilterSet.entries())
+            .map(([uniqueKey, selectedRowKeyGroups]) => {
+                const chart = this._genericAssayChartMap.get(uniqueKey);
+                if (chart?.chartKind !== 'PROFILE_FREQUENCY_TABLE') {
+                    return undefined;
+                }
+
+                return buildGenericAssaySelectionFilter(
+                    chart.profileType,
+                    !!chart.patientLevel,
+                    selectedRowKeyGroups
+                );
+            })
+            .filter(
+                (
+                    genericAssaySelectionFilter
+                ): genericAssaySelectionFilter is GenericAssayFrequencyTableSelectionFilter =>
+                    genericAssaySelectionFilter !== undefined
+            );
+    }
+
+    @observable filters: StudyViewFilter & {
+        genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+    };
 
     /**
      * Filters that are queued and not yet submitted
      */
     @computed
-    get filtersProxy(): StudyViewFilter {
-        const filters: Partial<StudyViewFilter> = {};
+    get filtersProxy(): StudyViewFilter & {
+        genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+    } {
+        const filters: Partial<
+            StudyViewFilter & {
+                genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+            }
+        > = {};
 
         if (this.genomicDataFilters.length > 0) {
             filters.genomicDataFilters = this.genomicDataFilters;
@@ -4879,6 +4802,11 @@ export class StudyViewPageStore
 
         if (this.genericAssayDataFilters.length > 0) {
             filters.genericAssayDataFilters = this.genericAssayDataFilters;
+        }
+
+        if (this.genericAssaySelectionFilters.length > 0) {
+            filters.genericAssaySelectionFilters =
+                this.genericAssaySelectionFilters;
         }
 
         if (this.clinicalDataFilters.length > 0) {
@@ -7910,7 +7838,10 @@ export class StudyViewPageStore
         if (!_.isEmpty(this.initialFilters.mutationDataFilters)) {
             pending = pending || this.molecularProfileOptions.isPending;
         }
-        if (!_.isEmpty(this.initialFilters.genericAssayDataFilters)) {
+        if (
+            !_.isEmpty(this.initialFilters.genericAssayDataFilters) ||
+            !_.isEmpty(this.initialFilters.genericAssaySelectionFilters)
+        ) {
             pending =
                 pending || this.genericAssayProfileOptionsByType.isPending;
         }
@@ -9081,6 +9012,28 @@ export class StudyViewPageStore
     @action
     initializeGenericAssayCharts(): void {
         this.registerGenericAssayFrequencyTableCharts();
+        if (!_.isEmpty(this.initialFilters.genericAssaySelectionFilters)) {
+            _.each(
+                this.initialFilters.genericAssaySelectionFilters,
+                genericAssaySelectionFilter => {
+                    const uniqueKey = getGenericAssayFrequencyTableUniqueKey(
+                        genericAssaySelectionFilter.profileType
+                    );
+                    const chart = this._genericAssayChartMap.get(uniqueKey);
+                    if (chart?.chartKind === 'PROFILE_FREQUENCY_TABLE') {
+                        this._genericAssayFrequencyTableFilterSet.set(
+                            uniqueKey,
+                            getGenericAssayFrequencyTableSelectedRowKeyGroups(
+                                this.initialFilters
+                                    .genericAssaySelectionFilters!,
+                                genericAssaySelectionFilter.profileType
+                            )
+                        );
+                        this.changeChartVisibility(uniqueKey, true);
+                    }
+                }
+            );
+        }
         // initialize generic assay continuous data chart
         if (!_.isEmpty(this.initialFilters.genericAssayDataFilters)) {
             _.map(

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -7616,7 +7616,7 @@ export class StudyViewPageStore
                             option.dataType === DataTypeConstants.CATEGORICAL
                     )
                     .map(option => ({
-                        name: `${option.label} Frequency Table`,
+                        name: `Frequency Table: ${option.label}`,
                         description: option.description,
                         profileType: option.value,
                         genericAssayType,
@@ -7649,7 +7649,7 @@ export class StudyViewPageStore
                             option.dataType === DataTypeConstants.CATEGORICAL
                     )
                     .map(option => ({
-                        name: `${option.label} Frequency Table`,
+                        name: `Frequency Table: ${option.label}`,
                         description: option.description,
                         profileType: option.value,
                         genericAssayType,

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -12,6 +12,7 @@ import {
     chartMetaComparator,
     ChartMetaDataTypeEnum,
     buildGenericAssayFrequencyTableDataFilters,
+    buildGenericAssaySelectionFilter,
     clinicalDataCountComparator,
     customBinsAreValid,
     DataBin,
@@ -24,6 +25,7 @@ import {
     formatFrequency,
     formatNumericalTickValues,
     formatRange,
+    GenericAssayFrequencyTableSelectionFilter,
     ensureBackwardCompatibilityOfFilters,
     GENE_FILTER_QUERY_DEFAULTS,
     geneFilterQueryFromOql,
@@ -44,6 +46,7 @@ import {
     getFilteredStudiesWithSamples,
     getFrequencyStr,
     getGenericAssayFrequencyTableDownloadData,
+    getGenericAssayFrequencyTableSelectedRowKeyGroups,
     getGenericAssayFrequencyTableSelectedRowKeys,
     getGroupedClinicalDataByBins,
     getNonZeroUniqueBins,
@@ -60,6 +63,7 @@ import {
     isDataBinSelected,
     isEveryBinDistinct,
     isFocusedChartShrunk,
+    isFiltered,
     isLogScaleByDataBins,
     isLogScaleByValues,
     isOccupied,
@@ -4218,6 +4222,92 @@ describe('StudyViewUtils', () => {
                         values: [{ value: 'Subtype C' } as DataFilterValue],
                     },
                 ]);
+            });
+
+            it('builds generic assay selection filters for row groups', () => {
+                const filter = buildGenericAssaySelectionFilter(
+                    'profile_type',
+                    true,
+                    [
+                        [
+                            'entityA::Subtype A::profile_type',
+                            'entityB::Subtype B::profile_type',
+                        ],
+                        ['entityC::NA::profile_type'],
+                    ]
+                );
+
+                assert.deepEqual(filter, {
+                    profileType: 'profile_type',
+                    patientLevel: true,
+                    values: [
+                        [
+                            { stableId: 'entityA', value: 'Subtype A' },
+                            { stableId: 'entityB', value: 'Subtype B' },
+                        ],
+                        [{ stableId: 'entityC', value: 'NA' }],
+                    ],
+                });
+            });
+
+            it('restores grouped row keys from generic assay selection filters', () => {
+                const selectedRowKeyGroups =
+                    getGenericAssayFrequencyTableSelectedRowKeyGroups(
+                        [
+                            {
+                                profileType: 'profile_type',
+                                patientLevel: false,
+                                values: [
+                                    [
+                                        {
+                                            stableId: 'entityA',
+                                            value: 'Subtype A',
+                                        },
+                                        {
+                                            stableId: 'entityB',
+                                            value: 'Subtype B',
+                                        },
+                                    ],
+                                    [
+                                        {
+                                            stableId: 'entityC',
+                                            value: 'NA',
+                                        },
+                                    ],
+                                ],
+                            } as GenericAssayFrequencyTableSelectionFilter,
+                        ],
+                        'profile_type'
+                    );
+
+                assert.deepEqual(selectedRowKeyGroups, [
+                    [
+                        'entityA::Subtype A::profile_type',
+                        'entityB::Subtype B::profile_type',
+                    ],
+                    ['entityC::NA::profile_type'],
+                ]);
+            });
+
+            it('treats generic assay selection filters as active filters', () => {
+                assert.isTrue(
+                    isFiltered({
+                        genericAssaySelectionFilters: [
+                            {
+                                profileType: 'profile_type',
+                                patientLevel: false,
+                                values: [
+                                    [
+                                        {
+                                            stableId: 'entityA',
+                                            value: 'Subtype A',
+                                        },
+                                    ],
+                                ],
+                            },
+                        ],
+                    })
+                );
             });
 
             it('splits generic assay frequency table row keys safely from the right', () => {

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -4344,7 +4344,7 @@ describe('StudyViewUtils', () => {
                 assert.equal(
                     downloadData,
                     [
-                        'Entity\tCategory\t# Samples\tFreq',
+                        'Entity\tCategory\t#\tFreq',
                         'Entity A Label\tSubtype A\t4\t40.0%',
                     ].join('\n')
                 );

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -4,6 +4,8 @@ import {
     ALTERATION_FILTER_DEFAULTS,
     annotationFilterActive,
     calcIntervalBinValues,
+    getGenericAssayChartDisplayName,
+    getGenericAssayEntityLabel,
     calculateLayout,
     calculateNewLayoutForFocusedChart,
     ChartMeta,
@@ -4062,6 +4064,26 @@ describe('StudyViewUtils', () => {
                     },
                 },
             } as any;
+
+            it('formats generic assay entity and chart labels from metadata', () => {
+                assert.equal(
+                    getGenericAssayEntityLabel(
+                        'entityA',
+                        'MUTATIONAL_SIGNATURE',
+                        entityMetaByStableId
+                    ),
+                    'Entity A Label'
+                );
+                assert.equal(
+                    getGenericAssayChartDisplayName(
+                        'entityA',
+                        'Mutational Signature v2',
+                        'MUTATIONAL_SIGNATURE',
+                        entityMetaByStableId
+                    ),
+                    'Entity A Label: Mutational Signature v2'
+                );
+            });
 
             it('flattens categorical counts into selectable table rows', () => {
                 const rows = flattenGenericAssayFrequencyTableRows(

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -4377,7 +4377,7 @@ describe('StudyViewUtils', () => {
                     {},
                     {
                         [uniqueKey]: {
-                            name: 'Mutational Signature Frequency Table',
+                            name: 'Frequency Table: Mutational Signature',
                             description: 'Mutational Signature v2',
                             genericAssayType: 'MUTATIONAL_SIGNATURE',
                             genericAssayEntityId:
@@ -4400,7 +4400,7 @@ describe('StudyViewUtils', () => {
                     id: uniqueKey,
                     chartType: ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE,
                     patientAttribute: false,
-                    name: 'Mutational Signature Frequency Table',
+                    name: 'Frequency Table: Mutational Signature',
                     description: 'Mutational Signature v2',
                     genericAssayType: 'MUTATIONAL_SIGNATURE',
                     genericAssayEntityId:

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -45,6 +45,7 @@ import {
     getFilteredSampleIdentifiers,
     getFilteredStudiesWithSamples,
     getFrequencyStr,
+    getChartSettingsMap,
     getGenericAssayFrequencyTableDownloadData,
     getGenericAssayFrequencyTableSelectedRowKeyGroups,
     getGenericAssayFrequencyTableSelectedRowKeys,
@@ -59,6 +60,7 @@ import {
     getSamplesByExcludingFiltersOnChart,
     getStudyViewTabId,
     getVirtualStudyDescription,
+    GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
     intervalFiltersDisplayValue,
     isDataBinSelected,
     isEveryBinDistinct,
@@ -4348,6 +4350,71 @@ describe('StudyViewUtils', () => {
                         'Entity A Label\tSubtype A\t4\t40.0%',
                     ].join('\n')
                 );
+            });
+
+            it('serializes generic assay frequency tables into chart settings for saved layouts', () => {
+                const uniqueKey =
+                    'GENERIC_ASSAY_FREQUENCY_TABLE_profile_type';
+                const chartSettingsMap = getChartSettingsMap(
+                    [
+                        {
+                            uniqueKey,
+                            patientAttribute: false,
+                        } as ChartMeta,
+                    ],
+                    [
+                        {
+                            uniqueKey,
+                            patientAttribute: false,
+                        } as ChartMeta,
+                    ],
+                    1,
+                    {},
+                    {
+                        [uniqueKey]:
+                            ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE,
+                    },
+                    {},
+                    {
+                        [uniqueKey]: {
+                            name: 'Mutational Signature Frequency Table',
+                            description: 'Mutational Signature v2',
+                            genericAssayType: 'MUTATIONAL_SIGNATURE',
+                            genericAssayEntityId:
+                                GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                            profileType: 'profile_type',
+                            dataType: DataTypeConstants.CATEGORICAL,
+                            patientLevel: true,
+                        } as any,
+                    },
+                    {},
+                    {},
+                    {},
+                    false,
+                    false,
+                    false,
+                    [{ i: uniqueKey, x: 0, y: 0, w: 2, h: 3 }]
+                );
+
+                assert.deepEqual(chartSettingsMap[uniqueKey], {
+                    id: uniqueKey,
+                    chartType: ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE,
+                    patientAttribute: false,
+                    name: 'Mutational Signature Frequency Table',
+                    description: 'Mutational Signature v2',
+                    genericAssayType: 'MUTATIONAL_SIGNATURE',
+                    genericAssayEntityId:
+                        GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                    profileType: 'profile_type',
+                    dataType: DataTypeConstants.CATEGORICAL,
+                    patientLevelProfile: true,
+                    layout: {
+                        x: 0,
+                        y: 0,
+                        w: 2,
+                        h: 3,
+                    },
+                });
             });
         });
         it('newlyAddedUnfilteredPromise should be used when the chart is not default visible attribute, at the time the chart is not filtered', () => {

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -43,6 +43,7 @@ import {
     getFilteredSampleIdentifiers,
     getFilteredStudiesWithSamples,
     getFrequencyStr,
+    getGenericAssayFrequencyTableDownloadData,
     getGenericAssayFrequencyTableSelectedRowKeys,
     getGroupedClinicalDataByBins,
     getNonZeroUniqueBins,
@@ -67,6 +68,7 @@ import {
     pickClinicalDataColors,
     shouldShowChart,
     showOriginStudiesInSummaryDescription,
+    splitGenericAssayFrequencyTableRowUniqueKey,
     statusFilterActive,
     StudyViewFilterWithSampleIdentifierFilters,
     toFixedDigit,
@@ -4216,6 +4218,46 @@ describe('StudyViewUtils', () => {
                         values: [{ value: 'Subtype C' } as DataFilterValue],
                     },
                 ]);
+            });
+
+            it('splits generic assay frequency table row keys safely from the right', () => {
+                assert.deepEqual(
+                    splitGenericAssayFrequencyTableRowUniqueKey(
+                        'entityA::Subtype::A::profile_type'
+                    ),
+                    {
+                        stableId: 'entityA',
+                        value: 'Subtype::A',
+                        profileType: 'profile_type',
+                    }
+                );
+            });
+
+            it('formats generic assay frequency table download rows', () => {
+                const downloadData = getGenericAssayFrequencyTableDownloadData(
+                    {
+                        result: [
+                            {
+                                uniqueKey: 'entityA::Subtype A::profile_type',
+                                entityStableId: 'entityA',
+                                entityLabel: 'Entity A Label',
+                                profileType: 'profile_type',
+                                category: 'Subtype A',
+                                count: 4,
+                                totalCount: 10,
+                            },
+                        ],
+                    } as any,
+                    true
+                );
+
+                assert.equal(
+                    downloadData,
+                    [
+                        'Entity\tCategory\t# Samples\tFreq',
+                        'Entity A Label\tSubtype A\t4\t40.0%',
+                    ].join('\n')
+                );
             });
         });
         it('newlyAddedUnfilteredPromise should be used when the chart is not default visible attribute, at the time the chart is not filtered', () => {

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -9,6 +9,7 @@ import {
     ChartMeta,
     chartMetaComparator,
     ChartMetaDataTypeEnum,
+    buildGenericAssayFrequencyTableDataFilters,
     clinicalDataCountComparator,
     customBinsAreValid,
     DataBin,
@@ -16,6 +17,7 @@ import {
     filterCategoryBins,
     filterIntervalBins,
     filterNumericalBins,
+    flattenGenericAssayFrequencyTableRows,
     findSpot,
     formatFrequency,
     formatNumericalTickValues,
@@ -39,6 +41,7 @@ import {
     getFilteredSampleIdentifiers,
     getFilteredStudiesWithSamples,
     getFrequencyStr,
+    getGenericAssayFrequencyTableSelectedRowKeys,
     getGroupedClinicalDataByBins,
     getNonZeroUniqueBins,
     getPatientIdentifiers,
@@ -105,6 +108,7 @@ import { autorun, observable, runInAction } from 'mobx';
 
 import { AlterationTypeConstants, DataTypeConstants } from 'shared/constants';
 import { SingleGeneQuery } from 'shared/lib/oql/oql-parser';
+import { COMMON_GENERIC_ASSAY_PROPERTY } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import {
     oqlQueryToStructVarGenePair,
     updateStructuralVariantQuery,
@@ -4041,6 +4045,156 @@ describe('StudyViewUtils', () => {
             );
             assert.equal(promises.length, 1);
             assert.isTrue(promises[0] === initialVisibleAttributesPromise);
+        });
+
+        describe('generic assay frequency table helpers', () => {
+            const entityMetaByStableId = {
+                entityA: {
+                    stableId: 'entityA',
+                    genericEntityMetaProperties: {
+                        [COMMON_GENERIC_ASSAY_PROPERTY.NAME]: 'Entity A Label',
+                    },
+                },
+                entityB: {
+                    stableId: 'entityB',
+                    genericEntityMetaProperties: {
+                        [COMMON_GENERIC_ASSAY_PROPERTY.NAME]: 'Entity B Label',
+                    },
+                },
+            } as any;
+
+            it('flattens categorical counts into selectable table rows', () => {
+                const rows = flattenGenericAssayFrequencyTableRows(
+                    [
+                        {
+                            stableId: 'entityA',
+                            counts: [
+                                { value: 'Subtype A', count: 4 },
+                                { value: 'Subtype B', count: 2 },
+                            ],
+                        },
+                        {
+                            stableId: 'entityB',
+                            counts: [{ value: 'Subtype C', count: 1 }],
+                        },
+                    ] as any,
+                    DataTypeConstants.CATEGORICAL,
+                    'profile_type',
+                    'MUTATIONAL_SIGNATURE',
+                    10,
+                    entityMetaByStableId
+                );
+
+                assert.deepEqual(rows, [
+                    {
+                        uniqueKey: 'entityA::Subtype A::profile_type',
+                        entityStableId: 'entityA',
+                        entityLabel: 'Entity A Label',
+                        profileType: 'profile_type',
+                        category: 'Subtype A',
+                        count: 4,
+                        totalCount: 10,
+                    },
+                    {
+                        uniqueKey: 'entityA::Subtype B::profile_type',
+                        entityStableId: 'entityA',
+                        entityLabel: 'Entity A Label',
+                        profileType: 'profile_type',
+                        category: 'Subtype B',
+                        count: 2,
+                        totalCount: 10,
+                    },
+                    {
+                        uniqueKey: 'entityB::Subtype C::profile_type',
+                        entityStableId: 'entityB',
+                        entityLabel: 'Entity B Label',
+                        profileType: 'profile_type',
+                        category: 'Subtype C',
+                        count: 1,
+                        totalCount: 10,
+                    },
+                ]);
+            });
+
+            it('derives selected row keys from filters for one profile only', () => {
+                const selectedRowKeys = getGenericAssayFrequencyTableSelectedRowKeys(
+                    [
+                        {
+                            stableId: 'entityA',
+                            profileType: 'profile_type',
+                            values: [
+                                { value: 'Subtype A' } as DataFilterValue,
+                                { value: 'Subtype B' } as DataFilterValue,
+                            ],
+                        },
+                        {
+                            stableId: 'entityB',
+                            profileType: 'other_profile',
+                            values: [{ value: 'Subtype C' } as DataFilterValue],
+                        },
+                    ] as any,
+                    'profile_type'
+                );
+
+                assert.deepEqual(selectedRowKeys, [
+                    'entityA::Subtype A::profile_type',
+                    'entityA::Subtype B::profile_type',
+                ]);
+            });
+
+            it('groups selected rows back into generic assay filters by entity', () => {
+                const rows = [
+                    {
+                        uniqueKey: 'entityA::Subtype A::profile_type',
+                        entityStableId: 'entityA',
+                        entityLabel: 'Entity A Label',
+                        profileType: 'profile_type',
+                        category: 'Subtype A',
+                        count: 4,
+                        totalCount: 10,
+                    },
+                    {
+                        uniqueKey: 'entityA::Subtype B::profile_type',
+                        entityStableId: 'entityA',
+                        entityLabel: 'Entity A Label',
+                        profileType: 'profile_type',
+                        category: 'Subtype B',
+                        count: 2,
+                        totalCount: 10,
+                    },
+                    {
+                        uniqueKey: 'entityB::Subtype C::profile_type',
+                        entityStableId: 'entityB',
+                        entityLabel: 'Entity B Label',
+                        profileType: 'profile_type',
+                        category: 'Subtype C',
+                        count: 1,
+                        totalCount: 10,
+                    },
+                ];
+
+                const filters = buildGenericAssayFrequencyTableDataFilters(rows, [
+                    'entityA::Subtype A::profile_type',
+                    'entityA::Subtype B::profile_type',
+                    'entityB::Subtype C::profile_type',
+                ]);
+
+                assert.deepEqual(filters, [
+                    {
+                        stableId: 'entityA',
+                        profileType: 'profile_type',
+                        values: [
+                            { value: 'Subtype A' } as DataFilterValue,
+                            { value: 'Subtype B' } as DataFilterValue,
+                        ],
+                    },
+                    {
+                        stableId: 'entityB',
+                        profileType: 'profile_type',
+                        values: [{ value: 'Subtype C' } as DataFilterValue],
+                    },
+                ]);
+            });
         });
         it('newlyAddedUnfilteredPromise should be used when the chart is not default visible attribute, at the time the chart is not filtered', () => {
             const promises = getRequestedAwaitPromisesForClinicalData(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -4395,7 +4395,7 @@ function shouldIncludeGenericAssayFrequencyValue(
     return true;
 }
 
-function getGenericAssayFrequencyTableEntityLabel(
+export function getGenericAssayEntityLabel(
     stableId: string,
     genericAssayType: string,
     entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
@@ -4415,6 +4415,19 @@ function getGenericAssayFrequencyTableEntityLabel(
         ?.selectionConfig?.formatChartNameUsingCompactLabel
         ? formatGenericAssayCompactLabelByNameAndId(stableId, entityName)
         : entityName;
+}
+
+export function getGenericAssayChartDisplayName(
+    stableId: string,
+    profileLabel: string,
+    genericAssayType: string,
+    entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
+): string {
+    return `${getGenericAssayEntityLabel(
+        stableId,
+        genericAssayType,
+        entityMetaByStableId
+    )}: ${profileLabel}`;
 }
 
 export function flattenGenericAssayFrequencyTableRows(
@@ -4442,7 +4455,7 @@ export function flattenGenericAssayFrequencyTableRows(
                     profileType
                 ),
                 entityStableId: countItem.stableId,
-                entityLabel: getGenericAssayFrequencyTableEntityLabel(
+                entityLabel: getGenericAssayEntityLabel(
                     countItem.stableId,
                     genericAssayType,
                     entityMetaByStableId

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -21,6 +21,7 @@ import {
     GenericAssayDataBin,
     GenericAssayDataFilter,
     GenericAssayDataMultipleStudyFilter,
+    GenericAssayMeta,
     GenomicDataBin,
     GenomicDataCount,
     MolecularDataMultipleStudyFilter,
@@ -124,6 +125,13 @@ import { toast } from 'react-toastify';
 import { useCallback } from 'react';
 import { MutationOptionConstants } from 'shared/constants';
 import { MolecularAlterationType_filenameSuffix } from 'shared/lib/StoreUtils';
+import {
+    COMMON_GENERIC_ASSAY_PROPERTY,
+    formatGenericAssayCompactLabelByNameAndId,
+    GenericAssayDataType,
+    getGenericAssayPropertyOrDefault,
+} from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+import { GENERIC_ASSAY_CONFIG } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
 import { MultiSelectionTableRow } from './table/MultiSelectionTable';
 import Survival from 'pages/groupComparison/Survival';
 import { StructVarMultiSelectionTableRow } from './table/StructuralVariantMultiSelectionTable';
@@ -147,6 +155,19 @@ export enum DataType {
 }
 
 export type ClinicalDataType = 'SAMPLE' | 'PATIENT';
+
+export type GenericAssayFrequencyTableRow = {
+    uniqueKey: string;
+    entityStableId: string;
+    entityLabel: string;
+    profileType: string;
+    category: string;
+    count: number;
+    totalCount: number;
+};
+
+export const GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID =
+    '__GENERIC_ASSAY_FREQUENCY_TABLE__';
 
 export type ChartType = keyof typeof ChartTypeEnum;
 
@@ -861,6 +882,20 @@ export function getGenericAssayChartUniqueKey(
     profileType: string
 ): string {
     return entityId + '_' + profileType;
+}
+
+export function getGenericAssayFrequencyTableUniqueKey(
+    profileType: string
+): string {
+    return `GENERIC_ASSAY_FREQUENCY_TABLE_${profileType}`;
+}
+
+export function getGenericAssayFrequencyTableRowUniqueKey(
+    stableId: string,
+    value: string,
+    profileType: string
+): string {
+    return `${stableId}::${value}::${profileType}`;
 }
 
 const UNIQUE_KEY_SEPARATOR = ':';
@@ -4328,6 +4363,139 @@ export function getDefaultClinicalDataBinFilter(
 
 export function generateColorMapKey(id: string, value: string): string {
     return `${id}.${value}`;
+}
+
+const GENERIC_ASSAY_HIDDEN_CATEGORY_VALUES = new Set(['', 'na']);
+const GENERIC_ASSAY_BINARY_NEGATIVE_VALUES = new Set([
+    '0',
+    'absent',
+    'false',
+    'n',
+    'negative',
+    'no',
+]);
+
+function normalizeGenericAssayFrequencyValue(value: string): string {
+    return value.trim().toLowerCase();
+}
+
+function shouldIncludeGenericAssayFrequencyValue(
+    value: string,
+    dataType: string
+): boolean {
+    const normalizedValue = normalizeGenericAssayFrequencyValue(value);
+    if (GENERIC_ASSAY_HIDDEN_CATEGORY_VALUES.has(normalizedValue)) {
+        return false;
+    }
+
+    if (dataType === GenericAssayDataType.BINARY) {
+        return !GENERIC_ASSAY_BINARY_NEGATIVE_VALUES.has(normalizedValue);
+    }
+
+    return true;
+}
+
+function getGenericAssayFrequencyTableEntityLabel(
+    stableId: string,
+    genericAssayType: string,
+    entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
+): string {
+    const meta = entityMetaByStableId[stableId];
+    if (meta === undefined) {
+        return stableId;
+    }
+
+    const entityName = getGenericAssayPropertyOrDefault(
+        meta.genericEntityMetaProperties,
+        COMMON_GENERIC_ASSAY_PROPERTY.NAME,
+        stableId
+    );
+
+    return GENERIC_ASSAY_CONFIG.genericAssayConfigByType[genericAssayType]
+        ?.selectionConfig?.formatChartNameUsingCompactLabel
+        ? formatGenericAssayCompactLabelByNameAndId(stableId, entityName)
+        : entityName;
+}
+
+export function flattenGenericAssayFrequencyTableRows(
+    countItems: GenericAssayDataCountItem[],
+    dataType: string,
+    profileType: string,
+    genericAssayType: string,
+    totalCount: number,
+    entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
+): GenericAssayFrequencyTableRow[] {
+    return _.flatMap(countItems, countItem =>
+        countItem.counts
+            .filter(
+                count =>
+                    count.count > 0 &&
+                    shouldIncludeGenericAssayFrequencyValue(
+                        count.value,
+                        dataType
+                    )
+            )
+            .map(count => ({
+                uniqueKey: getGenericAssayFrequencyTableRowUniqueKey(
+                    countItem.stableId,
+                    count.value,
+                    profileType
+                ),
+                entityStableId: countItem.stableId,
+                entityLabel: getGenericAssayFrequencyTableEntityLabel(
+                    countItem.stableId,
+                    genericAssayType,
+                    entityMetaByStableId
+                ),
+                profileType,
+                category: count.value,
+                count: count.count,
+                totalCount,
+            }))
+    );
+}
+
+export function getGenericAssayFrequencyTableSelectedRowKeys(
+    genericAssayDataFilters: GenericAssayDataFilter[],
+    profileType: string
+): string[] {
+    return _.flatMap(
+        genericAssayDataFilters.filter(
+            genericAssayDataFilter =>
+                genericAssayDataFilter.profileType === profileType
+        ),
+        genericAssayDataFilter =>
+            (genericAssayDataFilter.values || [])
+                .map(value => value.value)
+                .filter((value): value is string => !!value)
+                .map(value =>
+                    getGenericAssayFrequencyTableRowUniqueKey(
+                        genericAssayDataFilter.stableId,
+                        value,
+                        profileType
+                    )
+                )
+    );
+}
+
+export function buildGenericAssayFrequencyTableDataFilters(
+    rows: GenericAssayFrequencyTableRow[],
+    selectedRowKeys: string[]
+): GenericAssayDataFilter[] {
+    return _.chain(rows)
+        .filter(row => selectedRowKeys.includes(row.uniqueKey))
+        .groupBy(row => row.entityStableId)
+        .map(entityRows => ({
+            stableId: entityRows[0].entityStableId,
+            profileType: entityRows[0].profileType,
+            values: entityRows.map(
+                entityRow =>
+                    ({
+                        value: entityRow.category,
+                    }) as DataFilterValue
+            ),
+        }))
+        .value();
 }
 
 export async function invokeGenericAssayDataCount(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -898,6 +898,24 @@ export function getGenericAssayFrequencyTableRowUniqueKey(
     return `${stableId}::${value}::${profileType}`;
 }
 
+export function splitGenericAssayFrequencyTableRowUniqueKey(uniqueKey: string): {
+    stableId: string;
+    value: string;
+    profileType: string;
+} {
+    const stableIdSeparatorIndex = uniqueKey.indexOf('::');
+    const profileTypeSeparatorIndex = uniqueKey.lastIndexOf('::');
+
+    return {
+        stableId: uniqueKey.slice(0, stableIdSeparatorIndex),
+        value: uniqueKey.slice(
+            stableIdSeparatorIndex + 2,
+            profileTypeSeparatorIndex
+        ),
+        profileType: uniqueKey.slice(profileTypeSeparatorIndex + 2),
+    };
+}
+
 const UNIQUE_KEY_SEPARATOR = ':';
 const CHART_TYPE_SEPARATOR = ';';
 
@@ -5005,6 +5023,38 @@ export async function getMutatedGenesDownloadData(
         });
         return data.join('\n');
     } else return '';
+}
+
+export function getGenericAssayFrequencyTableDownloadData(
+    promise: MobxPromise<GenericAssayFrequencyTableRow[]>,
+    showCategoryColumn: boolean
+): string {
+    if (!promise.result) {
+        return '';
+    }
+
+    const header = showCategoryColumn
+        ? ['Entity', 'Category', '# Samples', 'Freq']
+        : ['Entity', '# Samples', 'Freq'];
+    const data = [header.join('\t')];
+
+    _.each(promise.result, record => {
+        const rowData = showCategoryColumn
+            ? [
+                  record.entityLabel,
+                  record.category,
+                  record.count,
+                  getFrequencyStr((record.count / record.totalCount) * 100),
+              ]
+            : [
+                  record.entityLabel,
+                  record.count,
+                  getFrequencyStr((record.count / record.totalCount) * 100),
+              ];
+        data.push(rowData.join('\t'));
+    });
+
+    return data.join('\n');
 }
 
 export function getStructuralVariantGenesDownloadData(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -5093,11 +5093,11 @@ export async function getMutatedGenesDownloadData(
     } else return '';
 }
 
-export function getGenericAssayFrequencyTableDownloadData(
-    promise: MobxPromise<GenericAssayFrequencyTableRow[]>,
+export function formatGenericAssayFrequencyTableDownloadData(
+    rows: GenericAssayFrequencyTableRow[],
     showCategoryColumn: boolean
 ): string {
-    if (!promise.result) {
+    if (!rows) {
         return '';
     }
 
@@ -5106,7 +5106,7 @@ export function getGenericAssayFrequencyTableDownloadData(
         : ['Entity', '# Samples', 'Freq'];
     const data = [header.join('\t')];
 
-    _.each(promise.result, record => {
+    _.each(rows, record => {
         const rowData = showCategoryColumn
             ? [
                   record.entityLabel,
@@ -5123,6 +5123,20 @@ export function getGenericAssayFrequencyTableDownloadData(
     });
 
     return data.join('\n');
+}
+
+export function getGenericAssayFrequencyTableDownloadData(
+    promise: MobxPromise<GenericAssayFrequencyTableRow[]>,
+    showCategoryColumn: boolean
+): string {
+    if (!promise.result) {
+        return '';
+    }
+
+    return formatGenericAssayFrequencyTableDownloadData(
+        promise.result,
+        showCategoryColumn
+    );
 }
 
 export function getStructuralVariantGenesDownloadData(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -233,6 +233,21 @@ export type StudyViewFilterWithSampleIdentifierFilters = StudyViewFilter & {
     sampleIdentifiersSet: { [id: string]: SampleIdentifier[] };
 };
 
+export type GenericAssayFrequencyTableSelectionValue = {
+    stableId: string;
+    value: string;
+};
+
+export type GenericAssayFrequencyTableSelectionFilter = {
+    profileType: string;
+    patientLevel: boolean;
+    values: GenericAssayFrequencyTableSelectionValue[][];
+};
+
+export type StudyViewFilterWithGenericAssaySelectionFilters = StudyViewFilter & {
+    genericAssaySelectionFilters?: GenericAssayFrequencyTableSelectionFilter[];
+};
+
 export type GenomicDataCountWithSampleUniqueKeys = GenomicDataCount & {
     sampleUniqueKeys: string[];
 };
@@ -1177,7 +1192,10 @@ export function getVirtualStudyDescription(
 }
 
 export function isFiltered(
-    filter: Partial<StudyViewFilterWithSampleIdentifierFilters>
+    filter: Partial<
+        StudyViewFilterWithSampleIdentifierFilters &
+            StudyViewFilterWithGenericAssaySelectionFilters
+    >
 ) {
     const flag = !(
         _.isEmpty(filter) ||
@@ -1189,6 +1207,7 @@ export function isFiltered(
             _.isEmpty(filter.mutationDataFilters) &&
             _.isEmpty(filter.namespaceDataFilters) &&
             _.isEmpty(filter.genericAssayDataFilters) &&
+            _.isEmpty(filter.genericAssaySelectionFilters) &&
             _.isEmpty(filter.caseLists) &&
             _.isEmpty(filter.customDataFilters) &&
             (!filter.patientTreatmentFilters ||
@@ -4527,6 +4546,55 @@ export function buildGenericAssayFrequencyTableDataFilters(
             ),
         }))
         .value();
+}
+
+export function buildGenericAssaySelectionFilter(
+    profileType: string,
+    patientLevel: boolean,
+    selectedRowKeyGroups: string[][]
+): GenericAssayFrequencyTableSelectionFilter | undefined {
+    const values = selectedRowKeyGroups
+        .map(group =>
+            _.uniq(group).map(rowKey => {
+                const { stableId, value } =
+                    splitGenericAssayFrequencyTableRowUniqueKey(rowKey);
+                return {
+                    stableId,
+                    value,
+                } as GenericAssayFrequencyTableSelectionValue;
+            })
+        )
+        .filter(group => group.length > 0);
+
+    if (_.isEmpty(values)) {
+        return undefined;
+    }
+
+    return {
+        profileType,
+        patientLevel,
+        values,
+    };
+}
+
+export function getGenericAssayFrequencyTableSelectedRowKeyGroups(
+    genericAssaySelectionFilters: GenericAssayFrequencyTableSelectionFilter[],
+    profileType: string
+): string[][] {
+    return (
+        genericAssaySelectionFilters.find(
+            genericAssaySelectionFilter =>
+                genericAssaySelectionFilter.profileType === profileType
+        )?.values || []
+    ).map(group =>
+        group.map(selectionValue =>
+            getGenericAssayFrequencyTableRowUniqueKey(
+                selectionValue.stableId,
+                selectionValue.value,
+                profileType
+            )
+        )
+    );
 }
 
 export async function invokeGenericAssayDataCount(

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -5102,8 +5102,8 @@ export function formatGenericAssayFrequencyTableDownloadData(
     }
 
     const header = showCategoryColumn
-        ? ['Entity', 'Category', '# Samples', 'Freq']
-        : ['Entity', '# Samples', 'Freq'];
+        ? ['Entity', 'Category', '#', 'Freq']
+        : ['Entity', '#', 'Freq'];
     const data = [header.join('\t')];
 
     _.each(rows, record => {

--- a/src/pages/studyView/TableUtils.tsx
+++ b/src/pages/studyView/TableUtils.tsx
@@ -99,6 +99,7 @@ export enum FreqColumnTypeEnum {
     STRUCTURAL_VARIANT_PAIR = 'structural variant pairs',
     CNA = 'copy number alterations',
     VA = 'variant annotations',
+    GENERIC_ASSAY = 'generic assay events',
     DATA = 'data',
 }
 

--- a/src/pages/studyView/UserSelections.tsx
+++ b/src/pages/studyView/UserSelections.tsx
@@ -412,28 +412,32 @@ export default class UserSelections extends React.Component<
                         genericAssayDataFilter.profileType
                     );
                     const chartMeta = this.props.attributesMetaSet[uniqueKey];
-                    if (chartMeta) {
-                        genericAssayFilterComponents.push(
-                            <div className={styles.parentGroupLogic}>
-                                <GroupLogic
-                                    components={[
-                                        <span
-                                            className={
-                                                styles.filterClinicalAttrName
-                                            }
-                                        >
-                                            {chartMeta.displayName}
-                                        </span>,
-                                        <PillTag
-                                            content={{
-                                                uniqueChartKey:
-                                                    chartMeta.uniqueKey,
-                                                element: intervalFiltersDisplayValue(
-                                                    genericAssayDataFilter.values,
-                                                    (newRange: {
-                                                        start?: number;
-                                                        end?: number;
-                                                    }) => {
+                    const displayName =
+                        chartMeta?.displayName ||
+                        this.props.store.getGenericAssayFilterDisplayName(
+                            genericAssayDataFilter.stableId,
+                            genericAssayDataFilter.profileType
+                        );
+
+                    genericAssayFilterComponents.push(
+                        <div className={styles.parentGroupLogic}>
+                            <GroupLogic
+                                components={[
+                                    <span
+                                        className={styles.filterClinicalAttrName}
+                                    >
+                                        {displayName}
+                                    </span>,
+                                    <PillTag
+                                        content={{
+                                            uniqueChartKey: uniqueKey,
+                                            element: intervalFiltersDisplayValue(
+                                                genericAssayDataFilter.values,
+                                                (newRange: {
+                                                    start?: number;
+                                                    end?: number;
+                                                }) => {
+                                                    if (chartMeta) {
                                                         updateCustomIntervalFilter(
                                                             newRange,
                                                             chartMeta,
@@ -447,27 +451,27 @@ export default class UserSelections extends React.Component<
                                                                 .updateGenericAssayDataFilters
                                                         );
                                                     }
-                                                ),
-                                            }}
-                                            backgroundColor={
-                                                STUDY_VIEW_CONFIG.colors.theme
-                                                    .clinicalFilterContent
-                                            }
-                                            onDelete={() =>
-                                                this.props.updateGenericAssayDataFilter(
-                                                    chartMeta.uniqueKey,
-                                                    []
-                                                )
-                                            }
-                                            store={this.props.store}
-                                        />,
-                                    ]}
-                                    operation={':'}
-                                    group={false}
-                                />
-                            </div>
-                        );
-                    }
+                                                }
+                                            ),
+                                        }}
+                                        backgroundColor={
+                                            STUDY_VIEW_CONFIG.colors.theme
+                                                .clinicalFilterContent
+                                        }
+                                        onDelete={() =>
+                                            this.props.updateGenericAssayDataFilter(
+                                                uniqueKey,
+                                                []
+                                            )
+                                        }
+                                        store={this.props.store}
+                                    />,
+                                ]}
+                                operation={':'}
+                                group={false}
+                            />
+                        </div>
+                    );
                 }
             );
         }

--- a/src/pages/studyView/UserSelections.tsx
+++ b/src/pages/studyView/UserSelections.tsx
@@ -403,6 +403,67 @@ export default class UserSelections extends React.Component<
 
         // Generic Assay chart filters
         let genericAssayFilterComponents: JSX.Element[] = [];
+        _.forEach(
+            this.props.store.getGenericAssayFrequencyTableSelections(),
+            ([uniqueKey, selectedRowKeyGroups]) => {
+                const chartMeta = this.props.attributesMetaSet[uniqueKey];
+                if (!chartMeta || _.isEmpty(selectedRowKeyGroups)) {
+                    return;
+                }
+
+                genericAssayFilterComponents.push(
+                    <div className={styles.parentGroupLogic}>
+                        <GroupLogic
+                            components={[
+                                <span className={styles.filterClinicalAttrName}>
+                                    {chartMeta.displayName}
+                                </span>,
+                                <GroupLogic
+                                    components={selectedRowKeyGroups.map(
+                                        rowKeyGroup => (
+                                            <GroupLogic
+                                                components={rowKeyGroup.map(
+                                                    rowKey => (
+                                                        <PillTag
+                                                            content={
+                                                                this.props.store.getGenericAssayFrequencyTableFilterDisplayName(
+                                                                    uniqueKey,
+                                                                    rowKey
+                                                                )
+                                                            }
+                                                            backgroundColor={
+                                                                STUDY_VIEW_CONFIG
+                                                                    .colors.theme
+                                                                    .clinicalFilterContent
+                                                            }
+                                                            onDelete={() =>
+                                                                this.props.store.removeGenericAssayFrequencyTableFilter(
+                                                                    uniqueKey,
+                                                                    rowKey
+                                                                )
+                                                            }
+                                                            store={
+                                                                this.props.store
+                                                            }
+                                                        />
+                                                    )
+                                                )}
+                                                operation="or"
+                                                group={rowKeyGroup.length > 1}
+                                            />
+                                        )
+                                    )}
+                                    operation="and"
+                                    group={selectedRowKeyGroups.length > 1}
+                                />,
+                            ]}
+                            operation={':'}
+                            group={false}
+                        />
+                    </div>
+                );
+            }
+        );
         if (this.props.filter.genericAssayDataFilters) {
             _.forEach(
                 this.props.filter.genericAssayDataFilters,

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -448,7 +448,9 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
             ],
             true
         );
-        this.updateInfoMessage(`Frequency Table:  added`);
+        this.updateInfoMessage(
+            `Frequency Table: ${option.profileName} added`
+        );
     }
 
     private getGenericAssayChartOptions(

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -639,7 +639,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         <GenericAssaySelection
                             containerWidth={this.getTabsWidth}
                             molecularProfileOptions={molecularProfileOptions}
-                            submitButtonText={'Add Chart'}
+                            submitButtonText={'Add individual charts'}
                             profileAction={
                                 selectedProfileSupportsFrequencyTable &&
                                 selectedProfileOption &&
@@ -653,7 +653,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                             )
                                         }
                                     >
-                                        Re-add frequency table
+                                        Show frequency table for all values
                                     </button>
                                 ) : undefined
                             }

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -31,6 +31,7 @@ import {
     ChartType,
     ChartDataCountSet,
     GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+    getGenericAssayChartUniqueKey,
     getOptionsByChartMetaDataType,
     getGenericAssayFrequencyTableUniqueKey,
     getGenomicChartUniqueKey,
@@ -451,22 +452,58 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
     }
 
     private getGenericAssayChartOptions(
+        genericAssayType: string,
         option: GenericAssayProfileSelectionOption,
+        entityIds: string[]
     ): GenericAssaySelectableChartOption[] {
         const allChartTypes = _.fromPairs(this.props.store.chartsType.toJSON());
+        const genericAssayChartMeta =
+            this.groupedChartMetaByDataType[ChartMetaDataTypeEnum.GENERIC_ASSAY] ||
+            [];
         const frequencyTableUniqueKey = getGenericAssayFrequencyTableUniqueKey(
             option.value
         );
+        const validEntityKeys = new Set(
+            entityIds.map(entityId =>
+                getGenericAssayChartUniqueKey(entityId, option.value)
+            )
+        );
+        const addedEntityChartOptions = _.sortBy(
+            getOptionsByChartMetaDataType(
+                genericAssayChartMeta.filter(
+                    chartMeta =>
+                        chartMeta.genericAssayType === genericAssayType &&
+                        chartMeta.uniqueKey !== frequencyTableUniqueKey &&
+                        validEntityKeys.has(chartMeta.uniqueKey)
+                ),
+                this.selectedAttrs,
+                allChartTypes
+            ),
+            chartOption => chartOption.label.toLowerCase()
+        ) as GenericAssaySelectableChartOption[];
 
         if (
             option.dataType !== DataTypeConstants.BINARY &&
             option.dataType !== DataTypeConstants.CATEGORICAL
         ) {
-            return [];
+            return addedEntityChartOptions;
+        }
+
+        const existingFrequencyTableOption = getOptionsByChartMetaDataType(
+            genericAssayChartMeta.filter(
+                chartMeta =>
+                    chartMeta.genericAssayType === genericAssayType &&
+                    chartMeta.uniqueKey === frequencyTableUniqueKey
+            ),
+            this.selectedAttrs,
+            allChartTypes
+        )[0] as GenericAssaySelectableChartOption | undefined;
+        if (existingFrequencyTableOption) {
+            existingFrequencyTableOption.isFrequencyTable = true;
         }
 
         return [
-            {
+            existingFrequencyTableOption || {
                 label: `${option.profileName} Frequency Table`,
                 key: frequencyTableUniqueKey,
                 chartType:
@@ -476,6 +513,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 selected: this.selectedAttrs.includes(frequencyTableUniqueKey),
                 isFrequencyTable: true,
             },
+            ...addedEntityChartOptions,
         ];
     }
 
@@ -495,7 +533,10 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         const chartOption = chartOptionsByKey[key];
         if (chartOption.isFrequencyTable) {
             this.onAddGenericAssayFrequencyTable(genericAssayType, option);
+            return;
         }
+
+        this.onToggleOption(key);
     }
 
     @action.bound
@@ -682,7 +723,9 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 ) as GenericAssayProfileSelectionOption | undefined;
                 const chartOptions = selectedProfileOption
                     ? this.getGenericAssayChartOptions(
-                          selectedProfileOption
+                          type,
+                          selectedProfileOption,
+                          _.keys(entityMap)
                       )
                     : [];
                 const chartOptionsByKey = _.keyBy(chartOptions, 'key');

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -30,7 +30,9 @@ import {
     ChartMetaDataTypeEnum,
     ChartType,
     ChartDataCountSet,
+    GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
     getOptionsByChartMetaDataType,
+    getGenericAssayFrequencyTableUniqueKey,
     getGenomicChartUniqueKey,
     ChartMeta,
 } from '../StudyViewUtils';
@@ -302,26 +304,6 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         }
     }
 
-    @computed
-    get genericAssayChartOptionsByGenericAssayType(): {
-        [genericAssayType: string]: ChartOption[];
-    } {
-        const groupedChartMetaByGenericAssayType = _.groupBy(
-            this.groupedChartMetaByDataType[
-                ChartMetaDataTypeEnum.GENERIC_ASSAY
-            ] || [],
-            chartMeta => chartMeta.genericAssayType
-        );
-
-        return _.mapValues(groupedChartMetaByGenericAssayType, chartMeta => {
-            return getOptionsByChartMetaDataType(
-                chartMeta,
-                this.selectedAttrs,
-                _.fromPairs(this.props.store.chartsType.toJSON())
-            );
-        });
-    }
-
     // provide chartMetaSet for current tab to disable appropriate options
     // if summary tab, disable survival attributes
     // if clinical data tab, disable survival plot attributes
@@ -430,6 +412,36 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
             genericAssayType,
             profileId
         );
+    }
+
+    @action.bound
+    private onAddGenericAssayFrequencyTable(
+        genericAssayType: string,
+        option: {
+            value: string;
+            label: string;
+            description: string;
+            dataType: string;
+            patientLevel?: boolean;
+        }
+    ) {
+        this.props.store.addGenericAssayFrequencyTableCharts(
+            [
+                {
+                    name: `${option.label} Frequency Table`,
+                    description: option.description,
+                    profileType: option.value,
+                    genericAssayType,
+                    genericAssayEntityId:
+                        GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                    dataType: option.dataType,
+                    patientLevel: option.patientLevel,
+                    chartKind: 'PROFILE_FREQUENCY_TABLE',
+                },
+            ],
+            true
+        );
+        this.updateInfoMessage(`${option.label} frequency table added`);
     }
 
     @action.bound
@@ -590,11 +602,6 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                     entityMap,
                     makeGenericAssayOption
                 );
-
-                const shouldShowChartOptionTable =
-                    this.genericAssayChartOptionsByGenericAssayType[type] &&
-                    this.genericAssayChartOptionsByGenericAssayType[type]
-                        .length > 0;
                 const molecularProfileOptions = options.map(option => {
                     return {
                         ...option,
@@ -604,6 +611,24 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         profileName: option.label,
                     };
                 });
+                const selectedProfileOption = molecularProfileOptions.find(
+                    option => option.value === molecularProfileIdSuffix
+                );
+                const selectedProfileSupportsFrequencyTable =
+                    selectedProfileOption !== undefined &&
+                    (selectedProfileOption.dataType ===
+                        DataTypeConstants.BINARY ||
+                        selectedProfileOption.dataType ===
+                            DataTypeConstants.CATEGORICAL);
+                const selectedProfileFrequencyTableVisible =
+                    selectedProfileSupportsFrequencyTable &&
+                    this.props.store.visibleAttributesForSummary.some(
+                        chartMeta =>
+                            chartMeta.uniqueKey ===
+                            getGenericAssayFrequencyTableUniqueKey(
+                                molecularProfileIdSuffix
+                            )
+                    );
 
                 return (
                     <MSKTab
@@ -611,6 +636,43 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         id={type}
                         linkText={deriveDisplayTextFromGenericAssayType(type)}
                     >
+                        {selectedProfileSupportsFrequencyTable &&
+                            selectedProfileOption && (
+                                <div
+                                    style={{
+                                        marginBottom: 10,
+                                    }}
+                                >
+                                    <div
+                                        style={{
+                                            fontSize: 12,
+                                            color: '#666',
+                                            marginBottom:
+                                                selectedProfileFrequencyTableVisible
+                                                    ? 0
+                                                    : 8,
+                                        }}
+                                    >
+                                        The frequency table is the profile-level
+                                        overview for this assay and is shown by
+                                        default. Use the selector below to add
+                                        entity-level charts.
+                                    </div>
+                                    {!selectedProfileFrequencyTableVisible && (
+                                        <button
+                                            className="btn btn-default btn-sm"
+                                            onClick={() =>
+                                                this.onAddGenericAssayFrequencyTable(
+                                                    type,
+                                                    selectedProfileOption
+                                                )
+                                            }
+                                        >
+                                            Re-add frequency table
+                                        </button>
+                                    )}
+                                </div>
+                            )}
                         <GenericAssaySelection
                             containerWidth={this.getTabsWidth}
                             molecularProfileOptions={molecularProfileOptions}
@@ -628,27 +690,6 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                 )
                             }
                         />
-                        {shouldShowChartOptionTable && (
-                            <div style={{ marginTop: 10 }}>
-                                <AddChartByType
-                                    width={this.getTabsWidth}
-                                    options={
-                                        this
-                                            .genericAssayChartOptionsByGenericAssayType[
-                                            type
-                                        ]
-                                    }
-                                    freqPromise={this.dataCount}
-                                    onAddAll={this.onAddAll}
-                                    onClearAll={this.onClearAll}
-                                    onToggleOption={this.onToggleOption}
-                                    hideControls={true}
-                                    firstColumnHeaderName={`${deriveDisplayTextFromGenericAssayType(
-                                        type
-                                    )} Chart`}
-                                />
-                            </div>
-                        )}
                     </MSKTab>
                 );
             }

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -432,10 +432,12 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         genericAssayType: string,
         option: GenericAssayProfileSelectionOption
     ) {
+        const frequencyTableName = `Frequency Table: ${option.profileName}`;
+        const uniqueKey = getGenericAssayFrequencyTableUniqueKey(option.value);
         this.props.store.addGenericAssayFrequencyTableCharts(
             [
                 {
-                    name: `Frequency Table: ${option.profileName}`,
+                    name: frequencyTableName,
                     description: option.description,
                     profileType: option.value,
                     genericAssayType,
@@ -449,7 +451,11 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
             true
         );
         this.updateInfoMessage(
-            `Frequency Table: ${option.profileName} added`
+            `${frequencyTableName} ${
+                this.selectedAttrs.includes(uniqueKey)
+                    ? 'is already'
+                    : 'has been'
+            } added`
         );
     }
 

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -31,10 +31,13 @@ import {
     ChartType,
     ChartDataCountSet,
     GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+    getGenericAssayChartDisplayName,
+    getGenericAssayChartUniqueKey,
     getOptionsByChartMetaDataType,
     getGenericAssayFrequencyTableUniqueKey,
     getGenomicChartUniqueKey,
     ChartMeta,
+    MolecularProfileOption,
 } from '../StudyViewUtils';
 import { MSKTab, MSKTabs } from '../../../shared/components/MSKTabs/MSKTabs';
 import { ChartTypeEnum, ChartTypeNameEnum } from '../StudyViewConfig';
@@ -89,6 +92,15 @@ export type ChartOption = {
     selected?: boolean;
     freq: number;
     isSharedChart?: boolean;
+};
+
+type GenericAssayProfileSelectionOption = MolecularProfileOption & {
+    profileName: string;
+};
+
+type GenericAssaySelectableChartOption = Omit<ChartOption, 'freq'> & {
+    genericAssayEntityId?: string;
+    isFrequencyTable?: boolean;
 };
 
 export const INFO_TIMEOUT = 10000;
@@ -373,11 +385,15 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
 
     @action.bound
     private onGenericAssaySubmit(charts: GenericAssayChart[]) {
-        // Update info message
         this.infoMessage = getInfoMessageForGenericAssayChart(
             charts,
             this.selectedAttrs
         );
+        this.addGenericAssayCharts(charts);
+    }
+
+    @action.bound
+    private addGenericAssayCharts(charts: GenericAssayChart[]) {
         const chartsGroupedByDataType = _.groupBy(
             charts,
             chart => chart.dataType
@@ -417,18 +433,12 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
     @action.bound
     private onAddGenericAssayFrequencyTable(
         genericAssayType: string,
-        option: {
-            value: string;
-            label: string;
-            description: string;
-            dataType: string;
-            patientLevel?: boolean;
-        }
+        option: GenericAssayProfileSelectionOption
     ) {
         this.props.store.addGenericAssayFrequencyTableCharts(
             [
                 {
-                    name: `${option.label} Frequency Table`,
+                    name: `${option.profileName} Frequency Table`,
                     description: option.description,
                     profileType: option.value,
                     genericAssayType,
@@ -441,7 +451,181 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
             ],
             true
         );
-        this.updateInfoMessage(`${option.label} frequency table added`);
+        this.updateInfoMessage(`${option.profileName} frequency table added`);
+    }
+
+    private buildGenericAssayCharts(
+        genericAssayType: string,
+        option: GenericAssayProfileSelectionOption,
+        entityMetaByStableId: { [stableId: string]: GenericAssayMeta },
+        entityIds: string[]
+    ): GenericAssayChart[] {
+        return entityIds.map(entityId => ({
+            genericAssayEntityId: entityId,
+            genericAssayType,
+            profileType: option.value,
+            chartKind: 'ENTITY',
+            name: getGenericAssayChartDisplayName(
+                entityId,
+                option.profileName,
+                genericAssayType,
+                entityMetaByStableId
+            ),
+            description: option.description,
+            dataType: option.dataType,
+            patientLevel: option.patientLevel,
+        }));
+    }
+
+    private getGenericAssayChartOptions(
+        genericAssayType: string,
+        option: GenericAssayProfileSelectionOption,
+        entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
+    ): GenericAssaySelectableChartOption[] {
+        const allChartTypes = _.fromPairs(this.props.store.chartsType.toJSON());
+        const frequencyTableUniqueKey = getGenericAssayFrequencyTableUniqueKey(
+            option.value
+        );
+        const entityOptions = _.sortBy(
+            _.keys(entityMetaByStableId).map(
+                entityId => {
+                    const uniqueKey = getGenericAssayChartUniqueKey(
+                        entityId,
+                        option.value
+                    );
+                    return {
+                        label: getGenericAssayChartDisplayName(
+                            entityId,
+                            option.profileName,
+                            genericAssayType,
+                            entityMetaByStableId
+                        ),
+                        key: uniqueKey,
+                        chartType:
+                            allChartTypes[uniqueKey] ||
+                            (option.dataType === DataTypeConstants.LIMITVALUE
+                                ? ChartTypeEnum.BAR_CHART
+                                : ChartTypeEnum.PIE_CHART),
+                        disabled: false,
+                        selected: this.selectedAttrs.includes(uniqueKey),
+                        genericAssayEntityId: entityId,
+                    } as GenericAssaySelectableChartOption;
+                }
+            ),
+            chartOption => chartOption.label.toLowerCase()
+        );
+
+        if (
+            option.dataType !== DataTypeConstants.BINARY &&
+            option.dataType !== DataTypeConstants.CATEGORICAL
+        ) {
+            return entityOptions;
+        }
+
+        return [
+            {
+                label: `${option.profileName} Frequency Table`,
+                key: frequencyTableUniqueKey,
+                chartType:
+                    allChartTypes[frequencyTableUniqueKey] ||
+                    ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE,
+                disabled: false,
+                selected: this.selectedAttrs.includes(frequencyTableUniqueKey),
+                isFrequencyTable: true,
+            },
+            ...entityOptions,
+        ];
+    }
+
+    @action.bound
+    private onAddAllGenericAssayValues(
+        genericAssayType: string,
+        option: GenericAssayProfileSelectionOption,
+        entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
+    ) {
+        this.onGenericAssaySubmit(
+            this.buildGenericAssayCharts(
+                genericAssayType,
+                option,
+                entityMetaByStableId,
+                _.keys(entityMetaByStableId)
+            )
+        );
+    }
+
+    @action.bound
+    private onToggleGenericAssayChartOption(
+        genericAssayType: string,
+        option: GenericAssayProfileSelectionOption,
+        entityMetaByStableId: { [stableId: string]: GenericAssayMeta },
+        chartOptionsByKey: { [key: string]: GenericAssaySelectableChartOption },
+        key: string
+    ) {
+        if (this.selectedAttrs.includes(key)) {
+            this.props.store.resetFilterAndChangeChartVisibility(key, false);
+            this.updateInfoMessage(`${chartOptionsByKey[key].label} removed`);
+            return;
+        }
+
+        const chartOption = chartOptionsByKey[key];
+        if (chartOption.isFrequencyTable) {
+            this.onAddGenericAssayFrequencyTable(genericAssayType, option);
+            return;
+        }
+
+        this.onGenericAssaySubmit(
+            this.buildGenericAssayCharts(
+                genericAssayType,
+                option,
+                entityMetaByStableId,
+                [chartOption.genericAssayEntityId!]
+            )
+        );
+    }
+
+    @action.bound
+    private onAddAllGenericAssayChartOptions(
+        genericAssayType: string,
+        option: GenericAssayProfileSelectionOption,
+        entityMetaByStableId: { [stableId: string]: GenericAssayMeta },
+        chartOptions: GenericAssaySelectableChartOption[]
+    ) {
+        const frequencyTableOption = _.find(chartOptions, chartOption =>
+            chartOption.isFrequencyTable
+        );
+        if (
+            frequencyTableOption &&
+            !this.selectedAttrs.includes(frequencyTableOption.key)
+        ) {
+            this.onAddGenericAssayFrequencyTable(genericAssayType, option);
+        }
+
+        const entityIds = chartOptions
+            .filter(chartOption => !chartOption.isFrequencyTable)
+            .map(chartOption => chartOption.genericAssayEntityId!);
+
+        if (!_.isEmpty(entityIds)) {
+            this.onGenericAssaySubmit(
+                this.buildGenericAssayCharts(
+                    genericAssayType,
+                    option,
+                    entityMetaByStableId,
+                    entityIds
+                )
+            );
+        }
+    }
+
+    @action.bound
+    private onClearAllGenericAssayChartOptions(keys: string[]) {
+        keys.forEach(key => {
+            if (this.selectedAttrs.includes(key)) {
+                this.props.store.resetFilterAndChangeChartVisibility(key, false);
+            }
+        });
+        this.updateInfoMessage(
+            `${keys.length} chart${keys.length > 1 ? 's' : ''} removed`
+        );
     }
 
     @action.bound
@@ -613,22 +797,15 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 });
                 const selectedProfileOption = molecularProfileOptions.find(
                     option => option.value === molecularProfileIdSuffix
-                );
-                const selectedProfileSupportsFrequencyTable =
-                    selectedProfileOption !== undefined &&
-                    (selectedProfileOption.dataType ===
-                        DataTypeConstants.BINARY ||
-                        selectedProfileOption.dataType ===
-                            DataTypeConstants.CATEGORICAL);
-                const selectedProfileFrequencyTableVisible =
-                    selectedProfileSupportsFrequencyTable &&
-                    this.props.store.visibleAttributesForSummary.some(
-                        chartMeta =>
-                            chartMeta.uniqueKey ===
-                            getGenericAssayFrequencyTableUniqueKey(
-                                molecularProfileIdSuffix
-                            )
-                    );
+                ) as GenericAssayProfileSelectionOption | undefined;
+                const chartOptions = selectedProfileOption
+                    ? this.getGenericAssayChartOptions(
+                          type,
+                          selectedProfileOption,
+                          entityMap
+                      )
+                    : [];
+                const chartOptionsByKey = _.keyBy(chartOptions, 'key');
 
                 return (
                     <MSKTab
@@ -639,21 +816,24 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         <GenericAssaySelection
                             containerWidth={this.getTabsWidth}
                             molecularProfileOptions={molecularProfileOptions}
-                            submitButtonText={'Add individual charts'}
-                            profileAction={
-                                selectedProfileSupportsFrequencyTable &&
-                                selectedProfileOption &&
-                                !selectedProfileFrequencyTableVisible ? (
+                            submitButtonText={'Add charts'}
+                            footerAction={
+                                selectedProfileOption ? (
                                     <button
-                                        className="btn btn-primary btn-sm"
+                                        className="btn btn-default btn-sm"
                                         onClick={() =>
-                                            this.onAddGenericAssayFrequencyTable(
+                                            this.onAddAllGenericAssayValues(
                                                 type,
-                                                selectedProfileOption
+                                                selectedProfileOption,
+                                                entityMap
                                             )
                                         }
+                                        disabled={
+                                            genericAssayEntityOptions.length ===
+                                            0
+                                        }
                                     >
-                                        Show frequency table for all values
+                                        Add all values
                                     </button>
                                 ) : undefined
                             }
@@ -670,6 +850,40 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                 )
                             }
                         />
+                        {chartOptions.length > 0 && (
+                            <AddChartByType
+                                width={this.getTabsWidth}
+                                options={chartOptions}
+                                hideControls={true}
+                                optionsGivenInSortedOrder={true}
+                                onToggleOption={key =>
+                                    selectedProfileOption &&
+                                    this.onToggleGenericAssayChartOption(
+                                        type,
+                                        selectedProfileOption,
+                                        entityMap,
+                                        chartOptionsByKey,
+                                        key
+                                    )
+                                }
+                                onAddAll={keys =>
+                                    selectedProfileOption &&
+                                    this.onAddAllGenericAssayChartOptions(
+                                        type,
+                                        selectedProfileOption,
+                                        entityMap,
+                                        chartOptions.filter(chartOption =>
+                                            keys.includes(chartOption.key)
+                                        )
+                                    )
+                                }
+                                onClearAll={keys =>
+                                    this.onClearAllGenericAssayChartOptions(
+                                        keys
+                                    )
+                                }
+                            />
+                        )}
                     </MSKTab>
                 );
             }

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -500,6 +500,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         )[0] as GenericAssaySelectableChartOption | undefined;
         if (existingFrequencyTableOption) {
             existingFrequencyTableOption.isFrequencyTable = true;
+            existingFrequencyTableOption.label = `Frequency Table: ${option.profileName}`;
         }
 
         return [

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -636,32 +636,27 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         id={type}
                         linkText={deriveDisplayTextFromGenericAssayType(type)}
                     >
-                        {selectedProfileSupportsFrequencyTable &&
-                            selectedProfileOption && (
-                                <div
-                                    style={{
-                                        marginBottom: 10,
-                                    }}
-                                >
-                                    {!selectedProfileFrequencyTableVisible && (
-                                        <button
-                                            className="btn btn-default btn-sm"
-                                            onClick={() =>
-                                                this.onAddGenericAssayFrequencyTable(
-                                                    type,
-                                                    selectedProfileOption
-                                                )
-                                            }
-                                        >
-                                            Re-add frequency table
-                                        </button>
-                                    )}
-                                </div>
-                            )}
                         <GenericAssaySelection
                             containerWidth={this.getTabsWidth}
                             molecularProfileOptions={molecularProfileOptions}
                             submitButtonText={'Add Chart'}
+                            profileAction={
+                                selectedProfileSupportsFrequencyTable &&
+                                selectedProfileOption &&
+                                !selectedProfileFrequencyTableVisible ? (
+                                    <button
+                                        className="btn btn-primary btn-sm"
+                                        onClick={() =>
+                                            this.onAddGenericAssayFrequencyTable(
+                                                type,
+                                                selectedProfileOption
+                                            )
+                                        }
+                                    >
+                                        Re-add frequency table
+                                    </button>
+                                ) : undefined
+                            }
                             genericAssayType={type}
                             genericAssayEntityOptions={
                                 genericAssayEntityOptions

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -31,8 +31,6 @@ import {
     ChartType,
     ChartDataCountSet,
     GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
-    getGenericAssayChartDisplayName,
-    getGenericAssayChartUniqueKey,
     getOptionsByChartMetaDataType,
     getGenericAssayFrequencyTableUniqueKey,
     getGenomicChartUniqueKey,
@@ -57,7 +55,6 @@ import styles from './styles.module.scss';
 import { openSocialAuthWindow } from 'shared/lib/openSocialAuthWindow';
 import { CustomChartData } from 'shared/api/session-service/sessionServiceModels';
 import ReactSelect from 'react-select';
-import { GenericAssayMeta } from 'cbioportal-ts-api-client';
 import { DataTypeConstants } from 'shared/constants';
 import { Else, If, Then } from 'react-if';
 import SaveChartSettingsButton from './SaveChartSettingsButton';
@@ -99,7 +96,6 @@ type GenericAssayProfileSelectionOption = MolecularProfileOption & {
 };
 
 type GenericAssaySelectableChartOption = Omit<ChartOption, 'freq'> & {
-    genericAssayEntityId?: string;
     isFrequencyTable?: boolean;
 };
 
@@ -454,72 +450,19 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         this.updateInfoMessage(`${option.profileName} frequency table added`);
     }
 
-    private buildGenericAssayCharts(
-        genericAssayType: string,
-        option: GenericAssayProfileSelectionOption,
-        entityMetaByStableId: { [stableId: string]: GenericAssayMeta },
-        entityIds: string[]
-    ): GenericAssayChart[] {
-        return entityIds.map(entityId => ({
-            genericAssayEntityId: entityId,
-            genericAssayType,
-            profileType: option.value,
-            chartKind: 'ENTITY',
-            name: getGenericAssayChartDisplayName(
-                entityId,
-                option.profileName,
-                genericAssayType,
-                entityMetaByStableId
-            ),
-            description: option.description,
-            dataType: option.dataType,
-            patientLevel: option.patientLevel,
-        }));
-    }
-
     private getGenericAssayChartOptions(
-        genericAssayType: string,
         option: GenericAssayProfileSelectionOption,
-        entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
     ): GenericAssaySelectableChartOption[] {
         const allChartTypes = _.fromPairs(this.props.store.chartsType.toJSON());
         const frequencyTableUniqueKey = getGenericAssayFrequencyTableUniqueKey(
             option.value
-        );
-        const entityOptions = _.sortBy(
-            _.keys(entityMetaByStableId).map(
-                entityId => {
-                    const uniqueKey = getGenericAssayChartUniqueKey(
-                        entityId,
-                        option.value
-                    );
-                    return {
-                        label: getGenericAssayChartDisplayName(
-                            entityId,
-                            option.profileName,
-                            genericAssayType,
-                            entityMetaByStableId
-                        ),
-                        key: uniqueKey,
-                        chartType:
-                            allChartTypes[uniqueKey] ||
-                            (option.dataType === DataTypeConstants.LIMITVALUE
-                                ? ChartTypeEnum.BAR_CHART
-                                : ChartTypeEnum.PIE_CHART),
-                        disabled: false,
-                        selected: this.selectedAttrs.includes(uniqueKey),
-                        genericAssayEntityId: entityId,
-                    } as GenericAssaySelectableChartOption;
-                }
-            ),
-            chartOption => chartOption.label.toLowerCase()
         );
 
         if (
             option.dataType !== DataTypeConstants.BINARY &&
             option.dataType !== DataTypeConstants.CATEGORICAL
         ) {
-            return entityOptions;
+            return [];
         }
 
         return [
@@ -533,31 +476,13 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 selected: this.selectedAttrs.includes(frequencyTableUniqueKey),
                 isFrequencyTable: true,
             },
-            ...entityOptions,
         ];
-    }
-
-    @action.bound
-    private onAddAllGenericAssayValues(
-        genericAssayType: string,
-        option: GenericAssayProfileSelectionOption,
-        entityMetaByStableId: { [stableId: string]: GenericAssayMeta }
-    ) {
-        this.onGenericAssaySubmit(
-            this.buildGenericAssayCharts(
-                genericAssayType,
-                option,
-                entityMetaByStableId,
-                _.keys(entityMetaByStableId)
-            )
-        );
     }
 
     @action.bound
     private onToggleGenericAssayChartOption(
         genericAssayType: string,
         option: GenericAssayProfileSelectionOption,
-        entityMetaByStableId: { [stableId: string]: GenericAssayMeta },
         chartOptionsByKey: { [key: string]: GenericAssaySelectableChartOption },
         key: string
     ) {
@@ -570,49 +495,6 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         const chartOption = chartOptionsByKey[key];
         if (chartOption.isFrequencyTable) {
             this.onAddGenericAssayFrequencyTable(genericAssayType, option);
-            return;
-        }
-
-        this.onGenericAssaySubmit(
-            this.buildGenericAssayCharts(
-                genericAssayType,
-                option,
-                entityMetaByStableId,
-                [chartOption.genericAssayEntityId!]
-            )
-        );
-    }
-
-    @action.bound
-    private onAddAllGenericAssayChartOptions(
-        genericAssayType: string,
-        option: GenericAssayProfileSelectionOption,
-        entityMetaByStableId: { [stableId: string]: GenericAssayMeta },
-        chartOptions: GenericAssaySelectableChartOption[]
-    ) {
-        const frequencyTableOption = _.find(chartOptions, chartOption =>
-            chartOption.isFrequencyTable
-        );
-        if (
-            frequencyTableOption &&
-            !this.selectedAttrs.includes(frequencyTableOption.key)
-        ) {
-            this.onAddGenericAssayFrequencyTable(genericAssayType, option);
-        }
-
-        const entityIds = chartOptions
-            .filter(chartOption => !chartOption.isFrequencyTable)
-            .map(chartOption => chartOption.genericAssayEntityId!);
-
-        if (!_.isEmpty(entityIds)) {
-            this.onGenericAssaySubmit(
-                this.buildGenericAssayCharts(
-                    genericAssayType,
-                    option,
-                    entityMetaByStableId,
-                    entityIds
-                )
-            );
         }
     }
 
@@ -800,9 +682,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 ) as GenericAssayProfileSelectionOption | undefined;
                 const chartOptions = selectedProfileOption
                     ? this.getGenericAssayChartOptions(
-                          type,
-                          selectedProfileOption,
-                          entityMap
+                          selectedProfileOption
                       )
                     : [];
                 const chartOptionsByKey = _.keyBy(chartOptions, 'key');
@@ -817,32 +697,18 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                             containerWidth={this.getTabsWidth}
                             molecularProfileOptions={molecularProfileOptions}
                             submitButtonText={'Add charts'}
-                            footerAction={
-                                selectedProfileOption ? (
-                                    <button
-                                        className="btn btn-default btn-sm"
-                                        onClick={() =>
-                                            this.onAddAllGenericAssayValues(
-                                                type,
-                                                selectedProfileOption,
-                                                entityMap
-                                            )
-                                        }
-                                        disabled={
-                                            genericAssayEntityOptions.length ===
-                                            0
-                                        }
-                                    >
-                                        Add all values
-                                    </button>
-                                ) : undefined
-                            }
                             genericAssayType={type}
                             genericAssayEntityOptions={
                                 genericAssayEntityOptions
                             }
                             entityMap={entityMap}
                             onChartSubmit={this.onGenericAssaySubmit}
+                            onFrequencyTableSubmit={option =>
+                                this.onAddGenericAssayFrequencyTable(
+                                    type,
+                                    option
+                                )
+                            }
                             onSelectGenericAssayProfile={profileId =>
                                 this.onSelectGenericAssayProfileByType(
                                     type,
@@ -861,22 +727,11 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                     this.onToggleGenericAssayChartOption(
                                         type,
                                         selectedProfileOption,
-                                        entityMap,
                                         chartOptionsByKey,
                                         key
                                     )
                                 }
-                                onAddAll={keys =>
-                                    selectedProfileOption &&
-                                    this.onAddAllGenericAssayChartOptions(
-                                        type,
-                                        selectedProfileOption,
-                                        entityMap,
-                                        chartOptions.filter(chartOption =>
-                                            keys.includes(chartOption.key)
-                                        )
-                                    )
-                                }
+                                onAddAll={_.noop}
                                 onClearAll={keys =>
                                     this.onClearAllGenericAssayChartOptions(
                                         keys

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -448,7 +448,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
             ],
             true
         );
-        this.updateInfoMessage(`${option.profileName} frequency table added`);
+        this.updateInfoMessage(`Frequency Table:  added`);
     }
 
     private getGenericAssayChartOptions(

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -434,6 +434,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
     ) {
         const frequencyTableName = `Frequency Table: ${option.profileName}`;
         const uniqueKey = getGenericAssayFrequencyTableUniqueKey(option.value);
+        const wasAlreadyVisible = this.selectedAttrs.includes(uniqueKey);
         this.props.store.addGenericAssayFrequencyTableCharts(
             [
                 {
@@ -452,9 +453,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         );
         this.updateInfoMessage(
             `${frequencyTableName} ${
-                this.selectedAttrs.includes(uniqueKey)
-                    ? 'is already'
-                    : 'has been'
+                wasAlreadyVisible ? 'is already' : 'has been'
             } added`
         );
     }

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -435,7 +435,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
         this.props.store.addGenericAssayFrequencyTableCharts(
             [
                 {
-                    name: `${option.profileName} Frequency Table`,
+                    name: `Frequency Table: ${option.profileName}`,
                     description: option.description,
                     profileType: option.value,
                     genericAssayType,
@@ -504,7 +504,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
 
         return [
             existingFrequencyTableOption || {
-                label: `${option.profileName} Frequency Table`,
+                label: `Frequency Table: ${option.profileName}`,
                 key: frequencyTableUniqueKey,
                 chartType:
                     allChartTypes[frequencyTableUniqueKey] ||

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -51,7 +51,6 @@ import {
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 
 import { getInfoMessageForGenericAssayChart } from './AddChartButtonHelper';
-import classnames from 'classnames';
 import styles from './styles.module.scss';
 import { openSocialAuthWindow } from 'shared/lib/openSocialAuthWindow';
 import { CustomChartData } from 'shared/api/session-service/sessionServiceModels';
@@ -829,7 +828,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                 notificationMessages.push(
                     <>
                         <span
-                            className={classnames({
+                            className={classNames({
                                 [styles.sharedChart]: true,
                             })}
                         >

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -643,21 +643,6 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                         marginBottom: 10,
                                     }}
                                 >
-                                    <div
-                                        style={{
-                                            fontSize: 12,
-                                            color: '#666',
-                                            marginBottom:
-                                                selectedProfileFrequencyTableVisible
-                                                    ? 0
-                                                    : 8,
-                                        }}
-                                    >
-                                        The frequency table is the profile-level
-                                        overview for this assay and is shown by
-                                        default. Use the selector below to add
-                                        entity-level charts.
-                                    </div>
                                     {!selectedProfileFrequencyTableVisible && (
                                         <button
                                             className="btn btn-default btn-sm"

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.spec.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.spec.tsx
@@ -1,0 +1,78 @@
+import { assert } from 'chai';
+import { DataTypeConstants } from 'shared/constants';
+import GenericAssaySelection, {
+    GENERIC_ASSAY_FREQUENCY_TABLE_OPTION,
+} from './GenericAssaySelection';
+
+describe('GenericAssaySelection', () => {
+    const supportedProfile = {
+        value: 'supported_profile',
+        label: 'Supported Profile',
+        profileName: 'Supported Profile',
+        description: 'supported profile',
+        dataType: DataTypeConstants.BINARY,
+        patientLevel: false,
+        count: 2,
+    };
+
+    const unsupportedProfile = {
+        value: 'unsupported_profile',
+        label: 'Unsupported Profile',
+        profileName: 'Unsupported Profile',
+        description: 'unsupported profile',
+        dataType: DataTypeConstants.LIMITVALUE,
+        patientLevel: false,
+        count: 1,
+    };
+
+    it('drops stale frequency-table and entity selections after switching profiles', () => {
+        let chartSubmitCount = 0;
+        let frequencyTableSubmitCount = 0;
+
+        const component = new GenericAssaySelection({
+            molecularProfileOptions: [supportedProfile, unsupportedProfile],
+            genericAssayEntityOptions: [
+                {
+                    value: 'entity_a',
+                    label: 'Entity A',
+                },
+            ],
+            entityMap: {},
+            genericAssayType: 'TEST_GENERIC_ASSAY',
+            submitButtonText: 'Add charts',
+            initialGenericAssayEntityIds: [
+                GENERIC_ASSAY_FREQUENCY_TABLE_OPTION,
+                'entity_a',
+            ],
+            onChartSubmit: () => {
+                chartSubmitCount += 1;
+            },
+            onFrequencyTableSubmit: () => {
+                frequencyTableSubmitCount += 1;
+            },
+        } as any);
+
+        assert.deepEqual(component.validSelectedGenericAssayEntityIds, [
+            GENERIC_ASSAY_FREQUENCY_TABLE_OPTION,
+            'entity_a',
+        ]);
+        assert.isFalse((component as any).buttonDisabled);
+
+        (component.props as any).genericAssayEntityOptions = [
+            {
+                value: 'entity_b',
+                label: 'Entity B',
+            },
+        ];
+        (component as any).handleProfileSelect(unsupportedProfile);
+
+        assert.deepEqual(component.validSelectedGenericAssayEntityIds, []);
+        assert.deepEqual(component.selectedGenericAssaysJS, []);
+        assert.isTrue((component as any).buttonDisabled);
+
+        (component as any).onSubmit();
+
+        assert.equal(chartSubmitCount, 0);
+        assert.equal(frequencyTableSubmitCount, 0);
+    });
+});

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
@@ -299,7 +299,7 @@ export default class GenericAssaySelection extends React.Component<
             ? _.concat(
                   {
                       value: GENERIC_ASSAY_ADD_ALL_VALUES_OPTION,
-                      label: 'Add all values',
+                      label: 'Frequency table',
                   } as ISelectOption,
                   this.props.genericAssayEntityOptions
               )

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
@@ -29,6 +29,7 @@ export interface IGenericAssaySelectionProps {
     };
     genericAssayType: string;
     submitButtonText: string;
+    profileAction?: React.ReactNode;
     containerWidth?: number;
     initialGenericAssayEntityIds?: string[];
     allowEmptySubmission?: boolean;
@@ -375,7 +376,13 @@ export default class GenericAssaySelection extends React.Component<
                         : 'auto',
                 }}
             >
-                <div data-test="GenericAssayProfileSelection">
+                <div
+                    data-test="GenericAssayProfileSelection"
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                    }}
+                >
                     {/* {this.isSelectedGenericAssayOptionsOverLimit && (
                         <div className="alert alert-warning">
                             <i
@@ -387,13 +394,20 @@ export default class GenericAssaySelection extends React.Component<
                             than 100 options.
                         </div>
                     )} */}
-                    <Select
-                        value={this.selectedProfileOption}
-                        onChange={this.handleProfileSelect}
-                        options={this.props.molecularProfileOptions}
-                        isClearable={false}
-                        isSearchable={false}
-                    />
+                    <div style={{ flex: 1 }}>
+                        <Select
+                            value={this.selectedProfileOption}
+                            onChange={this.handleProfileSelect}
+                            options={this.props.molecularProfileOptions}
+                            isClearable={false}
+                            isSearchable={false}
+                        />
+                    </div>
+                    {this.props.profileAction && (
+                        <div style={{ marginLeft: 10 }}>
+                            {this.props.profileAction}
+                        </div>
+                    )}
                 </div>
                 <div
                     style={{

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
@@ -16,6 +16,7 @@ import {
     getGenericAssayPropertyOrDefault,
 } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 import { GenericAssayMeta } from 'cbioportal-ts-api-client';
+import { DataTypeConstants } from 'shared/constants';
 
 export interface IGenericAssaySelectionProps {
     molecularProfileOptions:
@@ -29,7 +30,6 @@ export interface IGenericAssaySelectionProps {
     };
     genericAssayType: string;
     submitButtonText: string;
-    footerAction?: React.ReactNode;
     containerWidth?: number;
     initialGenericAssayEntityIds?: string[];
     allowEmptySubmission?: boolean;
@@ -43,6 +43,11 @@ export interface IGenericAssaySelectionProps {
     onSelectGenericAssayProfile?: (molecularProfileId: string) => void;
     onTrackSubmit?: (data: GenericAssayTrackInfo[]) => void;
     onChartSubmit?: (data: GenericAssayChart[]) => void;
+    onFrequencyTableSubmit?: (
+        option: MolecularProfileOption & {
+            profileName: string;
+        }
+    ) => void;
 }
 
 export type GenericAssayChartType =
@@ -64,6 +69,7 @@ interface ISelectOption {
 }
 
 export const DEFAULT_GENERIC_ASSAY_OPTIONS_SHOWING: number = 100;
+export const GENERIC_ASSAY_ADD_ALL_VALUES_OPTION = 'generic_assay_add_all_values';
 
 @observer
 export default class GenericAssaySelection extends React.Component<
@@ -100,13 +106,24 @@ export default class GenericAssaySelection extends React.Component<
     @action.bound
     private onSubmit() {
         if (this.selectedProfileOption !== undefined) {
+            const option = this.selectedProfileOption as MolecularProfileOption & {
+                profileName: string;
+            };
+            const shouldAddFrequencyTable = Boolean(
+                this.props.onFrequencyTableSubmit &&
+                    this._selectedGenericAssayEntityIds.includes(
+                        GENERIC_ASSAY_ADD_ALL_VALUES_OPTION
+                    )
+            );
+            const selectedEntityIds = this._selectedGenericAssayEntityIds.filter(
+                entityId => entityId !== GENERIC_ASSAY_ADD_ALL_VALUES_OPTION
+            );
             // Generic Assay chart submit (StudyView)
-            if (this.props.onChartSubmit) {
-                const option = this
-                    .selectedProfileOption as MolecularProfileOption & {
-                    profileName: string;
-                };
-                const charts = this._selectedGenericAssayEntityIds.map(
+            if (shouldAddFrequencyTable) {
+                this.props.onFrequencyTableSubmit!(option);
+            }
+            if (this.props.onChartSubmit && selectedEntityIds.length > 0) {
+                const charts = selectedEntityIds.map(
                     entityId => {
                         const entityName = GENERIC_ASSAY_CONFIG
                             .genericAssayConfigByType[
@@ -134,14 +151,15 @@ export default class GenericAssaySelection extends React.Component<
                     }
                 );
                 this.props.onChartSubmit(charts);
-                // clear selected entities after submit new charts
+            }
+            if (shouldAddFrequencyTable || selectedEntityIds.length > 0) {
                 this.clearSelectedEntities();
             }
             // Generic Assay track submit (OncoPrint)
             if (this.props.onTrackSubmit) {
                 const option = this.selectedProfileOption as ISelectOption;
                 // select profile if onSelectGenericAssayProfile exists
-                const info: GenericAssayTrackInfo[] = this._selectedGenericAssayEntityIds.map(
+                const info: GenericAssayTrackInfo[] = selectedEntityIds.map(
                     entityId => {
                         return {
                             profileId: option.value,
@@ -200,6 +218,20 @@ export default class GenericAssaySelection extends React.Component<
     }
 
     @computed
+    private get selectedProfileSupportsFrequencyTable() {
+        const option = this.selectedProfileOption as
+            | (MolecularProfileOption & {
+                  profileName: string;
+              })
+            | undefined;
+        return (
+            option !== undefined &&
+            (option.dataType === DataTypeConstants.BINARY ||
+                option.dataType === DataTypeConstants.CATEGORICAL)
+        );
+    }
+
+    @computed
     private get buttonDisabled() {
         // disable button only when we don't allow empty submissions and has zero selected entities
         if (this.props.allowEmptySubmission) {
@@ -213,7 +245,7 @@ export default class GenericAssaySelection extends React.Component<
         [value: string]: ISelectOption;
     } {
         return _.keyBy(
-            this.props.genericAssayEntityOptions,
+            this.genericAssayOptions,
             (option: ISelectOption) => option.value
         );
     }
@@ -263,7 +295,15 @@ export default class GenericAssaySelection extends React.Component<
     @computed get genericAssayOptions() {
         // add select all option only when options have been filtered and has at least one filtered option
         // one generic assay profile usually contains hundreds of options, we don't want user try to add all options without filtering the option
-        let allOptionsInSelectedProfile = this.props.genericAssayEntityOptions;
+        let allOptionsInSelectedProfile = this.selectedProfileSupportsFrequencyTable
+            ? _.concat(
+                  {
+                      value: GENERIC_ASSAY_ADD_ALL_VALUES_OPTION,
+                      label: 'Add all values',
+                  } as ISelectOption,
+                  this.props.genericAssayEntityOptions
+              )
+            : this.props.genericAssayEntityOptions;
         const filteredOptionsLength = this.props.genericAssayEntityOptions.filter(
             option =>
                 doesOptionMatchSearchText(
@@ -295,6 +335,11 @@ export default class GenericAssaySelection extends React.Component<
                 // do not filter out select all option
                 if (option.value === 'select_all_filtered_options') {
                     return true;
+                }
+                if (option.value === GENERIC_ASSAY_ADD_ALL_VALUES_OPTION) {
+                    return !this._selectedGenericAssayEntityIds.includes(
+                        option.value
+                    );
                 }
                 return doesOptionMatchSearchText(
                     this._genericAssaySearchText,
@@ -330,7 +375,10 @@ export default class GenericAssaySelection extends React.Component<
     @computed get filteredGenericAssayOptions() {
         return _.filter(this.genericAssayOptions, option => {
             // filter out select all option
-            if (option.value === 'select_all_filtered_options') {
+            if (
+                option.value === 'select_all_filtered_options' ||
+                option.value === GENERIC_ASSAY_ADD_ALL_VALUES_OPTION
+            ) {
                 return false;
             }
             return doesOptionMatchSearchText(
@@ -344,6 +392,9 @@ export default class GenericAssaySelection extends React.Component<
     filterGenericAssayOption(option: ISelectOption, filterString: string) {
         if (option.value === 'select_all_filtered_options') {
             return true;
+        }
+        if (option.value === GENERIC_ASSAY_ADD_ALL_VALUES_OPTION) {
+            return !this._selectedGenericAssayEntityIds.includes(option.value);
         }
         return (
             doesOptionMatchSearchText(filterString, option) &&
@@ -535,11 +586,6 @@ export default class GenericAssaySelection extends React.Component<
                     </div>
                 )}
                 <div style={{ display: 'flex', marginTop: 12 }}>
-                    {this.props.footerAction && (
-                        <div style={{ marginRight: 10 }}>
-                            {this.props.footerAction}
-                        </div>
-                    )}
                     <button
                         disabled={this.buttonDisabled}
                         className="btn btn-primary btn-sm"

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
@@ -110,13 +110,12 @@ export default class GenericAssaySelection extends React.Component<
             const option = this.selectedProfileOption as MolecularProfileOption & {
                 profileName: string;
             };
+            const selectedIds = this.validSelectedGenericAssayEntityIds;
             const shouldAddFrequencyTable = Boolean(
                 this.props.onFrequencyTableSubmit &&
-                    this._selectedGenericAssayEntityIds.includes(
-                        GENERIC_ASSAY_FREQUENCY_TABLE_OPTION
-                    )
+                    selectedIds.includes(GENERIC_ASSAY_FREQUENCY_TABLE_OPTION)
             );
-            const selectedEntityIds = this._selectedGenericAssayEntityIds.filter(
+            const selectedEntityIds = selectedIds.filter(
                 entityId => entityId !== GENERIC_ASSAY_FREQUENCY_TABLE_OPTION
             );
             // Generic Assay chart submit (StudyView)
@@ -194,7 +193,7 @@ export default class GenericAssaySelection extends React.Component<
         return total > 0 && total <= threshold;
     }
     @computed get bulkToggleIsClear() {
-        return this._selectedGenericAssayEntityIds.length > 0;
+        return this.validSelectedGenericAssayEntityIds.length > 0;
     }
 
     @action.bound
@@ -237,7 +236,7 @@ export default class GenericAssaySelection extends React.Component<
         if (this.props.allowEmptySubmission) {
             return false;
         } else {
-            return _.isEmpty(this._selectedGenericAssayEntityIds);
+            return _.isEmpty(this.validSelectedGenericAssayEntityIds);
         }
     }
 
@@ -248,6 +247,16 @@ export default class GenericAssaySelection extends React.Component<
             this.genericAssayOptions,
             (option: ISelectOption) => option.value
         );
+    }
+
+    @computed get validSelectedGenericAssayEntityIds(): string[] {
+        return this._selectedGenericAssayEntityIds.filter(entityId => {
+            if (entityId === GENERIC_ASSAY_FREQUENCY_TABLE_OPTION) {
+                return this.selectedProfileSupportsFrequencyTable;
+            }
+
+            return !!this.genericAssayEntitiesOptionsByValueMap[entityId];
+        });
     }
 
     @action.bound
@@ -279,11 +288,7 @@ export default class GenericAssaySelection extends React.Component<
     }
 
     @computed get selectedGenericAssayEntities(): ISelectOption[] {
-        const filteredSelectedGenericAssayEntityIds = _.intersection(
-            this._selectedGenericAssayEntityIds,
-            _.keys(this.genericAssayEntitiesOptionsByValueMap)
-        );
-        return filteredSelectedGenericAssayEntityIds.map(
+        return this.validSelectedGenericAssayEntityIds.map(
             o => this.genericAssayEntitiesOptionsByValueMap[o]
         );
     }

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
@@ -29,7 +29,7 @@ export interface IGenericAssaySelectionProps {
     };
     genericAssayType: string;
     submitButtonText: string;
-    profileAction?: React.ReactNode;
+    footerAction?: React.ReactNode;
     containerWidth?: number;
     initialGenericAssayEntityIds?: string[];
     allowEmptySubmission?: boolean;
@@ -403,11 +403,6 @@ export default class GenericAssaySelection extends React.Component<
                             isSearchable={false}
                         />
                     </div>
-                    {this.props.profileAction && (
-                        <div style={{ marginLeft: 10 }}>
-                            {this.props.profileAction}
-                        </div>
-                    )}
                 </div>
                 <div
                     style={{
@@ -540,6 +535,11 @@ export default class GenericAssaySelection extends React.Component<
                     </div>
                 )}
                 <div style={{ display: 'flex', marginTop: 12 }}>
+                    {this.props.footerAction && (
+                        <div style={{ marginRight: 10 }}>
+                            {this.props.footerAction}
+                        </div>
+                    )}
                     <button
                         disabled={this.buttonDisabled}
                         className="btn btn-primary btn-sm"

--- a/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
+++ b/src/pages/studyView/addChartButton/genericAssaySelection/GenericAssaySelection.tsx
@@ -69,7 +69,8 @@ interface ISelectOption {
 }
 
 export const DEFAULT_GENERIC_ASSAY_OPTIONS_SHOWING: number = 100;
-export const GENERIC_ASSAY_ADD_ALL_VALUES_OPTION = 'generic_assay_add_all_values';
+export const GENERIC_ASSAY_FREQUENCY_TABLE_OPTION =
+    'generic_assay_frequency_table';
 
 @observer
 export default class GenericAssaySelection extends React.Component<
@@ -112,11 +113,11 @@ export default class GenericAssaySelection extends React.Component<
             const shouldAddFrequencyTable = Boolean(
                 this.props.onFrequencyTableSubmit &&
                     this._selectedGenericAssayEntityIds.includes(
-                        GENERIC_ASSAY_ADD_ALL_VALUES_OPTION
+                        GENERIC_ASSAY_FREQUENCY_TABLE_OPTION
                     )
             );
             const selectedEntityIds = this._selectedGenericAssayEntityIds.filter(
-                entityId => entityId !== GENERIC_ASSAY_ADD_ALL_VALUES_OPTION
+                entityId => entityId !== GENERIC_ASSAY_FREQUENCY_TABLE_OPTION
             );
             // Generic Assay chart submit (StudyView)
             if (shouldAddFrequencyTable) {
@@ -172,7 +173,6 @@ export default class GenericAssaySelection extends React.Component<
                 this.props.onTrackSubmit(info);
             }
         }
-        // fail silently
     }
 
     @action.bound
@@ -298,7 +298,7 @@ export default class GenericAssaySelection extends React.Component<
         let allOptionsInSelectedProfile = this.selectedProfileSupportsFrequencyTable
             ? _.concat(
                   {
-                      value: GENERIC_ASSAY_ADD_ALL_VALUES_OPTION,
+                      value: GENERIC_ASSAY_FREQUENCY_TABLE_OPTION,
                       label: 'Frequency table',
                   } as ISelectOption,
                   this.props.genericAssayEntityOptions
@@ -336,7 +336,7 @@ export default class GenericAssaySelection extends React.Component<
                 if (option.value === 'select_all_filtered_options') {
                     return true;
                 }
-                if (option.value === GENERIC_ASSAY_ADD_ALL_VALUES_OPTION) {
+                if (option.value === GENERIC_ASSAY_FREQUENCY_TABLE_OPTION) {
                     return !this._selectedGenericAssayEntityIds.includes(
                         option.value
                     );
@@ -377,7 +377,7 @@ export default class GenericAssaySelection extends React.Component<
             // filter out select all option
             if (
                 option.value === 'select_all_filtered_options' ||
-                option.value === GENERIC_ASSAY_ADD_ALL_VALUES_OPTION
+                option.value === GENERIC_ASSAY_FREQUENCY_TABLE_OPTION
             ) {
                 return false;
             }
@@ -393,7 +393,7 @@ export default class GenericAssaySelection extends React.Component<
         if (option.value === 'select_all_filtered_options') {
             return true;
         }
-        if (option.value === GENERIC_ASSAY_ADD_ALL_VALUES_OPTION) {
+        if (option.value === GENERIC_ASSAY_FREQUENCY_TABLE_OPTION) {
             return !this._selectedGenericAssayEntityIds.includes(option.value);
         }
         return (
@@ -409,12 +409,6 @@ export default class GenericAssaySelection extends React.Component<
         } else if (inputInfo.action !== 'set-value') {
             this._genericAssaySearchText = '';
         }
-    }
-
-    // TODO: decide whether we need this or not
-    // disabled currently
-    @computed get isSelectedGenericAssayOptionsOverLimit() {
-        return this._selectedGenericAssayEntityIds.length > 100;
     }
 
     render() {
@@ -434,17 +428,6 @@ export default class GenericAssaySelection extends React.Component<
                         alignItems: 'center',
                     }}
                 >
-                    {/* {this.isSelectedGenericAssayOptionsOverLimit && (
-                        <div className="alert alert-warning">
-                            <i
-                                className="fa fa-warning"
-                                style={{ marginRight: 3 }}
-                            />
-                            Warning: we don't support adding more than 100
-                            options, please make sure your selection has less
-                            than 100 options.
-                        </div>
-                    )} */}
                     <div style={{ flex: 1 }}>
                         <Select
                             value={this.selectedProfileOption}

--- a/src/pages/studyView/chartHeader/ChartHeader.tsx
+++ b/src/pages/studyView/chartHeader/ChartHeader.tsx
@@ -220,6 +220,7 @@ export class ChartHeader extends React.Component<IChartHeaderProps, {}> {
             case ChartTypeEnum.VARIANT_ANNOTATIONS_TABLE:
             case ChartTypeEnum.CNA_GENES_TABLE:
             case ChartTypeEnum.STRUCTURAL_VARIANT_GENES_TABLE:
+            case ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE:
             case ChartTypeEnum.SAMPLE_TREATMENT_GROUPS_TABLE:
             case ChartTypeEnum.SAMPLE_TREATMENTS_TABLE:
             case ChartTypeEnum.PATIENT_TREATMENT_GROUPS_TABLE:

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -14,6 +14,7 @@ import {
 import { GenePanel, StudyViewFilter } from 'cbioportal-ts-api-client';
 import PieChart from 'pages/studyView/charts/pieChart/PieChart';
 import classnames from 'classnames';
+import autobind from 'autobind-decorator';
 import ClinicalTable from 'pages/studyView/table/ClinicalTable';
 import SurvivalChart, {
     LegendLocation,
@@ -25,6 +26,8 @@ import {
     ChartType,
     ClinicalDataCountSummary,
     DataBin,
+    formatGenericAssayFrequencyTableDownloadData,
+    GenericAssayFrequencyTableRow,
     getHeightByDimension,
     getRangeFromDataBins,
     getTableHeightByDimension,
@@ -203,6 +206,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
 
     @observable newlyAdded = false;
     @observable private selectedRowsKeys: string[] = [];
+    @observable.ref private genericAssayFrequencyTableDownloadRows: GenericAssayFrequencyTableRow[] = [];
 
     @observable alertContent: JSX.Element | string | null = null;
 
@@ -317,6 +321,38 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
         };
 
         makeObservable(this);
+    }
+
+    @action.bound
+    private onGenericAssayFrequencyTableDownloadRowsChange(
+        rows: GenericAssayFrequencyTableRow[]
+    ) {
+        if (!_.isEqual(this.genericAssayFrequencyTableDownloadRows, rows)) {
+            this.genericAssayFrequencyTableDownloadRows = rows;
+        }
+    }
+
+    @autobind
+    private async getDownloadData(
+        dataType?: DataType
+    ): Promise<string | null> {
+        if (this.props.chartType === ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE) {
+            return formatGenericAssayFrequencyTableDownloadData(
+                this.genericAssayFrequencyTableDownloadRows,
+                this.props.store.getMolecularChartDataType(
+                    this.props.chartMeta.uniqueKey
+                ) !== GenericAssayDataType.BINARY
+            );
+        }
+
+        const downloadData = this.props.getData?.(dataType);
+        if (downloadData === undefined || downloadData === null) {
+            return null;
+        }
+
+        return typeof downloadData === 'string'
+            ? downloadData
+            : await downloadData;
     }
 
     public toSVGDOMNode(): SVGElement {
@@ -657,6 +693,9 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                             this.handlers.onChangeSelectedRows
                         }
                         onSubmitSelection={this.handlers.onValueSelection}
+                        onDownloadRowsChange={
+                            this.onGenericAssayFrequencyTableDownloadRowsChange
+                        }
                         extraButtons={
                             this.comparisonButtonForTables && [
                                 this.comparisonButtonForTables,
@@ -1658,7 +1697,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                             this.toggleRenderPieChartForDownload
                         }
                         getSVG={() => Promise.resolve(this.toSVGDOMNode())}
-                        getData={this.props.getData}
+                        getData={this.getDownloadData}
                         downloadTypes={this.props.downloadTypes}
                         openComparisonPage={this.openComparisonPage}
                         placement={this.placement}

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -104,6 +104,7 @@ const COMPARISON_CHART_TYPES: ChartType[] = [
     ChartTypeEnum.MUTATED_GENES_TABLE,
     ChartTypeEnum.VARIANT_ANNOTATIONS_TABLE,
     ChartTypeEnum.CNA_GENES_TABLE,
+    ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE,
     ChartTypeEnum.SAMPLE_TREATMENTS_TABLE,
     ChartTypeEnum.SAMPLE_TREATMENT_GROUPS_TABLE,
     ChartTypeEnum.SAMPLE_TREATMENT_TARGET_TABLE,
@@ -650,8 +651,22 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                             this.props.dimension,
                             this.chartHeaderHeight
                         )}
-                        selectedRowsKeys={this.props.filters}
-                        onSelectionChange={this.handlers.onValueSelection}
+                        filters={this.props.filters}
+                        selectedRowsKeys={this.selectedRowsKeys}
+                        onChangeSelectedRows={
+                            this.handlers.onChangeSelectedRows
+                        }
+                        onSubmitSelection={this.handlers.onValueSelection}
+                        extraButtons={
+                            this.comparisonButtonForTables && [
+                                this.comparisonButtonForTables,
+                            ]
+                        }
+                        setOperationsButtonText={
+                            this.props.store.hesitateUpdate
+                                ? 'Add Filters '
+                                : 'Select Samples '
+                        }
                         showCategoryColumn={
                             this.props.store.getMolecularChartDataType(
                                 this.props.chartMeta.uniqueKey

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -667,6 +667,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                                 ? 'Add Filters '
                                 : 'Select Samples '
                         }
+                        genericAssayType={this.props.chartMeta.genericAssayType}
                         showCategoryColumn={
                             this.props.store.getMolecularChartDataType(
                                 this.props.chartMeta.uniqueKey

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -76,6 +76,7 @@ import { PatientSurvival } from 'shared/model/PatientSurvival';
 import ClinicalEventTypeCountTable, {
     ClinicalEventTypeCountColumnKey,
 } from 'pages/studyView/table/ClinicalEventTypeCountTable';
+import GenericAssayFrequencyTable from 'pages/studyView/table/GenericAssayFrequencyTable';
 import {
     StructuralVariantMultiSelectionTable,
     StructVarMultiSelectionTableColumn,
@@ -83,6 +84,7 @@ import {
 } from 'pages/studyView/table/StructuralVariantMultiSelectionTable';
 import { StructVarGenePair } from 'pages/studyView/StructVarUtils';
 import { Modal } from 'react-bootstrap';
+import { GenericAssayDataType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 
 export interface AbstractChart {
     toSVGDOMNode: () => Element;
@@ -634,6 +636,28 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                             </div>
                         )}
                     </>
+                );
+            }
+            case ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE: {
+                return () => (
+                    <GenericAssayFrequencyTable
+                        promise={this.props.promise}
+                        width={getWidthByDimension(
+                            this.props.dimension,
+                            this.borderWidth
+                        )}
+                        height={getTableHeightByDimension(
+                            this.props.dimension,
+                            this.chartHeaderHeight
+                        )}
+                        selectedRowsKeys={this.props.filters}
+                        onSelectionChange={this.handlers.onValueSelection}
+                        showCategoryColumn={
+                            this.props.store.getMolecularChartDataType(
+                                this.props.chartMeta.uniqueKey
+                            ) !== GenericAssayDataType.BINARY
+                        }
+                    />
                 );
             }
             case ChartTypeEnum.MUTATED_GENES_TABLE: {

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -27,7 +27,6 @@ import {
     ClinicalDataCountSummary,
     DataBin,
     formatGenericAssayFrequencyTableDownloadData,
-    GenericAssayFrequencyTableRow,
     getHeightByDimension,
     getRangeFromDataBins,
     getTableHeightByDimension,
@@ -197,6 +196,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
 
     private handlers: any;
     private plot: AbstractChart;
+    private genericAssayFrequencyTableRef: GenericAssayFrequencyTable | null = null;
 
     private mouseLeaveTimeout: any;
 
@@ -206,7 +206,6 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
 
     @observable newlyAdded = false;
     @observable private selectedRowsKeys: string[] = [];
-    @observable.ref private genericAssayFrequencyTableDownloadRows: GenericAssayFrequencyTableRow[] = [];
 
     @observable alertContent: JSX.Element | string | null = null;
 
@@ -323,22 +322,13 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
         makeObservable(this);
     }
 
-    @action.bound
-    private onGenericAssayFrequencyTableDownloadRowsChange(
-        rows: GenericAssayFrequencyTableRow[]
-    ) {
-        if (!_.isEqual(this.genericAssayFrequencyTableDownloadRows, rows)) {
-            this.genericAssayFrequencyTableDownloadRows = rows;
-        }
-    }
-
     @autobind
     private async getDownloadData(
         dataType?: DataType
     ): Promise<string | null> {
         if (this.props.chartType === ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE) {
             return formatGenericAssayFrequencyTableDownloadData(
-                this.genericAssayFrequencyTableDownloadRows,
+                this.genericAssayFrequencyTableRef?.getDownloadRowsData() || [],
                 this.props.store.getMolecularChartDataType(
                     this.props.chartMeta.uniqueKey
                 ) !== GenericAssayDataType.BINARY
@@ -678,6 +668,9 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
             case ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE: {
                 return () => (
                     <GenericAssayFrequencyTable
+                        ref={ref => {
+                            this.genericAssayFrequencyTableRef = ref;
+                        }}
                         promise={this.props.promise}
                         width={getWidthByDimension(
                             this.props.dimension,
@@ -686,16 +679,13 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                         height={getTableHeightByDimension(
                             this.props.dimension,
                             this.chartHeaderHeight
-                        )}
+                        )                        }
                         filters={this.props.filters}
                         selectedRowsKeys={this.selectedRowsKeys}
                         onChangeSelectedRows={
                             this.handlers.onChangeSelectedRows
                         }
                         onSubmitSelection={this.handlers.onValueSelection}
-                        onDownloadRowsChange={
-                            this.onGenericAssayFrequencyTableDownloadRowsChange
-                        }
                         extraButtons={
                             this.comparisonButtonForTables && [
                                 this.comparisonButtonForTables,

--- a/src/pages/studyView/table/FixedHeaderTable.spec.tsx
+++ b/src/pages/studyView/table/FixedHeaderTable.spec.tsx
@@ -1,0 +1,23 @@
+import { assert } from 'chai';
+import React from 'react';
+import FixedHeaderTable from './FixedHeaderTable';
+import { SelectionOperatorEnum } from '../TableUtils';
+
+describe('FixedHeaderTable', () => {
+    it('marks the current selection operator as active in the dropdown', () => {
+        const component = new FixedHeaderTable<any>({
+            columns: [],
+            data: [],
+            numberOfSelectedRows: 2,
+            defaultSelectionOperator: SelectionOperatorEnum.UNION,
+        });
+
+        const options = (component as any).getSelectionOptions() as React.ReactElement[];
+        const byLabel = Object.fromEntries(
+            options.map(option => [option.props.children.props.overlay.split(' ')[0], option])
+        );
+
+        assert.isFalse(byLabel.Intersection.props.active);
+        assert.isTrue(byLabel.Union.props.active);
+    });
+});

--- a/src/pages/studyView/table/FixedHeaderTable.tsx
+++ b/src/pages/studyView/table/FixedHeaderTable.tsx
@@ -456,6 +456,7 @@ export default class FixedHeaderTable<T> extends React.Component<
                                 id={`selectButton`}
                                 buttonClassName="btn btn-default btn-xs dropdown-toggle"
                                 data-test="selectSamplesDropdown"
+                                closeOnMenuClick
                             >
                                 {this.getSelectionOptions()}
                             </CustomDropdown>

--- a/src/pages/studyView/table/FixedHeaderTable.tsx
+++ b/src/pages/studyView/table/FixedHeaderTable.tsx
@@ -24,8 +24,9 @@ import { inputBoxChangeTimeoutEvent } from '../../../shared/lib/EventUtils';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import { SimpleGetterLazyMobXTableApplicationDataStore } from 'shared/lib/ILazyMobXTableApplicationDataStore';
 import { SelectionOperatorEnum } from '../TableUtils';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { MenuItem } from 'react-bootstrap';
 import classNames from 'classnames';
+import CustomDropdown from 'shared/components/oncoprint/controls/CustomDropdown';
 
 export type IFixedHeaderTableProps<T> = {
     columns: Column<T>[];
@@ -450,14 +451,14 @@ export default class FixedHeaderTable<T> extends React.Component<
                         </button>
 
                         <If condition={this.props.numberOfSelectedRows > 1}>
-                            <DropdownButton
-                                bsSize="xsmall"
-                                title={''}
+                            <CustomDropdown
+                                title=""
                                 id={`selectButton`}
-                                pullRight={true}
+                                buttonClassName="btn btn-default btn-xs dropdown-toggle"
+                                data-test="selectSamplesDropdown"
                             >
                                 {this.getSelectionOptions()}
-                            </DropdownButton>
+                            </CustomDropdown>
                         </If>
                     </div>
                 </If>

--- a/src/pages/studyView/table/FixedHeaderTable.tsx
+++ b/src/pages/studyView/table/FixedHeaderTable.tsx
@@ -339,9 +339,11 @@ export default class FixedHeaderTable<T> extends React.Component<
                 ];
             return (
                 <MenuItem
+                    key={selectionType}
                     onClick={() => this.changeSelectionType(selectionOperation)}
                     active={
-                        this.props.defaultSelectionOperator === selectionType
+                        this.props.defaultSelectionOperator ===
+                        selectionOperation
                     }
                 >
                     <DefaultTooltip

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.spec.ts
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.spec.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
 import {
     GenericAssayFrequencyTableColumnKey,
+    getGenericAssayFrequencyTableDefaultHiddenCategorySet,
     getGenericAssayFrequencyTableCategorySortValue,
     getGenericAssayFrequencyTableDefaultSortBy,
 } from './GenericAssayFrequencyTable';
+import GenericAssayFrequencyTable from './GenericAssayFrequencyTable';
 import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
 import { GenericAssayFrequencyTableRow } from 'pages/studyView/StudyViewUtils';
 
@@ -23,23 +25,23 @@ describe('GenericAssayFrequencyTable', () => {
     });
 
     describe('default sorting', () => {
-        it('uses curated category sorting for arm-level CNA', () => {
+        it('uses frequency sorting for arm-level CNA when default hidden categories are active', () => {
             assert.equal(
                 getGenericAssayFrequencyTableDefaultSortBy(
                     true,
                     GenericAssayTypeConstants.ARMLEVEL_CNA
                 ),
-                GenericAssayFrequencyTableColumnKey.CATEGORY
+                GenericAssayFrequencyTableColumnKey.FREQ
             );
         });
 
-        it('uses curated category sorting for LOH_HLA', () => {
+        it('uses frequency sorting for LOH_HLA when default hidden categories are active', () => {
             assert.equal(
                 getGenericAssayFrequencyTableDefaultSortBy(
                     true,
                     GenericAssayTypeConstants.LOH_HLA
                 ),
-                GenericAssayFrequencyTableColumnKey.CATEGORY
+                GenericAssayFrequencyTableColumnKey.FREQ
             );
         });
 
@@ -50,6 +52,29 @@ describe('GenericAssayFrequencyTable', () => {
                     GenericAssayTypeConstants.MUTATIONAL_SIGNATURE
                 ),
                 GenericAssayFrequencyTableColumnKey.FREQ
+            );
+        });
+    });
+
+    describe('default hidden categories', () => {
+        it('configures unchanged and unknown as hidden by default for curated arm-level types', () => {
+            assert.deepEqual(
+                getGenericAssayFrequencyTableDefaultHiddenCategorySet(
+                    GenericAssayTypeConstants.ARMLEVEL_CNA
+                ),
+                {
+                    unchanged: true,
+                    unknown: true,
+                }
+            );
+            assert.deepEqual(
+                getGenericAssayFrequencyTableDefaultHiddenCategorySet(
+                    GenericAssayTypeConstants.LOH_HLA
+                ),
+                {
+                    unchanged: true,
+                    unknown: true,
+                }
             );
         });
     });
@@ -104,6 +129,84 @@ describe('GenericAssayFrequencyTable', () => {
                 ),
                 'Subtype B'
             );
+        });
+    });
+
+    describe('component filtering behavior', () => {
+        it('keeps applied hidden rows pinned while hiding them from the selectable table and download rows include visible UI rows', () => {
+            const rows = [
+                makeRow('Loss', 7, 'Entity A'),
+                makeRow('Unchanged', 9, 'Entity B'),
+                makeRow('Unknown', 3, 'Entity C'),
+            ];
+            const component = new GenericAssayFrequencyTable({
+                promise: {
+                    result: rows,
+                    isComplete: true,
+                } as any,
+                width: 600,
+                height: 300,
+                genericAssayType: GenericAssayTypeConstants.ARMLEVEL_CNA,
+                filters: [['Entity B::Unchanged::profile_type']],
+                selectedRowsKeys: [],
+                onChangeSelectedRows: () => {},
+                onSubmitSelection: () => {},
+                showCategoryColumn: true,
+                setOperationsButtonText: 'Apply',
+            });
+
+            assert.deepEqual(
+                component.preSelectedRows.map(row => row.uniqueKey),
+                ['Entity B::Unchanged::profile_type']
+            );
+            assert.deepEqual(
+                component.selectableTableData.map(row => row.uniqueKey),
+                ['Entity A::Loss::profile_type']
+            );
+            assert.deepEqual(
+                component.downloadRows.map(row => row.uniqueKey),
+                [
+                    'Entity B::Unchanged::profile_type',
+                    'Entity A::Loss::profile_type',
+                ]
+            );
+        });
+
+        it('drops staged selections that become hidden when the category filter is enabled', () => {
+            let selectedRowsKeys = [
+                'Entity A::Loss::profile_type',
+                'Entity B::Unchanged::profile_type',
+            ];
+            const component = new GenericAssayFrequencyTable({
+                promise: {
+                    result: [
+                        makeRow('Loss', 7, 'Entity A'),
+                        makeRow('Unchanged', 9, 'Entity B'),
+                    ],
+                    isComplete: true,
+                } as any,
+                width: 600,
+                height: 300,
+                genericAssayType: GenericAssayTypeConstants.ARMLEVEL_CNA,
+                filters: [],
+                selectedRowsKeys,
+                onChangeSelectedRows: nextSelectedRowsKeys => {
+                    selectedRowsKeys = nextSelectedRowsKeys;
+                    (component.props as any).selectedRowsKeys = nextSelectedRowsKeys;
+                },
+                onSubmitSelection: () => {},
+                showCategoryColumn: true,
+                setOperationsButtonText: 'Apply',
+            });
+
+            component.toggleDefaultCategoryFilter({
+                stopPropagation: () => {},
+            } as any);
+            component.toggleDefaultCategoryFilter({
+                stopPropagation: () => {},
+            } as any);
+
+            assert.deepEqual(selectedRowsKeys, ['Entity A::Loss::profile_type']);
         });
     });
 });

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.spec.ts
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.spec.ts
@@ -55,7 +55,7 @@ describe('GenericAssayFrequencyTable', () => {
     });
 
     describe('curated category sort values', () => {
-        it('prioritizes altered arm-level CNA categories ahead of unchanged', () => {
+        it('sorts altered arm-level CNA categories by frequency before unchanged', () => {
             const loss = getGenericAssayFrequencyTableCategorySortValue(
                 makeRow('Loss', 2),
                 GenericAssayTypeConstants.ARMLEVEL_CNA
@@ -70,11 +70,13 @@ describe('GenericAssayFrequencyTable', () => {
             );
 
             assert.equal(loss, '00::000000000008::ENTITY A::loss');
-            assert.equal(gain, '01::000000000007::ENTITY A::gain');
+            assert.equal(gain, '00::000000000007::ENTITY A::gain');
             assert.equal(
                 unchanged,
-                '02::000000000001::ENTITY A::unchanged'
+                '01::000000000001::ENTITY A::unchanged'
             );
+            assert.isTrue(gain < loss);
+            assert.isTrue(loss < unchanged);
         });
 
         it('keeps higher-frequency rows first within the same curated category bucket', () => {

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.spec.ts
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.spec.ts
@@ -1,0 +1,107 @@
+import { assert } from 'chai';
+import {
+    GenericAssayFrequencyTableColumnKey,
+    getGenericAssayFrequencyTableCategorySortValue,
+    getGenericAssayFrequencyTableDefaultSortBy,
+} from './GenericAssayFrequencyTable';
+import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
+import { GenericAssayFrequencyTableRow } from 'pages/studyView/StudyViewUtils';
+
+describe('GenericAssayFrequencyTable', () => {
+    const makeRow = (
+        category: string,
+        count: number,
+        entityLabel = 'Entity A'
+    ): GenericAssayFrequencyTableRow => ({
+        uniqueKey: `${entityLabel}::${category}::profile_type`,
+        entityStableId: entityLabel,
+        entityLabel,
+        profileType: 'profile_type',
+        category,
+        count,
+        totalCount: 10,
+    });
+
+    describe('default sorting', () => {
+        it('uses curated category sorting for arm-level CNA', () => {
+            assert.equal(
+                getGenericAssayFrequencyTableDefaultSortBy(
+                    true,
+                    GenericAssayTypeConstants.ARMLEVEL_CNA
+                ),
+                GenericAssayFrequencyTableColumnKey.CATEGORY
+            );
+        });
+
+        it('uses curated category sorting for LOH_HLA', () => {
+            assert.equal(
+                getGenericAssayFrequencyTableDefaultSortBy(
+                    true,
+                    GenericAssayTypeConstants.LOH_HLA
+                ),
+                GenericAssayFrequencyTableColumnKey.CATEGORY
+            );
+        });
+
+        it('keeps frequency sorting for non-curated types', () => {
+            assert.equal(
+                getGenericAssayFrequencyTableDefaultSortBy(
+                    true,
+                    GenericAssayTypeConstants.MUTATIONAL_SIGNATURE
+                ),
+                GenericAssayFrequencyTableColumnKey.FREQ
+            );
+        });
+    });
+
+    describe('curated category sort values', () => {
+        it('prioritizes altered arm-level CNA categories ahead of unchanged', () => {
+            const loss = getGenericAssayFrequencyTableCategorySortValue(
+                makeRow('Loss', 2),
+                GenericAssayTypeConstants.ARMLEVEL_CNA
+            );
+            const gain = getGenericAssayFrequencyTableCategorySortValue(
+                makeRow('Gain', 3),
+                GenericAssayTypeConstants.ARMLEVEL_CNA
+            );
+            const unchanged = getGenericAssayFrequencyTableCategorySortValue(
+                makeRow('Unchanged', 9),
+                GenericAssayTypeConstants.ARMLEVEL_CNA
+            );
+
+            assert.equal(loss, '00::000000000008::ENTITY A::loss');
+            assert.equal(gain, '01::000000000007::ENTITY A::gain');
+            assert.equal(
+                unchanged,
+                '02::000000000001::ENTITY A::unchanged'
+            );
+        });
+
+        it('keeps higher-frequency rows first within the same curated category bucket', () => {
+            const lowerFrequencyLoss =
+                getGenericAssayFrequencyTableCategorySortValue(
+                    makeRow('Loss', 2, 'Entity B'),
+                    GenericAssayTypeConstants.LOH_HLA
+                );
+            const higherFrequencyLoss =
+                getGenericAssayFrequencyTableCategorySortValue(
+                    makeRow('loss', 6, 'Entity A'),
+                    GenericAssayTypeConstants.LOH_HLA
+                );
+
+            assert.match(lowerFrequencyLoss, /^00::/);
+            assert.match(higherFrequencyLoss, /^00::/);
+            assert.isTrue(higherFrequencyLoss < lowerFrequencyLoss);
+        });
+
+        it('falls back to alphabetical category sorting for non-curated types', () => {
+            assert.equal(
+                getGenericAssayFrequencyTableCategorySortValue(
+                    makeRow('Subtype B', 3),
+                    GenericAssayTypeConstants.MUTATIONAL_SIGNATURE
+                ),
+                'Subtype B'
+            );
+        });
+    });
+});

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -23,7 +23,7 @@ export enum GenericAssayFrequencyTableColumnKey {
     ENTITY = 'Entity',
     CATEGORY = 'Category',
     COUNT = '# Samples',
-    FREQ = 'Frequency',
+    FREQ = 'Freq',
 }
 
 export interface IGenericAssayFrequencyTableProps {

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -3,12 +3,18 @@ import { observer } from 'mobx-react';
 import { action, computed, makeObservable, observable } from 'mobx';
 import _ from 'lodash';
 import autobind from 'autobind-decorator';
-import { MobxPromise, stringListToSet } from 'cbioportal-frontend-commons';
+import {
+    MobxPromise,
+    stringListToIndexSet,
+    stringListToSet,
+} from 'cbioportal-frontend-commons';
 import {
     Column,
     SortDirection,
 } from 'shared/components/lazyMobXTable/LazyMobXTable';
-import FixedHeaderTable from 'pages/studyView/table/FixedHeaderTable';
+import FixedHeaderTable, {
+    IFixedHeaderTableProps,
+} from 'pages/studyView/table/FixedHeaderTable';
 import LabeledCheckbox from 'shared/components/labeledCheckbox/LabeledCheckbox';
 import styles from 'pages/studyView/table/tables.module.scss';
 import {
@@ -18,6 +24,11 @@ import {
     getFrequencyStr,
 } from 'pages/studyView/StudyViewUtils';
 import { TreatmentGenericColumnHeader } from 'pages/studyView/table/treatments/treatmentsTableUtil';
+import {
+    FreqColumnTypeEnum,
+    SelectionOperatorEnum,
+} from 'pages/studyView/TableUtils';
+import ifNotDefined from 'shared/lib/ifNotDefined';
 
 export enum GenericAssayFrequencyTableColumnKey {
     ENTITY = 'Entity',
@@ -30,8 +41,12 @@ export interface IGenericAssayFrequencyTableProps {
     promise: MobxPromise<GenericAssayFrequencyTableRow[]>;
     width: number;
     height: number;
+    filters: string[][];
     selectedRowsKeys: string[];
-    onSelectionChange: (selectedRowsKeys: string[]) => void;
+    onChangeSelectedRows: (selectedRowsKeys: string[]) => void;
+    onSubmitSelection: (selectedRowsKeys: string[][]) => void;
+    extraButtons?: IFixedHeaderTableProps<GenericAssayFrequencyTableRow>['extraButtons'];
+    setOperationsButtonText: string;
     showCategoryColumn: boolean;
 }
 
@@ -51,6 +66,7 @@ export default class GenericAssayFrequencyTable extends React.Component<
 > {
     @observable protected sortBy: GenericAssayFrequencyTableColumnKey;
     @observable protected sortDirection: SortDirection = 'desc';
+    @observable private _selectionType: SelectionOperatorEnum;
 
     constructor(props: IGenericAssayFrequencyTableProps) {
         super(props);
@@ -64,8 +80,62 @@ export default class GenericAssayFrequencyTable extends React.Component<
     }
 
     @computed
-    get selectedRowKeysSet() {
-        return stringListToSet(this.props.selectedRowsKeys);
+    get flattenedFilters() {
+        return _.flatMap(this.props.filters);
+    }
+
+    @computed
+    get preSelectedRows(): GenericAssayFrequencyTableRow[] {
+        if (this.flattenedFilters.length === 0) {
+            return [];
+        }
+
+        const order = stringListToIndexSet(this.flattenedFilters);
+        return this.tableData
+            .filter(row => this.flattenedFilters.includes(row.uniqueKey))
+            .sort((a, b) =>
+                ifNotDefined(order[a.uniqueKey], Number.POSITIVE_INFINITY) -
+                ifNotDefined(order[b.uniqueKey], Number.POSITIVE_INFINITY)
+            );
+    }
+
+    @computed
+    get preSelectedRowsKeys(): string[] {
+        return this.preSelectedRows.map(row => row.uniqueKey);
+    }
+
+    @computed
+    get selectableTableData(): GenericAssayFrequencyTableRow[] {
+        if (this.flattenedFilters.length === 0) {
+            return this.tableData;
+        }
+
+        return this.tableData.filter(
+            row => !this.flattenedFilters.includes(row.uniqueKey)
+        );
+    }
+
+    @computed
+    get allSelectedRowsKeysSet() {
+        return stringListToSet([
+            ...this.props.selectedRowsKeys,
+            ...this.preSelectedRowsKeys,
+        ]);
+    }
+
+    @computed
+    get filterKeyToIndexSet() {
+        return _.reduce(
+            this.props.filters,
+            (acc, next, index) => {
+                next.forEach(key => {
+                    acc[key] = index;
+                });
+
+                return acc;
+            },
+            {} as { [id: string]: number }
+        );
     }
 
     @computed
@@ -245,15 +315,79 @@ export default class GenericAssayFrequencyTable extends React.Component<
 
     @autobind
     isChecked(uniqueKey: string) {
-        return !!this.selectedRowKeysSet[uniqueKey];
+        return !!this.allSelectedRowsKeysSet[uniqueKey];
+    }
+
+    @autobind
+    isDisabled(uniqueKey: string) {
+        return this.preSelectedRowsKeys.includes(uniqueKey);
     }
 
     @action.bound
     toggleSelectRow(uniqueKey: string) {
-        const selectedRowsKeys = this.isChecked(uniqueKey)
-            ? this.props.selectedRowsKeys.filter(key => key !== uniqueKey)
-            : this.props.selectedRowsKeys.concat(uniqueKey);
-        this.props.onSelectionChange(selectedRowsKeys);
+        if (this.isDisabled(uniqueKey)) {
+            return;
+        }
+
+        const record = _.find(
+            this.props.selectedRowsKeys,
+            key => key === uniqueKey
+        );
+        if (_.isUndefined(record)) {
+            this.props.onChangeSelectedRows(
+                this.props.selectedRowsKeys.concat(uniqueKey)
+            );
+        } else {
+            this.props.onChangeSelectedRows(
+                this.props.selectedRowsKeys.filter(key => key !== uniqueKey)
+            );
+        }
+    }
+
+    @action.bound
+    afterSelectingRows() {
+        if (this.selectionType === SelectionOperatorEnum.UNION) {
+            this.props.onSubmitSelection([this.props.selectedRowsKeys]);
+        } else {
+            this.props.onSubmitSelection(
+                this.props.selectedRowsKeys.map(selectedRowsKey => [
+                    selectedRowsKey,
+                ])
+            );
+        }
+        this.props.onChangeSelectedRows([]);
+    }
+
+    @computed
+    get selectionType() {
+        if (this._selectionType) {
+            return this._selectionType;
+        }
+
+        switch (
+            (
+                localStorage.getItem(FreqColumnTypeEnum.GENERIC_ASSAY) || ''
+            ).toUpperCase()
+        ) {
+            case SelectionOperatorEnum.UNION.toUpperCase():
+                return SelectionOperatorEnum.UNION;
+            case SelectionOperatorEnum.INTERSECTION.toUpperCase():
+            default:
+                return SelectionOperatorEnum.INTERSECTION;
+        }
+    }
+
+    @action.bound
+    toggleSelectionOperator() {
+        const selectionType = this._selectionType || this.selectionType;
+        this._selectionType =
+            selectionType === SelectionOperatorEnum.INTERSECTION
+                ? SelectionOperatorEnum.UNION
+                : SelectionOperatorEnum.INTERSECTION;
+        localStorage.setItem(
+            FreqColumnTypeEnum.GENERIC_ASSAY,
+            this.selectionType
+        );
     }
 
     @autobind
@@ -261,20 +395,48 @@ export default class GenericAssayFrequencyTable extends React.Component<
         return this.isChecked(row.uniqueKey);
     }
 
+    @autobind
+    selectedRowClassName(row: GenericAssayFrequencyTableRow) {
+        const index = this.filterKeyToIndexSet[row.uniqueKey];
+        if (index === undefined) {
+            return this.props.filters.length % 2 === 0
+                ? styles.highlightedEvenRow
+                : styles.highlightedOddRow;
+        }
+
+        return index % 2 === 0
+            ? styles.highlightedEvenRow
+            : styles.highlightedOddRow;
+    }
+
     render() {
         return (
             <div data-test="generic-assay-frequency-table">
                 {this.props.promise.isComplete && (
                     <GenericAssayFrequencyTableComponent
+                        key={`generic-assay-frequency-table-${this.preSelectedRowsKeys.join(
+                            ','
+                        )}`}
                         width={this.props.width}
                         height={this.props.height}
-                        data={this.tableData}
+                        data={this.selectableTableData}
                         columns={this.tableColumns}
                         sortBy={this.sortBy}
                         sortDirection={this.sortDirection}
                         afterSorting={this.afterSorting}
                         isSelectedRow={this.isSelectedRow}
+                        highlightedRowClassName={this.selectedRowClassName}
                         numberOfSelectedRows={this.props.selectedRowsKeys.length}
+                        fixedTopRowsData={this.preSelectedRows}
+                        showSetOperationsButton={true}
+                        setOperationsButtonText={
+                            this.props.setOperationsButtonText
+                        }
+                        afterSelectingRows={this.afterSelectingRows}
+                        toggleSelectionOperator={this.toggleSelectionOperator}
+                        defaultSelectionOperator={this.selectionType}
+                        extraButtons={this.props.extraButtons}
+                        showControlsAtTop={true}
                     />
                 )}
             </div>

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -51,7 +51,6 @@ export interface IGenericAssayFrequencyTableProps {
     selectedRowsKeys: string[];
     onChangeSelectedRows: (selectedRowsKeys: string[]) => void;
     onSubmitSelection: (selectedRowsKeys: string[][]) => void;
-    onDownloadRowsChange?: (rows: GenericAssayFrequencyTableRow[]) => void;
     extraButtons?: IFixedHeaderTableProps<GenericAssayFrequencyTableRow>['extraButtons'];
     setOperationsButtonText: string;
     showCategoryColumn: boolean;
@@ -185,14 +184,6 @@ export default class GenericAssayFrequencyTable extends React.Component<
         );
     }
 
-    componentDidMount() {
-        this.emitDownloadRows();
-    }
-
-    componentDidUpdate() {
-        this.emitDownloadRows();
-    }
-
     @computed
     get tableData(): GenericAssayFrequencyTableRow[] {
         return this.props.promise.result || [];
@@ -266,6 +257,10 @@ export default class GenericAssayFrequencyTable extends React.Component<
             ...this.preSelectedRows,
             ...this.selectableTableData,
         ];
+    }
+
+    public getDownloadRowsData(): GenericAssayFrequencyTableRow[] {
+        return this.downloadRows;
     }
 
     @computed
@@ -610,10 +605,6 @@ export default class GenericAssayFrequencyTable extends React.Component<
         return index % 2 === 0
             ? styles.highlightedEvenRow
             : styles.highlightedOddRow;
-    }
-
-    private emitDownloadRows() {
-        this.props.onDownloadRowsChange?.(this.downloadRows);
     }
 
     render() {

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -21,12 +21,14 @@ import {
     correctMargin,
     GenericAssayFrequencyTableRow,
     getFixedHeaderNumberCellMargin,
+    getFixedHeaderTableMaxLengthStringPixel,
     getFrequencyStr,
 } from 'pages/studyView/StudyViewUtils';
 import { TreatmentGenericColumnHeader } from 'pages/studyView/table/treatments/treatmentsTableUtil';
 import {
     FreqColumnTypeEnum,
     SelectionOperatorEnum,
+    getTooltip,
 } from 'pages/studyView/TableUtils';
 import ifNotDefined from 'shared/lib/ifNotDefined';
 import {
@@ -318,10 +320,20 @@ export default class GenericAssayFrequencyTable extends React.Component<
 
     @computed
     get cellMargin() {
+        const countLocaleString = _.max(this.tableData.map(item => item.count))
+            ?.toLocaleString() || '0';
         return {
             [GenericAssayFrequencyTableColumnKey.ENTITY]: 0,
             [GenericAssayFrequencyTableColumnKey.CATEGORY]: 0,
-            [GenericAssayFrequencyTableColumnKey.COUNT]: 0,
+            [GenericAssayFrequencyTableColumnKey.COUNT]: correctMargin(
+                (this.columnsWidth[GenericAssayFrequencyTableColumnKey.COUNT] -
+                    10 -
+                    (getFixedHeaderTableMaxLengthStringPixel(
+                        countLocaleString
+                    ) +
+                        20)) /
+                    2
+            ),
             [GenericAssayFrequencyTableColumnKey.FREQ]: correctMargin(
                 getFixedHeaderNumberCellMargin(
                     this.columnsWidth[GenericAssayFrequencyTableColumnKey.FREQ],
@@ -399,21 +411,27 @@ export default class GenericAssayFrequencyTable extends React.Component<
             },
             [GenericAssayFrequencyTableColumnKey.COUNT]: {
                 name: columnKey,
+                tooltip: (
+                    <span>{getTooltip(FreqColumnTypeEnum.GENERIC_ASSAY, false)}</span>
+                ),
                 headerRender: () => (
-                    <TreatmentGenericColumnHeader
-                        margin={cellMargin}
-                        headerName={columnKey}
-                    />
+                    <div
+                        className={`${styles.displayFlex} ${styles.pullRight}`}
+                        style={{ marginLeft: cellMargin }}
+                    >
+                        {columnKey}
+                    </div>
                 ),
                 render: row => (
                     <LabeledCheckbox
                         checked={this.isChecked(row.uniqueKey)}
+                        disabled={this.isDisabled(row.uniqueKey)}
                         onChange={_ => this.toggleSelectRow(row.uniqueKey)}
                         labelProps={{
                             style: {
                                 display: 'flex',
                                 justifyContent: 'space-between',
-                                marginLeft: 0,
+                                marginLeft: cellMargin,
                                 marginRight: cellMargin,
                             },
                         }}
@@ -432,19 +450,20 @@ export default class GenericAssayFrequencyTable extends React.Component<
             },
             [GenericAssayFrequencyTableColumnKey.FREQ]: {
                 name: columnKey,
+                tooltip: (
+                    <span>{getTooltip(FreqColumnTypeEnum.GENERIC_ASSAY, true)}</span>
+                ),
                 headerRender: () => (
-                    <TreatmentGenericColumnHeader
-                        margin={cellMargin}
-                        headerName={columnKey}
-                    />
+                    <div style={{ marginLeft: cellMargin }}>{columnKey}</div>
                 ),
                 render: row => (
-                    <div
+                    <span
+                        data-test="freq-cell"
                         className={styles.pullRight}
                         style={{ marginLeft: cellMargin }}
                     >
                         {getFrequencyStr(this.getFrequency(row))}
-                    </div>
+                    </span>
                 ),
                 sortBy: row => this.getFrequency(row),
                 defaultSortDirection: 'desc',

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -29,7 +29,11 @@ import {
     SelectionOperatorEnum,
 } from 'pages/studyView/TableUtils';
 import ifNotDefined from 'shared/lib/ifNotDefined';
-import { getFrequencyTableCategoryPriority } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
+import {
+    getFrequencyTableCategoryPriority,
+    getFrequencyTableDefaultHiddenCategories,
+} from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
+import { TableHeaderCellFilterIcon } from 'pages/studyView/table/TableHeaderCellFilterIcon';
 
 export enum GenericAssayFrequencyTableColumnKey {
     ENTITY = 'Entity',
@@ -47,6 +51,7 @@ export interface IGenericAssayFrequencyTableProps {
     selectedRowsKeys: string[];
     onChangeSelectedRows: (selectedRowsKeys: string[]) => void;
     onSubmitSelection: (selectedRowsKeys: string[][]) => void;
+    onDownloadRowsChange?: (rows: GenericAssayFrequencyTableRow[]) => void;
     extraButtons?: IFixedHeaderTableProps<GenericAssayFrequencyTableRow>['extraButtons'];
     setOperationsButtonText: string;
     showCategoryColumn: boolean;
@@ -75,10 +80,36 @@ function hasCuratedCategorySorting(
     );
 }
 
+export function getGenericAssayFrequencyTableDefaultHiddenCategorySet(
+    genericAssayType?: string
+): { [value: string]: boolean } {
+    return stringListToSet(
+        (getFrequencyTableDefaultHiddenCategories(genericAssayType) || []).map(
+            normalizeCategoryValue
+        )
+    );
+}
+
+export function hasDefaultHiddenCategoryFilter(
+    showCategoryColumn: boolean,
+    genericAssayType?: string
+): boolean {
+    return (
+        showCategoryColumn &&
+        !_.isEmpty(
+            getFrequencyTableDefaultHiddenCategories(genericAssayType) || []
+        )
+    );
+}
+
 export function getGenericAssayFrequencyTableDefaultSortBy(
     showCategoryColumn: boolean,
     genericAssayType?: string
 ): GenericAssayFrequencyTableColumnKey {
+    if (hasDefaultHiddenCategoryFilter(showCategoryColumn, genericAssayType)) {
+        return GenericAssayFrequencyTableColumnKey.FREQ;
+    }
+
     return hasCuratedCategorySorting(showCategoryColumn, genericAssayType)
         ? GenericAssayFrequencyTableColumnKey.CATEGORY
         : GenericAssayFrequencyTableColumnKey.FREQ;
@@ -88,6 +119,10 @@ export function getGenericAssayFrequencyTableDefaultSortDirection(
     showCategoryColumn: boolean,
     genericAssayType?: string
 ): SortDirection {
+    if (hasDefaultHiddenCategoryFilter(showCategoryColumn, genericAssayType)) {
+        return 'desc';
+    }
+
     return hasCuratedCategorySorting(showCategoryColumn, genericAssayType)
         ? 'asc'
         : 'desc';
@@ -131,10 +166,15 @@ export default class GenericAssayFrequencyTable extends React.Component<
     @observable protected sortBy: GenericAssayFrequencyTableColumnKey;
     @observable protected sortDirection: SortDirection;
     @observable private _selectionType: SelectionOperatorEnum;
+    @observable private hideDefaultCategories: boolean;
 
     constructor(props: IGenericAssayFrequencyTableProps) {
         super(props);
         makeObservable(this);
+        this.hideDefaultCategories = hasDefaultHiddenCategoryFilter(
+            this.props.showCategoryColumn,
+            this.props.genericAssayType
+        );
         this.sortBy = getGenericAssayFrequencyTableDefaultSortBy(
             this.props.showCategoryColumn,
             this.props.genericAssayType
@@ -145,9 +185,43 @@ export default class GenericAssayFrequencyTable extends React.Component<
         );
     }
 
+    componentDidMount() {
+        this.emitDownloadRows();
+    }
+
+    componentDidUpdate() {
+        this.emitDownloadRows();
+    }
+
     @computed
     get tableData(): GenericAssayFrequencyTableRow[] {
         return this.props.promise.result || [];
+    }
+
+    @computed
+    get defaultHiddenCategorySet() {
+        return getGenericAssayFrequencyTableDefaultHiddenCategorySet(
+            this.props.genericAssayType
+        );
+    }
+
+    @computed
+    get shouldShowCategoryFilter() {
+        return hasDefaultHiddenCategoryFilter(
+            this.props.showCategoryColumn,
+            this.props.genericAssayType
+        );
+    }
+
+    @computed
+    get visibleTableData(): GenericAssayFrequencyTableRow[] {
+        if (!this.hideDefaultCategories) {
+            return this.tableData;
+        }
+
+        return this.tableData.filter(
+            row => !this.defaultHiddenCategorySet[normalizeCategoryValue(row.category)]
+        );
     }
 
     @computed
@@ -178,12 +252,20 @@ export default class GenericAssayFrequencyTable extends React.Component<
     @computed
     get selectableTableData(): GenericAssayFrequencyTableRow[] {
         if (this.flattenedFilters.length === 0) {
-            return this.tableData;
+            return this.visibleTableData;
         }
 
-        return this.tableData.filter(
+        return this.visibleTableData.filter(
             row => !this.flattenedFilters.includes(row.uniqueKey)
         );
+    }
+
+    @computed
+    get downloadRows(): GenericAssayFrequencyTableRow[] {
+        return [
+            ...this.preSelectedRows,
+            ...this.selectableTableData,
+        ];
     }
 
     @computed
@@ -291,12 +373,24 @@ export default class GenericAssayFrequencyTable extends React.Component<
             },
             [GenericAssayFrequencyTableColumnKey.CATEGORY]: {
                 name: columnKey,
-                headerRender: () => (
-                    <TreatmentGenericColumnHeader
-                        margin={cellMargin}
-                        headerName={columnKey}
-                    />
-                ),
+                headerRender: () =>
+                    this.shouldShowCategoryFilter ? (
+                        <TableHeaderCellFilterIcon
+                            cellMargin={cellMargin}
+                            dataTest="generic-assay-category-filter-header"
+                            showFilter={true}
+                            isFiltered={this.hideDefaultCategories}
+                            onClickCallback={this.toggleDefaultCategoryFilter}
+                            overlay={this.categoryFilterOverlay}
+                        >
+                            <span>{columnKey}</span>
+                        </TableHeaderCellFilterIcon>
+                    ) : (
+                        <TreatmentGenericColumnHeader
+                            margin={cellMargin}
+                            headerName={columnKey}
+                        />
+                    ),
                 render: row => <div>{row.category}</div>,
                 sortBy: row =>
                     getGenericAssayFrequencyTableCategorySortValue(
@@ -388,6 +482,24 @@ export default class GenericAssayFrequencyTable extends React.Component<
         this.sortDirection = sortDirection;
     }
 
+    @computed
+    get categoryFilterOverlay() {
+        if (!this.shouldShowCategoryFilter) {
+            return undefined;
+        }
+
+        return this.hideDefaultCategories ? (
+            <span>
+                Showing altered categories only. Click to include unchanged or
+                unknown rows.
+            </span>
+        ) : (
+            <span>
+                Showing all categories. Click to hide unchanged or unknown rows.
+            </span>
+        );
+    }
+
     @autobind
     isChecked(uniqueKey: string) {
         return !!this.allSelectedRowsKeysSet[uniqueKey];
@@ -416,6 +528,22 @@ export default class GenericAssayFrequencyTable extends React.Component<
             this.props.onChangeSelectedRows(
                 this.props.selectedRowsKeys.filter(key => key !== uniqueKey)
             );
+        }
+    }
+
+    @action.bound
+    toggleDefaultCategoryFilter(event: any) {
+        event.stopPropagation();
+        this.hideDefaultCategories = !this.hideDefaultCategories;
+
+        const visibleKeySet = stringListToSet(
+            this.visibleTableData.map(row => row.uniqueKey)
+        );
+        const nextSelectedRowsKeys = this.props.selectedRowsKeys.filter(
+            key => !!visibleKeySet[key]
+        );
+        if (nextSelectedRowsKeys.length !== this.props.selectedRowsKeys.length) {
+            this.props.onChangeSelectedRows(nextSelectedRowsKeys);
         }
     }
 
@@ -482,6 +610,10 @@ export default class GenericAssayFrequencyTable extends React.Component<
         return index % 2 === 0
             ? styles.highlightedEvenRow
             : styles.highlightedOddRow;
+    }
+
+    private emitDownloadRows() {
+        this.props.onDownloadRowsChange?.(this.downloadRows);
     }
 
     render() {

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -38,7 +38,7 @@ import { TableHeaderCellFilterIcon } from 'pages/studyView/table/TableHeaderCell
 export enum GenericAssayFrequencyTableColumnKey {
     ENTITY = 'Entity',
     CATEGORY = 'Category',
-    COUNT = '# Samples',
+    COUNT = '#',
     FREQ = 'Freq',
 }
 

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { observer } from 'mobx-react';
+import { action, computed, makeObservable, observable } from 'mobx';
+import _ from 'lodash';
+import autobind from 'autobind-decorator';
+import { MobxPromise, stringListToSet } from 'cbioportal-frontend-commons';
+import {
+    Column,
+    SortDirection,
+} from 'shared/components/lazyMobXTable/LazyMobXTable';
+import FixedHeaderTable from 'pages/studyView/table/FixedHeaderTable';
+import LabeledCheckbox from 'shared/components/labeledCheckbox/LabeledCheckbox';
+import styles from 'pages/studyView/table/tables.module.scss';
+import {
+    correctMargin,
+    GenericAssayFrequencyTableRow,
+    getFixedHeaderNumberCellMargin,
+    getFrequencyStr,
+} from 'pages/studyView/StudyViewUtils';
+import { TreatmentGenericColumnHeader } from 'pages/studyView/table/treatments/treatmentsTableUtil';
+
+export enum GenericAssayFrequencyTableColumnKey {
+    ENTITY = 'Entity',
+    CATEGORY = 'Category',
+    COUNT = '# Samples',
+    FREQ = 'Frequency',
+}
+
+export interface IGenericAssayFrequencyTableProps {
+    promise: MobxPromise<GenericAssayFrequencyTableRow[]>;
+    width: number;
+    height: number;
+    selectedRowsKeys: string[];
+    onSelectionChange: (selectedRowsKeys: string[]) => void;
+    showCategoryColumn: boolean;
+}
+
+const DEFAULT_COLUMN_WIDTH_RATIO = {
+    [GenericAssayFrequencyTableColumnKey.ENTITY]: 0.4,
+    [GenericAssayFrequencyTableColumnKey.CATEGORY]: 0.25,
+    [GenericAssayFrequencyTableColumnKey.COUNT]: 0.2,
+    [GenericAssayFrequencyTableColumnKey.FREQ]: 0.15,
+};
+
+class GenericAssayFrequencyTableComponent extends FixedHeaderTable<GenericAssayFrequencyTableRow> {}
+
+@observer
+export default class GenericAssayFrequencyTable extends React.Component<
+    IGenericAssayFrequencyTableProps,
+    {}
+> {
+    @observable protected sortBy: GenericAssayFrequencyTableColumnKey;
+    @observable protected sortDirection: SortDirection = 'desc';
+
+    constructor(props: IGenericAssayFrequencyTableProps) {
+        super(props);
+        makeObservable(this);
+        this.sortBy = GenericAssayFrequencyTableColumnKey.FREQ;
+    }
+
+    @computed
+    get tableData(): GenericAssayFrequencyTableRow[] {
+        return this.props.promise.result || [];
+    }
+
+    @computed
+    get selectedRowKeysSet() {
+        return stringListToSet(this.props.selectedRowsKeys);
+    }
+
+    @computed
+    get visibleColumns(): GenericAssayFrequencyTableColumnKey[] {
+        return this.props.showCategoryColumn
+            ? [
+                  GenericAssayFrequencyTableColumnKey.ENTITY,
+                  GenericAssayFrequencyTableColumnKey.CATEGORY,
+                  GenericAssayFrequencyTableColumnKey.COUNT,
+                  GenericAssayFrequencyTableColumnKey.FREQ,
+              ]
+            : [
+                  GenericAssayFrequencyTableColumnKey.ENTITY,
+                  GenericAssayFrequencyTableColumnKey.COUNT,
+                  GenericAssayFrequencyTableColumnKey.FREQ,
+              ];
+    }
+
+    @computed
+    get columnsWidth() {
+        const widthRatio = this.props.showCategoryColumn
+            ? DEFAULT_COLUMN_WIDTH_RATIO
+            : {
+                  ...DEFAULT_COLUMN_WIDTH_RATIO,
+                  [GenericAssayFrequencyTableColumnKey.ENTITY]: 0.65,
+                  [GenericAssayFrequencyTableColumnKey.COUNT]: 0.2,
+                  [GenericAssayFrequencyTableColumnKey.FREQ]: 0.15,
+              };
+
+        return _.mapValues(widthRatio, ratio => ratio * this.props.width);
+    }
+
+    @computed
+    get cellMargin() {
+        return {
+            [GenericAssayFrequencyTableColumnKey.ENTITY]: 0,
+            [GenericAssayFrequencyTableColumnKey.CATEGORY]: 0,
+            [GenericAssayFrequencyTableColumnKey.COUNT]: 0,
+            [GenericAssayFrequencyTableColumnKey.FREQ]: correctMargin(
+                getFixedHeaderNumberCellMargin(
+                    this.columnsWidth[GenericAssayFrequencyTableColumnKey.FREQ],
+                    getFrequencyStr(
+                        _.max(
+                            this.tableData.map(
+                                item => this.getFrequency(item)
+                            )
+                        ) || 0
+                    )
+                )
+            ),
+        };
+    }
+
+    private getFrequency(row: GenericAssayFrequencyTableRow): number {
+        return row.totalCount > 0 ? (row.count / row.totalCount) * 100 : -1;
+    }
+
+    getDefaultColumnDefinition(
+        columnKey: GenericAssayFrequencyTableColumnKey,
+        columnWidth: number,
+        cellMargin: number
+    ): Column<GenericAssayFrequencyTableRow> {
+        const defaults: {
+            [key in GenericAssayFrequencyTableColumnKey]: Column<GenericAssayFrequencyTableRow>;
+        } = {
+            [GenericAssayFrequencyTableColumnKey.ENTITY]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: row => <div>{row.entityLabel}</div>,
+                sortBy: row => row.entityLabel,
+                defaultSortDirection: 'asc',
+                filter: (row, filter) =>
+                    row.entityLabel
+                        .toUpperCase()
+                        .includes(filter.toUpperCase()),
+                width: columnWidth,
+            },
+            [GenericAssayFrequencyTableColumnKey.CATEGORY]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: row => <div>{row.category}</div>,
+                sortBy: row => row.category,
+                defaultSortDirection: 'asc',
+                filter: (row, filter) =>
+                    row.category.toUpperCase().includes(filter.toUpperCase()),
+                width: columnWidth,
+            },
+            [GenericAssayFrequencyTableColumnKey.COUNT]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: row => (
+                    <LabeledCheckbox
+                        checked={this.isChecked(row.uniqueKey)}
+                        onChange={_ => this.toggleSelectRow(row.uniqueKey)}
+                        labelProps={{
+                            style: {
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                marginLeft: 0,
+                                marginRight: cellMargin,
+                            },
+                        }}
+                        inputProps={{
+                            className: styles.autoMarginCheckbox,
+                        }}
+                    >
+                        <span>{row.count.toLocaleString()}</span>
+                    </LabeledCheckbox>
+                ),
+                sortBy: row => row.count,
+                defaultSortDirection: 'desc',
+                filter: (row, filter) =>
+                    row.count.toLocaleString().includes(filter),
+                width: columnWidth,
+            },
+            [GenericAssayFrequencyTableColumnKey.FREQ]: {
+                name: columnKey,
+                headerRender: () => (
+                    <TreatmentGenericColumnHeader
+                        margin={cellMargin}
+                        headerName={columnKey}
+                    />
+                ),
+                render: row => (
+                    <div
+                        className={styles.pullRight}
+                        style={{ marginLeft: cellMargin }}
+                    >
+                        {getFrequencyStr(this.getFrequency(row))}
+                    </div>
+                ),
+                sortBy: row => this.getFrequency(row),
+                defaultSortDirection: 'desc',
+                filter: (row, filter) =>
+                    getFrequencyStr(this.getFrequency(row)).includes(filter),
+                width: columnWidth,
+            },
+        };
+
+        return defaults[columnKey];
+    }
+
+    @computed
+    get tableColumns() {
+        return this.visibleColumns.map(column =>
+            this.getDefaultColumnDefinition(
+                column,
+                this.columnsWidth[column],
+                this.cellMargin[column]
+            )
+        );
+    }
+
+    @action.bound
+    afterSorting(
+        sortBy: GenericAssayFrequencyTableColumnKey,
+        sortDirection: SortDirection
+    ) {
+        this.sortBy = sortBy;
+        this.sortDirection = sortDirection;
+    }
+
+    @autobind
+    isChecked(uniqueKey: string) {
+        return !!this.selectedRowKeysSet[uniqueKey];
+    }
+
+    @action.bound
+    toggleSelectRow(uniqueKey: string) {
+        const selectedRowsKeys = this.isChecked(uniqueKey)
+            ? this.props.selectedRowsKeys.filter(key => key !== uniqueKey)
+            : this.props.selectedRowsKeys.concat(uniqueKey);
+        this.props.onSelectionChange(selectedRowsKeys);
+    }
+
+    @autobind
+    isSelectedRow(row: GenericAssayFrequencyTableRow) {
+        return this.isChecked(row.uniqueKey);
+    }
+
+    render() {
+        return (
+            <div data-test="generic-assay-frequency-table">
+                {this.props.promise.isComplete && (
+                    <GenericAssayFrequencyTableComponent
+                        width={this.props.width}
+                        height={this.props.height}
+                        data={this.tableData}
+                        columns={this.tableColumns}
+                        sortBy={this.sortBy}
+                        sortDirection={this.sortDirection}
+                        afterSorting={this.afterSorting}
+                        isSelectedRow={this.isSelectedRow}
+                        numberOfSelectedRows={this.props.selectedRowsKeys.length}
+                    />
+                )}
+            </div>
+        );
+    }
+}

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -29,6 +29,7 @@ import {
     SelectionOperatorEnum,
 } from 'pages/studyView/TableUtils';
 import ifNotDefined from 'shared/lib/ifNotDefined';
+import { getFrequencyTableCategoryPriority } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
 
 export enum GenericAssayFrequencyTableColumnKey {
     ENTITY = 'Entity',
@@ -41,6 +42,7 @@ export interface IGenericAssayFrequencyTableProps {
     promise: MobxPromise<GenericAssayFrequencyTableRow[]>;
     width: number;
     height: number;
+    genericAssayType?: string;
     filters: string[][];
     selectedRowsKeys: string[];
     onChangeSelectedRows: (selectedRowsKeys: string[]) => void;
@@ -59,19 +61,88 @@ const DEFAULT_COLUMN_WIDTH_RATIO = {
 
 class GenericAssayFrequencyTableComponent extends FixedHeaderTable<GenericAssayFrequencyTableRow> {}
 
+function normalizeCategoryValue(value: string): string {
+    return value.trim().toLowerCase();
+}
+
+function hasCuratedCategorySorting(
+    showCategoryColumn: boolean,
+    genericAssayType?: string
+): boolean {
+    return (
+        showCategoryColumn &&
+        !!getFrequencyTableCategoryPriority(genericAssayType)?.length
+    );
+}
+
+export function getGenericAssayFrequencyTableDefaultSortBy(
+    showCategoryColumn: boolean,
+    genericAssayType?: string
+): GenericAssayFrequencyTableColumnKey {
+    return hasCuratedCategorySorting(showCategoryColumn, genericAssayType)
+        ? GenericAssayFrequencyTableColumnKey.CATEGORY
+        : GenericAssayFrequencyTableColumnKey.FREQ;
+}
+
+export function getGenericAssayFrequencyTableDefaultSortDirection(
+    showCategoryColumn: boolean,
+    genericAssayType?: string
+): SortDirection {
+    return hasCuratedCategorySorting(showCategoryColumn, genericAssayType)
+        ? 'asc'
+        : 'desc';
+}
+
+export function getGenericAssayFrequency(row: GenericAssayFrequencyTableRow): number {
+    return row.totalCount > 0 ? (row.count / row.totalCount) * 100 : -1;
+}
+
+export function getGenericAssayFrequencyTableCategorySortValue(
+    row: GenericAssayFrequencyTableRow,
+    genericAssayType?: string
+): string {
+    const categoryPriority = getFrequencyTableCategoryPriority(genericAssayType);
+    if (!categoryPriority?.length) {
+        return row.category;
+    }
+
+    const normalizedCategory = normalizeCategoryValue(row.category);
+    const priorityIndex = categoryPriority.findIndex(priorityGroup =>
+        priorityGroup.includes(normalizedCategory)
+    );
+
+    const priorityKey = `${priorityIndex === -1 ? 99 : priorityIndex}`.padStart(
+        2,
+        '0'
+    );
+    const countKey = `${Math.max(0, row.totalCount - row.count)}`.padStart(
+        12,
+        '0'
+    );
+
+    return `${priorityKey}::${countKey}::${row.entityLabel.toUpperCase()}::${normalizedCategory}`;
+}
+
 @observer
 export default class GenericAssayFrequencyTable extends React.Component<
     IGenericAssayFrequencyTableProps,
     {}
 > {
     @observable protected sortBy: GenericAssayFrequencyTableColumnKey;
-    @observable protected sortDirection: SortDirection = 'desc';
+    @observable protected sortDirection: SortDirection;
     @observable private _selectionType: SelectionOperatorEnum;
 
     constructor(props: IGenericAssayFrequencyTableProps) {
         super(props);
         makeObservable(this);
-        this.sortBy = GenericAssayFrequencyTableColumnKey.FREQ;
+        this.sortBy = getGenericAssayFrequencyTableDefaultSortBy(
+            this.props.showCategoryColumn,
+            this.props.genericAssayType
+        );
+        this.sortDirection = getGenericAssayFrequencyTableDefaultSortDirection(
+            this.props.showCategoryColumn,
+            this.props.genericAssayType
+        );
     }
 
     @computed
@@ -190,7 +261,7 @@ export default class GenericAssayFrequencyTable extends React.Component<
     }
 
     private getFrequency(row: GenericAssayFrequencyTableRow): number {
-        return row.totalCount > 0 ? (row.count / row.totalCount) * 100 : -1;
+        return getGenericAssayFrequency(row);
     }
 
     getDefaultColumnDefinition(
@@ -227,7 +298,11 @@ export default class GenericAssayFrequencyTable extends React.Component<
                     />
                 ),
                 render: row => <div>{row.category}</div>,
-                sortBy: row => row.category,
+                sortBy: row =>
+                    getGenericAssayFrequencyTableCategorySortValue(
+                        row,
+                        this.props.genericAssayType
+                    ),
                 defaultSortDirection: 'asc',
                 filter: (row, filter) =>
                     row.category.toUpperCase().includes(filter.toUpperCase()),

--- a/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
+++ b/src/pages/studyView/table/GenericAssayFrequencyTable.tsx
@@ -436,7 +436,6 @@ export default class GenericAssayFrequencyTable extends React.Component<
                         toggleSelectionOperator={this.toggleSelectionOperator}
                         defaultSelectionOperator={this.selectionType}
                         extraButtons={this.props.extraButtons}
-                        showControlsAtTop={true}
                     />
                 )}
             </div>

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -39,6 +39,7 @@ import {
     getScatterDownloadData,
     getSurvivalDownloadData,
     getMutatedGenesDownloadData,
+    getGenericAssayFrequencyTableDownloadData,
     getStructuralVariantGenesDownloadData,
     getGenesCNADownloadData,
     getPatientTreatmentDownloadData,
@@ -48,6 +49,7 @@ import { DataType } from 'cbioportal-frontend-commons';
 import DelayedRender from 'shared/components/DelayedRender';
 import { getRemoteDataGroupStatus } from 'cbioportal-utils';
 import { getServerConfig } from 'config/config';
+import { GenericAssayDataType } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
 
 export interface IStudySummaryTabProps {
     store: StudyViewPageStore;
@@ -208,11 +210,16 @@ export class StudySummaryTab extends React.Component<
             },
             onGenericAssayFrequencyTableSelection: (
                 chartMeta: ChartMeta,
-                values: string[]
+                values: string[][]
             ) => {
                 this.store.setGenericAssayFrequencyTableFilters(
                     chartMeta.uniqueKey,
                     values
+                );
+            },
+            onResetGenericAssayFrequencyTableSelection: (chartMeta: ChartMeta) => {
+                this.store.resetGenericAssayFrequencyTableFilters(
+                    chartMeta.uniqueKey
                 );
             },
         };
@@ -463,8 +470,15 @@ export class StudySummaryTab extends React.Component<
                 onValueSelection:
                     this.handlers.onGenericAssayFrequencyTableSelection,
                 onResetSelection:
-                    this.handlers.onGenericAssayFrequencyTableSelection,
+                    this.handlers.onResetGenericAssayFrequencyTableSelection,
                 promise: this.store.getGenericAssayFrequencyTableData(chartMeta),
+                getData: () =>
+                    getGenericAssayFrequencyTableDownloadData(
+                        this.store.getGenericAssayFrequencyTableData(chartMeta),
+                        this.store.getMolecularChartDataType(chartMeta.uniqueKey) !==
+                            GenericAssayDataType.BINARY
+                    ),
+                downloadTypes: ['Data'],
             }),
             [ChartTypeEnum.MUTATED_GENES_TABLE]: () => ({
                 filters: this.store.getGeneFiltersByUniqueKey(

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -206,6 +206,15 @@ export class StudySummaryTab extends React.Component<
                     values
                 );
             },
+            onGenericAssayFrequencyTableSelection: (
+                chartMeta: ChartMeta,
+                values: string[]
+            ) => {
+                this.store.setGenericAssayFrequencyTableFilters(
+                    chartMeta.uniqueKey,
+                    values
+                );
+            },
         };
 
         this.chartTypeConfig = (
@@ -446,6 +455,16 @@ export class StudySummaryTab extends React.Component<
                     onValueSelection: this.handlers.onValueSelection,
                     onResetSelection: this.handlers.onValueSelection,
                 }),
+            }),
+            [ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE]: () => ({
+                filters: this.store.getGenericAssayFrequencyTableSelectedRowKeys(
+                    chartMeta.uniqueKey
+                ),
+                onValueSelection:
+                    this.handlers.onGenericAssayFrequencyTableSelection,
+                onResetSelection:
+                    this.handlers.onGenericAssayFrequencyTableSelection,
+                promise: this.store.getGenericAssayFrequencyTableData(chartMeta),
             }),
             [ChartTypeEnum.MUTATED_GENES_TABLE]: () => ({
                 filters: this.store.getGeneFiltersByUniqueKey(

--- a/src/shared/components/oncoprint/controls/CustomDropdown.spec.tsx
+++ b/src/shared/components/oncoprint/controls/CustomDropdown.spec.tsx
@@ -1,0 +1,31 @@
+import { assert } from 'chai';
+import React from 'react';
+import CustomDropdown from './CustomDropdown';
+
+describe('CustomDropdown', () => {
+    it('wires menu clicks to hide only when closeOnMenuClick is enabled', () => {
+        const autocloseDropdown = new CustomDropdown({
+            id: 'autoclose',
+            title: '',
+            closeOnMenuClick: true,
+            children: <div>Option</div>,
+        });
+        const persistentDropdown = new CustomDropdown({
+            id: 'persistent',
+            title: '',
+            children: <div>Option</div>,
+        });
+
+        const autocloseMenu = (
+            (autocloseDropdown.render().props.children as React.ReactElement)
+                .props.children as React.ReactElement[]
+        )[1];
+        const persistentMenu = (
+            (persistentDropdown.render().props.children as React.ReactElement)
+                .props.children as React.ReactElement[]
+        )[1];
+
+        assert.isFunction(autocloseMenu.props.onClick);
+        assert.isUndefined(persistentMenu.props.onClick);
+    });
+});

--- a/src/shared/components/oncoprint/controls/CustomDropdown.tsx
+++ b/src/shared/components/oncoprint/controls/CustomDropdown.tsx
@@ -9,6 +9,7 @@ export interface ICustomDropdownProps extends ButtonProps {
     titleElement?: JSX.Element;
     styles?: any;
     buttonClassName?: string;
+    closeOnMenuClick?: boolean;
 }
 
 class CustomButton extends React.Component<any, {}> {
@@ -27,12 +28,13 @@ class CustomButton extends React.Component<any, {}> {
 }
 class CustomMenu extends React.Component<any, {}> {
     render() {
-        const { className, styles, children } = this.props;
+        const { className, styles, children, onClick } = this.props;
 
         return (
             <div
                 className={classNames('dropdown-menu', className)}
                 style={{ padding: '6px', ...styles }}
+                onClick={onClick}
             >
                 {children}
             </div>
@@ -50,7 +52,7 @@ export default class CustomDropdown extends React.Component<
     private toggle: () => void;
     public hide: () => void;
 
-    constructor(props: ButtonProps) {
+    constructor(props: ICustomDropdownProps) {
         super(props);
         makeObservable(this);
         this.toggle = () => {
@@ -62,7 +64,15 @@ export default class CustomDropdown extends React.Component<
     }
 
     render() {
-        const { children, id, className, styles, ref, ...props } = this.props;
+        const {
+            children,
+            id,
+            className,
+            styles,
+            closeOnMenuClick,
+            ref,
+            ...props
+        } = this.props;
         return (
             <RootCloseWrapper onRootClose={this.hide}>
                 <Dropdown id={id + ''} open={this.open}>
@@ -77,6 +87,7 @@ export default class CustomDropdown extends React.Component<
                         bsRole="menu"
                         className={className}
                         styles={styles}
+                        onClick={closeOnMenuClick ? this.hide : undefined}
                     >
                         {children}
                     </CustomMenu>

--- a/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
@@ -12,6 +12,7 @@ export const GenericAssayTypeConstants: { [s: string]: string } = {
     TREATMENT_RESPONSE: 'TREATMENT_RESPONSE',
     MUTATIONAL_SIGNATURE: 'MUTATIONAL_SIGNATURE',
     ARMLEVEL_CNA: 'ARMLEVEL_CNA',
+    LOH_HLA: 'LOH_HLA',
     METHYLATION: 'METHYLATION',
 };
 
@@ -22,6 +23,7 @@ export type GenericAssayTypeConfig = {
     oncoprintTrackConfig?: OncoprintTrackConfig;
     plotsTabConfig?: PlotsTabConfig;
     selectionConfig?: SelectionConfig;
+    frequencyTableConfig?: FrequencyTableConfig;
     downloadTabConfig?: DownloadTabConfig;
 };
 
@@ -46,6 +48,10 @@ export type SelectionConfig = {
 
 export type DownloadTabConfig = {
     formatDownloadHeaderUsingCompactLabel?: boolean;
+};
+
+export type FrequencyTableConfig = {
+    categoryPriority?: string[][];
 };
 
 // We have some customizations for Gene related Generic Assay profiles (e.g. Methylation)
@@ -97,6 +103,20 @@ export function initializeGenericAssayServerConfig() {
 
 const DEFAULT_GENERIC_ASSAY_CONFIG: GenericAssayConfig = {
     genericAssayConfigByType: {
+        [GenericAssayTypeConstants.ARMLEVEL_CNA]: {
+            frequencyTableConfig: {
+                categoryPriority: [
+                    ['loss', 'deletion'],
+                    ['gain', 'amp', 'amplification'],
+                    ['unchanged', 'diploid', 'neutral'],
+                ],
+            },
+        },
+        [GenericAssayTypeConstants.LOH_HLA]: {
+            frequencyTableConfig: {
+                categoryPriority: [['loss'], ['unchanged']],
+            },
+        },
         [GenericAssayTypeConstants.METHYLATION]: {
             globalConfig: {
                 entityTitle: 'Gene / Probe',
@@ -123,3 +143,12 @@ export const GENERIC_ASSAY_CONFIG: GenericAssayConfig = _.merge(
     DEFAULT_GENE_RELATED_CONFIG,
     DEFAULT_GENERIC_ASSAY_CONFIG
 );
+
+export function getFrequencyTableCategoryPriority(
+    genericAssayType?: string
+): string[][] | undefined {
+    return genericAssayType
+        ? GENERIC_ASSAY_CONFIG.genericAssayConfigByType[genericAssayType]
+              ?.frequencyTableConfig?.categoryPriority
+        : undefined;
+}

--- a/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
@@ -106,8 +106,7 @@ const DEFAULT_GENERIC_ASSAY_CONFIG: GenericAssayConfig = {
         [GenericAssayTypeConstants.ARMLEVEL_CNA]: {
             frequencyTableConfig: {
                 categoryPriority: [
-                    ['loss', 'deletion'],
-                    ['gain', 'amp', 'amplification'],
+                    ['loss', 'deletion', 'gain', 'amp', 'amplification'],
                     ['unchanged', 'diploid', 'neutral'],
                 ],
             },

--- a/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
@@ -52,6 +52,7 @@ export type DownloadTabConfig = {
 
 export type FrequencyTableConfig = {
     categoryPriority?: string[][];
+    defaultHiddenCategories?: string[];
 };
 
 // We have some customizations for Gene related Generic Assay profiles (e.g. Methylation)
@@ -109,11 +110,13 @@ const DEFAULT_GENERIC_ASSAY_CONFIG: GenericAssayConfig = {
                     ['loss', 'deletion', 'gain', 'amp', 'amplification'],
                     ['unchanged', 'diploid', 'neutral'],
                 ],
+                defaultHiddenCategories: ['unchanged', 'unknown'],
             },
         },
         [GenericAssayTypeConstants.LOH_HLA]: {
             frequencyTableConfig: {
                 categoryPriority: [['loss'], ['unchanged']],
+                defaultHiddenCategories: ['unchanged', 'unknown'],
             },
         },
         [GenericAssayTypeConstants.METHYLATION]: {
@@ -149,5 +152,14 @@ export function getFrequencyTableCategoryPriority(
     return genericAssayType
         ? GENERIC_ASSAY_CONFIG.genericAssayConfigByType[genericAssayType]
               ?.frequencyTableConfig?.categoryPriority
+        : undefined;
+}
+
+export function getFrequencyTableDefaultHiddenCategories(
+    genericAssayType?: string
+): string[] | undefined {
+    return genericAssayType
+        ? GENERIC_ASSAY_CONFIG.genericAssayConfigByType[genericAssayType]
+              ?.frequencyTableConfig?.defaultHiddenCategories
         : undefined;
 }


### PR DESCRIPTION
Adds a new **Generic Assay frequency/counts table** to Study View for supported binary and categorical Generic Assay profiles.

This gives users a cohort-level summary of Generic Assay data directly in Study View, so they can quickly see how common each assay event is in the current cohort without exporting data.

## Highlights

- Adds a **profile-level frequency table** for Generic Assay data in Study View
- Shows both **counts** and **frequency** for Generic Assay values across the current cohort
- Supports interactive row selection so users can filter the cohort from the table
- Preserves existing per-entity Generic Assay charts while adding this new cohort summary view
- Improves the Add Chart experience for Generic Assay profiles
- Aligns the table behavior and styling with other Study View tables

## User impact

Researchers can now:
- get an at-a-glance cohort summary for Generic Assay datasets (e.g. Arm-Level CNA or HLA LOH)
- identify common assay events more quickly
- use the table as part of the normal Study View filtering workflow

## Screenshots / GIFs
<img width="738" height="319" alt="image" src="https://github.com/user-attachments/assets/85f0ec22-da7e-43a8-a2e3-ade53def7e62" />

<img width="811" height="356" alt="image" src="https://github.com/user-attachments/assets/19218a14-f951-4ba6-985f-04f1023c1ad4" />
