### PR TITLE
Fix login dropdown closing immediately after opening (React 18 regression)

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -18,8 +18,22 @@ import { FeatureFlagEnum } from 'shared/featureFlags';
 @observer
 export default class PortalHeader extends React.Component<
     { appStore: AppStore },
-    {}
+    { datDropdownOpen: boolean }
 > {
+    state = { datDropdownOpen: false };
+
+    private handleDatDropdownToggle = (isOpen: boolean) => {
+        if (isOpen) {
+            // Defer by one tick: RootCloseWrapper adds its document click
+            // listener synchronously during React's commit phase, which runs
+            // inside the same browser click dispatch. Without the defer it
+            // catches the opening click and immediately closes the dropdown.
+            setTimeout(() => this.setState({ datDropdownOpen: true }), 0);
+        } else {
+            this.setState({ datDropdownOpen: false });
+        }
+    };
+
     private tabs() {
         return [
             {
@@ -190,7 +204,11 @@ export default class PortalHeader extends React.Component<
                         <If condition={this.props.appStore.isLoggedIn}>
                             <Then>
                                 <div className="identity">
-                                    <Dropdown id="dat-dropdown">
+                                    <Dropdown
+                                        id="dat-dropdown"
+                                        open={this.state.datDropdownOpen}
+                                        onToggle={this.handleDatDropdownToggle}
+                                    >
                                         <Dropdown.Toggle className="btn-sm username">
                                             Logged in as{' '}
                                             {this.props.appStore.userName}

--- a/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
+++ b/src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx
@@ -86,7 +86,7 @@ export class DataAccessTokensDropdown extends React.Component<
         });
 
         return shownListItems.map(l => {
-            return <li>{l.action}</li>;
+            return <li key={l.id}>{l.action}</li>;
         });
     }
 


### PR DESCRIPTION
## Root cause

React 18 moved event delegation from \`document\` to the React root container. This broke react-bootstrap's \`RootCloseWrapper\`, which registers an outside-click listener on \`document\` to close open dropdowns.

**React 16 (working):** React's own listener fired at \`document\` — the final stop in the bubble chain. Per the DOM spec, listeners added to the *current dispatch target* during an event do not fire for that same event. So \`RootCloseWrapper\` adding its listener to \`document\` during React's commit phase was safe — the listener was silently ignored for the current click.

**React 18 (broken):** React's listener now fires at the React root div — an *intermediate* element. \`RootCloseWrapper\` still adds its listener to \`document\` during React's commit phase. The click event then **continues bubbling** to \`document\`, where the newly-registered listener fires, treats the click as "outside", and immediately closes the dropdown. The open→close cycle completes within the same frame, so the user sees nothing happen.

## Fix

**`src/appShell/App/PortalHeader.tsx`**
- Convert the uncontrolled react-bootstrap `Dropdown` to controlled mode, driving `open` via React `state`. This removes the `uncontrollable` HOC from the state loop and gives us explicit control over when the dropdown opens.
- Defer `setState(true)` by one tick (`setTimeout 0`) when opening, so `RootCloseWrapper` only attaches its document listener *after* the triggering click has fully dispatched. Closing remains synchronous.

**`src/shared/components/dataAccessTokens/DataAccessTokensDropdown.tsx`**
- Add `key={l.id}` to list items to fix a React key warning.

## Test plan

- [x] Log in to a cBioPortal instance
- [x] Click the "Logged in as..." button — dropdown should open and stay open
- [x] Confirm "Sign out" link is present and works
- [x] If `dat_method` is `oauth2` or `uuid`, confirm "Data Access Token" link is present
- [x] Click outside the dropdown — it should close
- [x] Click the toggle again — it should close
- [x] Confirm behaviour across pages (study view, results view, patient view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)