### PR TITLE
Show chat button to all users on MSK portal

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -128,13 +128,19 @@ export default class PortalHeader extends React.Component<
                         ? 'https://chat.cbioportal.aws.mskcc.org'
                         : 'https://chat.cbioportal.org',
                 internal: false,
-                hide: () =>
-                    !this.props.appStore.featureFlagStore.has(
-                        FeatureFlagEnum.CHAT
-                    ) ||
-                    !['public-portal', 'mskcc-portal'].includes(
-                        getServerConfig().app_name!
-                    ),
+                hide: () => {
+                    const appName = getServerConfig().app_name;
+                    // Always show on the MSK portal; gate every other
+                    // instance behind the CHAT feature flag.
+                    if (appName === 'mskcc-portal') {
+                        return false;
+                    }
+                    return (
+                        !this.props.appStore.featureFlagStore.has(
+                            FeatureFlagEnum.CHAT
+                        ) || appName !== 'public-portal'
+                    );
+                },
             },
 
             {


### PR DESCRIPTION
## What

The Chat (cBioAgent) tab in the portal header was gated behind the client-side `CHAT` feature flag (set via `?featureFlags=CHAT` or `localStorage`), so users on the MSK portal never saw it by default. This shows the tab unconditionally when `app_name === 'mskcc-portal'`.

Other instances (e.g. `public-portal`) remain behind the `CHAT` feature flag, so their behavior is unchanged.

## Preview

- https://deploy-preview-5604.preview.cbioportal.org/

## Verification

Verified locally with Puppeteer against the dev server, overriding `app_name` via `localStorage.frontendConfig`:

- `app_name = mskcc-portal`, **no** feature flag → Chat tab **shown** (href `https://chat.cbioportal.aws.mskcc.org`)
- `app_name = public-portal`, **no** feature flag → Chat tab **hidden** (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783746229&installation_id=126502837&pr_number=5604&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5604&signature=4e2c19f578bb1db8ae93f14ac4d55ff184d59452a2ddfb3f387bbe87dc95b537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
