### PR TITLE
Stabilize patient view default columns localdb e2e tests

### DIFF
--- a/end-to-end-test-playwright/tests/local/init-columns-in-mutation-tables.spec.ts
+++ b/end-to-end-test-playwright/tests/local/init-columns-in-mutation-tables.spec.ts
@@ -67,9 +67,9 @@ async function namespaceColumnsAreDisplayed(page: Page) {
 }
 
 async function namespaceColumnsAreNotDisplayed(page: Page) {
-    return !(
-        (await isHeaderVisible(page, 'Zygosity Code')) &&
-        (await isHeaderVisible(page, 'Zygosity Name'))
+    return (
+        !(await isHeaderVisible(page, 'Zygosity Code')) &&
+        !(await isHeaderVisible(page, 'Zygosity Name'))
     );
 }
 
@@ -232,6 +232,12 @@ test.describe('default init columns in mutation tables', () => {
                 {}
             );
             await waitForPatientViewMutationTable(page);
+            // Copy # loads after a separate async copy-number request; wait for
+            // it so the no-timeout isVisible() checks in
+            // defaultPatientColumnsAreDisplayed see the complete column set.
+            await expect(
+                headerLocator(page, DEFAULT_PATIENT_COLS.COPY_NUM)
+            ).toBeVisible({ timeout: 15000 });
             expect(await defaultPatientColumnsAreDisplayed(page)).toBe(true);
             expect(await namespaceColumnsAreNotDisplayed(page)).toBe(true);
         });
@@ -248,6 +254,11 @@ test.describe('default init columns in mutation tables', () => {
                 }
             );
             await waitForPatientViewMutationTable(page);
+            // Same async race as above: wait for Copy # before the no-timeout
+            // isVisible() checks.
+            await expect(
+                headerLocator(page, DEFAULT_PATIENT_COLS.COPY_NUM)
+            ).toBeVisible({ timeout: 15000 });
             expect(await defaultPatientColumnsAreDisplayed(page)).toBe(true);
             expect(await namespaceColumnsAreDisplayed(page)).toBe(true);
         });


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784926868&installation_id=126502837&pr_number=5634&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5634&signature=5246a1b7710c77dd5a15691e7279ec4d018be4c9f4350dd4f7a82286af1d4762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->