### PR TITLE
Fix flaky study view group color chooser e2e localdb tests

### DIFF
--- a/end-to-end-test-playwright/tests/local/group-color-chooser.spec.ts
+++ b/end-to-end-test-playwright/tests/local/group-color-chooser.spec.ts
@@ -52,13 +52,51 @@ test.describe.serial('color chooser for groups menu in study view', () => {
             typeof icon === 'string' ? page.locator(icon) : icon;
         for (let attempt = 0; attempt < 3; attempt++) {
             if (!(await page.locator(swatchSel).isVisible())) {
+                // react-overlays 0.7.x's RootCloseWrapper adds its document-level
+                // close handler during the opening click's event processing (inside
+                // componentDidMount, which React runs while the click is still
+                // bubbling from #reactRoot to document in React 18).  That handler
+                // then fires when the same click reaches document — immediately
+                // closing the picker that was just opened.
+                //
+                // Fix: register a bubble-phase listener on document BEFORE the
+                // click fires.  Listeners fire in FIFO order per element/phase, so
+                // ours always runs before the RootCloseWrapper handler (which is
+                // only registered partway through the event's propagation).
+                // stopImmediatePropagation silences all subsequent listeners at
+                // document for this one event.
+                await page.evaluate(() => {
+                    document.addEventListener(
+                        'click',
+                        e => e.stopImmediatePropagation(),
+                        { capture: false, once: true }
+                    );
+                });
                 await iconLocator.click();
+                // circle-picker does a secondary layout re-render right after
+                // mounting; wait for it to settle before trying to click a swatch.
+                await page.waitForTimeout(300);
             }
             try {
                 await expect(page.locator(swatchSel)).toBeVisible({
                     timeout: 5000,
                 });
                 await page.locator(swatchSel).click({ timeout: 5000 });
+                // The OverlayTrigger (trigger="click") doesn't auto-close when
+                // content inside it is clicked — closure depends on whether React
+                // remounts GroupCheckbox on the color update, which is
+                // non-deterministic.  Wait briefly for an auto-close; if it
+                // doesn't happen, click the icon again to force-toggle it shut.
+                const autoClosedInTime = await expect(page.locator(swatchSel))
+                    .not.toBeVisible({ timeout: 500 })
+                    .then(() => true)
+                    .catch(() => false);
+                if (!autoClosedInTime) {
+                    await iconLocator.click();
+                    await expect(page.locator(swatchSel))
+                        .not.toBeVisible({ timeout: 3000 })
+                        .catch(() => {});
+                }
                 return;
             } catch {
                 if (attempt === 2)
@@ -173,7 +211,6 @@ test.describe.serial('color chooser for groups menu in study view', () => {
             .click();
 
         await selectColorPickerSwatch(gbGroupColorIcon, colorPickerBlue);
-        await setDropdownOpen(page, false, gbGroupColorIcon, colorPickerBlue);
 
         const secondColorIcon = page.locator(colorIcon).nth(1);
         await selectColorPickerSwatch(secondColorIcon, colorPickerBlue);


### PR DESCRIPTION
### Problem

The group-color-chooser.spec.ts tests were intermittently failing with three distinct errors when trying to open the color picker:

 1. Element detached from DOM — circle-picker performs a secondary layout re-render immediately after mounting, briefly detaching its swatch elements before re-attaching them.
 2. Picker closes immediately after opening — the most common failure. The picker would open and then close in the same event cycle before any swatch could be clicked.
 3. "Couldn't close dropdown" — the setDropdownOpen helper's toggle retries exhausted because the picker state was non-deterministic.

The root cause of failure 2 is a React 18 + react-overlays 0.7.x incompatibility. React 18 moved its event delegation from document to the app's root element (#reactRoot). react-overlays' RootCloseWrapper registers its document-level close handler inside componentDidMount, which React runs synchronously while the opening click is still bubbling from #reactRoot toward document. By the time the click reaches document, the close handler is already registered there and fires — immediately collapsing the picker that was just opened.

A secondary issue: OverlayTrigger(trigger="click") doesn't reliably auto-close after a swatch is selected. Whether it closes depends on whether MobX triggers a GroupCheckbox remount, which is non-deterministic.

### Fix

Opening the picker (selectColorPickerSwatch helper): Before each icon click, a one-shot bubble-phase listener is registered on document via page.evaluate. DOM listeners fire in FIFO registration order per element and phase, so our listener always runs before RootCloseWrapper's handler (which is only added partway through the event's propagation, at #reactRoot). Calling stopImmediatePropagation() silences all subsequent listeners at document for that single event, preventing the spurious close. Playwright's native click() is then used so React receives a trusted user event and processes it correctly.

A 300 ms wait after opening lets circle-picker's secondary re-render settle before attempting to click a swatch.

Closing the picker after a swatch selection: the helper waits up to 500 ms for an auto-close. If the picker is still open, it clicks the icon again to force-toggle it shut. This ensures a clean state before each subsequent selectColorPickerSwatch call.

The setDropdownOpen calls that were previously used to manage the picker (and were the source of the toggle-race failures) are removed in favour of this self-contained helper.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784920148&installation_id=126502837&pr_number=5632&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5632&signature=e0765f8c741a85c9f7f4df910399b784f50ca0a8e8d41b385426b26180a367b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->