### PR TITLE
Feat/external resource

### DIFF
--- a/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
+++ b/packages/cbioportal-ts-api-client/src/generated/CBioPortalAPIInternal.ts
@@ -1139,6 +1139,8 @@ export type ResourceDefinition = {
 
         'studyId': string
 
+        'externalTarget': string
+
 };
 export type ResponseEntityReferenceGenomeGene = {
     'body': ReferenceGenomeGene

--- a/src/pages/studyView/resources/FilesAndLinks.tsx
+++ b/src/pages/studyView/resources/FilesAndLinks.tsx
@@ -103,6 +103,8 @@ function buildItemsAndResources(resourceData: {
                 description: resource?.resourceDefinition?.description,
                 url: resource?.url,
                 resourceId: resource?.resourceId,
+                externalTarget:
+                    resource?.resourceDefinition?.externalTarget || '',
             }))
         )
         .value();
@@ -308,7 +310,7 @@ export class FilesAndLinks extends React.Component<IFilesLinksTable, {}> {
                             <a
                                 href={data.url}
                                 style={{ fontSize: 10 }}
-                                target={'_blank'}
+                                target={data.externalTarget || '_blank'}
                             >
                                 <i
                                     className={`fa fa-external-link fa-sm`}

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -78,6 +78,38 @@ export default class ResourceTab extends React.Component<
         return this.currentResourceIndex === this.props.resourceData.length - 1;
     }
 
+    @computed get externalTarget() {
+        return this.currentResourceDatum.resourceDefinition?.externalTarget;
+    }
+
+    @computed get shouldAutoOpenExternal() {
+        return !!this.externalTarget && this.externalTarget !== '_blank';
+    }
+
+    private lastAutoOpenedKey?: string;
+
+    private maybeAutoOpenExternal() {
+        if (!this.shouldAutoOpenExternal) return;
+        const url = this.currentResourceDatum.url;
+        const target = this.externalTarget!;
+        const key = `${target}|${url}`;
+        if (this.lastAutoOpenedKey === key) return;
+        this.lastAutoOpenedKey = key;
+        try {
+            window.open(url, target, 'noopener,noreferrer');
+        } catch (e) {
+            console.warn('ResourceTab: failed to auto-open external target', e);
+        }
+    }
+
+    componentDidMount() {
+        this.maybeAutoOpenExternal();
+    }
+
+    componentDidUpdate() {
+        this.maybeAutoOpenExternal();
+    }
+
     @computed get httpIframeWithHttpsPortal() {
         return (
             getBrowserWindow().location.protocol === 'https:' &&
@@ -155,14 +187,27 @@ export default class ResourceTab extends React.Component<
                             />
                         </div>
                     )}
-                    {this.httpIframeWithHttpsPortal ? (
-                        <div>
+                    {this.httpIframeWithHttpsPortal || this.externalTarget ? (
+                        <div
+                            style={{
+                                flex: 1,
+                                textAlign: 'center',
+                                wordBreak: 'break-all',
+                            }}
+                        >
                             <span>
-                                We can't show this URL in the portal. Please use
-                                the link below:
+                                {this.shouldAutoOpenExternal
+                                    ? 'Opening resource in another tab. If nothing happens, click the link below:'
+                                    : this.externalTarget
+                                    ? 'Please click the link below to view the resource.'
+                                    : "We can't show this URL in the portal. Please use the link below:"}
                             </span>
                             <br />
-                            <a href={this.currentResourceDatum.url}>
+                            <a
+                                href={this.currentResourceDatum.url}
+                                target={this.externalTarget || '_blank'}
+                                rel="noopener noreferrer"
+                            >
                                 {this.currentResourceDatum.url}
                             </a>
                         </div>

--- a/src/shared/components/resources/ResourceTable.tsx
+++ b/src/shared/components/resources/ResourceTable.tsx
@@ -87,7 +87,10 @@ const ResourceTable = observer(
                                     <a
                                         href={resource.url}
                                         style={{ fontSize: 10 }}
-                                        target={'_blank'}
+                                        target={
+                                            resource.resourceDefinition
+                                                ?.externalTarget || '_blank'
+                                        }
                                     >
                                         <i
                                             className={`fa fa-external-link fa-sm`}


### PR DESCRIPTION
Allow external target for custom resources

Describe changes proposed in this pull request:
- if you need to open a resource in external window, now you can specify it like so, and even name the window to target a specific context
  - for example when your SSO cannot work inside the iframe you are better forcing it to a new window
- contains center alignmeng fix for the link-only container

The design choice now is to have new attribute which of course also enfocres backend changes: new column, database migration.
If we should instead use some of the 'optional generic key-value map attributes' and avoid explicitly naming the parameter, it is also an option. I have locally backend update too, I just want to now discuss the best way of doing this before opening also the backend PR, which might not even be needed in case we just (re)use the generic map.

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
<img width="1181" height="715" alt="image" src="https://github.com/user-attachments/assets/990f5fa3-f098-4fc8-9efa-8ee7392826c4" />

## Notify reviewers
@inodb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782649681&installation_id=126502837&pr_number=5597&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5597&signature=6e818ef32db954e42307c14c39106dc89b71de30dffebfae30bbfb74f8333781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->