### PR TITLE
Fix empty Genomic Overview for hg38 studies (broken IGV cytoband URL)

### DIFF
--- a/src/shared/components/igv/IntegrativeGenomicsViewer.tsx
+++ b/src/shared/components/igv/IntegrativeGenomicsViewer.tsx
@@ -274,6 +274,15 @@ export default class IntegrativeGenomicsViewer extends React.Component<
                         );
                     }
                 });
+            },
+            (error: any) => {
+                // a failed genome/reference load (e.g. an unreachable cytoband
+                // URL) rejects here; surface it instead of silently leaving the
+                // container empty
+                console.error('Failed to initialize IGV browser', error);
+                if (this.props.onRenderingComplete) {
+                    this.props.onRenderingComplete();
+                }
             }
         );
     }

--- a/src/shared/lib/IGVUtils.ts
+++ b/src/shared/lib/IGVUtils.ts
@@ -56,7 +56,7 @@ export function defaultGrch38ReferenceProps() {
         indexURL:
             'https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai',
         cytobandURL:
-            'https://s3.amazonaws.com/igv.broadinstitute.org/annotations/',
+            'https://s3.amazonaws.com/igv.org.genomes/hg38/annotations/cytoBandIdeo.txt.gz',
     };
 }
 


### PR DESCRIPTION
## Problem

The patient-view **Genomic Overview** container renders empty for **hg38** studies, even when the sample has mutation and copy-number-segment data. This is visible on the new CCLE study, e.g.:

`/patient?sampleId=SET2_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE&studyId=ccle_broad_2025`

For that sample the backend returns **347 CNA segments** and **120 mutations**, so the data is present — nothing renders.

## Root cause

In `src/shared/lib/IGVUtils.ts`, `defaultGrch38ReferenceProps()` set `cytobandURL` to a bare S3 **directory** rather than a file:

```
https://s3.amazonaws.com/igv.broadinstitute.org/annotations/
```

That URL returns **HTTP 403 AccessDenied**, so igv.js cannot build the hg38 genome and `igv.createBrowser()` rejects. `initBrowser()` in `IntegrativeGenomicsViewer.tsx` only had a *success* handler on that promise, so the rejection was swallowed and the track list (mutations + segments) was never loaded — the container just stayed empty.

This has affected every hg38 patient view since the IGV genomic overview was introduced in #4188; hg19 studies were unaffected because their `cytobandURL` points at a real file. It went unnoticed until an hg38 study with segment/mutation data (`ccle_broad_2025`) surfaced it.

## Fix

1. Point the hg38 `cytobandURL` at the cytoband file igv.js itself uses for its built-in hg38 reference (verified HTTP 200):
   `https://s3.amazonaws.com/igv.org.genomes/hg38/annotations/cytoBandIdeo.txt.gz`
   (igv.js 2.11.2 reads gzipped cytobands natively.)
2. Add a rejection handler to `igv.createBrowser()` so a future reference-load failure logs to the console instead of silently rendering an empty container.

## Testing

- Confirmed the old URL returns 403 and the new one returns 200.
- Manually verify the Genomic Overview tracks now render on an hg38 patient view (e.g. the SET2 / `ccle_broad_2025` link above) once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784309881&installation_id=126502837&pr_number=5615&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5615&signature=11fd33228bc51c3ceffc0ad921fd20a7643c1ba40b2798636299c9dc02620abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

fixes https://github.com/cBioPortal/cbioportal/issues/12224