### PR TITLE
Add mRNA violin plot chart to study view (re-apply of #5617 + improvements)

### DIFF
--- a/src/pages/patientView/mrna/mrnaTabGeneGroups.ts
+++ b/src/pages/patientView/mrna/mrnaTabGeneGroups.ts
@@ -15,7 +15,27 @@ export interface GeneGroup {
     genes: string[];
 }
 
+export const STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID = 'msk-target';
+
 export const MRNA_TAB_GENE_GROUPS: GeneGroup[] = [
+    {
+        id: STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
+        label: 'Study view default ADC targets',
+        abbrev: 'MSK-T',
+        color: '#1f5fa8',
+        genes: [
+            'CD276',
+            'CLDN18',
+            'DLL3',
+            'EGFR',
+            'ERBB2',
+            'ERBB3',
+            'FOLR1',
+            'MET',
+            'NECTIN4',
+            'TACSTD2',
+        ],
+    },
     {
         id: 'fda-adc',
         label: 'FDA-approved ADC targets',
@@ -392,13 +412,10 @@ export const ALL_GENE_GROUP_LABEL_META: GeneGroupLabelMeta[] = [
 
 const GENE_GROUP_LABEL_META_BY_ID: {
     [id: string]: GeneGroupLabelMeta;
-} = ALL_GENE_GROUP_LABEL_META.reduce(
-    (acc, m) => {
-        acc[m.id] = m;
-        return acc;
-    },
-    {} as { [id: string]: GeneGroupLabelMeta }
-);
+} = ALL_GENE_GROUP_LABEL_META.reduce((acc, m) => {
+    acc[m.id] = m;
+    return acc;
+}, {} as { [id: string]: GeneGroupLabelMeta });
 
 export function getGeneGroupLabelMeta(
     id: string

--- a/src/pages/studyView/StudyViewConfig.ts
+++ b/src/pages/studyView/StudyViewConfig.ts
@@ -85,6 +85,7 @@ export enum ChartTypeEnum {
     PATIENT_TREATMENT_TARGET_TABLE = 'PATIENT_TREATMENT_TARGET_TABLE',
     CLINICAL_EVENT_TYPE_COUNTS_TABLE = 'CLINICAL_EVENT_TYPE_COUNTS_TABLE',
     MRNA_VIOLIN_PLOT = 'MRNA_VIOLIN_PLOT',
+    GENE_SPECIFIC_VIOLIN_PLOT = 'GENE_SPECIFIC_VIOLIN_PLOT',
     NONE = 'NONE',
 }
 
@@ -112,6 +113,7 @@ export enum ChartTypeNameEnum {
     PATIENT_TREATMENT_TARGET_TABLE = 'table',
     CLINICAL_EVENT_TYPE_COUNTS_TABLE = 'table',
     MRNA_VIOLIN_PLOT = 'mRNA violin plot',
+    GENE_SPECIFIC_VIOLIN_PLOT = 'violin plot',
     NONE = 'none',
 }
 
@@ -293,6 +295,11 @@ const studyViewFrontEnd = {
                 minW: 2,
             },
             [ChartTypeEnum.MRNA_VIOLIN_PLOT]: {
+                w: 2,
+                h: 2,
+                minW: 2,
+            },
+            [ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT]: {
                 w: 2,
                 h: 2,
                 minW: 2,

--- a/src/pages/studyView/StudyViewConfig.ts
+++ b/src/pages/studyView/StudyViewConfig.ts
@@ -84,6 +84,7 @@ export enum ChartTypeEnum {
     PATIENT_TREATMENT_GROUPS_TABLE = 'PATIENT_TREATMENT_GROUPS_TABLE',
     PATIENT_TREATMENT_TARGET_TABLE = 'PATIENT_TREATMENT_TARGET_TABLE',
     CLINICAL_EVENT_TYPE_COUNTS_TABLE = 'CLINICAL_EVENT_TYPE_COUNTS_TABLE',
+    MRNA_VIOLIN_PLOT = 'MRNA_VIOLIN_PLOT',
     NONE = 'NONE',
 }
 
@@ -110,6 +111,7 @@ export enum ChartTypeNameEnum {
     PATIENT_TREATMENT_GROUPS_TABLE = 'table',
     PATIENT_TREATMENT_TARGET_TABLE = 'table',
     CLINICAL_EVENT_TYPE_COUNTS_TABLE = 'table',
+    MRNA_VIOLIN_PLOT = 'mRNA violin plot',
     NONE = 'none',
 }
 
@@ -287,6 +289,11 @@ const studyViewFrontEnd = {
             [ChartTypeEnum.CLINICAL_EVENT_TYPE_COUNTS_TABLE]: {
                 w: 2,
                 h: 2,
+                minW: 2,
+            },
+            [ChartTypeEnum.MRNA_VIOLIN_PLOT]: {
+                w: 2,
+                h: 3,
                 minW: 2,
             },
             [ChartTypeEnum.NONE]: {

--- a/src/pages/studyView/StudyViewConfig.ts
+++ b/src/pages/studyView/StudyViewConfig.ts
@@ -129,6 +129,7 @@ const studyViewFrontEnd = {
     priority: {
         CANCER_TYPE: 3000,
         CANCER_TYPE_DETAILED: 2000,
+        MRNA_VIOLIN_PLOT: 1900,
         GENOMIC_PROFILES_SAMPLE_COUNT: 1000,
         CASE_LISTS_SAMPLE_COUNT: 1000,
         OS_SURVIVAL: 400,
@@ -293,7 +294,7 @@ const studyViewFrontEnd = {
             },
             [ChartTypeEnum.MRNA_VIOLIN_PLOT]: {
                 w: 2,
-                h: 3,
+                h: 2,
                 minW: 2,
             },
             [ChartTypeEnum.NONE]: {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8691,29 +8691,31 @@ export class StudyViewPageStore
                 this.changeChartVisibility(chartMeta.uniqueKey, true);
             }
 
-            // Auto-add a default-configured gene-specific violin only for a
-            // single-study view with a z-score mRNA profile. The chart plots
-            // multiple genes on a shared axis, which is only meaningful in
-            // cohort-comparable units (z-scores); absolute/log profiles keep
-            // each gene's own baseline. And precalculated z-scores aren't
-            // comparable across studies (each is standardized against its own
-            // cohort/reference), so we restrict to single-study to avoid
-            // pooling incomparable values.
+            // Auto-add a default-configured gene-specific violin from mRNA
+            // profiles. z-score profiles are only valid for single-study
+            // views; for multi-study (or when z-scores are unavailable), use
+            // non-zscore mRNA profiles instead.
             const isSingleStudy =
                 (this.queriedPhysicalStudyIds.result?.length ?? 0) === 1;
-            const mrnaZscoreProfiles = this.molecularProfiles.result.filter(
-                p =>
-                    p.molecularAlterationType === 'MRNA_EXPRESSION' &&
-                    p.datatype === DataTypeConstants.ZSCORE
+            const mrnaProfiles = this.molecularProfiles.result.filter(
+                p => p.molecularAlterationType === 'MRNA_EXPRESSION'
             );
-            if (isSingleStudy && mrnaZscoreProfiles.length > 0) {
-                // Prefer "all-sample" z-scores: bounded across the cohort, so
-                // the shared cross-gene axis stays sane (diploid-reference
-                // z-scores can explode for genes silent in normal tissue).
+            const mrnaZscoreProfiles = mrnaProfiles.filter(
+                p => p.datatype === DataTypeConstants.ZSCORE
+            );
+            const mrnaNonZscoreProfiles = mrnaProfiles.filter(
+                p => p.datatype !== DataTypeConstants.ZSCORE
+            );
+            const eligibleMrnaProfiles =
+                isSingleStudy && mrnaZscoreProfiles.length > 0
+                    ? mrnaZscoreProfiles
+                    : mrnaNonZscoreProfiles;
+            if (eligibleMrnaProfiles.length > 0) {
+                // Prefer "all-sample" variants when available.
                 const profile =
-                    mrnaZscoreProfiles.find(p =>
+                    eligibleMrnaProfiles.find(p =>
                         /all[_]?sample/i.test(p.molecularProfileId)
-                    ) ?? mrnaZscoreProfiles[0];
+                    ) ?? eligibleMrnaProfiles[0];
                 const defaultGenes =
                     MRNA_TAB_GENE_GROUPS.find(
                         g =>

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8512,11 +8512,21 @@ export class StudyViewPageStore
                 this.changeChartVisibility(chartMeta.uniqueKey, true);
             }
 
-            // Show the mRNA violin plot when mRNA expression profiles exist
-            const hasMrnaProfiles = this.molecularProfiles.result.some(
-                p => p.molecularAlterationType === 'MRNA_EXPRESSION'
+            // Show the mRNA violin plot only for a single-study view with a
+            // z-score mRNA profile. The chart plots multiple genes on a shared
+            // axis, which is only meaningful in cohort-comparable units
+            // (z-scores); absolute/log profiles keep each gene's own baseline.
+            // And precalculated z-scores aren't comparable across studies
+            // (each is standardized against its own cohort/reference), so we
+            // restrict to single-study to avoid pooling incomparable values.
+            const isSingleStudy =
+                (this.queriedPhysicalStudyIds.result?.length ?? 0) === 1;
+            const hasMrnaZscoreProfile = this.molecularProfiles.result.some(
+                p =>
+                    p.molecularAlterationType === 'MRNA_EXPRESSION' &&
+                    p.datatype === DataTypeConstants.ZSCORE
             );
-            if (hasMrnaProfiles) {
+            if (isSingleStudy && hasMrnaZscoreProfile) {
                 this.chartsType.set(
                     SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
                     ChartTypeEnum.MRNA_VIOLIN_PLOT

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -2917,6 +2917,10 @@ export class StudyViewPageStore
         [id: string]: MobxPromise<GenericAssayFrequencyTableRow[]>;
     } = {};
 
+    public mrnaViolinDistributionSamplePromises: {
+        [id: string]: MobxPromise<Sample[]>;
+    } = {};
+
     private _chartSampleIdentifiersFilterSet = observable.map<
         ChartUniqueKey,
         SampleIdentifier[]
@@ -9633,6 +9637,69 @@ export class StudyViewPageStore
             }
         },
     });
+
+    /**
+     * Samples filtered by every active filter EXCEPT the gene-level range
+     * selections owned by one mRNA violin chart. This lets a violin reflect
+     * other charts' filters while still showing the full distribution of its
+     * own genes (the selected range is recolored, not filtered away).
+     */
+    public getMrnaViolinDistributionSamples(
+        profileType: string | null,
+        hugoGeneSymbols: string[]
+    ): MobxPromise<Sample[]> {
+        const symbolKey = _.uniq(hugoGeneSymbols.map(s => s.toUpperCase()))
+            .sort()
+            .join(',');
+        const key = `${profileType ?? ''}::${symbolKey}`;
+        if (!this.mrnaViolinDistributionSamplePromises[key]) {
+            const symbolSet = new Set(
+                hugoGeneSymbols.map(s => s.toUpperCase())
+            );
+            this.mrnaViolinDistributionSamplePromises[key] = remoteData<
+                Sample[]
+            >({
+                // Await selectedSamples so this re-runs whenever any filter
+                // changes (including this chart's own selection).
+                await: () => [
+                    this.samples,
+                    this.selectedSamples,
+                    this.molecularProfiles,
+                ],
+                invoke: () => {
+                    const reducedGenomic = this.genomicDataFilters.filter(
+                        f =>
+                            !(
+                                symbolSet.has(
+                                    f.hugoGeneSymbol.toUpperCase()
+                                ) &&
+                                (!profileType ||
+                                    f.profileType === profileType)
+                            )
+                    );
+                    // No filter active at all (not even our own) → full cohort,
+                    // avoiding a redundant fetch on the common unfiltered load.
+                    if (!this.chartsAreFiltered) {
+                        return Promise.resolve(this.samples.result);
+                    }
+                    const studyViewFilter: StudyViewFilter = {
+                        ...this.filters,
+                    };
+                    if (reducedGenomic.length > 0) {
+                        studyViewFilter.genomicDataFilters = reducedGenomic;
+                    } else {
+                        delete (studyViewFilter as Partial<StudyViewFilter>)
+                            .genomicDataFilters;
+                    }
+                    return this.internalClient.fetchFilteredSamplesUsingPOST({
+                        studyViewFilter,
+                    });
+                },
+                default: [],
+            });
+        }
+        return this.mrnaViolinDistributionSamplePromises[key];
+    }
 
     @computed private get hasFilteredSamples(): boolean {
         return (

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8464,6 +8464,27 @@ export class StudyViewPageStore
             if (chartMeta && chartMeta.priority !== 0) {
                 this.changeChartVisibility(chartMeta.uniqueKey, true);
             }
+
+            // Show the mRNA violin plot when mRNA expression profiles exist
+            const hasMrnaProfiles = this.molecularProfiles.result.some(
+                p => p.molecularAlterationType === 'MRNA_EXPRESSION'
+            );
+            if (hasMrnaProfiles) {
+                this.chartsType.set(
+                    SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
+                    ChartTypeEnum.MRNA_VIOLIN_PLOT
+                );
+                this.chartsDimension.set(
+                    SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
+                    STUDY_VIEW_CONFIG.layout.dimensions[
+                        ChartTypeEnum.MRNA_VIOLIN_PLOT
+                    ]
+                );
+                this.changeChartVisibility(
+                    SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
+                    true
+                );
+            }
         }
 
         if (this.shouldDisplayPatientTreatments.result) {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -150,6 +150,7 @@ import {
     getGenericAssayFrequencyTableUniqueKey,
     splitGenericAssayFrequencyTableRowUniqueKey,
     getGenericAssayDataAsClinicalData,
+    getGeneSpecificViolinChartUniqueKey,
     getGenomicChartUniqueKey,
     getGenomicDataAsClinicalData,
     getGroupsFromBins,
@@ -3019,6 +3020,14 @@ export class StudyViewPageStore
         ChartUniqueKey,
         ChartMeta
     >({}, { deep: false });
+    // Multi-gene violin charts: one continuous-numeric profile rendered as a
+    // shared-axis violin across several genes. Keyed by the same uniqueKey as
+    // the chart's ChartMeta in _geneSpecificCharts. Holds the gene list and
+    // profile so ChartContainer can render the (data-source-agnostic) violin.
+    @observable private _geneSpecificViolinChartMap = observable.map<
+        ChartUniqueKey,
+        { profileType: string; profileName: string; genes: string[] }
+    >({}, { deep: false });
     //used in saving generic assay charts
     @observable private _genericAssayChartMap = observable.map<
         ChartUniqueKey,
@@ -4032,10 +4041,7 @@ export class StudyViewPageStore
         range: { start?: number; end?: number } | null
     ): void {
         const uniqueKey = getGenomicChartUniqueKey(hugoGeneSymbol, profileType);
-        if (
-            range &&
-            (range.start !== undefined || range.end !== undefined)
-        ) {
+        if (range && (range.start !== undefined || range.end !== undefined)) {
             trackStudyViewFilterEvent('genomicDataInterval', this);
             const genomicDataFilter: GenomicDataFilter = {
                 hugoGeneSymbol,
@@ -4060,9 +4066,7 @@ export class StudyViewPageStore
         const uniqueKey = getGenomicChartUniqueKey(hugoGeneSymbol, profileType);
         const filter = this._genomicDataFilterSet.get(uniqueKey);
         const value = filter?.values?.[0];
-        return value
-            ? { start: value.start, end: value.end }
-            : undefined;
+        return value ? { start: value.start, end: value.end } : undefined;
     }
 
     @action.bound
@@ -7414,6 +7418,14 @@ export class StudyViewPageStore
         if (!loadedfromUserSettings) {
             this.newlyAddedCharts.clear();
         }
+
+        // Multiple genes on a single continuous-numeric profile render as one
+        // shared-axis violin chart rather than N separate bar charts.
+        if (this.isMultiGeneViolinSelection(newCharts)) {
+            this.addGeneSpecificViolinChart(newCharts, loadedfromUserSettings);
+            return;
+        }
+
         newCharts.forEach(newChart => {
             const uniqueKey = getGenomicChartUniqueKey(
                 newChart.hugoGeneSymbol,
@@ -7485,6 +7497,90 @@ export class StudyViewPageStore
                 this.newlyAddedCharts.push(uniqueKey);
             }
         });
+    }
+
+    /**
+     * True when a gene-level selection should become a single multi-track
+     * violin chart: more than one gene, all on the same continuous-numeric
+     * profile (no mutation sub-option). A single gene stays a bar chart, and
+     * categorical profiles stay one pie chart per gene.
+     */
+    public isMultiGeneViolinSelection(newCharts: GenomicChart[]): boolean {
+        return (
+            newCharts.length > 1 &&
+            newCharts.every(
+                c =>
+                    c.dataType === DataType.NUMBER &&
+                    !c.mutationOptionType &&
+                    c.profileType === newCharts[0].profileType
+            )
+        );
+    }
+
+    @action.bound
+    private addGeneSpecificViolinChart(
+        newCharts: GenomicChart[],
+        loadedfromUserSettings: boolean = false
+    ): void {
+        const profileType = newCharts[0].profileType;
+        const genes = newCharts.map(c => c.hugoGeneSymbol);
+        const uniqueKey = getGeneSpecificViolinChartUniqueKey(
+            profileType,
+            genes
+        );
+
+        if (this._geneSpecificViolinChartMap.has(uniqueKey)) {
+            this.changeChartVisibility(uniqueKey, true);
+        } else {
+            // The per-gene chart name is "GENE: Profile Label"; strip the gene
+            // prefix to recover the bare profile label for the chart title.
+            const profileName =
+                newCharts[0].name?.replace(
+                    `${newCharts[0].hugoGeneSymbol}: `,
+                    ''
+                ) ?? profileType;
+            const displayName = `${profileName} (${genes.length} genes)`;
+
+            const chartMeta: ChartMeta = {
+                uniqueKey,
+                displayName,
+                description: newCharts[0].description || displayName,
+                dataType: ChartMetaDataTypeEnum.GENE_SPECIFIC,
+                patientAttribute: false,
+                renderWhenDataChange: false,
+                priority: 0,
+            };
+
+            this._geneSpecificCharts.set(uniqueKey, chartMeta);
+            this._geneSpecificViolinChartMap.set(uniqueKey, {
+                profileType,
+                profileName,
+                genes,
+            });
+            this.chartsType.set(
+                uniqueKey,
+                ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT
+            );
+            this.chartsDimension.set(
+                uniqueKey,
+                STUDY_VIEW_CONFIG.layout.dimensions[
+                    ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT
+                ]
+            );
+            this.changeChartVisibility(uniqueKey, true);
+        }
+
+        if (!loadedfromUserSettings) {
+            this.newlyAddedCharts.push(uniqueKey);
+        }
+    }
+
+    public getGeneSpecificViolinChart(
+        uniqueKey: string
+    ):
+        | { profileType: string; profileName: string; genes: string[] }
+        | undefined {
+        return this._geneSpecificViolinChartMap.get(uniqueKey);
     }
 
     @action.bound

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -3029,6 +3029,12 @@ export class StudyViewPageStore
         ChartUniqueKey,
         { profileType: string; profileName: string; genes: string[] }
     >({}, { deep: false });
+    // Per-chart log-scale state for gene-specific violins, toggled from the
+    // chart-header options menu.
+    @observable private _geneSpecificViolinLogScale = observable.map<
+        ChartUniqueKey,
+        boolean
+    >({}, { deep: false });
     //used in saving generic assay charts
     @observable private _genericAssayChartMap = observable.map<
         ChartUniqueKey,
@@ -7600,6 +7606,18 @@ export class StudyViewPageStore
         | { profileType: string; profileName: string; genes: string[] }
         | undefined {
         return this._geneSpecificViolinChartMap.get(uniqueKey);
+    }
+
+    public isGeneSpecificViolinLogScale(uniqueKey: string): boolean {
+        return !!this._geneSpecificViolinLogScale.get(uniqueKey);
+    }
+
+    @action.bound
+    public toggleGeneSpecificViolinLogScale(uniqueKey: string): void {
+        this._geneSpecificViolinLogScale.set(
+            uniqueKey,
+            !this._geneSpecificViolinLogScale.get(uniqueKey)
+        );
     }
 
     @action.bound

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -4018,6 +4018,53 @@ export class StudyViewPageStore
         }
     }
 
+    /**
+     * Apply (or clear) a value-range filter for a single gene's molecular
+     * profile, driven by a drag selection on the mRNA violin plot. Unlike
+     * updateGenomicDataFiltersByValues this does not require a registered
+     * gene-specific chart — it owns the GenomicDataFilter directly, keyed by
+     * the same uniqueKey scheme so it round-trips through study-view filters.
+     */
+    @action.bound
+    updateMrnaViolinSelection(
+        hugoGeneSymbol: string,
+        profileType: string,
+        range: { start?: number; end?: number } | null
+    ): void {
+        const uniqueKey = getGenomicChartUniqueKey(hugoGeneSymbol, profileType);
+        if (
+            range &&
+            (range.start !== undefined || range.end !== undefined)
+        ) {
+            trackStudyViewFilterEvent('genomicDataInterval', this);
+            const genomicDataFilter: GenomicDataFilter = {
+                hugoGeneSymbol,
+                profileType,
+                values: [
+                    {
+                        start: range.start,
+                        end: range.end,
+                    } as DataFilterValue,
+                ],
+            };
+            this._genomicDataFilterSet.set(uniqueKey, genomicDataFilter);
+        } else {
+            this._genomicDataFilterSet.delete(uniqueKey);
+        }
+    }
+
+    public getMrnaViolinSelection(
+        hugoGeneSymbol: string,
+        profileType: string
+    ): { start?: number; end?: number } | undefined {
+        const uniqueKey = getGenomicChartUniqueKey(hugoGeneSymbol, profileType);
+        const filter = this._genomicDataFilterSet.get(uniqueKey);
+        const value = filter?.values?.[0];
+        return value
+            ? { start: value.start, end: value.end }
+            : undefined;
+    }
+
     @action.bound
     updateGenericAssayDataFiltersByValues(
         uniqueKey: string,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8158,6 +8158,19 @@ export class StudyViewPageStore
                 _.fromPairs(this._genericAssayChartMap.toJSON()),
                 _.fromPairs(this._XvsYScatterChartMap.toJSON()),
                 _.fromPairs(this._XvsYViolinChartMap.toJSON()),
+                _.fromPairs(
+                    Array.from(this._geneSpecificViolinChartMap.keys()).map(
+                        key => [
+                            key,
+                            {
+                                ...this._geneSpecificViolinChartMap.get(key)!,
+                                logScale: this._geneSpecificViolinLogScale.get(
+                                    key
+                                ),
+                            },
+                        ]
+                    )
+                ),
                 _.fromPairs(this._clinicalDataBinFilterSet.toJSON()),
                 this._filterMutatedGenesTableByCancerGenes,
                 this._filterSVGenesTableByCancerGenes,
@@ -8400,6 +8413,7 @@ export class StudyViewPageStore
             this._defaultGenericAssayChartMap,
             this._defaultXvsYChartMap,
             {},
+            {},
             _.fromPairs(this._defaultClinicalDataBinFilterSet.toJSON())
         );
     }
@@ -8481,6 +8495,31 @@ export class StudyViewPageStore
                     ],
                     true
                 );
+            }
+            if (
+                chartUserSettings.chartType ===
+                    ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT &&
+                chartUserSettings.hugoGeneSymbols &&
+                chartUserSettings.profileType
+            ) {
+                const profileType = chartUserSettings.profileType;
+                // The persisted name holds the bare profile label; rebuild the
+                // per-gene "GENE: Profile" names so addGeneSpecificCharts routes
+                // them back into a single violin with the right title.
+                const profileName = chartUserSettings.name ?? profileType;
+                this.addGeneSpecificCharts(
+                    chartUserSettings.hugoGeneSymbols.map(gene => ({
+                        name: `${gene}: ${profileName}`,
+                        description: chartUserSettings.description,
+                        profileType,
+                        hugoGeneSymbol: gene,
+                        dataType: DataType.NUMBER,
+                    })),
+                    true
+                );
+                if (chartUserSettings.violinLogScale) {
+                    this.toggleGeneSpecificViolinLogScale(chartUserSettings.id);
+                }
             }
             if (chartUserSettings.profileType && chartUserSettings.genericAssayType) {
                 if (

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8727,14 +8727,25 @@ export class StudyViewPageStore
                                 g.id ===
                                 STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID
                         )?.genes ?? [];
+                    const geneTablePriorities = [
+                        STUDY_VIEW_CONFIG.priority.MUTATED_GENES_TABLE,
+                        STUDY_VIEW_CONFIG.priority
+                            .STRUCTURAL_VARIANT_GENES_TABLE,
+                        STUDY_VIEW_CONFIG.priority.CNA_GENES_TABLE,
+                    ].filter((priority): priority is number =>
+                        Number.isFinite(priority)
+                    );
+                    const priorityAfterGeneTables =
+                        geneTablePriorities.length > 0
+                            ? Math.min(...geneTablePriorities) - 1
+                            : 79;
                     this.registerGeneSpecificViolinChart({
                         profileType: getSuffixOfMolecularProfile(profile),
                         profileName: profile.name,
                         genes: defaultGenes,
-                        // Slot just below the genomic-profile/case-list summary
-                        // charts (priority 1000) so the violin lands after them
-                        // rather than at the very top.
-                        priority: 990,
+                        // Keep the default violin directly after the core gene
+                        // tables, while still allowing site-specific overrides.
+                        priority: priorityAfterGeneTables,
                     });
                 }
             }

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -288,6 +288,7 @@ import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
 import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
+import { MRNA_TAB_GENE_GROUPS } from 'pages/patientView/mrna/mrnaTabGeneGroups';
 import {
     createAlteredGeneComparisonSession,
     doesChartHaveComparisonGroupsLimit,
@@ -7522,33 +7523,54 @@ export class StudyViewPageStore
         newCharts: GenomicChart[],
         loadedfromUserSettings: boolean = false
     ): void {
-        const profileType = newCharts[0].profileType;
-        const genes = newCharts.map(c => c.hugoGeneSymbol);
+        // The per-gene chart name is "GENE: Profile Label"; strip the gene
+        // prefix to recover the bare profile label for the chart title.
+        const profileName =
+            newCharts[0].name?.replace(
+                `${newCharts[0].hugoGeneSymbol}: `,
+                ''
+            ) ?? newCharts[0].profileType;
+        const uniqueKey = this.registerGeneSpecificViolinChart({
+            profileType: newCharts[0].profileType,
+            profileName,
+            genes: newCharts.map(c => c.hugoGeneSymbol),
+            description: newCharts[0].description,
+        });
+
+        if (!loadedfromUserSettings) {
+            this.newlyAddedCharts.push(uniqueKey);
+        }
+    }
+
+    /**
+     * Register a multi-gene violin chart (idempotent by uniqueKey) and make it
+     * visible. Shared by the Add Chart flow and the default auto-added violin.
+     * Returns the chart's uniqueKey.
+     */
+    @action
+    private registerGeneSpecificViolinChart(config: {
+        profileType: string;
+        profileName: string;
+        genes: string[];
+        description?: string;
+        priority?: number;
+    }): string {
+        const { profileType, profileName, genes, description } = config;
         const uniqueKey = getGeneSpecificViolinChartUniqueKey(
             profileType,
             genes
         );
 
-        if (this._geneSpecificViolinChartMap.has(uniqueKey)) {
-            this.changeChartVisibility(uniqueKey, true);
-        } else {
-            // The per-gene chart name is "GENE: Profile Label"; strip the gene
-            // prefix to recover the bare profile label for the chart title.
-            const profileName =
-                newCharts[0].name?.replace(
-                    `${newCharts[0].hugoGeneSymbol}: `,
-                    ''
-                ) ?? profileType;
+        if (!this._geneSpecificViolinChartMap.has(uniqueKey)) {
             const displayName = `${profileName} (${genes.length} genes)`;
-
             const chartMeta: ChartMeta = {
                 uniqueKey,
                 displayName,
-                description: newCharts[0].description || displayName,
+                description: description || displayName,
                 dataType: ChartMetaDataTypeEnum.GENE_SPECIFIC,
                 patientAttribute: false,
                 renderWhenDataChange: false,
-                priority: 0,
+                priority: config.priority ?? 0,
             };
 
             this._geneSpecificCharts.set(uniqueKey, chartMeta);
@@ -7567,12 +7589,9 @@ export class StudyViewPageStore
                     ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT
                 ]
             );
-            this.changeChartVisibility(uniqueKey, true);
         }
-
-        if (!loadedfromUserSettings) {
-            this.newlyAddedCharts.push(uniqueKey);
-        }
+        this.changeChartVisibility(uniqueKey, true);
+        return uniqueKey;
     }
 
     public getGeneSpecificViolinChart(
@@ -8608,35 +8627,41 @@ export class StudyViewPageStore
                 this.changeChartVisibility(chartMeta.uniqueKey, true);
             }
 
-            // Show the mRNA violin plot only for a single-study view with a
-            // z-score mRNA profile. The chart plots multiple genes on a shared
-            // axis, which is only meaningful in cohort-comparable units
-            // (z-scores); absolute/log profiles keep each gene's own baseline.
-            // And precalculated z-scores aren't comparable across studies
-            // (each is standardized against its own cohort/reference), so we
-            // restrict to single-study to avoid pooling incomparable values.
+            // Auto-add a default-configured gene-specific violin only for a
+            // single-study view with a z-score mRNA profile. The chart plots
+            // multiple genes on a shared axis, which is only meaningful in
+            // cohort-comparable units (z-scores); absolute/log profiles keep
+            // each gene's own baseline. And precalculated z-scores aren't
+            // comparable across studies (each is standardized against its own
+            // cohort/reference), so we restrict to single-study to avoid
+            // pooling incomparable values.
             const isSingleStudy =
                 (this.queriedPhysicalStudyIds.result?.length ?? 0) === 1;
-            const hasMrnaZscoreProfile = this.molecularProfiles.result.some(
+            const mrnaZscoreProfiles = this.molecularProfiles.result.filter(
                 p =>
                     p.molecularAlterationType === 'MRNA_EXPRESSION' &&
                     p.datatype === DataTypeConstants.ZSCORE
             );
-            if (isSingleStudy && hasMrnaZscoreProfile) {
-                this.chartsType.set(
-                    SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
-                    ChartTypeEnum.MRNA_VIOLIN_PLOT
-                );
-                this.chartsDimension.set(
-                    SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
-                    STUDY_VIEW_CONFIG.layout.dimensions[
-                        ChartTypeEnum.MRNA_VIOLIN_PLOT
-                    ]
-                );
-                this.changeChartVisibility(
-                    SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
-                    true
-                );
+            if (isSingleStudy && mrnaZscoreProfiles.length > 0) {
+                // Prefer "all-sample" z-scores: bounded across the cohort, so
+                // the shared cross-gene axis stays sane (diploid-reference
+                // z-scores can explode for genes silent in normal tissue).
+                const profile =
+                    mrnaZscoreProfiles.find(p =>
+                        /all[_]?sample/i.test(p.molecularProfileId)
+                    ) ?? mrnaZscoreProfiles[0];
+                const defaultGenes =
+                    MRNA_TAB_GENE_GROUPS.find(g => g.id === 'msk-trial')
+                        ?.genes ?? [];
+                this.registerGeneSpecificViolinChart({
+                    profileType: getSuffixOfMolecularProfile(profile),
+                    profileName: profile.name,
+                    genes: defaultGenes.slice(0, 10),
+                    // Slot just below the genomic-profile/case-list summary
+                    // charts (priority 1000) so the violin lands after them
+                    // rather than at the very top.
+                    priority: 990,
+                });
             }
         }
 

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8692,45 +8692,51 @@ export class StudyViewPageStore
             }
 
             // Auto-add a default-configured gene-specific violin from mRNA
-            // profiles. z-score profiles are only valid for single-study
-            // views; for multi-study (or when z-scores are unavailable), use
-            // non-zscore mRNA profiles instead.
-            const isSingleStudy =
-                (this.queriedPhysicalStudyIds.result?.length ?? 0) === 1;
-            const mrnaProfiles = this.molecularProfiles.result.filter(
-                p => p.molecularAlterationType === 'MRNA_EXPRESSION'
-            );
-            const mrnaZscoreProfiles = mrnaProfiles.filter(
-                p => p.datatype === DataTypeConstants.ZSCORE
-            );
-            const mrnaNonZscoreProfiles = mrnaProfiles.filter(
-                p => p.datatype !== DataTypeConstants.ZSCORE
-            );
-            const eligibleMrnaProfiles =
-                isSingleStudy && mrnaZscoreProfiles.length > 0
-                    ? mrnaZscoreProfiles
-                    : mrnaNonZscoreProfiles;
-            if (eligibleMrnaProfiles.length > 0) {
-                // Prefer "all-sample" variants when available.
-                const profile =
-                    eligibleMrnaProfiles.find(p =>
-                        /all[_]?sample/i.test(p.molecularProfileId)
-                    ) ?? eligibleMrnaProfiles[0];
-                const defaultGenes =
-                    MRNA_TAB_GENE_GROUPS.find(
-                        g =>
-                            g.id ===
-                            STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID
-                    )?.genes ?? [];
-                this.registerGeneSpecificViolinChart({
-                    profileType: getSuffixOfMolecularProfile(profile),
-                    profileName: profile.name,
-                    genes: defaultGenes,
-                    // Slot just below the genomic-profile/case-list summary
-                    // charts (priority 1000) so the violin lands after them
-                    // rather than at the very top.
-                    priority: 990,
-                });
+            // profiles, if the feature flag is enabled. z-score profiles are
+            // only valid for single-study views; for multi-study (or when
+            // z-scores are unavailable), use non-zscore mRNA profiles instead.
+            if (
+                this.appStore.featureFlagStore.has(
+                    FeatureFlagEnum.GENE_SPECIFIC_VIOLIN_PLOT
+                )
+            ) {
+                const isSingleStudy =
+                    (this.queriedPhysicalStudyIds.result?.length ?? 0) === 1;
+                const mrnaProfiles = this.molecularProfiles.result.filter(
+                    p => p.molecularAlterationType === 'MRNA_EXPRESSION'
+                );
+                const mrnaZscoreProfiles = mrnaProfiles.filter(
+                    p => p.datatype === DataTypeConstants.ZSCORE
+                );
+                const mrnaNonZscoreProfiles = mrnaProfiles.filter(
+                    p => p.datatype !== DataTypeConstants.ZSCORE
+                );
+                const eligibleMrnaProfiles =
+                    isSingleStudy && mrnaZscoreProfiles.length > 0
+                        ? mrnaZscoreProfiles
+                        : mrnaNonZscoreProfiles;
+                if (eligibleMrnaProfiles.length > 0) {
+                    // Prefer "all-sample" variants when available.
+                    const profile =
+                        eligibleMrnaProfiles.find(p =>
+                            /all[_]?sample/i.test(p.molecularProfileId)
+                        ) ?? eligibleMrnaProfiles[0];
+                    const defaultGenes =
+                        MRNA_TAB_GENE_GROUPS.find(
+                            g =>
+                                g.id ===
+                                STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID
+                        )?.genes ?? [];
+                    this.registerGeneSpecificViolinChart({
+                        profileType: getSuffixOfMolecularProfile(profile),
+                        profileName: profile.name,
+                        genes: defaultGenes,
+                        // Slot just below the genomic-profile/case-list summary
+                        // charts (priority 1000) so the violin lands after them
+                        // rather than at the very top.
+                        priority: 990,
+                    });
+                }
             }
         }
 

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -288,7 +288,10 @@ import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
 import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
-import { MRNA_TAB_GENE_GROUPS } from 'pages/patientView/mrna/mrnaTabGeneGroups';
+import {
+    MRNA_TAB_GENE_GROUPS,
+    STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
+} from 'pages/patientView/mrna/mrnaTabGeneGroups';
 import {
     createAlteredGeneComparisonSession,
     doesChartHaveComparisonGroupsLimit,
@@ -8712,12 +8715,15 @@ export class StudyViewPageStore
                         /all[_]?sample/i.test(p.molecularProfileId)
                     ) ?? mrnaZscoreProfiles[0];
                 const defaultGenes =
-                    MRNA_TAB_GENE_GROUPS.find(g => g.id === 'msk-trial')
-                        ?.genes ?? [];
+                    MRNA_TAB_GENE_GROUPS.find(
+                        g =>
+                            g.id ===
+                            STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID
+                    )?.genes ?? [];
                 this.registerGeneSpecificViolinChart({
                     profileType: getSuffixOfMolecularProfile(profile),
                     profileName: profile.name,
-                    genes: defaultGenes.slice(0, 10),
+                    genes: defaultGenes,
                     // Slot just below the genomic-profile/case-list summary
                     // charts (priority 1000) so the violin lands after them
                     // rather than at the very top.
@@ -9670,11 +9676,8 @@ export class StudyViewPageStore
                     const reducedGenomic = this.genomicDataFilters.filter(
                         f =>
                             !(
-                                symbolSet.has(
-                                    f.hugoGeneSymbol.toUpperCase()
-                                ) &&
-                                (!profileType ||
-                                    f.profileType === profileType)
+                                symbolSet.has(f.hugoGeneSymbol.toUpperCase()) &&
+                                (!profileType || f.profileType === profileType)
                             )
                     );
                     // No filter active at all (not even our own) → full cohort,

--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -4203,11 +4203,14 @@ describe('StudyViewUtils', () => {
                     },
                 ];
 
-                const filters = buildGenericAssayFrequencyTableDataFilters(rows, [
-                    'entityA::Subtype A::profile_type',
-                    'entityA::Subtype B::profile_type',
-                    'entityB::Subtype C::profile_type',
-                ]);
+                const filters = buildGenericAssayFrequencyTableDataFilters(
+                    rows,
+                    [
+                        'entityA::Subtype A::profile_type',
+                        'entityA::Subtype B::profile_type',
+                        'entityB::Subtype C::profile_type',
+                    ]
+                );
 
                 assert.deepEqual(filters, [
                     {
@@ -4253,34 +4256,33 @@ describe('StudyViewUtils', () => {
             });
 
             it('restores grouped row keys from generic assay selection filters', () => {
-                const selectedRowKeyGroups =
-                    getGenericAssayFrequencyTableSelectedRowKeyGroups(
-                        [
-                            {
-                                profileType: 'profile_type',
-                                patientLevel: false,
-                                values: [
-                                    [
-                                        {
-                                            stableId: 'entityA',
-                                            value: 'Subtype A',
-                                        },
-                                        {
-                                            stableId: 'entityB',
-                                            value: 'Subtype B',
-                                        },
-                                    ],
-                                    [
-                                        {
-                                            stableId: 'entityC',
-                                            value: 'NA',
-                                        },
-                                    ],
+                const selectedRowKeyGroups = getGenericAssayFrequencyTableSelectedRowKeyGroups(
+                    [
+                        {
+                            profileType: 'profile_type',
+                            patientLevel: false,
+                            values: [
+                                [
+                                    {
+                                        stableId: 'entityA',
+                                        value: 'Subtype A',
+                                    },
+                                    {
+                                        stableId: 'entityB',
+                                        value: 'Subtype B',
+                                    },
                                 ],
-                            } as GenericAssayFrequencyTableSelectionFilter,
-                        ],
-                        'profile_type'
-                    );
+                                [
+                                    {
+                                        stableId: 'entityC',
+                                        value: 'NA',
+                                    },
+                                ],
+                            ],
+                        } as GenericAssayFrequencyTableSelectionFilter,
+                    ],
+                    'profile_type'
+                );
 
                 assert.deepEqual(selectedRowKeyGroups, [
                     [
@@ -4353,8 +4355,7 @@ describe('StudyViewUtils', () => {
             });
 
             it('serializes generic assay frequency tables into chart settings for saved layouts', () => {
-                const uniqueKey =
-                    'GENERIC_ASSAY_FREQUENCY_TABLE_profile_type';
+                const uniqueKey = 'GENERIC_ASSAY_FREQUENCY_TABLE_profile_type';
                 const chartSettingsMap = getChartSettingsMap(
                     [
                         {
@@ -4380,13 +4381,13 @@ describe('StudyViewUtils', () => {
                             name: 'Frequency Table: Mutational Signature',
                             description: 'Mutational Signature v2',
                             genericAssayType: 'MUTATIONAL_SIGNATURE',
-                            genericAssayEntityId:
-                                GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                            genericAssayEntityId: GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
                             profileType: 'profile_type',
                             dataType: DataTypeConstants.CATEGORICAL,
                             patientLevel: true,
                         } as any,
                     },
+                    {},
                     {},
                     {},
                     {},
@@ -4403,8 +4404,7 @@ describe('StudyViewUtils', () => {
                     name: 'Frequency Table: Mutational Signature',
                     description: 'Mutational Signature v2',
                     genericAssayType: 'MUTATIONAL_SIGNATURE',
-                    genericAssayEntityId:
-                        GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                    genericAssayEntityId: GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
                     profileType: 'profile_type',
                     dataType: DataTypeConstants.CATEGORICAL,
                     patientLevelProfile: true,

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -326,9 +326,9 @@ export const SPECIAL_CHARTS: ChartMetaWithDimensionAndChartType[] = [
     },
     {
         uniqueKey: SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
-        displayName: 'mRNA Expression (10 Genes)',
+        displayName: 'mRNA Expression (ADC Targets)',
         description:
-            'mRNA expression violin plots for TP53, EGFR, KRAS, MYC, PTEN, RB1, CDH1, PIK3CA, BRCA1, BRCA2',
+            'mRNA expression violin plots for ADC targets in trial at MSK. Genes shown depend on availability in this study.',
         chartType: ChartTypeEnum.MRNA_VIOLIN_PLOT,
         dataType: ChartMetaDataTypeEnum.GENOMIC,
         patientAttribute: false,

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -334,9 +334,9 @@ export const SPECIAL_CHARTS: ChartMetaWithDimensionAndChartType[] = [
         patientAttribute: false,
         dimension: {
             w: 2,
-            h: 3,
+            h: 2,
         },
-        priority: 5,
+        priority: 100,
         renderWhenDataChange: false,
     },
 ];

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -947,6 +947,21 @@ export function splitGenericAssayFrequencyTableRowUniqueKey(uniqueKey: string): 
     };
 }
 
+/**
+ * Unique key for a multi-gene violin chart (one continuous-numeric profile,
+ * several genes on a shared axis). Genes are sorted so the key is stable
+ * regardless of selection order, letting a re-add toggle visibility instead of
+ * creating a duplicate.
+ */
+export function getGeneSpecificViolinChartUniqueKey(
+    profileType: string,
+    hugoGeneSymbols: string[]
+): string {
+    return (
+        [...hugoGeneSymbols].sort().join('_') + '_' + profileType + '_VIOLIN'
+    );
+}
+
 const UNIQUE_KEY_SEPARATOR = ':';
 const CHART_TYPE_SEPARATOR = ';';
 

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -2954,6 +2954,14 @@ export function getChartSettingsMap(
     genericAssayChartSet: { [id: string]: GenericAssayChart },
     XvsYScatterChartSet: { [id: string]: XvsYScatterChart },
     XvsYViolinChartSet: { [id: string]: XvsYViolinChart },
+    geneSpecificViolinChartSet: {
+        [id: string]: {
+            profileType: string;
+            profileName: string;
+            genes: string[];
+            logScale?: boolean;
+        };
+    },
     clinicalDataBinFilterSet: {
         [uniqueId: string]: ClinicalDataBinFilter & { showNA?: boolean };
     },
@@ -3020,6 +3028,15 @@ export function getChartSettingsMap(
                 XvsYViolinChart.categoricalAttr.clinicalAttributeId;
             chartSetting.numericalAttrId =
                 XvsYViolinChart.numericalAttr.clinicalAttributeId;
+        }
+        const geneSpecificViolinChart = geneSpecificViolinChartSet[id];
+        if (geneSpecificViolinChart) {
+            chartSetting.name = geneSpecificViolinChart.profileName;
+            chartSetting.profileType = geneSpecificViolinChart.profileType;
+            chartSetting.hugoGeneSymbols = geneSpecificViolinChart.genes;
+            if (geneSpecificViolinChart.logScale) {
+                chartSetting.violinLogScale = true;
+            }
         }
         if (clinicalDataBinFilterSet[id]) {
             if (clinicalDataBinFilterSet[id].disableLogScale) {

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -187,6 +187,7 @@ export enum SpecialChartsUniqueKeyEnum {
     SAMPLE_TREATMENT_GROUPS = 'SAMPLE_TREATMENT_GROUPS',
     SAMPLE_TREATMENT_TARGET = 'SAMPLE_TREATMENT_TARGET',
     CLINICAL_EVENT_TYPE_COUNTS = 'CLINICAL_EVENT_TYPE_COUNTS',
+    MRNA_VIOLIN_PLOT = 'MRNA_VIOLIN_PLOT',
 }
 
 export type AnalysisGroup = {
@@ -321,6 +322,21 @@ export const SPECIAL_CHARTS: ChartMetaWithDimensionAndChartType[] = [
             h: 2,
         },
         priority: 70,
+        renderWhenDataChange: false,
+    },
+    {
+        uniqueKey: SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
+        displayName: 'mRNA Expression (10 Genes)',
+        description:
+            'mRNA expression violin plots for TP53, EGFR, KRAS, MYC, PTEN, RB1, CDH1, PIK3CA, BRCA1, BRCA2',
+        chartType: ChartTypeEnum.MRNA_VIOLIN_PLOT,
+        dataType: ChartMetaDataTypeEnum.GENOMIC,
+        patientAttribute: false,
+        dimension: {
+            w: 2,
+            h: 3,
+        },
+        priority: 5,
         renderWhenDataChange: false,
     },
 ];
@@ -1927,6 +1943,7 @@ export function getChartMetaDataType(uniqueKey: string): ChartMetaDataTypeEnum {
         SpecialChartsUniqueKeyEnum.MUTATION_COUNT,
         SpecialChartsUniqueKeyEnum.FRACTION_GENOME_ALTERED,
         SpecialChartsUniqueKeyEnum.GENOMIC_PROFILES_SAMPLE_COUNT,
+        SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
     ];
     return _.includes(GENOMIC_DATA_TYPES, uniqueKey)
         ? ChartMetaDataTypeEnum.GENOMIC

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -324,21 +324,6 @@ export const SPECIAL_CHARTS: ChartMetaWithDimensionAndChartType[] = [
         priority: 70,
         renderWhenDataChange: false,
     },
-    {
-        uniqueKey: SpecialChartsUniqueKeyEnum.MRNA_VIOLIN_PLOT,
-        displayName: 'mRNA Expression (ADC Targets)',
-        description:
-            'mRNA expression violin plots for ADC targets in trial at MSK. Genes shown depend on availability in this study.',
-        chartType: ChartTypeEnum.MRNA_VIOLIN_PLOT,
-        dataType: ChartMetaDataTypeEnum.GENOMIC,
-        patientAttribute: false,
-        dimension: {
-            w: 2,
-            h: 2,
-        },
-        priority: 100,
-        renderWhenDataChange: false,
-    },
 ];
 
 export const COLORS = [

--- a/src/pages/studyView/UserSelections.tsx
+++ b/src/pages/studyView/UserSelections.tsx
@@ -33,6 +33,7 @@ import {
     intervalFiltersDisplayValue,
     StudyViewFilterWithSampleIdentifierFilters,
     ChartMeta,
+    ChartMetaDataTypeEnum,
     getUniqueKeyFromGeneFilterMolecularProfileIds,
 } from 'pages/studyView/StudyViewUtils';
 import { PillTag } from '../../shared/components/PillTag/PillTag';
@@ -278,6 +279,55 @@ export default class UserSelections extends React.Component<
                                         }
                                     >
                                         {chartMeta.displayName}
+                                    </span>,
+                                    dataFilterComponent,
+                                ]}
+                                operation={':'}
+                                group={false}
+                            />
+                        </div>
+                    );
+                } else {
+                    // No registered chart for this filter (e.g. an mRNA violin
+                    // plot drag-selection, which owns its GenomicDataFilter
+                    // directly). Render a fallback pill so the selection is
+                    // still visible and removable from the filter bar.
+                    const { hugoGeneSymbol, profileType } = genomicDataFilter;
+                    const fallbackMeta = {
+                        uniqueKey,
+                        displayName: `${hugoGeneSymbol} mRNA`,
+                        description: `${hugoGeneSymbol} ${profileType}`,
+                        priority: 0,
+                        dataType: ChartMetaDataTypeEnum.GENE_SPECIFIC,
+                        patientAttribute: false,
+                        renderWhenDataChange: false,
+                    } as ChartMeta;
+                    const dataFilterComponent = this.renderDataBinFilter(
+                        genomicDataFilter.values,
+                        (_key, update) =>
+                            this.props.store.updateMrnaViolinSelection(
+                                hugoGeneSymbol,
+                                profileType,
+                                update
+                            ),
+                        () =>
+                            this.props.store.updateMrnaViolinSelection(
+                                hugoGeneSymbol,
+                                profileType,
+                                null
+                            ),
+                        fallbackMeta
+                    );
+                    acc.push(
+                        <div className={styles.parentGroupLogic}>
+                            <GroupLogic
+                                components={[
+                                    <span
+                                        className={
+                                            styles.filterClinicalAttrName
+                                        }
+                                    >
+                                        {fallbackMeta.displayName}
                                     </span>,
                                     dataFilterComponent,
                                 ]}

--- a/src/pages/studyView/UserSelections.tsx
+++ b/src/pages/studyView/UserSelections.tsx
@@ -295,7 +295,7 @@ export default class UserSelections extends React.Component<
                     const { hugoGeneSymbol, profileType } = genomicDataFilter;
                     const fallbackMeta = {
                         uniqueKey,
-                        displayName: `${hugoGeneSymbol} mRNA`,
+                        displayName: `${hugoGeneSymbol} (${profileType})`,
                         description: `${hugoGeneSymbol} ${profileType}`,
                         priority: 0,
                         dataType: ChartMetaDataTypeEnum.GENE_SPECIFIC,

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -1061,6 +1061,14 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                                 : 'has been'
                                         } added.`
                                     );
+                                } else if (
+                                    this.props.store.isMultiGeneViolinSelection(
+                                        charts
+                                    )
+                                ) {
+                                    this.updateInfoMessage(
+                                        `Violin chart added (${charts.length} genes)`
+                                    );
                                 } else {
                                     this.updateInfoMessage(
                                         `${charts.length} charts added`

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
@@ -23,6 +23,8 @@ import {
     MutationOptionConstantsLabel,
 } from 'shared/constants';
 import autobind from 'autobind-decorator';
+import gene_lists from 'shared/components/query/gene_lists';
+import { getServerConfig, ServerConfigHelpers } from 'config/config';
 
 export interface IGeneLevelSelectionProps {
     molecularProfileOptionsPromise: MobxPromise<MolecularProfileOption[]>;
@@ -99,6 +101,45 @@ export default class GeneLevelSelection extends React.Component<
             });
             this.props.onSubmit(charts);
         }
+    }
+
+    // Curated gene sets for the dropdown above the textarea (same source as the
+    // query page's gene-set selector): the built-in pathway lists, overridden by
+    // the server's query_sets_of_genes config when present.
+    @computed
+    private get geneSetOptions() {
+        let geneList: { id: string; genes: string[] }[] = gene_lists;
+        if (getServerConfig().query_sets_of_genes) {
+            const parsed = ServerConfigHelpers.parseQuerySetsOfGenes(
+                getServerConfig().query_sets_of_genes!
+            );
+            if (parsed) {
+                geneList = parsed;
+            }
+        }
+        return [
+            { label: 'User-defined List', value: '' },
+            ...geneList.map(item => ({
+                label: `${item.id} (${item.genes.length} genes)`,
+                value: item.genes.join(' '),
+            })),
+        ];
+    }
+
+    @computed
+    private get selectedGeneSetOption() {
+        return (
+            this.geneSetOptions.find(
+                opt => opt.value === (this._queryStr || '')
+            ) || null
+        );
+    }
+
+    // Selecting a set populates the textarea; OQLTextArea reacts to the new
+    // inputGeneQuery and validates it, which feeds validGenes.
+    @action.bound
+    private handleGeneSetSelect(option: any) {
+        this._queryStr = option ? option.value : '';
     }
 
     @action.bound
@@ -222,9 +263,19 @@ export default class GeneLevelSelection extends React.Component<
             }
             return (
                 <div style={{ width: this.props.containerWidth - 20 }}>
+                    <div style={{ marginBottom: '5px' }}>
+                        <ReactSelect
+                            value={this.selectedGeneSetOption}
+                            onChange={this.handleGeneSetSelect}
+                            options={this.geneSetOptions}
+                            isClearable={false}
+                            isSearchable={true}
+                            placeholder={'Select a gene set...'}
+                        />
+                    </div>
                     <OQLTextArea
                         inputGeneQuery={this._queryStr}
-                        validateInputGeneQuery={false}
+                        validateInputGeneQuery={true}
                         callback={(...args) => {
                             this._oql = args[0];
                             this._genes = args[1];

--- a/src/pages/studyView/chartHeader/styles.module.scss
+++ b/src/pages/studyView/chartHeader/styles.module.scss
@@ -28,6 +28,10 @@ $iconFontSize: 14px;
     border-radius: $border-radius-base;
     right: -1px;
     top: -1px;
+    // Keep header controls above the chart body. Some charts (e.g. the mRNA
+    // violin plot) create their own stacking context for internal overlays,
+    // which would otherwise paint over and cut off these controls.
+    z-index: 2;
 }
 
 .menuToggle {

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -1621,6 +1621,26 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                     />
                 );
             }
+            case ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT: {
+                const violinChart = this.props.store.getGeneSpecificViolinChart(
+                    this.props.chartMeta.uniqueKey
+                );
+                return () => (
+                    <MrnaViolinPlotChart
+                        store={this.props.store}
+                        width={getWidthByDimension(
+                            this.props.dimension,
+                            this.borderWidth
+                        )}
+                        height={getHeightByDimension(
+                            this.props.dimension,
+                            this.chartHeaderHeight
+                        )}
+                        genes={violinChart?.genes}
+                        profileType={violinChart?.profileType}
+                    />
+                );
+            }
             default:
                 return null;
         }

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -74,6 +74,7 @@ import {
     SURVIVAL_PLOT_Y_LABEL_TOOLTIP,
 } from 'pages/resultsView/survival/SurvivalUtil';
 import StudyViewViolinPlotTable from 'pages/studyView/charts/violinPlotTable/StudyViewViolinPlotTable';
+import MrnaViolinPlotChart from 'pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart';
 import { PatientSurvival } from 'shared/model/PatientSurvival';
 import ClinicalEventTypeCountTable, {
     ClinicalEventTypeCountColumnKey,
@@ -1605,6 +1606,21 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                     );
                 };
                 break;
+            case ChartTypeEnum.MRNA_VIOLIN_PLOT: {
+                return () => (
+                    <MrnaViolinPlotChart
+                        store={this.props.store}
+                        width={getWidthByDimension(
+                            this.props.dimension,
+                            this.borderWidth
+                        )}
+                        height={getHeightByDimension(
+                            this.props.dimension,
+                            this.chartHeaderHeight
+                        )}
+                    />
+                );
+            }
             default:
                 return null;
         }

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -391,6 +391,13 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                     boxPlotChecked: this.props.boxPlotChecked,
                 };
                 break;
+            case ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT: {
+                controls = {
+                    showLogScaleToggle: this.props.showLogScaleToggle,
+                    logScaleChecked: this.props.logScaleChecked,
+                };
+                break;
+            }
             case ChartTypeEnum.PIE_CHART: {
                 controls = { showTableIcon: true };
                 break;
@@ -1638,6 +1645,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                         )}
                         genes={violinChart?.genes}
                         profileType={violinChart?.profileType}
+                        logScale={this.props.logScaleChecked}
                     />
                 );
             }

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -8,12 +8,18 @@ import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicato
 import _ from 'lodash';
 import { Gene, MolecularProfile } from 'cbioportal-ts-api-client';
 import { DataTypeConstants } from 'shared/constants';
-import { MRNA_TAB_GENE_GROUPS } from 'pages/patientView/mrna/mrnaTabGeneGroups';
+import {
+    MRNA_TAB_GENE_GROUPS,
+    STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
+} from 'pages/patientView/mrna/mrnaTabGeneGroups';
 import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
 
-const MSK_TRIAL_GENES: string[] = MRNA_TAB_GENE_GROUPS.find(
-    g => g.id === 'msk-trial'
-)!.genes;
+const DEFAULT_GENE_GROUP =
+    MRNA_TAB_GENE_GROUPS.find(
+        g => g.id === STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID
+    ) ?? MRNA_TAB_GENE_GROUPS[0];
+const DEFAULT_MRNA_GENES: string[] = DEFAULT_GENE_GROUP.genes;
+const DEFAULT_MRNA_GENE_GROUP_LABEL = DEFAULT_GENE_GROUP.label;
 
 const DEFAULT_GENE_COUNT = 10;
 const MAX_GENES = 10;
@@ -154,7 +160,7 @@ export default class MrnaViolinPlotChart extends React.Component<
     IMrnaViolinPlotChartProps,
     {}
 > {
-    @observable selectedSymbols: string[] = MSK_TRIAL_GENES.slice(
+    @observable selectedSymbols: string[] = DEFAULT_MRNA_GENES.slice(
         0,
         DEFAULT_GENE_COUNT
     );
@@ -309,18 +315,16 @@ export default class MrnaViolinPlotChart extends React.Component<
                 byGene: { [entrezGeneId: number]: number[] };
                 count: number;
             }> => {
-                const ids = cohort
-                    .slice(0, MAX_SAMPLES)
-                    .flatMap(sample => {
-                        const profile = chosenProfileByStudy[sample.studyId];
-                        if (!profile) return [];
-                        return [
-                            {
-                                molecularProfileId: profile.molecularProfileId,
-                                sampleId: sample.sampleId,
-                            },
-                        ];
-                    });
+                const ids = cohort.slice(0, MAX_SAMPLES).flatMap(sample => {
+                    const profile = chosenProfileByStudy[sample.studyId];
+                    if (!profile) return [];
+                    return [
+                        {
+                            molecularProfileId: profile.molecularProfileId,
+                            sampleId: sample.sampleId,
+                        },
+                    ];
+                });
                 if (ids.length === 0 || entrezGeneIds.length === 0) {
                     return { byGene: {}, count: 0 };
                 }
@@ -1085,8 +1089,8 @@ export default class MrnaViolinPlotChart extends React.Component<
                         marginBottom: 4,
                     }}
                 >
-                    Select up to {MAX_GENES} genes &mdash; ADC targets in trial
-                    at MSK
+                    Select up to {MAX_GENES} genes &mdash;{' '}
+                    {DEFAULT_MRNA_GENE_GROUP_LABEL}
                     {atMax && (
                         <span style={{ color: '#c00', marginLeft: 6 }}>
                             (max reached)
@@ -1094,7 +1098,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                     )}
                 </div>
                 <div style={{ columnCount: 2, columnGap: 8 }}>
-                    {MSK_TRIAL_GENES.map(symbol => {
+                    {DEFAULT_MRNA_GENES.map(symbol => {
                         const checked = selectedSymbols.includes(symbol);
                         const disabled = !checked && atMax;
                         return (

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -287,17 +287,15 @@ export default class MrnaViolinPlotChart extends React.Component<
     }
 
     @computed get layout() {
-        const marginLeft = 68;
+        const marginLeft = 80;
         const marginRight = 16;
         const marginTop = 38;
         const marginBottom = 6;
         const svgHeight = this.props.height - TOOLBAR_HEIGHT;
         const plotW = this.props.width - marginLeft - marginRight;
         const plotH = svgHeight - marginTop - marginBottom;
-        const rowH =
-            this.currentGenes.length > 0
-                ? plotH / this.currentGenes.length
-                : plotH / DEFAULT_GENE_COUNT;
+        // Always divide by MAX_GENES so row height is consistent regardless of selection count.
+        const rowH = plotH / MAX_GENES;
         return {
             marginLeft,
             marginRight,
@@ -478,10 +476,16 @@ export default class MrnaViolinPlotChart extends React.Component<
         });
         const result = this.mrnaData.result!;
         const profileName = result.profilesUsed[0]?.name ?? 'mRNA Expression';
-        const axisLabel =
+        const rawLabel =
             this.logScale && this.canLogScale
                 ? `log₂(${profileName}+1)`
                 : profileName;
+        // Truncate only when the estimated text width (fontSize 10 ≈ 5.5px/char) exceeds the axis.
+        const maxChars = Math.floor(plotW / 5.5);
+        const isTruncated = rawLabel.length > maxChars;
+        const axisLabel = isTruncated
+            ? rawLabel.slice(0, maxChars - 1) + '…'
+            : rawLabel;
         return (
             <g transform={`translate(0, 0)`}>
                 <line
@@ -489,7 +493,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                     x2={plotW}
                     y1={0}
                     y2={0}
-                    stroke="#aaa"
+                    stroke="black"
                     strokeWidth={1}
                 />
                 {ticks.map(t => (
@@ -499,7 +503,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                             x2={0}
                             y1={0}
                             y2={-4}
-                            stroke="#aaa"
+                            stroke="black"
                             strokeWidth={1}
                         />
                         <text
@@ -507,7 +511,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                             y={-7}
                             textAnchor="middle"
                             fontSize={9}
-                            fill="#555"
+                            fill="black"
                         >
                             {t.val.toFixed(1)}
                         </text>
@@ -518,29 +522,11 @@ export default class MrnaViolinPlotChart extends React.Component<
                     y={-20}
                     textAnchor="middle"
                     fontSize={10}
-                    fill="#333"
+                    fill="black"
                 >
+                    {isTruncated && <title>{rawLabel}</title>}
                     {axisLabel}
                 </text>
-            </g>
-        );
-    }
-
-    private renderRowSeparators(): JSX.Element {
-        const { plotW, rowH } = this.layout;
-        return (
-            <g>
-                {this.currentGenes.map((_, i) => (
-                    <line
-                        key={i}
-                        x1={0}
-                        x2={plotW}
-                        y1={rowH * i}
-                        y2={rowH * i}
-                        stroke="#eee"
-                        strokeWidth={1}
-                    />
-                ))}
             </g>
         );
     }
@@ -552,7 +538,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                 {this.currentGenes.map((gene, i) => (
                     <text
                         key={gene.hugoSymbol}
-                        x={4}
+                        x={10}
                         y={marginTop + rowH * (i + 0.5) + 4}
                         textAnchor="start"
                         fontSize={11}
@@ -637,7 +623,7 @@ export default class MrnaViolinPlotChart extends React.Component<
 
     render() {
         const { width, height } = this.props;
-        const { marginLeft, marginTop, svgHeight } = this.layout;
+        const { marginLeft, marginTop, svgHeight, plotH, rowH } = this.layout;
 
         const isPending =
             this.mrnaData.isPending || this.resolvedGenes.isPending;
@@ -687,6 +673,15 @@ export default class MrnaViolinPlotChart extends React.Component<
                         {this.currentGenes.map((gene, i) =>
                             this.renderGeneRow(gene, i)
                         )}
+                        {/* Y-axis line — height matches the number of active gene rows */}
+                        <line
+                            x1={0}
+                            x2={0}
+                            y1={0}
+                            y2={rowH * this.currentGenes.length}
+                            stroke="black"
+                            strokeWidth={1}
+                        />
                         {this.renderXAxis()}
                     </g>
                 </svg>
@@ -718,6 +713,11 @@ export default class MrnaViolinPlotChart extends React.Component<
                         position: 'relative',
                         zIndex: 3,
                     }}
+                    onClick={action(() => {
+                        // Close picker when clicking anywhere in the toolbar
+                        // (the Genes button stops propagation to handle its own toggle)
+                        this.showGenePicker = false;
+                    })}
                 >
                     <label
                         style={{
@@ -751,7 +751,8 @@ export default class MrnaViolinPlotChart extends React.Component<
                         Log scale
                     </label>
                     <button
-                        onClick={action(() => {
+                        onClick={action((e: React.MouseEvent) => {
+                            e.stopPropagation(); // don't let toolbar's close-handler fire
                             this.showGenePicker = !this.showGenePicker;
                         })}
                         style={{
@@ -769,7 +770,25 @@ export default class MrnaViolinPlotChart extends React.Component<
                     </button>
                 </div>
                 {bodyContent}
-                {this.showGenePicker && this.renderGenePicker()}
+                {this.showGenePicker && (
+                    <>
+                        {/* Invisible overlay to catch outside clicks */}
+                        <div
+                            style={{
+                                position: 'fixed',
+                                top: 0,
+                                left: 0,
+                                right: 0,
+                                bottom: 0,
+                                zIndex: 1,
+                            }}
+                            onClick={action(() => {
+                                this.showGenePicker = false;
+                            })}
+                        />
+                        {this.renderGenePicker()}
+                    </>
+                )}
             </div>
         );
     }

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -409,9 +409,8 @@ export default class MrnaViolinPlotChart extends React.Component<
                 {violinPath && (
                     <path
                         d={violinPath}
-                        fill="#4a90d9"
-                        fillOpacity={0.55}
-                        stroke="#2a6aad"
+                        fill="#2986E2"
+                        stroke="#2986E2"
                         strokeWidth={0.5}
                     />
                 )}

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -209,6 +209,18 @@ export default class MrnaViolinPlotChart extends React.Component<
         default: [],
     });
 
+    /**
+     * Sample cohort the violin distribution is drawn from: filtered by every
+     * other chart but not by this violin's own gene range selections. Keyed by
+     * profile + gene set, so toggling genes resolves to the right cohort.
+     */
+    get distributionSamplesPromise() {
+        return this.props.store.getMrnaViolinDistributionSamples(
+            this.props.profileType ?? null,
+            this.selectedSymbols
+        );
+    }
+
     readonly mrnaData = remoteData<{
         profilesUsed: MolecularProfile[];
         sampleCount: number;
@@ -219,7 +231,11 @@ export default class MrnaViolinPlotChart extends React.Component<
     }>({
         await: () => [
             this.props.store.molecularProfiles,
+            // Non-anchor genes follow every filter (the conditional cohort);
+            // the anchor gene keeps its full distribution from a cohort that
+            // excludes only its own range selection.
             this.props.store.selectedSamples,
+            this.distributionSamplesPromise,
             this.resolvedGenes,
         ],
         invoke: async () => {
@@ -268,9 +284,6 @@ export default class MrnaViolinPlotChart extends React.Component<
                 entrezGeneId: number;
             }>;
 
-            const samples = this.props.store.selectedSamples.result!;
-            const samplesSubset = samples.slice(0, MAX_SAMPLES);
-
             const profilesByStudy = _.groupBy(allMrnaProfiles, p => p.studyId);
             const chosenProfileByStudy: {
                 [studyId: string]: MolecularProfile;
@@ -284,56 +297,80 @@ export default class MrnaViolinPlotChart extends React.Component<
                     : pickBestMrnaProfile(profiles);
             }
 
-            const sampleMolecularIdentifiers = samplesSubset.flatMap(sample => {
-                const profile = chosenProfileByStudy[sample.studyId];
-                if (!profile) return [];
-                return [
-                    {
-                        molecularProfileId: profile.molecularProfileId,
-                        sampleId: sample.sampleId,
-                    },
-                ];
-            });
-
-            if (sampleMolecularIdentifiers.length === 0) {
-                return { profilesUsed: [], sampleCount: 0, genes, byGene: {} };
-            }
-
-            const profilesUsed = Object.values(chosenProfileByStudy);
-            console.info(
-                '[MrnaViolinPlotChart] Using profiles:',
-                profilesUsed.map(p => `${p.name} (${p.datatype})`)
-            );
-
-            const data = await getClient().fetchMolecularDataInMultipleMolecularProfilesUsingPOST(
-                {
-                    molecularDataMultipleStudyFilter: {
-                        entrezGeneIds: genes.map(g => g.entrezGeneId),
-                        sampleMolecularIdentifiers,
-                    } as any,
+            // Fetch z-scores for a set of genes over a sample cohort, grouped by
+            // gene. Used twice: the conditional cohort (all filters) for the
+            // non-anchor genes, and the anchor's own full cohort.
+            const fetchByGene = async (
+                cohort: { studyId: string; sampleId: string }[],
+                entrezGeneIds: number[]
+            ): Promise<{
+                byGene: { [entrezGeneId: number]: number[] };
+                count: number;
+            }> => {
+                const ids = cohort
+                    .slice(0, MAX_SAMPLES)
+                    .flatMap(sample => {
+                        const profile = chosenProfileByStudy[sample.studyId];
+                        if (!profile) return [];
+                        return [
+                            {
+                                molecularProfileId: profile.molecularProfileId,
+                                sampleId: sample.sampleId,
+                            },
+                        ];
+                    });
+                if (ids.length === 0 || entrezGeneIds.length === 0) {
+                    return { byGene: {}, count: 0 };
                 }
-            );
+                const data = await getClient().fetchMolecularDataInMultipleMolecularProfilesUsingPOST(
+                    {
+                        molecularDataMultipleStudyFilter: {
+                            entrezGeneIds,
+                            sampleMolecularIdentifiers: ids,
+                        } as any,
+                    }
+                );
+                const byGene: { [entrezGeneId: number]: number[] } = {};
+                for (const d of data) {
+                    if (!byGene[d.entrezGeneId]) byGene[d.entrezGeneId] = [];
+                    byGene[d.entrezGeneId].push(d.value);
+                }
+                return { byGene, count: ids.length };
+            };
 
-            const byGene: { [entrezGeneId: number]: number[] } = {};
-            for (const d of data) {
-                if (!byGene[d.entrezGeneId]) byGene[d.entrezGeneId] = [];
-                byGene[d.entrezGeneId].push(d.value);
+            // Non-anchor genes follow every filter (including the anchor's
+            // range): their violins are the conditional distribution
+            // P(gene | anchor ∈ selected range).
+            const base = await fetchByGene(
+                this.props.store.selectedSamples.result!,
+                genes.map(g => g.entrezGeneId)
+            );
+            const byGene = base.byGene;
+
+            // The single selected "anchor" gene keeps its FULL distribution,
+            // drawn from the cohort filtered by everything except its own range,
+            // so its shape is stable and the selected slice is highlighted.
+            const anchor = this.profileType
+                ? genes.find(
+                      g =>
+                          this.props.store.getMrnaViolinSelection(
+                              g.hugoSymbol,
+                              this.profileType!
+                          ) !== undefined
+                  )
+                : undefined;
+            if (anchor) {
+                const anchorData = await fetchByGene(
+                    this.distributionSamplesPromise.result!,
+                    [anchor.entrezGeneId]
+                );
+                byGene[anchor.entrezGeneId] =
+                    anchorData.byGene[anchor.entrezGeneId] || [];
             }
-
-            console.info(
-                '[MrnaViolinPlotChart] Value ranges per gene:',
-                genes.map(g => {
-                    const vals = byGene[g.entrezGeneId] || [];
-                    if (!vals.length) return `${g.hugoSymbol}: no data`;
-                    return `${g.hugoSymbol}: [${Math.min(...vals).toFixed(
-                        2
-                    )}, ${Math.max(...vals).toFixed(2)}] n=${vals.length}`;
-                })
-            );
 
             return {
-                profilesUsed,
-                sampleCount: sampleMolecularIdentifiers.length,
+                profilesUsed: Object.values(chosenProfileByStudy),
+                sampleCount: base.count,
                 genes,
                 byGene,
             };
@@ -527,11 +564,34 @@ export default class MrnaViolinPlotChart extends React.Component<
                 ? undefined
                 : this.displayToRaw(this.xToDisplayValue(hi));
 
+        // Single-anchor model: only one gene may be selected at a time. Clear
+        // any other gene's selection so the rest stay conditional on this one.
+        this.clearOtherViolinSelections(gene.hugoSymbol);
         this.props.store.updateMrnaViolinSelection(
             gene.hugoSymbol,
             this.profileType,
             { start, end }
         );
+    }
+
+    /** Clear committed selections on every gene in this chart except one. */
+    private clearOtherViolinSelections(exceptSymbol: string) {
+        if (!this.profileType) return;
+        for (const g of this.currentGenes) {
+            if (
+                g.hugoSymbol !== exceptSymbol &&
+                this.props.store.getMrnaViolinSelection(
+                    g.hugoSymbol,
+                    this.profileType
+                ) !== undefined
+            ) {
+                this.props.store.updateMrnaViolinSelection(
+                    g.hugoSymbol,
+                    this.profileType,
+                    null
+                );
+            }
+        }
     }
 
     @action.bound
@@ -569,10 +629,42 @@ export default class MrnaViolinPlotChart extends React.Component<
         rowIndex: number
     ): JSX.Element | null {
         const values = this.displayByGene[gene.entrezGeneId] || [];
-        const { rowH } = this.layout;
+        const { rowH, plotW } = this.layout;
         const centerY = rowH * (rowIndex + 0.5);
         const violinHalfH = rowH * 0.44;
         const boxHalfH = rowH * 0.14;
+
+        // Committed selection on this gene → recolor the in-range slice of the
+        // distribution rather than filtering it away. selPx is the pixel band
+        // [lo, hi] along the value axis; null when nothing is selected here.
+        const selection = this.profileType
+            ? this.props.store.getMrnaViolinSelection(
+                  gene.hugoSymbol,
+                  this.profileType
+              )
+            : undefined;
+        let selPx: { lo: number; hi: number } | null = null;
+        if (selection) {
+            const xs =
+                selection.start === undefined
+                    ? 0
+                    : this.xScale(this.rawToDisplay(selection.start));
+            const xe =
+                selection.end === undefined
+                    ? plotW
+                    : this.xScale(this.rawToDisplay(selection.end));
+            selPx = { lo: Math.min(xs, xe), hi: Math.max(xs, xe) };
+        }
+        // When a range is selected the base distribution fades to grey and the
+        // selected slice keeps the prominent blue; with no selection the whole
+        // violin stays blue.
+        const baseFill = selPx ? '#EAEAEA' : '#D6E6F9';
+        const baseStroke = selPx ? '#BDBDBD' : '#1A5DAB';
+        const selFill = '#D6E6F9';
+        const selStroke = '#1A5DAB';
+        const inSel = (v: number) =>
+            !selPx ||
+            (this.xScale(v) >= selPx.lo && this.xScale(v) <= selPx.hi);
 
         if (values.length === 0) {
             return (
@@ -613,7 +705,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                             cx={this.xScale(v)}
                             cy={centerY + jitterFraction(i) * violinHalfH}
                             r={1.5}
-                            fill="#1A5DAB"
+                            fill={inSel(v) ? '#1A5DAB' : '#C8C8C8'}
                             fillOpacity={0.45}
                         />
                     ))}
@@ -652,13 +744,36 @@ export default class MrnaViolinPlotChart extends React.Component<
                             ).toFixed(1)}`
                     )
                     .join(' ');
+                const pathD = `M ${upperPts} L ${lowerPts} Z`;
+                const clipId = `violin-sel-${gene.entrezGeneId}`;
                 shape = (
-                    <path
-                        d={`M ${upperPts} L ${lowerPts} Z`}
-                        fill="#D6E6F9"
-                        stroke="#1A5DAB"
-                        strokeWidth={1}
-                    />
+                    <g>
+                        <path
+                            d={pathD}
+                            fill={baseFill}
+                            stroke={baseStroke}
+                            strokeWidth={1}
+                        />
+                        {selPx && (
+                            <>
+                                <clipPath id={clipId}>
+                                    <rect
+                                        x={selPx.lo}
+                                        y={centerY - violinHalfH}
+                                        width={Math.max(selPx.hi - selPx.lo, 0)}
+                                        height={violinHalfH * 2}
+                                    />
+                                </clipPath>
+                                <path
+                                    d={pathD}
+                                    fill={selFill}
+                                    stroke={selStroke}
+                                    strokeWidth={1}
+                                    clipPath={`url(#${clipId})`}
+                                />
+                            </>
+                        )}
+                    </g>
                 );
             }
         }
@@ -747,18 +862,44 @@ export default class MrnaViolinPlotChart extends React.Component<
                 selection.end === undefined
                     ? plotW
                     : this.xScale(this.rawToDisplay(selection.end));
+            const lo = Math.min(xs, xe);
+            const hi = Math.max(xs, xe);
+            // The recolored violin slice carries the selection; here we add a
+            // faint band and dashed edges so the chosen window stays legible
+            // even where the distribution is thin.
             committed = (
-                <rect
-                    x={Math.min(xs, xe)}
-                    y={bandTop}
-                    width={Math.max(Math.abs(xe - xs), 1)}
-                    height={bandH}
-                    fill="#FFD54F"
-                    fillOpacity={0.3}
-                    stroke="#F5A623"
-                    strokeWidth={1}
-                    pointerEvents="none"
-                />
+                <g pointerEvents="none">
+                    <rect
+                        x={lo}
+                        y={bandTop}
+                        width={Math.max(hi - lo, 1)}
+                        height={bandH}
+                        fill="#1A5DAB"
+                        fillOpacity={0.06}
+                    />
+                    {selection.start !== undefined && (
+                        <line
+                            x1={lo}
+                            x2={lo}
+                            y1={bandTop}
+                            y2={bandTop + bandH}
+                            stroke="#1A5DAB"
+                            strokeWidth={1}
+                            strokeDasharray="3,2"
+                        />
+                    )}
+                    {selection.end !== undefined && (
+                        <line
+                            x1={hi}
+                            x2={hi}
+                            y1={bandTop}
+                            y2={bandTop + bandH}
+                            stroke="#1A5DAB"
+                            strokeWidth={1}
+                            strokeDasharray="3,2"
+                        />
+                    )}
+                </g>
             );
         }
 
@@ -894,21 +1035,58 @@ export default class MrnaViolinPlotChart extends React.Component<
 
     private renderYLabels(): JSX.Element {
         const { marginTop, rowH } = this.layout;
+        const hasAnchor =
+            !!this.profileType &&
+            this.currentGenes.some(
+                g =>
+                    this.props.store.getMrnaViolinSelection(
+                        g.hugoSymbol,
+                        this.profileType!
+                    ) !== undefined
+            );
         return (
             <g>
-                {this.currentGenes.map((gene, i) => (
-                    <text
-                        key={gene.hugoSymbol}
-                        x={10}
-                        y={marginTop + rowH * (i + 0.5) + 4}
-                        textAnchor="start"
-                        fontSize={13}
-                        fontStyle="normal"
-                        fill="#333"
-                    >
-                        {gene.hugoSymbol}
-                    </text>
-                ))}
+                {this.currentGenes.map((gene, i) => {
+                    const n = (this.displayByGene[gene.entrezGeneId] || [])
+                        .length;
+                    const isAnchor =
+                        !!this.profileType &&
+                        this.props.store.getMrnaViolinSelection(
+                            gene.hugoSymbol,
+                            this.profileType
+                        ) !== undefined;
+                    // With an anchor active, the non-anchor rows are conditional
+                    // on it; flag that so the reduced n reads correctly.
+                    const nLabel = isAnchor
+                        ? `n=${n} · selected`
+                        : hasAnchor
+                        ? `n=${n} · conditional`
+                        : `n=${n}`;
+                    return (
+                        <g key={gene.hugoSymbol}>
+                            <text
+                                x={10}
+                                y={marginTop + rowH * (i + 0.5)}
+                                textAnchor="start"
+                                fontSize={13}
+                                fontStyle="normal"
+                                fontWeight={isAnchor ? 600 : 'normal'}
+                                fill="#333"
+                            >
+                                {gene.hugoSymbol}
+                            </text>
+                            <text
+                                x={10}
+                                y={marginTop + rowH * (i + 0.5) + 13}
+                                textAnchor="start"
+                                fontSize={9}
+                                fill="#888"
+                            >
+                                {nLabel}
+                            </text>
+                        </g>
+                    );
+                })}
             </g>
         );
     }

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -1035,58 +1035,21 @@ export default class MrnaViolinPlotChart extends React.Component<
 
     private renderYLabels(): JSX.Element {
         const { marginTop, rowH } = this.layout;
-        const hasAnchor =
-            !!this.profileType &&
-            this.currentGenes.some(
-                g =>
-                    this.props.store.getMrnaViolinSelection(
-                        g.hugoSymbol,
-                        this.profileType!
-                    ) !== undefined
-            );
         return (
             <g>
-                {this.currentGenes.map((gene, i) => {
-                    const n = (this.displayByGene[gene.entrezGeneId] || [])
-                        .length;
-                    const isAnchor =
-                        !!this.profileType &&
-                        this.props.store.getMrnaViolinSelection(
-                            gene.hugoSymbol,
-                            this.profileType
-                        ) !== undefined;
-                    // With an anchor active, the non-anchor rows are conditional
-                    // on it; flag that so the reduced n reads correctly.
-                    const nLabel = isAnchor
-                        ? `n=${n} · selected`
-                        : hasAnchor
-                        ? `n=${n} · conditional`
-                        : `n=${n}`;
-                    return (
-                        <g key={gene.hugoSymbol}>
-                            <text
-                                x={10}
-                                y={marginTop + rowH * (i + 0.5)}
-                                textAnchor="start"
-                                fontSize={13}
-                                fontStyle="normal"
-                                fontWeight={isAnchor ? 600 : 'normal'}
-                                fill="#333"
-                            >
-                                {gene.hugoSymbol}
-                            </text>
-                            <text
-                                x={10}
-                                y={marginTop + rowH * (i + 0.5) + 13}
-                                textAnchor="start"
-                                fontSize={9}
-                                fill="#888"
-                            >
-                                {nLabel}
-                            </text>
-                        </g>
-                    );
-                })}
+                {this.currentGenes.map((gene, i) => (
+                    <text
+                        key={gene.hugoSymbol}
+                        x={10}
+                        y={marginTop + rowH * (i + 0.5) + 4}
+                        textAnchor="start"
+                        fontSize={13}
+                        fontStyle="normal"
+                        fill="#333"
+                    >
+                        {gene.hugoSymbol}
+                    </text>
+                ))}
             </g>
         );
     }

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -942,7 +942,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                         justifyContent: 'center',
                     }}
                 >
-                    <LoadingIndicator isLoading={true} size={'big'} />
+                    <LoadingIndicator isLoading={true} size={'small'} />
                 </div>
             );
         } else if (isError || !hasData) {

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -289,8 +289,8 @@ export default class MrnaViolinPlotChart extends React.Component<
     @computed get layout() {
         const marginLeft = 68;
         const marginRight = 16;
-        const marginTop = 14;
-        const marginBottom = 36;
+        const marginTop = 38;
+        const marginBottom = 6;
         const svgHeight = this.props.height - TOOLBAR_HEIGHT;
         const plotW = this.props.width - marginLeft - marginRight;
         const plotH = svgHeight - marginTop - marginBottom;
@@ -466,7 +466,7 @@ export default class MrnaViolinPlotChart extends React.Component<
     private renderXAxis(): JSX.Element {
         const range = this.globalValueRange;
         if (!range) return <g />;
-        const { plotW, plotH } = this.layout;
+        const { plotW } = this.layout;
         const nTicks = 5;
         const ticks = Array.from({ length: nTicks }, (_, i) => {
             const val =
@@ -483,7 +483,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                 ? `log₂(${profileName}+1)`
                 : profileName;
         return (
-            <g transform={`translate(0, ${plotH})`}>
+            <g transform={`translate(0, 0)`}>
                 <line
                     x1={0}
                     x2={plotW}
@@ -498,13 +498,13 @@ export default class MrnaViolinPlotChart extends React.Component<
                             x1={0}
                             x2={0}
                             y1={0}
-                            y2={4}
+                            y2={-4}
                             stroke="#aaa"
                             strokeWidth={1}
                         />
                         <text
                             x={0}
-                            y={14}
+                            y={-7}
                             textAnchor="middle"
                             fontSize={9}
                             fill="#555"
@@ -515,7 +515,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                 ))}
                 <text
                     x={plotW / 2}
-                    y={28}
+                    y={-20}
                     textAnchor="middle"
                     fontSize={10}
                     fill="#333"
@@ -546,17 +546,17 @@ export default class MrnaViolinPlotChart extends React.Component<
     }
 
     private renderYLabels(): JSX.Element {
-        const { marginLeft, marginTop, rowH } = this.layout;
+        const { marginTop, rowH } = this.layout;
         return (
             <g>
                 {this.currentGenes.map((gene, i) => (
                     <text
                         key={gene.hugoSymbol}
-                        x={marginLeft - 6}
+                        x={4}
                         y={marginTop + rowH * (i + 0.5) + 4}
-                        textAnchor="end"
+                        textAnchor="start"
                         fontSize={11}
-                        fontStyle="italic"
+                        fontStyle="normal"
                         fill="#333"
                     >
                         {gene.hugoSymbol}
@@ -579,7 +579,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                     bottom: 0,
                     background: '#fff',
                     borderTop: '1px solid #ccc',
-                    zIndex: 100,
+                    zIndex: 2,
                     overflowY: 'auto',
                     padding: '6px 8px',
                 }}
@@ -626,7 +626,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                                     onChange={() => this.toggleGene(symbol)}
                                     style={{ margin: 0 }}
                                 />
-                                <i>{symbol}</i>
+                                <span>{symbol}</span>
                             </label>
                         );
                     })}
@@ -639,132 +639,44 @@ export default class MrnaViolinPlotChart extends React.Component<
         const { width, height } = this.props;
         const { marginLeft, marginTop, svgHeight } = this.layout;
 
-        const toolbar = (
-            <div
-                style={{
-                    height: TOOLBAR_HEIGHT,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 12,
-                    padding: '0 8px',
-                    borderBottom: '1px solid #eee',
-                    fontSize: 11,
-                    flexShrink: 0,
-                    background: '#fff',
-                    position: 'relative',
-                    zIndex: 101,
-                }}
-            >
-                <label
+        const isPending =
+            this.mrnaData.isPending || this.resolvedGenes.isPending;
+        const isError = this.mrnaData.isError;
+        const hasData = !isPending && !isError && !!this.globalValueRange;
+
+        let bodyContent: JSX.Element;
+        if (isPending) {
+            bodyContent = (
+                <div
                     style={{
-                        display: 'inline-flex',
+                        flex: 1,
+                        display: 'flex',
                         alignItems: 'center',
-                        gap: 4,
-                        cursor: this.canLogScale ? 'pointer' : 'not-allowed',
-                        color: this.canLogScale ? '#333' : '#999',
-                        fontWeight: 'normal',
-                        margin: 0,
-                    }}
-                    title={
-                        this.canLogScale
-                            ? 'Toggle between log₂ and linear value axis'
-                            : 'Linear only — data contains negative values'
-                    }
-                >
-                    <input
-                        type="checkbox"
-                        checked={this.logScale && this.canLogScale}
-                        disabled={!this.canLogScale}
-                        onChange={action(
-                            (e: React.ChangeEvent<HTMLInputElement>) => {
-                                this.logScale = e.target.checked;
-                            }
-                        )}
-                        style={{ margin: 0 }}
-                    />
-                    Log scale
-                </label>
-                <button
-                    onClick={action(() => {
-                        this.showGenePicker = !this.showGenePicker;
-                    })}
-                    style={{
-                        fontSize: 11,
-                        padding: '2px 7px',
-                        border: '1px solid #ccc',
-                        borderRadius: 3,
-                        background: this.showGenePicker ? '#e8f0fc' : '#f5f5f5',
-                        cursor: 'pointer',
+                        justifyContent: 'center',
                     }}
                 >
-                    Genes ({this.selectedSymbols.length}) ▾
-                </button>
-            </div>
-        );
-
-        if (this.mrnaData.isPending || this.resolvedGenes.isPending) {
-            return (
-                <div
-                    style={{
-                        height,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        position: 'relative',
-                    }}
-                >
-                    {toolbar}
-                    <div style={{ flex: 1 }}>
-                        <LoadingIndicator
-                            isLoading={true}
-                            center={true}
-                            size={'big'}
-                        />
-                    </div>
-                    {this.showGenePicker && this.renderGenePicker()}
+                    <LoadingIndicator isLoading={true} size={'big'} />
                 </div>
             );
-        }
-
-        if (this.mrnaData.isError || !this.globalValueRange) {
-            return (
+        } else if (isError || !hasData) {
+            bodyContent = (
                 <div
                     style={{
-                        height,
+                        flex: 1,
                         display: 'flex',
-                        flexDirection: 'column',
-                        position: 'relative',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: '#888',
+                        fontSize: 12,
                     }}
                 >
-                    {toolbar}
-                    <div
-                        style={{
-                            flex: 1,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            color: '#888',
-                            fontSize: 12,
-                        }}
-                    >
-                        {this.mrnaData.isError
-                            ? 'Error loading mRNA data.'
-                            : 'No mRNA expression data available for this study.'}
-                    </div>
-                    {this.showGenePicker && this.renderGenePicker()}
+                    {isError
+                        ? 'Error loading mRNA data.'
+                        : 'No mRNA expression data available for this study.'}
                 </div>
             );
-        }
-
-        return (
-            <div
-                style={{
-                    height,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    position: 'relative',
-                }}
-            >
-                {toolbar}
+        } else {
+            bodyContent = (
                 <svg
                     width={width}
                     height={svgHeight}
@@ -772,13 +684,91 @@ export default class MrnaViolinPlotChart extends React.Component<
                 >
                     {this.renderYLabels()}
                     <g transform={`translate(${marginLeft}, ${marginTop})`}>
-                        {this.renderRowSeparators()}
                         {this.currentGenes.map((gene, i) =>
                             this.renderGeneRow(gene, i)
                         )}
                         {this.renderXAxis()}
                     </g>
                 </svg>
+            );
+        }
+
+        return (
+            <div
+                style={{
+                    width,
+                    height,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    position: 'relative',
+                    isolation: 'isolate',
+                }}
+            >
+                <div
+                    style={{
+                        height: TOOLBAR_HEIGHT,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 12,
+                        padding: '0 8px',
+                        borderBottom: '1px solid #eee',
+                        fontSize: 11,
+                        flexShrink: 0,
+                        background: '#fff',
+                        position: 'relative',
+                        zIndex: 3,
+                    }}
+                >
+                    <label
+                        style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 4,
+                            cursor: this.canLogScale
+                                ? 'pointer'
+                                : 'not-allowed',
+                            color: this.canLogScale ? '#333' : '#999',
+                            fontWeight: 'normal',
+                            margin: 0,
+                        }}
+                        title={
+                            this.canLogScale
+                                ? 'Toggle between log₂ and linear value axis'
+                                : 'Linear only — data contains negative values'
+                        }
+                    >
+                        <input
+                            type="checkbox"
+                            checked={this.logScale && this.canLogScale}
+                            disabled={!this.canLogScale}
+                            onChange={action(
+                                (e: React.ChangeEvent<HTMLInputElement>) => {
+                                    this.logScale = e.target.checked;
+                                }
+                            )}
+                            style={{ margin: 0 }}
+                        />
+                        Log scale
+                    </label>
+                    <button
+                        onClick={action(() => {
+                            this.showGenePicker = !this.showGenePicker;
+                        })}
+                        style={{
+                            fontSize: 11,
+                            padding: '2px 7px',
+                            border: '1px solid #ccc',
+                            borderRadius: 3,
+                            background: this.showGenePicker
+                                ? '#e8f0fc'
+                                : '#f5f5f5',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        Genes ({this.selectedSymbols.length}) ▾
+                    </button>
+                </div>
+                {bodyContent}
                 {this.showGenePicker && this.renderGenePicker()}
             </div>
         );

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -1,0 +1,786 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { action, computed, makeObservable, observable } from 'mobx';
+import { remoteData } from 'cbioportal-frontend-commons';
+import { StudyViewPageStore } from 'pages/studyView/StudyViewPageStore';
+import { getClient } from 'shared/api/cbioportalClientInstance';
+import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
+import _ from 'lodash';
+import { Gene, MolecularProfile } from 'cbioportal-ts-api-client';
+import { DataTypeConstants } from 'shared/constants';
+import { MRNA_TAB_GENE_GROUPS } from 'pages/patientView/mrna/mrnaTabGeneGroups';
+
+const MSK_TRIAL_GENES: string[] = MRNA_TAB_GENE_GROUPS.find(
+    g => g.id === 'msk-trial'
+)!.genes;
+
+const DEFAULT_GENE_COUNT = 10;
+const MAX_GENES = 10;
+const MAX_SAMPLES = 1000;
+const KDE_POINTS = 80;
+const TOOLBAR_HEIGHT = 34;
+
+// Profile datatype preference order for multi-profile studies.
+const SCALED_DATATYPE_PRIORITY = [
+    DataTypeConstants.ZSCORE,
+    DataTypeConstants.LOG2VALUE,
+    DataTypeConstants.LOGVALUE,
+];
+
+function pickBestMrnaProfile(profiles: MolecularProfile[]): MolecularProfile {
+    for (const dt of SCALED_DATATYPE_PRIORITY) {
+        const m = profiles.find(p => p.datatype === dt);
+        if (m) return m;
+    }
+    // Belt-and-suspenders: profile ID pattern fallback (TCGA naming)
+    return (
+        profiles.find(p => /zscores?$/i.test(p.molecularProfileId)) ??
+        profiles.find(p => /log[\d_]/i.test(p.molecularProfileId)) ??
+        profiles[0]
+    );
+}
+
+function gaussianKernel(u: number): number {
+    return Math.exp(-0.5 * u * u) / Math.sqrt(2 * Math.PI);
+}
+
+/**
+ * Gaussian KDE. Bandwidth = max(Silverman's rule, 5% of data range)
+ * so concentrated distributions still produce a visible violin.
+ */
+function computeKDE(data: number[], nPoints: number): Array<[number, number]> {
+    if (data.length < 2) return [];
+    const min = Math.min(...data);
+    const max = Math.max(...data);
+    if (min === max) return [];
+    const mean = data.reduce((s, v) => s + v, 0) / data.length;
+    const std = Math.sqrt(
+        data.reduce((s, v) => s + (v - mean) ** 2, 0) / data.length
+    );
+    const silverman = std === 0 ? 1 : 1.06 * std * Math.pow(data.length, -0.2);
+    const bw = Math.max(silverman, (max - min) * 0.05);
+    const step = (max - min) / (nPoints - 1);
+    return Array.from({ length: nPoints }, (_, i) => {
+        const x = min + i * step;
+        const density =
+            data.reduce((s, xi) => s + gaussianKernel((x - xi) / bw), 0) /
+            (data.length * bw);
+        return [x, density] as [number, number];
+    });
+}
+
+interface BoxStats {
+    q1: number;
+    median: number;
+    q3: number;
+    whiskerLow: number;
+    whiskerHigh: number;
+}
+
+function computeBoxStats(data: number[]): BoxStats {
+    const sorted = [...data].sort((a, b) => a - b);
+    const n = sorted.length;
+    const q1 = sorted[Math.floor(n * 0.25)];
+    const q3 = sorted[Math.floor(n * 0.75)];
+    const median =
+        n % 2 === 0
+            ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+            : sorted[Math.floor(n / 2)];
+    const iqr = q3 - q1;
+    return {
+        q1,
+        q3,
+        median,
+        whiskerLow: Math.max(sorted[0], q1 - 1.5 * iqr),
+        whiskerHigh: Math.min(sorted[n - 1], q3 + 1.5 * iqr),
+    };
+}
+
+export interface IMrnaViolinPlotChartProps {
+    store: StudyViewPageStore;
+    width: number;
+    height: number;
+}
+
+@observer
+export default class MrnaViolinPlotChart extends React.Component<
+    IMrnaViolinPlotChartProps,
+    {}
+> {
+    @observable selectedSymbols: string[] = MSK_TRIAL_GENES.slice(
+        0,
+        DEFAULT_GENE_COUNT
+    );
+    @observable logScale = false;
+    @observable showGenePicker = false;
+
+    constructor(props: IMrnaViolinPlotChartProps) {
+        super(props);
+        makeObservable(this);
+    }
+
+    /** Resolve selected Hugo symbols → Gene objects (entrezGeneId). */
+    readonly resolvedGenes = remoteData<Gene[]>({
+        invoke: async () => {
+            const symbols = this.selectedSymbols.slice(); // access observable to track it
+            return getClient().fetchGenesUsingPOST({
+                geneIdType: 'HUGO_GENE_SYMBOL',
+                geneIds: symbols,
+            });
+        },
+        default: [],
+    });
+
+    readonly mrnaData = remoteData<{
+        profilesUsed: MolecularProfile[];
+        sampleCount: number;
+        /** Ordered list matching the user's gene selection. */
+        genes: Array<{ hugoSymbol: string; entrezGeneId: number }>;
+        /** Raw API values (no transform), keyed by entrezGeneId. */
+        byGene: { [entrezGeneId: number]: number[] };
+    }>({
+        await: () => [
+            this.props.store.molecularProfiles,
+            this.props.store.selectedSamples,
+            this.resolvedGenes,
+        ],
+        invoke: async () => {
+            const allMrnaProfiles = this.props.store.molecularProfiles.result!.filter(
+                p => p.molecularAlterationType === 'MRNA_EXPRESSION'
+            );
+
+            console.info(
+                '[MrnaViolinPlotChart] Available mRNA profiles:',
+                allMrnaProfiles.map(
+                    p => `${p.molecularProfileId} (${p.datatype})`
+                )
+            );
+
+            if (allMrnaProfiles.length === 0) {
+                return {
+                    profilesUsed: [],
+                    sampleCount: 0,
+                    genes: [],
+                    byGene: {},
+                };
+            }
+
+            const rawGenes = this.resolvedGenes.result!;
+            const geneMap = _.keyBy(rawGenes, g =>
+                g.hugoGeneSymbol.toUpperCase()
+            );
+            const genes = this.selectedSymbols
+                .map(s => {
+                    const g = geneMap[s.toUpperCase()];
+                    return g
+                        ? {
+                              hugoSymbol: g.hugoGeneSymbol,
+                              entrezGeneId: g.entrezGeneId,
+                          }
+                        : null;
+                })
+                .filter(Boolean) as Array<{
+                hugoSymbol: string;
+                entrezGeneId: number;
+            }>;
+
+            const samples = this.props.store.selectedSamples.result!;
+            const samplesSubset = samples.slice(0, MAX_SAMPLES);
+
+            const profilesByStudy = _.groupBy(allMrnaProfiles, p => p.studyId);
+            const chosenProfileByStudy: {
+                [studyId: string]: MolecularProfile;
+            } = {};
+            for (const [studyId, profiles] of Object.entries(profilesByStudy)) {
+                chosenProfileByStudy[studyId] = pickBestMrnaProfile(profiles);
+            }
+
+            const sampleMolecularIdentifiers = samplesSubset.flatMap(sample => {
+                const profile = chosenProfileByStudy[sample.studyId];
+                if (!profile) return [];
+                return [
+                    {
+                        molecularProfileId: profile.molecularProfileId,
+                        sampleId: sample.sampleId,
+                    },
+                ];
+            });
+
+            if (sampleMolecularIdentifiers.length === 0) {
+                return { profilesUsed: [], sampleCount: 0, genes, byGene: {} };
+            }
+
+            const profilesUsed = Object.values(chosenProfileByStudy);
+            console.info(
+                '[MrnaViolinPlotChart] Using profiles:',
+                profilesUsed.map(p => `${p.name} (${p.datatype})`)
+            );
+
+            const data = await getClient().fetchMolecularDataInMultipleMolecularProfilesUsingPOST(
+                {
+                    molecularDataMultipleStudyFilter: {
+                        entrezGeneIds: genes.map(g => g.entrezGeneId),
+                        sampleMolecularIdentifiers,
+                    } as any,
+                }
+            );
+
+            const byGene: { [entrezGeneId: number]: number[] } = {};
+            for (const d of data) {
+                if (!byGene[d.entrezGeneId]) byGene[d.entrezGeneId] = [];
+                byGene[d.entrezGeneId].push(d.value);
+            }
+
+            console.info(
+                '[MrnaViolinPlotChart] Value ranges per gene:',
+                genes.map(g => {
+                    const vals = byGene[g.entrezGeneId] || [];
+                    if (!vals.length) return `${g.hugoSymbol}: no data`;
+                    return `${g.hugoSymbol}: [${Math.min(...vals).toFixed(
+                        2
+                    )}, ${Math.max(...vals).toFixed(2)}] n=${vals.length}`;
+                })
+            );
+
+            return {
+                profilesUsed,
+                sampleCount: sampleMolecularIdentifiers.length,
+                genes,
+                byGene,
+            };
+        },
+        onError: (e: Error) => {
+            console.error('[MrnaViolinPlotChart] fetch error', e);
+        },
+        default: { profilesUsed: [], sampleCount: 0, genes: [], byGene: {} },
+    });
+
+    /**
+     * Log scale is valid as long as no values are negative.
+     * Zeros are fine because the transform is log₂(x+1), which maps 0 → 0.
+     */
+    @computed get canLogScale(): boolean {
+        if (!this.mrnaData.isComplete) return false;
+        for (const vals of Object.values(this.mrnaData.result!.byGene)) {
+            if ((vals as number[]).some(v => v < 0)) return false;
+        }
+        return Object.keys(this.mrnaData.result!.byGene).length > 0;
+    }
+
+    /** Values with optional log₂(x+1) transform for display. */
+    @computed get displayByGene(): { [entrezGeneId: number]: number[] } {
+        if (!this.mrnaData.isComplete) return {};
+        const raw = this.mrnaData.result!.byGene;
+        if (!this.logScale || !this.canLogScale) return raw;
+        const out: { [entrezGeneId: number]: number[] } = {};
+        for (const [id, vals] of Object.entries(raw)) {
+            out[Number(id)] = (vals as number[]).map(v => Math.log2(v + 1));
+        }
+        return out;
+    }
+
+    @computed get currentGenes(): Array<{
+        hugoSymbol: string;
+        entrezGeneId: number;
+    }> {
+        return this.mrnaData.result?.genes ?? [];
+    }
+
+    @computed get layout() {
+        const marginLeft = 68;
+        const marginRight = 16;
+        const marginTop = 14;
+        const marginBottom = 36;
+        const svgHeight = this.props.height - TOOLBAR_HEIGHT;
+        const plotW = this.props.width - marginLeft - marginRight;
+        const plotH = svgHeight - marginTop - marginBottom;
+        const rowH =
+            this.currentGenes.length > 0
+                ? plotH / this.currentGenes.length
+                : plotH / DEFAULT_GENE_COUNT;
+        return {
+            marginLeft,
+            marginRight,
+            marginTop,
+            marginBottom,
+            plotW,
+            plotH,
+            rowH,
+            svgHeight,
+        };
+    }
+
+    /** 1st–99th percentile range across all genes, to avoid outlier collapse. */
+    @computed get globalValueRange(): { min: number; max: number } | null {
+        const byGene = this.displayByGene;
+        const allVals: number[] = [];
+        for (const gene of this.currentGenes) {
+            (byGene[gene.entrezGeneId] || []).forEach(v => allVals.push(v));
+        }
+        if (allVals.length === 0) return null;
+        const sorted = [...allVals].sort((a, b) => a - b);
+        return {
+            min: sorted[Math.floor(sorted.length * 0.01)],
+            max: sorted[Math.floor(sorted.length * 0.99)],
+        };
+    }
+
+    private xScale(value: number): number {
+        const range = this.globalValueRange!;
+        const { plotW } = this.layout;
+        const clamped = Math.min(Math.max(value, range.min), range.max);
+        return ((clamped - range.min) / (range.max - range.min)) * plotW;
+    }
+
+    @action.bound
+    private toggleGene(symbol: string) {
+        if (this.selectedSymbols.includes(symbol)) {
+            if (this.selectedSymbols.length > 1) {
+                this.selectedSymbols = this.selectedSymbols.filter(
+                    s => s !== symbol
+                );
+            }
+        } else if (this.selectedSymbols.length < MAX_GENES) {
+            this.selectedSymbols = [...this.selectedSymbols, symbol];
+        }
+    }
+
+    private renderGeneRow(
+        gene: { hugoSymbol: string; entrezGeneId: number },
+        rowIndex: number
+    ): JSX.Element | null {
+        const values = this.displayByGene[gene.entrezGeneId] || [];
+        const { rowH } = this.layout;
+        const centerY = rowH * (rowIndex + 0.5);
+        const violinHalfH = rowH * 0.44;
+        const boxHalfH = rowH * 0.14;
+
+        if (values.length === 0) {
+            return (
+                <text
+                    key={gene.hugoSymbol}
+                    x={this.layout.plotW / 2}
+                    y={centerY + 4}
+                    textAnchor="middle"
+                    fill="#999"
+                    fontSize={10}
+                >
+                    no data
+                </text>
+            );
+        }
+
+        const kdePoints = computeKDE(values, KDE_POINTS);
+        const maxDensity =
+            kdePoints.length > 0 ? Math.max(...kdePoints.map(p => p[1])) : 1;
+
+        let violinPath = '';
+        if (kdePoints.length >= 2 && maxDensity > 0) {
+            const scale = violinHalfH / maxDensity;
+            const upperPts = kdePoints
+                .map(
+                    ([x, d]) =>
+                        `${this.xScale(x).toFixed(1)},${(
+                            centerY -
+                            d * scale
+                        ).toFixed(1)}`
+                )
+                .join(' ');
+            const lowerPts = [...kdePoints]
+                .reverse()
+                .map(
+                    ([x, d]) =>
+                        `${this.xScale(x).toFixed(1)},${(
+                            centerY +
+                            d * scale
+                        ).toFixed(1)}`
+                )
+                .join(' ');
+            violinPath = `M ${upperPts} L ${lowerPts} Z`;
+        }
+
+        const box = computeBoxStats(values);
+        const x1 = this.xScale(box.q1);
+        const x3 = this.xScale(box.q3);
+        const xMed = this.xScale(box.median);
+        const xWL = this.xScale(box.whiskerLow);
+        const xWH = this.xScale(box.whiskerHigh);
+
+        return (
+            <g key={gene.hugoSymbol}>
+                {violinPath && (
+                    <path
+                        d={violinPath}
+                        fill="#4a90d9"
+                        fillOpacity={0.55}
+                        stroke="#2a6aad"
+                        strokeWidth={0.5}
+                    />
+                )}
+                <line
+                    x1={xWL}
+                    x2={xWH}
+                    y1={centerY}
+                    y2={centerY}
+                    stroke="#333"
+                    strokeWidth={1}
+                />
+                <line
+                    x1={xWL}
+                    x2={xWL}
+                    y1={centerY - boxHalfH}
+                    y2={centerY + boxHalfH}
+                    stroke="#333"
+                    strokeWidth={1}
+                />
+                <line
+                    x1={xWH}
+                    x2={xWH}
+                    y1={centerY - boxHalfH}
+                    y2={centerY + boxHalfH}
+                    stroke="#333"
+                    strokeWidth={1}
+                />
+                <rect
+                    x={x1}
+                    y={centerY - boxHalfH}
+                    width={Math.max(x3 - x1, 1)}
+                    height={boxHalfH * 2}
+                    fill="#fff"
+                    fillOpacity={0.75}
+                    stroke="#333"
+                    strokeWidth={0.8}
+                />
+                <line
+                    x1={xMed}
+                    x2={xMed}
+                    y1={centerY - boxHalfH}
+                    y2={centerY + boxHalfH}
+                    stroke="#e63b3b"
+                    strokeWidth={1.5}
+                />
+            </g>
+        );
+    }
+
+    private renderXAxis(): JSX.Element {
+        const range = this.globalValueRange;
+        if (!range) return <g />;
+        const { plotW, plotH } = this.layout;
+        const nTicks = 5;
+        const ticks = Array.from({ length: nTicks }, (_, i) => {
+            const val =
+                range.min + ((range.max - range.min) * i) / (nTicks - 1);
+            return {
+                val,
+                x: ((val - range.min) / (range.max - range.min)) * plotW,
+            };
+        });
+        const result = this.mrnaData.result!;
+        const profileName = result.profilesUsed[0]?.name ?? 'mRNA Expression';
+        const axisLabel =
+            this.logScale && this.canLogScale
+                ? `log₂(${profileName}+1)`
+                : profileName;
+        return (
+            <g transform={`translate(0, ${plotH})`}>
+                <line
+                    x1={0}
+                    x2={plotW}
+                    y1={0}
+                    y2={0}
+                    stroke="#aaa"
+                    strokeWidth={1}
+                />
+                {ticks.map(t => (
+                    <g key={t.val} transform={`translate(${t.x}, 0)`}>
+                        <line
+                            x1={0}
+                            x2={0}
+                            y1={0}
+                            y2={4}
+                            stroke="#aaa"
+                            strokeWidth={1}
+                        />
+                        <text
+                            x={0}
+                            y={14}
+                            textAnchor="middle"
+                            fontSize={9}
+                            fill="#555"
+                        >
+                            {t.val.toFixed(1)}
+                        </text>
+                    </g>
+                ))}
+                <text
+                    x={plotW / 2}
+                    y={28}
+                    textAnchor="middle"
+                    fontSize={10}
+                    fill="#333"
+                >
+                    {axisLabel}
+                </text>
+            </g>
+        );
+    }
+
+    private renderRowSeparators(): JSX.Element {
+        const { plotW, rowH } = this.layout;
+        return (
+            <g>
+                {this.currentGenes.map((_, i) => (
+                    <line
+                        key={i}
+                        x1={0}
+                        x2={plotW}
+                        y1={rowH * i}
+                        y2={rowH * i}
+                        stroke="#eee"
+                        strokeWidth={1}
+                    />
+                ))}
+            </g>
+        );
+    }
+
+    private renderYLabels(): JSX.Element {
+        const { marginLeft, marginTop, rowH } = this.layout;
+        return (
+            <g>
+                {this.currentGenes.map((gene, i) => (
+                    <text
+                        key={gene.hugoSymbol}
+                        x={marginLeft - 6}
+                        y={marginTop + rowH * (i + 0.5) + 4}
+                        textAnchor="end"
+                        fontSize={11}
+                        fontStyle="italic"
+                        fill="#333"
+                    >
+                        {gene.hugoSymbol}
+                    </text>
+                ))}
+            </g>
+        );
+    }
+
+    private renderGenePicker(): JSX.Element {
+        const { selectedSymbols } = this;
+        const atMax = selectedSymbols.length >= MAX_GENES;
+        return (
+            <div
+                style={{
+                    position: 'absolute',
+                    top: TOOLBAR_HEIGHT,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    background: '#fff',
+                    borderTop: '1px solid #ccc',
+                    zIndex: 100,
+                    overflowY: 'auto',
+                    padding: '6px 8px',
+                }}
+            >
+                <div
+                    style={{
+                        fontSize: 11,
+                        color: '#666',
+                        marginBottom: 4,
+                    }}
+                >
+                    Select up to {MAX_GENES} genes &mdash; ADC targets in trial
+                    at MSK
+                    {atMax && (
+                        <span style={{ color: '#c00', marginLeft: 6 }}>
+                            (max reached)
+                        </span>
+                    )}
+                </div>
+                <div style={{ columnCount: 2, columnGap: 8 }}>
+                    {MSK_TRIAL_GENES.map(symbol => {
+                        const checked = selectedSymbols.includes(symbol);
+                        const disabled = !checked && atMax;
+                        return (
+                            <label
+                                key={symbol}
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 4,
+                                    fontSize: 11,
+                                    cursor: disabled
+                                        ? 'not-allowed'
+                                        : 'pointer',
+                                    color: disabled ? '#aaa' : '#333',
+                                    padding: '1px 0',
+                                    breakInside: 'avoid',
+                                }}
+                            >
+                                <input
+                                    type="checkbox"
+                                    checked={checked}
+                                    disabled={disabled}
+                                    onChange={() => this.toggleGene(symbol)}
+                                    style={{ margin: 0 }}
+                                />
+                                <i>{symbol}</i>
+                            </label>
+                        );
+                    })}
+                </div>
+            </div>
+        );
+    }
+
+    render() {
+        const { width, height } = this.props;
+        const { marginLeft, marginTop, svgHeight } = this.layout;
+
+        const toolbar = (
+            <div
+                style={{
+                    height: TOOLBAR_HEIGHT,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 12,
+                    padding: '0 8px',
+                    borderBottom: '1px solid #eee',
+                    fontSize: 11,
+                    flexShrink: 0,
+                    background: '#fff',
+                    position: 'relative',
+                    zIndex: 101,
+                }}
+            >
+                <label
+                    style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 4,
+                        cursor: this.canLogScale ? 'pointer' : 'not-allowed',
+                        color: this.canLogScale ? '#333' : '#999',
+                        fontWeight: 'normal',
+                        margin: 0,
+                    }}
+                    title={
+                        this.canLogScale
+                            ? 'Toggle between log₂ and linear value axis'
+                            : 'Linear only — data contains negative values'
+                    }
+                >
+                    <input
+                        type="checkbox"
+                        checked={this.logScale && this.canLogScale}
+                        disabled={!this.canLogScale}
+                        onChange={action(
+                            (e: React.ChangeEvent<HTMLInputElement>) => {
+                                this.logScale = e.target.checked;
+                            }
+                        )}
+                        style={{ margin: 0 }}
+                    />
+                    Log scale
+                </label>
+                <button
+                    onClick={action(() => {
+                        this.showGenePicker = !this.showGenePicker;
+                    })}
+                    style={{
+                        fontSize: 11,
+                        padding: '2px 7px',
+                        border: '1px solid #ccc',
+                        borderRadius: 3,
+                        background: this.showGenePicker ? '#e8f0fc' : '#f5f5f5',
+                        cursor: 'pointer',
+                    }}
+                >
+                    Genes ({this.selectedSymbols.length}) ▾
+                </button>
+            </div>
+        );
+
+        if (this.mrnaData.isPending || this.resolvedGenes.isPending) {
+            return (
+                <div
+                    style={{
+                        height,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        position: 'relative',
+                    }}
+                >
+                    {toolbar}
+                    <div style={{ flex: 1 }}>
+                        <LoadingIndicator
+                            isLoading={true}
+                            center={true}
+                            size={'big'}
+                        />
+                    </div>
+                    {this.showGenePicker && this.renderGenePicker()}
+                </div>
+            );
+        }
+
+        if (this.mrnaData.isError || !this.globalValueRange) {
+            return (
+                <div
+                    style={{
+                        height,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        position: 'relative',
+                    }}
+                >
+                    {toolbar}
+                    <div
+                        style={{
+                            flex: 1,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            color: '#888',
+                            fontSize: 12,
+                        }}
+                    >
+                        {this.mrnaData.isError
+                            ? 'Error loading mRNA data.'
+                            : 'No mRNA expression data available for this study.'}
+                    </div>
+                    {this.showGenePicker && this.renderGenePicker()}
+                </div>
+            );
+        }
+
+        return (
+            <div
+                style={{
+                    height,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    position: 'relative',
+                }}
+            >
+                {toolbar}
+                <svg
+                    width={width}
+                    height={svgHeight}
+                    style={{ display: 'block' }}
+                >
+                    {this.renderYLabels()}
+                    <g transform={`translate(${marginLeft}, ${marginTop})`}>
+                        {this.renderRowSeparators()}
+                        {this.currentGenes.map((gene, i) =>
+                            this.renderGeneRow(gene, i)
+                        )}
+                        {this.renderXAxis()}
+                    </g>
+                </svg>
+                {this.showGenePicker && this.renderGenePicker()}
+            </div>
+        );
+    }
+}

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -46,7 +46,9 @@ function pickBestMrnaProfile(profiles: MolecularProfile[]): MolecularProfile {
     }
     // Belt-and-suspenders: profile ID pattern fallback (TCGA naming)
     return (
-        profiles.find(p => /all[_]?sample_zscores?$/i.test(p.molecularProfileId)) ??
+        profiles.find(p =>
+            /all[_]?sample_zscores?$/i.test(p.molecularProfileId)
+        ) ??
         profiles.find(p => /zscores?$/i.test(p.molecularProfileId)) ??
         profiles.find(p => /log[\d_]/i.test(p.molecularProfileId)) ??
         profiles[0]
@@ -134,6 +136,12 @@ export interface IMrnaViolinPlotChartProps {
     store: StudyViewPageStore;
     width: number;
     height: number;
+    // Gene-specific mode: when both are supplied the chart plots exactly these
+    // genes on the given molecular-profile suffix (any continuous-numeric
+    // profile, not just mRNA) and the built-in gene picker is hidden. When
+    // omitted, the chart runs in its original auto-added mRNA mode.
+    genes?: string[];
+    profileType?: string;
 }
 
 @observer
@@ -162,7 +170,15 @@ export default class MrnaViolinPlotChart extends React.Component<
 
     constructor(props: IMrnaViolinPlotChartProps) {
         super(props);
+        if (props.genes && props.genes.length > 0) {
+            this.selectedSymbols = props.genes.slice();
+        }
         makeObservable(this);
+    }
+
+    /** Gene-specific mode: fixed gene list + explicit profile, no gene picker. */
+    @computed private get isGeneSpecificMode(): boolean {
+        return !!this.props.profileType;
     }
 
     /** Resolve selected Hugo symbols → Gene objects (entrezGeneId). */
@@ -191,12 +207,18 @@ export default class MrnaViolinPlotChart extends React.Component<
             this.resolvedGenes,
         ],
         invoke: async () => {
+            const profileType = this.props.profileType;
+            // Gene-specific mode keys off the chosen profile suffix; auto-added
+            // mRNA mode falls back to any mRNA-expression profile.
             const allMrnaProfiles = this.props.store.molecularProfiles.result!.filter(
-                p => p.molecularAlterationType === 'MRNA_EXPRESSION'
+                p =>
+                    profileType
+                        ? getSuffixOfMolecularProfile(p) === profileType
+                        : p.molecularAlterationType === 'MRNA_EXPRESSION'
             );
 
             console.info(
-                '[MrnaViolinPlotChart] Available mRNA profiles:',
+                '[MrnaViolinPlotChart] Available profiles:',
                 allMrnaProfiles.map(
                     p => `${p.molecularProfileId} (${p.datatype})`
                 )
@@ -238,7 +260,12 @@ export default class MrnaViolinPlotChart extends React.Component<
                 [studyId: string]: MolecularProfile;
             } = {};
             for (const [studyId, profiles] of Object.entries(profilesByStudy)) {
-                chosenProfileByStudy[studyId] = pickBestMrnaProfile(profiles);
+                // A profile suffix maps to one profile per study, so in
+                // gene-specific mode take it directly; otherwise pick the best
+                // mRNA profile by datatype priority.
+                chosenProfileByStudy[studyId] = profileType
+                    ? profiles[0]
+                    : pickBestMrnaProfile(profiles);
             }
 
             const sampleMolecularIdentifiers = samplesSubset.flatMap(sample => {
@@ -340,8 +367,11 @@ export default class MrnaViolinPlotChart extends React.Component<
         const svgHeight = this.props.height - TOOLBAR_HEIGHT;
         const plotW = this.props.width - marginLeft - marginRight;
         const plotH = svgHeight - marginTop - marginBottom;
-        // Always divide by MAX_GENES so row height is consistent regardless of selection count.
-        const rowH = plotH / MAX_GENES;
+        // Fixed row height: divide by MAX_GENES so each track is the same size
+        // regardless of how many genes are shown — fewer genes leave empty
+        // space below rather than stretching the tracks. Only shrink below this
+        // when a selection exceeds MAX_GENES, so the rows still fit the chart.
+        const rowH = plotH / Math.max(MAX_GENES, this.selectedSymbols.length);
         return {
             marginLeft,
             marginRight,
@@ -381,6 +411,7 @@ export default class MrnaViolinPlotChart extends React.Component<
      * (e.g. "rna_seq_v2_mrna_median_Zscores"). Null until data has loaded.
      */
     @computed get profileType(): string | null {
+        if (this.props.profileType) return this.props.profileType;
         const profile = this.mrnaData.result?.profilesUsed[0];
         return profile ? getSuffixOfMolecularProfile(profile) : null;
     }
@@ -970,7 +1001,9 @@ export default class MrnaViolinPlotChart extends React.Component<
                     }}
                 >
                     {isError
-                        ? 'Error loading mRNA data.'
+                        ? 'Error loading data.'
+                        : this.isGeneSpecificMode
+                        ? 'No data available for this study.'
                         : 'No mRNA expression data available for this study.'}
                 </div>
             );
@@ -1070,24 +1103,26 @@ export default class MrnaViolinPlotChart extends React.Component<
                         />
                         Log scale
                     </label>
-                    <button
-                        onClick={action((e: React.MouseEvent) => {
-                            e.stopPropagation(); // don't let toolbar's close-handler fire
-                            this.showGenePicker = !this.showGenePicker;
-                        })}
-                        style={{
-                            fontSize: 11,
-                            padding: '2px 7px',
-                            border: '1px solid #ccc',
-                            borderRadius: 3,
-                            background: this.showGenePicker
-                                ? '#e8f0fc'
-                                : '#f5f5f5',
-                            cursor: 'pointer',
-                        }}
-                    >
-                        Genes ({this.selectedSymbols.length}) ▾
-                    </button>
+                    {!this.isGeneSpecificMode && (
+                        <button
+                            onClick={action((e: React.MouseEvent) => {
+                                e.stopPropagation(); // don't let toolbar's close-handler fire
+                                this.showGenePicker = !this.showGenePicker;
+                            })}
+                            style={{
+                                fontSize: 11,
+                                padding: '2px 7px',
+                                border: '1px solid #ccc',
+                                borderRadius: 3,
+                                background: this.showGenePicker
+                                    ? '#e8f0fc'
+                                    : '#f5f5f5',
+                                cursor: 'pointer',
+                            }}
+                        >
+                            Genes ({this.selectedSymbols.length}) ▾
+                        </button>
+                    )}
                     <span style={{ color: '#999', fontStyle: 'italic' }}>
                         Drag across a track to filter; click it to clear
                     </span>

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -336,7 +336,7 @@ export default class MrnaViolinPlotChart extends React.Component<
         const marginLeft = 80;
         const marginRight = 16;
         const marginTop = 38;
-        const marginBottom = 6;
+        const marginBottom = 9;
         const svgHeight = this.props.height - TOOLBAR_HEIGHT;
         const plotW = this.props.width - marginLeft - marginRight;
         const plotH = svgHeight - marginTop - marginBottom;
@@ -854,7 +854,7 @@ export default class MrnaViolinPlotChart extends React.Component<
                         x={10}
                         y={marginTop + rowH * (i + 0.5) + 4}
                         textAnchor="start"
-                        fontSize={11}
+                        fontSize={13}
                         fontStyle="normal"
                         fill="#333"
                     >

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -17,6 +17,8 @@ const MSK_TRIAL_GENES: string[] = MRNA_TAB_GENE_GROUPS.find(
 
 const DEFAULT_GENE_COUNT = 10;
 const MAX_GENES = 10;
+/** Cap per-gene track height when fewer than MAX_GENES genes fill the plot. */
+const MAX_ROW_HEIGHT = 50;
 const MAX_SAMPLES = 1000;
 const KDE_POINTS = 80;
 const TOOLBAR_HEIGHT = 34;
@@ -421,11 +423,15 @@ export default class MrnaViolinPlotChart extends React.Component<
             this.props.height - (this.showToolbar ? TOOLBAR_HEIGHT : 0);
         const plotW = this.props.width - marginLeft - marginRight;
         const plotH = svgHeight - marginTop - marginBottom;
-        // Fixed row height: divide by MAX_GENES so each track is the same size
-        // regardless of how many genes are shown — fewer genes leave empty
-        // space below rather than stretching the tracks. Only shrink below this
-        // when a selection exceeds MAX_GENES, so the rows still fit the chart.
-        const rowH = plotH / Math.max(MAX_GENES, this.selectedSymbols.length);
+        // With a full slate of genes the rows divide the plot evenly. With
+        // fewer, scale each row up to fill the space instead of leaving it
+        // empty, but cap the height so a couple of genes don't produce absurdly
+        // tall tracks. More than MAX_GENES shrinks the rows to still fit.
+        const geneCount = Math.max(1, this.selectedSymbols.length);
+        const rowH =
+            geneCount >= MAX_GENES
+                ? plotH / geneCount
+                : Math.min(MAX_ROW_HEIGHT, plotH / geneCount);
         return {
             marginLeft,
             marginRight,

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -142,6 +142,9 @@ export interface IMrnaViolinPlotChartProps {
     // omitted, the chart runs in its original auto-added mRNA mode.
     genes?: string[];
     profileType?: string;
+    // Log scale is controlled by the chart-header options menu (like other
+    // charts), so it comes in as a prop rather than living in the toolbar.
+    logScale?: boolean;
 }
 
 @observer
@@ -153,7 +156,6 @@ export default class MrnaViolinPlotChart extends React.Component<
         0,
         DEFAULT_GENE_COUNT
     );
-    @observable logScale = false;
     @observable showGenePicker = false;
 
     // Drag-selection state. A drag is locked to a single gene row (track) for
@@ -179,6 +181,20 @@ export default class MrnaViolinPlotChart extends React.Component<
     /** Gene-specific mode: fixed gene list + explicit profile, no gene picker. */
     @computed private get isGeneSpecificMode(): boolean {
         return !!this.props.profileType;
+    }
+
+    /** Log scale is driven by the chart-header options menu. */
+    @computed private get logScale(): boolean {
+        return !!this.props.logScale;
+    }
+
+    /**
+     * The toolbar only carries the gene picker, which exists in the legacy
+     * auto-added mRNA mode. Gene-specific mode has no toolbar (log scale moved
+     * to the chart-header menu), so its plot reclaims that vertical space.
+     */
+    @computed private get showToolbar(): boolean {
+        return !this.isGeneSpecificMode;
     }
 
     /** Resolve selected Hugo symbols → Gene objects (entrezGeneId). */
@@ -364,7 +380,8 @@ export default class MrnaViolinPlotChart extends React.Component<
         const marginRight = 16;
         const marginTop = 38;
         const marginBottom = 9;
-        const svgHeight = this.props.height - TOOLBAR_HEIGHT;
+        const svgHeight =
+            this.props.height - (this.showToolbar ? TOOLBAR_HEIGHT : 0);
         const plotW = this.props.width - marginLeft - marginRight;
         const plotH = svgHeight - marginTop - marginBottom;
         // Fixed row height: divide by MAX_GENES so each track is the same size
@@ -1052,58 +1069,27 @@ export default class MrnaViolinPlotChart extends React.Component<
                     isolation: 'isolate',
                 }}
             >
-                <div
-                    style={{
-                        height: TOOLBAR_HEIGHT,
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 12,
-                        padding: '0 8px',
-                        borderBottom: '1px solid #eee',
-                        fontSize: 11,
-                        flexShrink: 0,
-                        background: '#fff',
-                        position: 'relative',
-                        zIndex: 3,
-                    }}
-                    onClick={action(() => {
-                        // Close picker when clicking anywhere in the toolbar
-                        // (the Genes button stops propagation to handle its own toggle)
-                        this.showGenePicker = false;
-                    })}
-                >
-                    <label
+                {this.showToolbar && (
+                    <div
                         style={{
-                            display: 'inline-flex',
+                            height: TOOLBAR_HEIGHT,
+                            display: 'flex',
                             alignItems: 'center',
-                            gap: 4,
-                            cursor: this.canLogScale
-                                ? 'pointer'
-                                : 'not-allowed',
-                            color: this.canLogScale ? '#333' : '#999',
-                            fontWeight: 'normal',
-                            margin: 0,
+                            gap: 12,
+                            padding: '0 8px',
+                            borderBottom: '1px solid #eee',
+                            fontSize: 11,
+                            flexShrink: 0,
+                            background: '#fff',
+                            position: 'relative',
+                            zIndex: 3,
                         }}
-                        title={
-                            this.canLogScale
-                                ? 'Toggle between log₂ and linear value axis'
-                                : 'Linear only — data contains negative values'
-                        }
+                        onClick={action(() => {
+                            // Close picker when clicking anywhere in the toolbar
+                            // (the Genes button stops propagation to toggle itself)
+                            this.showGenePicker = false;
+                        })}
                     >
-                        <input
-                            type="checkbox"
-                            checked={this.logScale && this.canLogScale}
-                            disabled={!this.canLogScale}
-                            onChange={action(
-                                (e: React.ChangeEvent<HTMLInputElement>) => {
-                                    this.logScale = e.target.checked;
-                                }
-                            )}
-                            style={{ margin: 0 }}
-                        />
-                        Log scale
-                    </label>
-                    {!this.isGeneSpecificMode && (
                         <button
                             onClick={action((e: React.MouseEvent) => {
                                 e.stopPropagation(); // don't let toolbar's close-handler fire
@@ -1122,11 +1108,8 @@ export default class MrnaViolinPlotChart extends React.Component<
                         >
                             Genes ({this.selectedSymbols.length}) ▾
                         </button>
-                    )}
-                    <span style={{ color: '#999', fontStyle: 'italic' }}>
-                        Drag across a track to filter; click it to clear
-                    </span>
-                </div>
+                    </div>
+                )}
                 {bodyContent}
                 {this.showGenePicker && (
                     <>

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -257,13 +257,6 @@ export default class MrnaViolinPlotChart extends React.Component<
                         : p.molecularAlterationType === 'MRNA_EXPRESSION'
             );
 
-            console.info(
-                '[MrnaViolinPlotChart] Available profiles:',
-                allMrnaProfiles.map(
-                    p => `${p.molecularProfileId} (${p.datatype})`
-                )
-            );
-
             if (allMrnaProfiles.length === 0) {
                 return {
                     profilesUsed: [],

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -30,11 +30,23 @@ const SCALED_DATATYPE_PRIORITY = [
 
 function pickBestMrnaProfile(profiles: MolecularProfile[]): MolecularProfile {
     for (const dt of SCALED_DATATYPE_PRIORITY) {
-        const m = profiles.find(p => p.datatype === dt);
-        if (m) return m;
+        const matches = profiles.filter(p => p.datatype === dt);
+        if (matches.length > 0) {
+            // Among z-score profiles, prefer "all-sample" z-scores: they are
+            // standardized across the study cohort and stay bounded (~±√n),
+            // which keeps the shared cross-gene axis sane. Diploid/normal-
+            // reference z-scores can explode for genes silent in normal tissue
+            // (e.g. MAGEA4 reaches z > 200), wrecking the shared axis.
+            return (
+                matches.find(p =>
+                    /all[_]?sample/i.test(p.molecularProfileId)
+                ) ?? matches[0]
+            );
+        }
     }
     // Belt-and-suspenders: profile ID pattern fallback (TCGA naming)
     return (
+        profiles.find(p => /all[_]?sample_zscores?$/i.test(p.molecularProfileId)) ??
         profiles.find(p => /zscores?$/i.test(p.molecularProfileId)) ??
         profiles.find(p => /log[\d_]/i.test(p.molecularProfileId)) ??
         profiles[0]

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import { Gene, MolecularProfile } from 'cbioportal-ts-api-client';
 import { DataTypeConstants } from 'shared/constants';
 import { MRNA_TAB_GENE_GROUPS } from 'pages/patientView/mrna/mrnaTabGeneGroups';
+import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
 
 const MSK_TRIAL_GENES: string[] = MRNA_TAB_GENE_GROUPS.find(
     g => g.id === 'msk-trial'
@@ -44,15 +45,30 @@ function gaussianKernel(u: number): number {
     return Math.exp(-0.5 * u * u) / Math.sqrt(2 * Math.PI);
 }
 
+/** Percentile of an ascending-sorted array (nearest-rank). */
+function percentile(sortedAsc: number[], p: number): number {
+    if (sortedAsc.length === 0) return NaN;
+    const i = Math.min(
+        Math.max(Math.floor(p * sortedAsc.length), 0),
+        sortedAsc.length - 1
+    );
+    return sortedAsc[i];
+}
+
 /**
- * Gaussian KDE. Bandwidth = max(Silverman's rule, 5% of data range)
- * so concentrated distributions still produce a visible violin.
+ * Gaussian KDE evaluated over an explicit [min, max] domain. The caller passes
+ * a robust per-gene domain (e.g. 1st–99th percentile) so a few extreme
+ * outliers can't stretch the domain and collapse the violin into a spike.
+ * Bandwidth = max(Silverman's rule, 5% of the domain) so concentrated
+ * distributions still produce a visible violin.
  */
-function computeKDE(data: number[], nPoints: number): Array<[number, number]> {
-    if (data.length < 2) return [];
-    const min = Math.min(...data);
-    const max = Math.max(...data);
-    if (min === max) return [];
+function computeKDE(
+    data: number[],
+    nPoints: number,
+    min: number,
+    max: number
+): Array<[number, number]> {
+    if (data.length < 2 || min === max) return [];
     const mean = data.reduce((s, v) => s + v, 0) / data.length;
     const std = Math.sqrt(
         data.reduce((s, v) => s + (v - mean) ** 2, 0) / data.length
@@ -67,6 +83,12 @@ function computeKDE(data: number[], nPoints: number): Array<[number, number]> {
             (data.length * bw);
         return [x, density] as [number, number];
     });
+}
+
+/** Deterministic pseudo-random jitter in [-1, 1] from an integer index. */
+function jitterFraction(i: number): number {
+    const v = Math.sin(i * 12.9898) * 43758.5453;
+    return (v - Math.floor(v)) * 2 - 1;
 }
 
 interface BoxStats {
@@ -113,6 +135,18 @@ export default class MrnaViolinPlotChart extends React.Component<
     );
     @observable logScale = false;
     @observable showGenePicker = false;
+
+    // Drag-selection state. A drag is locked to a single gene row (track) for
+    // its whole lifetime, so selections can never span across tracks.
+    @observable private dragRowIndex: number | null = null;
+    @observable private dragStartX: number | null = null;
+    @observable private dragCurrentX: number | null = null;
+    // Plot-relative x of the cursor while hovering, for the dashed guide line,
+    // plus the row it is over so the line spans only that one track.
+    @observable private hoverX: number | null = null;
+    @observable private hoverRowIndex: number | null = null;
+
+    private svgRef = React.createRef<SVGSVGElement>();
 
     constructor(props: IMrnaViolinPlotChartProps) {
         super(props);
@@ -330,6 +364,133 @@ export default class MrnaViolinPlotChart extends React.Component<
         return ((clamped - range.min) / (range.max - range.min)) * plotW;
     }
 
+    /**
+     * Profile suffix used as the cross-study key for genomic-data filters
+     * (e.g. "rna_seq_v2_mrna_median_Zscores"). Null until data has loaded.
+     */
+    @computed get profileType(): string | null {
+        const profile = this.mrnaData.result?.profilesUsed[0];
+        return profile ? getSuffixOfMolecularProfile(profile) : null;
+    }
+
+    /** Inverse of xScale: plot pixel x → display-space value. */
+    private xToDisplayValue(px: number): number {
+        const range = this.globalValueRange!;
+        const { plotW } = this.layout;
+        const frac = Math.min(Math.max(px / plotW, 0), 1);
+        return range.min + frac * (range.max - range.min);
+    }
+
+    /** Undo the optional log₂(x+1) display transform to get a raw profile value. */
+    private displayToRaw(displayValue: number): number {
+        return this.logScale && this.canLogScale
+            ? Math.pow(2, displayValue) - 1
+            : displayValue;
+    }
+
+    /** Apply the optional log₂(x+1) display transform to a raw profile value. */
+    private rawToDisplay(rawValue: number): number {
+        return this.logScale && this.canLogScale
+            ? Math.log2(rawValue + 1)
+            : rawValue;
+    }
+
+    /** Plot-relative x of a pointer event, clamped to [0, plotW]. */
+    private clientXToPlotX(clientX: number): number {
+        const svg = this.svgRef.current;
+        const { marginLeft, plotW } = this.layout;
+        if (!svg) return 0;
+        const rect = svg.getBoundingClientRect();
+        const x = clientX - rect.left - marginLeft;
+        return Math.min(Math.max(x, 0), plotW);
+    }
+
+    @action.bound
+    private onRowMouseDown(e: React.MouseEvent, rowIndex: number) {
+        // Left-button drags only; ignore modifier-clicks.
+        if (e.button !== 0) return;
+        e.preventDefault();
+        const x = this.clientXToPlotX(e.clientX);
+        this.dragRowIndex = rowIndex;
+        this.dragStartX = x;
+        this.dragCurrentX = x;
+        window.addEventListener('mousemove', this.onDragMove);
+        window.addEventListener('mouseup', this.onDragEnd);
+    }
+
+    @action.bound
+    private onDragMove(e: MouseEvent) {
+        if (this.dragRowIndex === null) return;
+        // X is clamped to the plot, so the selection stays within this one
+        // track no matter where the cursor wanders vertically.
+        this.dragCurrentX = this.clientXToPlotX(e.clientX);
+    }
+
+    @action.bound
+    private onDragEnd() {
+        window.removeEventListener('mousemove', this.onDragMove);
+        window.removeEventListener('mouseup', this.onDragEnd);
+
+        const rowIndex = this.dragRowIndex;
+        const startX = this.dragStartX;
+        const endX = this.dragCurrentX;
+        this.dragRowIndex = null;
+        this.dragStartX = null;
+        this.dragCurrentX = null;
+
+        if (rowIndex === null || startX === null || endX === null) return;
+        const gene = this.currentGenes[rowIndex];
+        if (!gene || !this.profileType) return;
+
+        const lo = Math.min(startX, endX);
+        const hi = Math.max(startX, endX);
+
+        // Treat a negligible drag as a click → clear this track's selection.
+        if (hi - lo < 3) {
+            this.props.store.updateMrnaViolinSelection(
+                gene.hugoSymbol,
+                this.profileType,
+                null
+            );
+            return;
+        }
+
+        const { plotW } = this.layout;
+        // Open-end the bound when the drag reaches an axis edge, so clipped
+        // outliers beyond the 1st/99th percentile range are still included.
+        const start =
+            lo <= plotW * 0.005
+                ? undefined
+                : this.displayToRaw(this.xToDisplayValue(lo));
+        const end =
+            hi >= plotW * 0.995
+                ? undefined
+                : this.displayToRaw(this.xToDisplayValue(hi));
+
+        this.props.store.updateMrnaViolinSelection(
+            gene.hugoSymbol,
+            this.profileType,
+            { start, end }
+        );
+    }
+
+    @action.bound
+    private onHoverMove(e: React.MouseEvent, rowIndex: number) {
+        this.hoverX = this.clientXToPlotX(e.clientX);
+        this.hoverRowIndex = rowIndex;
+    }
+
+    @action.bound
+    private onHoverLeave() {
+        this.hoverX = null;
+        this.hoverRowIndex = null;
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('mousemove', this.onDragMove);
+        window.removeEventListener('mouseup', this.onDragEnd);
+    }
+
     @action.bound
     private toggleGene(symbol: string) {
         if (this.selectedSymbols.includes(symbol)) {
@@ -368,36 +529,79 @@ export default class MrnaViolinPlotChart extends React.Component<
             );
         }
 
-        const kdePoints = computeKDE(values, KDE_POINTS);
-        const maxDensity =
-            kdePoints.length > 0 ? Math.max(...kdePoints.map(p => p[1])) : 1;
-
-        let violinPath = '';
-        if (kdePoints.length >= 2 && maxDensity > 0) {
-            const scale = violinHalfH / maxDensity;
-            const upperPts = kdePoints
-                .map(
-                    ([x, d]) =>
-                        `${this.xScale(x).toFixed(1)},${(
-                            centerY -
-                            d * scale
-                        ).toFixed(1)}`
-                )
-                .join(' ');
-            const lowerPts = [...kdePoints]
-                .reverse()
-                .map(
-                    ([x, d]) =>
-                        `${this.xScale(x).toFixed(1)},${(
-                            centerY +
-                            d * scale
-                        ).toFixed(1)}`
-                )
-                .join(' ');
-            violinPath = `M ${upperPts} L ${lowerPts} Z`;
-        }
-
         const box = computeBoxStats(values);
+
+        // Count distinct values to detect near-constant distributions (e.g.
+        // cancer-testis antigens silent in nearly every sample). A KDE can't
+        // meaningfully represent these, so we fall back to a strip plot.
+        const sorted = [...values].sort((a, b) => a - b);
+        let uniqueCount = sorted.length > 0 ? 1 : 0;
+        for (let i = 1; i < sorted.length; i++) {
+            if (sorted[i] !== sorted[i - 1]) uniqueCount++;
+        }
+        const isDegenerate = uniqueCount <= 2 || box.q3 - box.q1 === 0;
+
+        let shape: JSX.Element | null = null;
+        if (isDegenerate) {
+            // Strip plot: draw each sample as a jittered dot. Off-scale
+            // outliers clamp to the plot edge via xScale.
+            shape = (
+                <g>
+                    {values.map((v, i) => (
+                        <circle
+                            key={i}
+                            cx={this.xScale(v)}
+                            cy={centerY + jitterFraction(i) * violinHalfH}
+                            r={1.5}
+                            fill="#1A5DAB"
+                            fillOpacity={0.45}
+                        />
+                    ))}
+                </g>
+            );
+        } else {
+            // Robust per-gene domain: trim to the 1st–99th percentile so a few
+            // extreme values don't blow up the KDE domain.
+            const lo = percentile(sorted, 0.01);
+            const hi = percentile(sorted, 0.99);
+            const trimmed = values.filter(v => v >= lo && v <= hi);
+            const kdePoints = computeKDE(trimmed, KDE_POINTS, lo, hi);
+            const maxDensity =
+                kdePoints.length > 0
+                    ? Math.max(...kdePoints.map(p => p[1]))
+                    : 1;
+
+            if (kdePoints.length >= 2 && maxDensity > 0) {
+                const scale = violinHalfH / maxDensity;
+                const upperPts = kdePoints
+                    .map(
+                        ([x, d]) =>
+                            `${this.xScale(x).toFixed(1)},${(
+                                centerY -
+                                d * scale
+                            ).toFixed(1)}`
+                    )
+                    .join(' ');
+                const lowerPts = [...kdePoints]
+                    .reverse()
+                    .map(
+                        ([x, d]) =>
+                            `${this.xScale(x).toFixed(1)},${(
+                                centerY +
+                                d * scale
+                            ).toFixed(1)}`
+                    )
+                    .join(' ');
+                shape = (
+                    <path
+                        d={`M ${upperPts} L ${lowerPts} Z`}
+                        fill="#D6E6F9"
+                        stroke="#1A5DAB"
+                        strokeWidth={1}
+                    />
+                );
+            }
+        }
         const x1 = this.xScale(box.q1);
         const x3 = this.xScale(box.q3);
         const xMed = this.xScale(box.median);
@@ -406,14 +610,7 @@ export default class MrnaViolinPlotChart extends React.Component<
 
         return (
             <g key={gene.hugoSymbol}>
-                {violinPath && (
-                    <path
-                        d={violinPath}
-                        fill="#2986E2"
-                        stroke="#2986E2"
-                        strokeWidth={0.5}
-                    />
-                )}
+                {shape}
                 <line
                     x1={xWL}
                     x2={xWH}
@@ -457,6 +654,111 @@ export default class MrnaViolinPlotChart extends React.Component<
                     strokeWidth={1.5}
                 />
             </g>
+        );
+    }
+
+    /**
+     * Per-row interaction layer: a transparent capture rect that starts a
+     * drag, the committed selection highlight (read back from the store), and
+     * the live drag rectangle while this row is being dragged.
+     */
+    private renderRowOverlay(
+        gene: { hugoSymbol: string; entrezGeneId: number },
+        rowIndex: number
+    ): JSX.Element {
+        const { rowH, plotW } = this.layout;
+        const bandTop = rowH * rowIndex + 2;
+        const bandH = rowH - 4;
+
+        // Committed selection for this track, mapped raw → display → pixel.
+        let committed: JSX.Element | null = null;
+        const selection = this.profileType
+            ? this.props.store.getMrnaViolinSelection(
+                  gene.hugoSymbol,
+                  this.profileType
+              )
+            : undefined;
+        if (selection) {
+            const xs =
+                selection.start === undefined
+                    ? 0
+                    : this.xScale(this.rawToDisplay(selection.start));
+            const xe =
+                selection.end === undefined
+                    ? plotW
+                    : this.xScale(this.rawToDisplay(selection.end));
+            committed = (
+                <rect
+                    x={Math.min(xs, xe)}
+                    y={bandTop}
+                    width={Math.max(Math.abs(xe - xs), 1)}
+                    height={bandH}
+                    fill="#FFD54F"
+                    fillOpacity={0.3}
+                    stroke="#F5A623"
+                    strokeWidth={1}
+                    pointerEvents="none"
+                />
+            );
+        }
+
+        // Live drag rectangle (only for the row currently being dragged).
+        let dragRect: JSX.Element | null = null;
+        if (
+            this.dragRowIndex === rowIndex &&
+            this.dragStartX !== null &&
+            this.dragCurrentX !== null
+        ) {
+            const lo = Math.min(this.dragStartX, this.dragCurrentX);
+            const hi = Math.max(this.dragStartX, this.dragCurrentX);
+            dragRect = (
+                <rect
+                    x={lo}
+                    y={bandTop}
+                    width={Math.max(hi - lo, 1)}
+                    height={bandH}
+                    fill="#2986E2"
+                    fillOpacity={0.2}
+                    stroke="#2986E2"
+                    strokeWidth={1}
+                    pointerEvents="none"
+                />
+            );
+        }
+
+        return (
+            <g key={`overlay-${gene.hugoSymbol}`}>
+                {committed}
+                {dragRect}
+                <rect
+                    x={0}
+                    y={rowH * rowIndex}
+                    width={plotW}
+                    height={rowH}
+                    fill="transparent"
+                    style={{ cursor: 'default' }}
+                    onMouseDown={e => this.onRowMouseDown(e, rowIndex)}
+                    onMouseMove={e => this.onHoverMove(e, rowIndex)}
+                />
+            </g>
+        );
+    }
+
+    /** Vertical dashed guide line tracking the cursor within the hovered track. */
+    private renderHoverLine(): JSX.Element | null {
+        if (this.hoverX === null || this.hoverRowIndex === null) return null;
+        const { rowH } = this.layout;
+        return (
+            <line
+                x1={this.hoverX}
+                x2={this.hoverX}
+                y1={rowH * this.hoverRowIndex}
+                y2={rowH * (this.hoverRowIndex + 1)}
+                stroke="#000"
+                strokeWidth={2}
+                strokeDasharray="4,3"
+                pointerEvents="none"
+            />
         );
     }
 
@@ -663,9 +965,11 @@ export default class MrnaViolinPlotChart extends React.Component<
         } else {
             bodyContent = (
                 <svg
+                    ref={this.svgRef}
                     width={width}
                     height={svgHeight}
                     style={{ display: 'block' }}
+                    onMouseLeave={this.onHoverLeave}
                 >
                     {this.renderYLabels()}
                     <g transform={`translate(${marginLeft}, ${marginTop})`}>
@@ -682,6 +986,11 @@ export default class MrnaViolinPlotChart extends React.Component<
                             strokeWidth={1}
                         />
                         {this.renderXAxis()}
+                        {/* Drag-selection layer sits on top of the violins. */}
+                        {this.currentGenes.map((gene, i) =>
+                            this.renderRowOverlay(gene, i)
+                        )}
+                        {this.renderHoverLine()}
                     </g>
                 </svg>
             );
@@ -767,6 +1076,9 @@ export default class MrnaViolinPlotChart extends React.Component<
                     >
                         Genes ({this.selectedSymbols.length}) ▾
                     </button>
+                    <span style={{ color: '#999', fontStyle: 'italic' }}>
+                        Drag across a track to filter; click it to clear
+                    </span>
                 </div>
                 {bodyContent}
                 {this.showGenePicker && (

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -924,6 +924,15 @@ export class StudySummaryTab extends React.Component<
                 // gives ChartContainer a valid MobxPromise to await.
                 promise: this.store.selectedSamples,
                 filters: [],
+                // Log scale lives in the chart-header options menu.
+                showLogScaleToggle: true,
+                logScaleChecked: this.store.isGeneSpecificViolinLogScale(
+                    chartMeta.uniqueKey
+                ),
+                onToggleLogScale: () =>
+                    this.store.toggleGeneSpecificViolinLogScale(
+                        chartMeta.uniqueKey
+                    ),
             }),
         });
     }

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -919,6 +919,12 @@ export class StudySummaryTab extends React.Component<
                 promise: this.store.selectedSamples,
                 filters: [],
             }),
+            [ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT]: () => ({
+                // Self-contained like the mRNA violin; selectedSamples just
+                // gives ChartContainer a valid MobxPromise to await.
+                promise: this.store.selectedSamples,
+                filters: [],
+            }),
         });
     }
 

--- a/src/pages/studyView/tabs/SummaryTab.tsx
+++ b/src/pages/studyView/tabs/SummaryTab.tsx
@@ -913,6 +913,12 @@ export class StudySummaryTab extends React.Component<
                     this.store.resetClinicalEventTypeFilter();
                 },
             }),
+            [ChartTypeEnum.MRNA_VIOLIN_PLOT]: () => ({
+                // The chart is self-contained; use selectedSamples as the
+                // promise so ChartContainer always has a valid MobxPromise.
+                promise: this.store.selectedSamples,
+                filters: [],
+            }),
         });
     }
 

--- a/src/shared/api/session-service/sessionServiceModels.ts
+++ b/src/shared/api/session-service/sessionServiceModels.ts
@@ -89,6 +89,10 @@ export type ChartUserSetting = {
     description?: string;
     profileType?: string;
     hugoGeneSymbol?: string;
+    // Multiple genes for a gene-specific violin chart (one continuous-numeric
+    // profile across several genes).
+    hugoGeneSymbols?: string[];
+    violinLogScale?: boolean;
     genericAssayType?: string;
     genericAssayEntityId?: string;
     dataType?: string;

--- a/src/shared/featureFlags.ts
+++ b/src/shared/featureFlags.ts
@@ -2,4 +2,5 @@ export enum FeatureFlagEnum {
     LEFT_TRUNCATION_ADJUSTMENT = 'LEFT_TRUNCATION_ADJUSTMENT',
     CHAT = 'CHAT',
     PATIENT_MRNA_TAB = 'patientMRNATab',
+    GENE_SPECIFIC_VIOLIN_PLOT = 'geneSpecificViolinPlot',
 }


### PR DESCRIPTION
Re-applies the mRNA violin plot chart for the study view. The original PR (#5617) was merged and then reverted; this branch brings the feature back along with several follow-up fixes and a new drag-to-filter interaction.

The original feature commits were squash-merged upstream, so they are not in `master` history — this PR shows the full feature diff and merges cleanly against current `master`.

## What's included
Original feature (from #5617):
- mRNA violin plot chart in the study view summary tab, with gene picker, log-scale toggle, KDE violins and box/whisker overlays.

New in this PR:
- **Drag-to-filter:** drag across a single violin track to filter the study view by that gene's expression range. Drags are locked to one track, so a selection can never span across tracks; click a track to clear it. Selections apply via a standard `GenomicDataFilter` so they round-trip through study-view filters.
- **Removable filter pill:** violin selections show as a removable pill in the filter bar (fallback rendering for genomic filters that don't have a registered chart).
- **Per-track hover guide line** confined to the hovered track.
- **Robust rendering:** near-constant distributions (e.g. cancer-testis antigens like MAGEA4, silent in nearly all samples with a couple of extreme outliers) now render as a jittered strip plot instead of a degenerate KDE spike, and each violin's KDE is computed over a robust per-gene 1st–99th percentile domain so outliers can't flatten the shape.
- **Styling/UX:** dark-blue violin outline with a light-blue fill; chart header controls kept above chart bodies that create their own stacking context (fixes the top-right buttons being cut off); small loading indicator on chart reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784828483&installation_id=126502837&pr_number=5627&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5627&signature=6c9c565b3070bb093fc03f500f94dfa9695697c9a45aa524efaada5850ab3833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->