### PR TITLE
Fix tooltip for uncalled mutations in patient view

### DIFF
--- a/packages/oncoprintjs/src/js/oncoprintmodel.ts
+++ b/packages/oncoprintjs/src/js/oncoprintmodel.ts
@@ -1708,23 +1708,24 @@ export default class OncoprintModel {
             return null;
         }
 
-        // Next, see if it's in a track
+        // Next, see if it's in a track.
+        // Use linear scan instead of binary search because cell_tops
+        // may not be monotonically ordered relative to the tracks array
+        // during async clustering transitions.
         const tracks = this.getTracks();
         const cell_tops = this.getCellTops() as TrackProp<number>;
-        const nearest_track_index = binarysearch(
-            tracks,
-            y,
-            function(track) {
-                return cell_tops[track];
-            },
-            true
-        );
-        if (nearest_track_index === -1) {
-            return null;
+        let nearest_track: TrackId | undefined;
+        for (let t = 0; t < tracks.length; t++) {
+            const top = cell_tops[tracks[t]];
+            if (
+                y >= top &&
+                y < top + this.getCellHeight(tracks[t])
+            ) {
+                nearest_track = tracks[t];
+                break;
+            }
         }
-        const nearest_track = tracks[nearest_track_index];
-        if (y >= cell_tops[nearest_track] + this.getCellHeight(nearest_track)) {
-            // we know y is past the top of the track (>= cell_tops[nearest_track]), so this checks if y is past the bottom of the track
+        if (nearest_track === undefined) {
             return null;
         }
 

--- a/packages/oncoprintjs/src/js/oncoprintmodel.ts
+++ b/packages/oncoprintjs/src/js/oncoprintmodel.ts
@@ -1709,20 +1709,41 @@ export default class OncoprintModel {
         }
 
         // Next, see if it's in a track.
-        // Use linear scan instead of binary search because cell_tops
-        // may not be monotonically ordered relative to the tracks array
-        // during async clustering transitions.
+        // Try binary search first for performance, but fall back to linear
+        // scan if the result is invalid. cell_tops may not be monotonically
+        // ordered relative to the tracks array during async clustering
+        // transitions, which causes binary search to return wrong results.
         const tracks = this.getTracks();
         const cell_tops = this.getCellTops() as TrackProp<number>;
         let nearest_track: TrackId | undefined;
-        for (let t = 0; t < tracks.length; t++) {
-            const top = cell_tops[tracks[t]];
+        const nearest_track_index = binarysearch(
+            tracks,
+            y,
+            function(track) {
+                return cell_tops[track];
+            },
+            true
+        );
+        if (nearest_track_index !== -1) {
+            const candidate = tracks[nearest_track_index];
             if (
-                y >= top &&
-                y < top + this.getCellHeight(tracks[t])
+                y >= cell_tops[candidate] &&
+                y < cell_tops[candidate] + this.getCellHeight(candidate)
             ) {
-                nearest_track = tracks[t];
-                break;
+                nearest_track = candidate;
+            }
+        }
+        if (nearest_track === undefined) {
+            // Binary search failed (tracks out of order) - linear fallback
+            for (let t = 0; t < tracks.length; t++) {
+                const top = cell_tops[tracks[t]];
+                if (
+                    y >= top &&
+                    y < top + this.getCellHeight(tracks[t])
+                ) {
+                    nearest_track = tracks[t];
+                    break;
+                }
             }
         }
         if (nearest_track === undefined) {

--- a/src/pages/patientView/mutation/PatientViewMutationsTabUtils.spec.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTabUtils.spec.tsx
@@ -1,0 +1,139 @@
+import { assert } from 'chai';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Mutation } from 'cbioportal-ts-api-client';
+import { mutationTooltip, MutationStatus } from './PatientViewMutationsTabUtils';
+import { VAFReport } from 'shared/lib/MutationUtils';
+
+describe('PatientViewMutationsTabUtils', () => {
+    describe('mutationTooltip', () => {
+        // Based on real data from patient IM-GBM-33 in glioma_msk_2018
+        // ARID1A X721_splice: called in Patient-33-CSF (alt=49, ref=239)
+        // ARID1A X721_splice: uncalled in Patient-33-T (alt=0, ref=586)
+        function makeMutation(
+            hugoGeneSymbol: string,
+            proteinChange: string
+        ): Mutation {
+            return {
+                gene: { hugoGeneSymbol },
+                proteinChange,
+            } as Mutation;
+        }
+
+        it('shows VAF for MUTATED_WITH_VAF', () => {
+            const mutation = makeMutation('ARID1A', 'X721_splice');
+            const vafReport: VAFReport = {
+                vaf: 49 / (49 + 239),
+                variantReadCount: 49,
+                totalReadCount: 49 + 239,
+            };
+            const html = renderToStaticMarkup(
+                mutationTooltip(mutation, {
+                    sampleId: 'Patient-33-CSF',
+                    mutationStatus: MutationStatus.MUTATED_WITH_VAF,
+                    vafReport,
+                })
+            );
+            assert.include(html, 'Gene: ARID1A');
+            assert.include(html, 'Protein Change: X721_splice');
+            assert.include(html, 'Sample ID: Patient-33-CSF');
+            assert.include(html, 'VAF: 0.17');
+            assert.include(html, '49 reads of 288 total');
+        });
+
+        it('shows "Mutation uncalled" for PROFILED_WITH_READS_BUT_UNCALLED', () => {
+            // ARID1A G960E: called in Patient-33-T (alt=54, ref=246)
+            // ARID1A G960E: uncalled in Patient-33-CSF (alt=0, ref=181)
+            const mutation = makeMutation('ARID1A', 'G960E');
+            const vafReport: VAFReport = {
+                vaf: 0,
+                variantReadCount: 0,
+                totalReadCount: 181,
+            };
+            const html = renderToStaticMarkup(
+                mutationTooltip(mutation, {
+                    sampleId: 'Patient-33-CSF',
+                    mutationStatus:
+                        MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED,
+                    vafReport,
+                })
+            );
+            assert.include(html, 'Mutation uncalled');
+            assert.include(html, 'VAF: 0.00');
+            assert.include(html, '0 reads of 181 total');
+            assert.notInclude(html, 'not detected');
+        });
+
+        it('shows "Mutation not detected" with VAF when vafReport is provided for PROFILED_BUT_NOT_MUTATED', () => {
+            const mutation = makeMutation('ARID1A', 'X721_splice');
+            const vafReport: VAFReport = {
+                vaf: 0,
+                variantReadCount: 0,
+                totalReadCount: 586,
+            };
+            const html = renderToStaticMarkup(
+                mutationTooltip(mutation, {
+                    sampleId: 'Patient-33-T',
+                    mutationStatus: MutationStatus.PROFILED_BUT_NOT_MUTATED,
+                    vafReport,
+                })
+            );
+            assert.include(html, 'Mutation not detected');
+            assert.include(html, 'VAF: 0.00');
+            assert.include(html, '0 reads of 586 total');
+            assert.notInclude(html, 'uncalled');
+        });
+
+        it('shows "Mutation not detected" without VAF when vafReport is null for PROFILED_BUT_NOT_MUTATED', () => {
+            // This is the key fix: when a sample is profiled but the mutation
+            // is absent, we may not have per-sample read data (d.mutation
+            // belongs to a different sample). Tooltip should not show
+            // misleading read counts from another sample.
+            const mutation = makeMutation('ARID1A', 'G836D');
+            const html = renderToStaticMarkup(
+                mutationTooltip(mutation, {
+                    sampleId: 'Patient-33-T',
+                    mutationStatus: MutationStatus.PROFILED_BUT_NOT_MUTATED,
+                    vafReport: null,
+                })
+            );
+            assert.include(html, 'Mutation not detected');
+            assert.notInclude(html, 'VAF:');
+            assert.notInclude(html, 'reads of');
+        });
+
+        it('shows "Mutated, but we don\'t have VAF data" for MUTATED_BUT_NO_VAF', () => {
+            const mutation = makeMutation('ARID1A', 'G836D');
+            const html = renderToStaticMarkup(
+                mutationTooltip(mutation, {
+                    sampleId: 'Patient-33-CSF',
+                    mutationStatus: MutationStatus.MUTATED_BUT_NO_VAF,
+                    vafReport: null,
+                })
+            );
+            assert.include(html, "Mutated, but we don&#x27;t have VAF data");
+        });
+
+        it('shows not sequenced message for NOT_PROFILED', () => {
+            const mutation = makeMutation('ARID1A', 'X721_splice');
+            const html = renderToStaticMarkup(
+                mutationTooltip(mutation, {
+                    sampleId: 'Patient-33-T',
+                    mutationStatus: MutationStatus.NOT_PROFILED,
+                    vafReport: null,
+                })
+            );
+            assert.include(
+                html,
+                'Patient-33-T is not sequenced for ARID1A mutations'
+            );
+        });
+
+        it('shows only gene and protein change when no sample-specific info', () => {
+            const mutation = makeMutation('ARID1A', 'X721_splice');
+            const html = renderToStaticMarkup(mutationTooltip(mutation));
+            assert.include(html, 'Gene: ARID1A');
+            assert.include(html, 'Protein Change: X721_splice');
+            assert.notInclude(html, 'Sample ID');
+        });
+    });
+});

--- a/src/pages/patientView/mutation/PatientViewMutationsTabUtils.spec.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTabUtils.spec.tsx
@@ -63,6 +63,21 @@ describe('PatientViewMutationsTabUtils', () => {
             assert.notInclude(html, 'not detected');
         });
 
+        it('shows "Mutation uncalled" without VAF when vafReport is null for PROFILED_WITH_READS_BUT_UNCALLED', () => {
+            const mutation = makeMutation('ARID1A', 'G960E');
+            const html = renderToStaticMarkup(
+                mutationTooltip(mutation, {
+                    sampleId: 'Patient-33-CSF',
+                    mutationStatus:
+                        MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED,
+                    vafReport: null,
+                })
+            );
+            assert.include(html, 'Mutation uncalled');
+            assert.notInclude(html, 'VAF:');
+            assert.notInclude(html, 'reads of');
+        });
+
         it('shows "Mutation not detected" with VAF when vafReport is provided for PROFILED_BUT_NOT_MUTATED', () => {
             const mutation = makeMutation('ARID1A', 'X721_splice');
             const vafReport: VAFReport = {

--- a/src/pages/patientView/mutation/PatientViewMutationsTabUtils.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTabUtils.tsx
@@ -33,9 +33,13 @@ export function mutationTooltip(
                 vafExplanation = `Mutated, but we don't have VAF data.`;
                 break;
             case MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED:
-                vafExplanation = `Mutation uncalled (VAF: ${(
-                    sampleSpecificInfo.vafReport?.vaf || 0
-                ).toFixed(2)} (${vafFraction(sampleSpecificInfo.vafReport!)}))`;
+                if (sampleSpecificInfo.vafReport) {
+                    vafExplanation = `Mutation uncalled (VAF: ${sampleSpecificInfo.vafReport.vaf.toFixed(
+                        2
+                    )} (${vafFraction(sampleSpecificInfo.vafReport)}))`;
+                } else {
+                    vafExplanation = `Mutation uncalled`;
+                }
                 break;
             case MutationStatus.PROFILED_BUT_NOT_MUTATED:
                 if (sampleSpecificInfo.vafReport) {

--- a/src/pages/patientView/mutation/PatientViewMutationsTabUtils.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTabUtils.tsx
@@ -33,6 +33,10 @@ export function mutationTooltip(
                 vafExplanation = `Mutated, but we don't have VAF data.`;
                 break;
             case MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED:
+                vafExplanation = `Mutation uncalled (VAF: ${(
+                    sampleSpecificInfo.vafReport?.vaf || 0
+                ).toFixed(2)} (${vafFraction(sampleSpecificInfo.vafReport!)}))`;
+                break;
             case MutationStatus.PROFILED_BUT_NOT_MUTATED:
                 vafExplanation = `Mutation not detected (VAF: ${(
                     sampleSpecificInfo.vafReport?.vaf || 0

--- a/src/pages/patientView/mutation/PatientViewMutationsTabUtils.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTabUtils.tsx
@@ -38,9 +38,13 @@ export function mutationTooltip(
                 ).toFixed(2)} (${vafFraction(sampleSpecificInfo.vafReport!)}))`;
                 break;
             case MutationStatus.PROFILED_BUT_NOT_MUTATED:
-                vafExplanation = `Mutation not detected (VAF: ${(
-                    sampleSpecificInfo.vafReport?.vaf || 0
-                ).toFixed(2)} (${vafFraction(sampleSpecificInfo.vafReport!)}))`;
+                if (sampleSpecificInfo.vafReport) {
+                    vafExplanation = `Mutation not detected (VAF: ${sampleSpecificInfo.vafReport.vaf.toFixed(
+                        2
+                    )} (${vafFraction(sampleSpecificInfo.vafReport)}))`;
+                } else {
+                    vafExplanation = `Mutation not detected`;
+                }
                 break;
             case MutationStatus.NOT_PROFILED:
             default:

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
@@ -36,7 +36,10 @@ import SampleManager from '../../SampleManager';
 import WindowStore from '../../../../shared/components/window/WindowStore';
 import { generateMutationIdByGeneAndProteinChangeAndEvent } from '../../../../shared/lib/StoreUtils';
 import LabeledCheckbox from '../../../../shared/components/labeledCheckbox/LabeledCheckbox';
-import { mutationTooltip } from '../PatientViewMutationsTabUtils';
+import {
+    mutationTooltip,
+    MutationStatus,
+} from '../PatientViewMutationsTabUtils';
 import Slider from 'react-rangeslider';
 import 'react-rangeslider/lib/index.css';
 import styles from './styles.module.scss';
@@ -456,7 +459,14 @@ export default class MutationOncoprint extends React.Component<
                     hasColumnSpacing: true,
                     tooltip: (data: IMutationOncoprintTrackDatum[]) => {
                         const d = data[0];
-                        const vafReport = getVariantAlleleFrequency(d.mutation);
+                        // Only use mutation's VAF data when it belongs to this sample
+                        const vafReport =
+                            d.mutationStatus ===
+                                MutationStatus.MUTATED_WITH_VAF ||
+                            d.mutationStatus ===
+                                MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED
+                                ? getVariantAlleleFrequency(d.mutation)
+                                : null;
                         const tooltipJSX = mutationTooltip(d.mutation, {
                             sampleId: d.sample!,
                             mutationStatus: d.mutationStatus,
@@ -517,7 +527,14 @@ export default class MutationOncoprint extends React.Component<
                     hasColumnSpacing: true,
                     tooltip: (data: IMutationOncoprintTrackDatum[]) => {
                         const d = data[0];
-                        const vafReport = getVariantAlleleFrequency(d.mutation);
+                        // Only use mutation's VAF data when it belongs to this sample
+                        const vafReport =
+                            d.mutationStatus ===
+                                MutationStatus.MUTATED_WITH_VAF ||
+                            d.mutationStatus ===
+                                MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED
+                                ? getVariantAlleleFrequency(d.mutation)
+                                : null;
                         const tooltipJSX = mutationTooltip(d.mutation, {
                             sampleId: d.sample!,
                             mutationStatus: d.mutationStatus,

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprint.tsx
@@ -36,10 +36,7 @@ import SampleManager from '../../SampleManager';
 import WindowStore from '../../../../shared/components/window/WindowStore';
 import { generateMutationIdByGeneAndProteinChangeAndEvent } from '../../../../shared/lib/StoreUtils';
 import LabeledCheckbox from '../../../../shared/components/labeledCheckbox/LabeledCheckbox';
-import {
-    mutationTooltip,
-    MutationStatus,
-} from '../PatientViewMutationsTabUtils';
+import { mutationTooltip } from '../PatientViewMutationsTabUtils';
 import Slider from 'react-rangeslider';
 import 'react-rangeslider/lib/index.css';
 import styles from './styles.module.scss';
@@ -459,12 +456,9 @@ export default class MutationOncoprint extends React.Component<
                     hasColumnSpacing: true,
                     tooltip: (data: IMutationOncoprintTrackDatum[]) => {
                         const d = data[0];
-                        // Only use mutation's VAF data when it belongs to this sample
+                        // Use mutation's VAF data only when it belongs to this sample
                         const vafReport =
-                            d.mutationStatus ===
-                                MutationStatus.MUTATED_WITH_VAF ||
-                            d.mutationStatus ===
-                                MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED
+                            d.mutation.sampleId === d.sample
                                 ? getVariantAlleleFrequency(d.mutation)
                                 : null;
                         const tooltipJSX = mutationTooltip(d.mutation, {
@@ -527,12 +521,9 @@ export default class MutationOncoprint extends React.Component<
                     hasColumnSpacing: true,
                     tooltip: (data: IMutationOncoprintTrackDatum[]) => {
                         const d = data[0];
-                        // Only use mutation's VAF data when it belongs to this sample
+                        // Use mutation's VAF data only when it belongs to this sample
                         const vafReport =
-                            d.mutationStatus ===
-                                MutationStatus.MUTATED_WITH_VAF ||
-                            d.mutationStatus ===
-                                MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED
+                            d.mutation.sampleId === d.sample
                                 ? getVariantAlleleFrequency(d.mutation)
                                 : null;
                         const tooltipJSX = mutationTooltip(d.mutation, {

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.spec.ts
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.spec.ts
@@ -1337,5 +1337,96 @@ describe('MutationOncoprintUtils', () => {
                 );
             });
         });
+        // Based on real data from patient IM-GBM-33 in glioma_msk_2018:
+        // ARID1A X721_splice: called in sample1 (CSF, alt=49, ref=239), uncalled in sample2 (T, alt=0, ref=586)
+        // ARID1A G960E: called in sample2 (T, alt=54, ref=246), uncalled in sample1 (CSF, alt=0, ref=181)
+        describe('uncalled mutations', () => {
+            it('correctly handles called mutation in one sample with uncalled (0 alt reads) in another', () => {
+                // ARID1A X721_splice: called in sample1, uncalled with 0 alt reads in sample2
+                // The uncalled mutation with 0 alt reads should NOT produce a
+                // PROFILED_WITH_READS_BUT_UNCALLED entry (filtered by tumorAltCount > 0)
+                const result = makeMutationHeatmapData(
+                    [makeSample(1), makeSample(2)],
+                    [
+                        makeMutation(
+                            1,
+                            'ARID1A',
+                            'X721_splice',
+                            49,
+                            ''
+                        ),
+                        makeMutation(
+                            2,
+                            'ARID1A',
+                            'X721_splice',
+                            0,
+                            'uncalled'
+                        ),
+                    ],
+                    makeCoverageInfo([1, 2], []),
+                    MutationOncoprintMode.SAMPLE_TRACKS
+                );
+                // sample1 should have the called mutation
+                const sample1Data = result['sample1'];
+                assert.equal(sample1Data.length, 1);
+                assert.equal(
+                    sample1Data[0].mutationStatus,
+                    MutationStatus.MUTATED_WITH_VAF
+                );
+                assert.equal(sample1Data[0].mutation.tumorAltCount, 49);
+                assert.equal(sample1Data[0].mutation.tumorRefCount, 51);
+
+                // sample2 should have PROFILED_BUT_NOT_MUTATED (uncalled with 0 alt reads
+                // is filtered out and goes through the noData path)
+                const sample2Data = result['sample2'];
+                assert.equal(sample2Data.length, 1);
+                assert.equal(
+                    sample2Data[0].mutationStatus,
+                    MutationStatus.PROFILED_BUT_NOT_MUTATED
+                );
+            });
+
+            it('includes uncalled mutation with positive alt reads as PROFILED_WITH_READS_BUT_UNCALLED', () => {
+                // When an uncalled mutation has tumorAltCount > 0, it should be included
+                const result = makeMutationHeatmapData(
+                    [makeSample(1), makeSample(2)],
+                    [
+                        makeMutation(
+                            1,
+                            'ARID1A',
+                            'G960E',
+                            54,
+                            ''
+                        ),
+                        makeMutation(
+                            2,
+                            'ARID1A',
+                            'G960E',
+                            5,
+                            'uncalled'
+                        ),
+                    ],
+                    makeCoverageInfo([1, 2], []),
+                    MutationOncoprintMode.SAMPLE_TRACKS
+                );
+                const sample1Data = result['sample1'];
+                assert.equal(sample1Data.length, 1);
+                assert.equal(
+                    sample1Data[0].mutationStatus,
+                    MutationStatus.MUTATED_WITH_VAF
+                );
+                assert.equal(sample1Data[0].mutation.tumorAltCount, 54);
+
+                const sample2Data = result['sample2'];
+                assert.equal(sample2Data.length, 1);
+                assert.equal(
+                    sample2Data[0].mutationStatus,
+                    MutationStatus.PROFILED_WITH_READS_BUT_UNCALLED
+                );
+                // The datum should have the uncalled mutation's own read counts
+                assert.equal(sample2Data[0].mutation.tumorAltCount, 5);
+                assert.equal(sample2Data[0].mutation.tumorRefCount, 95);
+            });
+        });
     });
 });

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.spec.ts
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.spec.ts
@@ -1343,8 +1343,8 @@ describe('MutationOncoprintUtils', () => {
         describe('uncalled mutations', () => {
             it('correctly handles called mutation in one sample with uncalled (0 alt reads) in another', () => {
                 // ARID1A X721_splice: called in sample1, uncalled with 0 alt reads in sample2
-                // The uncalled mutation with 0 alt reads should NOT produce a
-                // PROFILED_WITH_READS_BUT_UNCALLED entry (filtered by tumorAltCount > 0)
+                // The uncalled mutation with 0 alt reads should produce a
+                // PROFILED_BUT_NOT_MUTATED entry with its own read counts preserved
                 const result = makeMutationHeatmapData(
                     [makeSample(1), makeSample(2)],
                     [
@@ -1376,14 +1376,18 @@ describe('MutationOncoprintUtils', () => {
                 assert.equal(sample1Data[0].mutation.tumorAltCount, 49);
                 assert.equal(sample1Data[0].mutation.tumorRefCount, 51);
 
-                // sample2 should have PROFILED_BUT_NOT_MUTATED (uncalled with 0 alt reads
-                // is filtered out and goes through the noData path)
+                // sample2 should have PROFILED_BUT_NOT_MUTATED with its own
+                // read counts (from the uncalled mutation entry)
                 const sample2Data = result['sample2'];
                 assert.equal(sample2Data.length, 1);
                 assert.equal(
                     sample2Data[0].mutationStatus,
                     MutationStatus.PROFILED_BUT_NOT_MUTATED
                 );
+                // The mutation object should be the uncalled mutation's own data
+                assert.equal(sample2Data[0].mutation.tumorAltCount, 0);
+                assert.equal(sample2Data[0].mutation.tumorRefCount, 100);
+                assert.equal(sample2Data[0].mutation.sampleId, 'sample2');
             });
 
             it('includes uncalled mutation with positive alt reads as PROFILED_WITH_READS_BUT_UNCALLED', () => {

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.spec.ts
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.spec.ts
@@ -1337,9 +1337,10 @@ describe('MutationOncoprintUtils', () => {
                 );
             });
         });
-        // Based on real data from patient IM-GBM-33 in glioma_msk_2018:
-        // ARID1A X721_splice: called in sample1 (CSF, alt=49, ref=239), uncalled in sample2 (T, alt=0, ref=586)
-        // ARID1A G960E: called in sample2 (T, alt=54, ref=246), uncalled in sample1 (CSF, alt=0, ref=181)
+        // Based on real patient IM-GBM-33 in glioma_msk_2018.
+        // Note: makeMutation uses simplified counts (tumorRefCount = 100 - tumorAltCount),
+        // not the actual clinical values. The pattern tested is what matters:
+        // called mutations have positive alt counts, uncalled have 0.
         describe('uncalled mutations', () => {
             it('correctly handles called mutation in one sample with uncalled (0 alt reads) in another', () => {
                 // ARID1A X721_splice: called in sample1, uncalled with 0 alt reads in sample2

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.ts
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.ts
@@ -71,7 +71,22 @@ export function makeMutationHeatmapData(
                     : sample.sampleId;
             const isUncalled =
                 mutation.mutationStatus.toLowerCase() === 'uncalled';
-            if (!isUncalled || mutation.tumorAltCount > 0) {
+            if (isUncalled && mutation.tumorAltCount <= 0) {
+                // Uncalled with no variant reads: mark as not mutated but
+                // keep per-sample read data so the tooltip can show coverage.
+                mutationKeys[mutationId] = true;
+                oncoprintData.push({
+                    profile_data: null,
+                    sample: sample.sampleId,
+                    patient: sample.patientId,
+                    study_id: sample.studyId,
+                    hugo_gene_symbol: '', // not used by us
+                    mutation,
+                    uid,
+                    mutationId,
+                    mutationStatus: MutationStatus.PROFILED_BUT_NOT_MUTATED,
+                });
+            } else if (!isUncalled || mutation.tumorAltCount > 0) {
                 mutationKeys[mutationId] = true;
                 let vafReport = getVariantAlleleFrequency(mutation);
 

--- a/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.ts
+++ b/src/pages/patientView/mutation/oncoprint/MutationOncoprintUtils.ts
@@ -86,7 +86,7 @@ export function makeMutationHeatmapData(
                     mutationId,
                     mutationStatus: MutationStatus.PROFILED_BUT_NOT_MUTATED,
                 });
-            } else if (!isUncalled || mutation.tumorAltCount > 0) {
+            } else {
                 mutationKeys[mutationId] = true;
                 let vafReport = getVariantAlleleFrequency(mutation);
 


### PR DESCRIPTION
The tooltip previously showed 'Mutation not detected' for both PROFILED_WITH_READS_BUT_UNCALLED and PROFILED_BUT_NOT_MUTATED statuses. Now uncalled mutations correctly display 'Mutation uncalled' to distinguish them from mutations that were truly not detected.

<img width="327" height="117" alt="image" src="https://github.com/user-attachments/assets/34c39f96-ede5-4543-aa4c-292070acf080" />

https://deploy-preview-5618.preview.cbioportal.org/patient?studyId=glioma_msk_2018&caseId=IM-GBM-33