### PR TITLE
Patient view: don't flash the Summary tab when deep-linking to the mRNA/Plots tab

### DIFF
--- a/src/pages/patientView/PatientViewPageTabs.tsx
+++ b/src/pages/patientView/PatientViewPageTabs.tsx
@@ -84,7 +84,6 @@ export function patientViewTabs(
             onTabClick={(id: string) => urlWrapper.setActiveTab(id)}
             className="mainTabs"
             getPaginationWidth={WindowStore.getWindowWidth}
-            onMount={() => console.log('TABS MOUNT')}
             contentWindowExtra={
                 <HelpWidget path={urlWrapper.routing.location.pathname} />
             }
@@ -493,22 +492,31 @@ export function tabs(
             </MSKTab>
         );
 
-    // The mRNA and Plots tabs share the same gating: shown only for the MSKCC
-    // portal, or when the "patientMRNATab" feature flag is on
-    // (?featureFlags=patientMRNATab) — and only when the study actually has an
-    // mRNA expression profile, so studies without one don't get empty tabs. The
-    // enablement check is evaluated first so non-enabled portals don't trigger
-    // the profile lookup.
+    // The mRNA and Plots tabs are gated by the MSKCC portal, or the
+    // "patientMRNATab" feature flag (?featureFlags=patientMRNATab). When enabled
+    // they normally appear only once the study is confirmed to have an mRNA
+    // expression profile, so studies without one don't get empty tabs.
+    //
+    // Exception: when one of these tabs is the active (deep-linked) tab, show it
+    // immediately — before the profile resolves — so the deep link doesn't
+    // briefly fall back to (and flash) the Summary tab while the async profile
+    // lookup is pending. The tab's own content renders a loader until the
+    // profile/data loads, then either the plot or a "no mRNA data" message.
+    const expressionTabsEnabled =
+        getServerConfig().app_name === 'mskcc-portal' ||
+        pageComponent.props.appStore.featureFlagStore.has(
+            FeatureFlagEnum.PATIENT_MRNA_TAB
+        );
+    const activeTabIsExpressionTab =
+        urlWrapper.activeTabId === PatientViewPageTabs.MRNA ||
+        urlWrapper.activeTabId === PatientViewPageTabs.Plots;
     const mrnaProfilePromise =
         pageComponent.patientViewPageStore.plotsStore
             .mrnaExpressionMolecularProfile;
     const showExpressionTabs =
-        (getServerConfig().app_name === 'mskcc-portal' ||
-            pageComponent.props.appStore.featureFlagStore.has(
-                FeatureFlagEnum.PATIENT_MRNA_TAB
-            )) &&
-        mrnaProfilePromise.isComplete &&
-        !!mrnaProfilePromise.result;
+        expressionTabsEnabled &&
+        (activeTabIsExpressionTab ||
+            (mrnaProfilePromise.isComplete && !!mrnaProfilePromise.result));
 
     tabs.push(
         <MSKTab


### PR DESCRIPTION
## Problem

Deep-linking to the patient-view mRNA tab (`/patient/mrna?...`) briefly **flashes the Summary tab** — including its timeline — before the mRNA tab renders.

### Why
The mRNA and Plots tabs are conditionally rendered based on the async `mrnaExpressionMolecularProfile` (via `showExpressionTabs`), but the patient tab area renders before that profile resolves (it only awaits `patientViewData` / `sampleManager` / `studyMetaData`). So:

1. On first paint the profile is pending → the mRNA tab isn't in `MSKTabs`' children.
2. `activeTabId === 'mrna'` isn't found among the children, so `MSKTabs` falls back to its **first child — the Summary tab** (which renders the timeline).
3. The profile resolves a moment later → the mRNA tab is added → `MSKTabs` switches to it. That switch is the flash.

## Fix

Show the expression tabs immediately when one of them is the **active (deep-linked) tab** — a synchronous `activeTabId` check — in addition to the existing "study has an mRNA profile" condition:

```ts
const showExpressionTabs =
    expressionTabsEnabled &&
    (activeTabIsExpressionTab ||
        (mrnaProfilePromise.isComplete && !!mrnaProfilePromise.result));
```

The tab is then in `MSKTabs`' children from the first render, so it activates immediately — no Summary flash. The tab content already handles every state (spinner while `patientSamplesExpression` loads, then the plot, or the "No mRNA expression data is available" alert), so nothing needs to flash.

Behavior:

| Scenario | Result |
|---|---|
| Deep-link to mRNA, study has mRNA | Tab active immediately → spinner → plot. **No flash.** |
| Deep-link to mRNA, study has no mRNA | Tab active immediately → spinner → "no data" message. |
| Normal nav (land on Summary), study has mRNA | Tab appears once profile loads (unchanged). |
| Normal nav, study has no mRNA | Tab never appears (no empty-tab clutter — preserved). |

The mskcc-portal/feature-flag enablement check still short-circuits first, so non-enabled portals don't trigger the profile lookup.

Also removes a stray `console.log('TABS MOUNT')` debug line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783784990&installation_id=126502837&pr_number=5606&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5606&signature=335272245f94be6439d423b816c5aab63dcce0c84e6aab37a7b687b95f12ae4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->