### PR TITLE
fix(query): default-select sole molecular profile (fixes cBioPortal/c…

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -288,7 +288,7 @@ import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
 import {
-    getDefaultProfileSuffixWhenNoMutationData,
+    getFallbackSelectableProfileSuffix,
     getSuffixOfMolecularProfile,
 } from 'shared/lib/molecularProfileUtils';
 import {
@@ -11452,7 +11452,7 @@ export class StudyViewPageStore
             molecularProfileFilters.length === 0 &&
             this.molecularProfiles.isComplete
         ) {
-            const defaultSuffix = getDefaultProfileSuffixWhenNoMutationData(
+            const defaultSuffix = getFallbackSelectableProfileSuffix(
                 this.molecularProfiles.result
             );
             if (defaultSuffix) {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -287,7 +287,10 @@ import StudyViewURLWrapper from './StudyViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
-import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from 'shared/lib/molecularProfileUtils';
 import {
     MRNA_TAB_GENE_GROUPS,
     STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
@@ -11441,6 +11444,20 @@ export class StudyViewPageStore
                 .map(profile => getSuffixOfMolecularProfile(profile))
                 .uniq()
                 .value();
+        }
+
+        if (
+            this.filteredVirtualStudies.result.length === 0 &&
+            this.studyIds.length === 1 &&
+            molecularProfileFilters.length === 0 &&
+            this.molecularProfiles.isComplete
+        ) {
+            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+                this.molecularProfiles.result
+            );
+            if (singleSuffix) {
+                molecularProfileFilters.push(singleSuffix);
+            }
         }
 
         if (molecularProfileFilters.length > 0) {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -288,7 +288,7 @@ import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
 import {
-    getSingleSelectableProfileSuffixIfUnique,
+    getDefaultProfileSuffixWhenNoMutationData,
     getSuffixOfMolecularProfile,
 } from 'shared/lib/molecularProfileUtils';
 import {
@@ -11452,11 +11452,11 @@ export class StudyViewPageStore
             molecularProfileFilters.length === 0 &&
             this.molecularProfiles.isComplete
         ) {
-            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+            const defaultSuffix = getDefaultProfileSuffixWhenNoMutationData(
                 this.molecularProfiles.result
             );
-            if (singleSuffix) {
-                molecularProfileFilters.push(singleSuffix);
+            if (defaultSuffix) {
+                molecularProfileFilters.push(defaultSuffix);
             }
         }
 

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -66,7 +66,10 @@ import {
     ResultsViewURLQueryEnum,
 } from 'pages/resultsView/ResultsViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
-import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from 'shared/lib/molecularProfileUtils';
 import { VirtualStudy } from 'shared/api/session-service/sessionServiceModels';
 import { isQueriedStudyAuthorized } from 'pages/studyView/StudyViewUtils';
 import { toQueryString } from 'shared/lib/query/textQueryUtils';
@@ -463,6 +466,23 @@ export class QueryStore {
                 }
             } else {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());
+            }
+        }
+        // #11569: default-select the only molecular profile when nothing else
+        // matched (e.g. RNA-only studies). Only when selection is still empty so we
+        // do not override mutation/CNA/SV defaults in mixed cohorts (see PR #5462).
+        if (
+            this.validProfileIdSetForSelectedStudies.isComplete &&
+            _.isEmpty(selectedIdSet) &&
+            _.isEmpty(this.profileFilterSetFromUrl) &&
+            _.isEmpty(this.profileIdsFromUrl)
+        ) {
+            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+                this.molecularProfilesInSelectedStudies.result || [],
+                { forDownloadTab: this.forDownloadTab }
+            );
+            if (singleSuffix) {
+                selectedIdSet[singleSuffix] = true;
             }
         }
         return selectedIdSet;
@@ -1091,6 +1111,13 @@ export class QueryStore {
                 this.studiesHaveChangedSinceInitialization
             ) {
                 this.profileFilterSet = undefined;
+
+                // Keep default auto-selection in the load lifecycle so UI
+                // reflects the checked profile immediately after profiles load.
+                const defaultProfile = this.defaultProfileToSelect;
+                if (defaultProfile) {
+                    this.selectMolecularProfile(defaultProfile, true);
+                }
             }
         },
     });
@@ -1795,6 +1822,58 @@ export class QueryStore {
         );
     }
 
+    @computed get shouldSelectDefaultProfile() {
+        if (Object.keys(this.selectedProfileIdSet).length > 0) {
+            return false;
+        }
+        if (
+            !_.isEmpty(this.profileFilterSetFromUrl) ||
+            !_.isEmpty(this.profileIdsFromUrl)
+        ) {
+            return false;
+        }
+
+        let profileTypeCount = 0;
+        Object.values(AlterationTypeConstants).forEach(profileType => {
+            if (
+                this.getFilteredProfiles(
+                    profileType as MolecularProfile['molecularAlterationType']
+                ).length > 0
+            ) {
+                profileTypeCount++;
+            }
+        });
+
+        if (profileTypeCount === 1) {
+            return true;
+        }
+
+        const hasMutationProfile =
+            this.getFilteredProfiles(AlterationTypeConstants.MUTATION_EXTENDED)
+                .length > 0;
+        const hasMrnaProfile =
+            this.getFilteredProfiles(AlterationTypeConstants.MRNA_EXPRESSION)
+                .length > 0;
+
+        return !hasMutationProfile && hasMrnaProfile;
+    }
+
+    @computed get defaultProfileToSelect() {
+        if (!this.shouldSelectDefaultProfile) {
+            return undefined;
+        }
+
+        for (const profileType of Object.values(AlterationTypeConstants)) {
+            const profiles = this.getFilteredProfiles(
+                profileType as MolecularProfile['molecularAlterationType']
+            );
+            if (profiles.length > 0) {
+                return profiles[0];
+            }
+        }
+        return undefined;
+    }
+
     // SAMPLE LIST
 
     @computed get defaultSelectedSampleListId() {
@@ -2255,6 +2334,7 @@ export class QueryStore {
         );
 
         this.profileIdsFromUrl = _.compact(profileIds);
+        this.profileFilterSetFromUrl = undefined;
         this.zScoreThreshold = params.Z_SCORE_THRESHOLD || '2.0';
         this.rppaScoreThreshold = params.RPPA_SCORE_THRESHOLD || '2.0';
         if (params.data_priority) {
@@ -2262,7 +2342,9 @@ export class QueryStore {
         }
         if (params.profileFilter) {
             if (isNaN(parseInt(params.profileFilter, 10))) {
-                this.profileFilterSetFromUrl = params.profileFilter.split(',');
+                this.profileFilterSetFromUrl = _.compact(
+                    params.profileFilter.split(',')
+                );
             }
         }
 

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -67,7 +67,7 @@ import {
 } from 'pages/resultsView/ResultsViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import {
-    getSingleSelectableProfileSuffixIfUnique,
+    getFallbackSelectableProfileSuffix,
     getSuffixOfMolecularProfile,
 } from 'shared/lib/molecularProfileUtils';
 import { VirtualStudy } from 'shared/api/session-service/sessionServiceModels';
@@ -468,8 +468,8 @@ export class QueryStore {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());
             }
         }
-        // #11569: default-select the only molecular profile when nothing else
-        // matched (e.g. RNA-only studies). Only when selection is still empty so we
+        // #11569: when Mutations / SV / CNA defaults did not match, fall back to
+        // the first selectable profile. Only when selection is still empty so we
         // do not override mutation/CNA/SV defaults in mixed cohorts (see PR #5462).
         if (
             this.validProfileIdSetForSelectedStudies.isComplete &&
@@ -477,12 +477,12 @@ export class QueryStore {
             _.isEmpty(this.profileFilterSetFromUrl) &&
             _.isEmpty(this.profileIdsFromUrl)
         ) {
-            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+            const fallbackSuffix = getFallbackSelectableProfileSuffix(
                 this.molecularProfilesInSelectedStudies.result || [],
                 { forDownloadTab: this.forDownloadTab }
             );
-            if (singleSuffix) {
-                selectedIdSet[singleSuffix] = true;
+            if (fallbackSuffix) {
+                selectedIdSet[fallbackSuffix] = true;
             }
         }
         return selectedIdSet;
@@ -1848,16 +1848,31 @@ export class QueryStore {
             return true;
         }
 
+        // When Mutations / Structural Variant / Copy Number Alterations are
+        // missing, fall back to the first available selectable profile
+        // (mRNA, protein, etc.) — do not special-case a single data type.
         const hasMutationProfile =
             this.getFilteredProfiles(
                 AlterationTypeConstants.MUTATION_EXTENDED as MolecularProfile['molecularAlterationType']
             ).length > 0;
-        const hasMrnaProfile =
+        const hasCnaProfile =
             this.getFilteredProfiles(
-                AlterationTypeConstants.MRNA_EXPRESSION as MolecularProfile['molecularAlterationType']
+                AlterationTypeConstants.COPY_NUMBER_ALTERATION as MolecularProfile['molecularAlterationType']
+            ).length > 0;
+        const hasStructuralVariantProfile =
+            this.getFilteredProfiles(
+                AlterationTypeConstants.STRUCTURAL_VARIANT as MolecularProfile['molecularAlterationType']
             ).length > 0;
 
-        return !hasMutationProfile && hasMrnaProfile;
+        if (
+            hasMutationProfile ||
+            hasCnaProfile ||
+            hasStructuralVariantProfile
+        ) {
+            return false;
+        }
+
+        return profileTypeCount > 0;
     }
 
     @computed get defaultProfileToSelect() {

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1849,11 +1849,13 @@ export class QueryStore {
         }
 
         const hasMutationProfile =
-            this.getFilteredProfiles(AlterationTypeConstants.MUTATION_EXTENDED)
-                .length > 0;
+            this.getFilteredProfiles(
+                AlterationTypeConstants.MUTATION_EXTENDED as MolecularProfile['molecularAlterationType']
+            ).length > 0;
         const hasMrnaProfile =
-            this.getFilteredProfiles(AlterationTypeConstants.MRNA_EXPRESSION)
-                .length > 0;
+            this.getFilteredProfiles(
+                AlterationTypeConstants.MRNA_EXPRESSION as MolecularProfile['molecularAlterationType']
+            ).length > 0;
 
         return !hasMutationProfile && hasMrnaProfile;
     }

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -106,6 +106,16 @@ export function getDefaultStructuralVariantProfile(
     );
 }
 
+export function getDefaultMrnaProfile(profiles: MolecularProfile[]) {
+    return _.find(
+        profiles,
+        profile =>
+            profile.molecularAlterationType ===
+                AlterationTypeConstants.MRNA_EXPRESSION &&
+            profile.showProfileInAnalysisTab
+    );
+}
+
 export function getDefaultGeneSetProfile(profiles: MolecularProfile[]) {
     return _.find(
         profiles,
@@ -157,6 +167,15 @@ export function getFilteredMolecularProfiles(
         const selectable = profiles.filter(p => p.showProfileInAnalysisTab);
         if (selectable.length === 1) {
             defaultProfiles = [selectable[0]];
+        } else {
+            const mrnaProfile = getDefaultMrnaProfile(profiles);
+            const hasAlterationProfile =
+                !!getDefaultMutationProfile(profiles) ||
+                !!getDefaultCNAProfile(profiles) ||
+                !!getDefaultStructuralVariantProfile(profiles);
+            if (mrnaProfile && !hasAlterationProfile) {
+                defaultProfiles = [mrnaProfile];
+            }
         }
     }
     return _.compact(defaultProfiles);

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -153,6 +153,11 @@ export function getFilteredMolecularProfiles(
                 );
         }
     }
-    // get rid of any undefined items
+    if (_.compact(defaultProfiles).length === 0) {
+        const selectable = profiles.filter(p => p.showProfileInAnalysisTab);
+        if (selectable.length === 1) {
+            defaultProfiles = [selectable[0]];
+        }
+    }
     return _.compact(defaultProfiles);
 }

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -2,7 +2,10 @@ import { MolecularProfile } from 'cbioportal-ts-api-client';
 import _ from 'lodash';
 import { AlterationTypeConstants } from 'shared/constants';
 import { GeneSetProfilesEnum } from 'shared/components/query/QueryStoreUtils';
-import { getSuffixOfMolecularProfile } from './molecularProfileUtils';
+import {
+    getFirstSelectableProfile,
+    getSuffixOfMolecularProfile,
+} from './molecularProfileUtils';
 
 export enum MolecularProfileFilterEnum {
     MutationAndCNA = 0,
@@ -106,16 +109,6 @@ export function getDefaultStructuralVariantProfile(
     );
 }
 
-export function getDefaultMrnaProfile(profiles: MolecularProfile[]) {
-    return _.find(
-        profiles,
-        profile =>
-            profile.molecularAlterationType ===
-                AlterationTypeConstants.MRNA_EXPRESSION &&
-            profile.showProfileInAnalysisTab
-    );
-}
-
 export function getDefaultGeneSetProfile(profiles: MolecularProfile[]) {
     return _.find(
         profiles,
@@ -164,18 +157,10 @@ export function getFilteredMolecularProfiles(
         }
     }
     if (_.compact(defaultProfiles).length === 0) {
-        const selectable = profiles.filter(p => p.showProfileInAnalysisTab);
-        if (selectable.length === 1) {
-            defaultProfiles = [selectable[0]];
-        } else {
-            const mrnaProfile = getDefaultMrnaProfile(profiles);
-            const hasAlterationProfile =
-                !!getDefaultMutationProfile(profiles) ||
-                !!getDefaultCNAProfile(profiles) ||
-                !!getDefaultStructuralVariantProfile(profiles);
-            if (mrnaProfile && !hasAlterationProfile) {
-                defaultProfiles = [mrnaProfile];
-            }
+        // No Mutations / SV / CNA defaults — fall back to first selectable profile
+        const fallback = getFirstSelectableProfile(profiles);
+        if (fallback) {
+            defaultProfiles = [fallback];
         }
     }
     return _.compact(defaultProfiles);

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import {
+    getDefaultProfileSuffixWhenNoMutationData,
     getSingleSelectableProfileSuffixIfUnique,
     getSuffixOfMolecularProfile,
 } from './molecularProfileUtils';
@@ -78,9 +79,84 @@ describe('MolecularProfileUtils', () => {
         });
     });
 
+    describe('getDefaultProfileSuffixWhenNoMutationData', () => {
+        it('returns mRNA suffix when no mutation/CNA/SV but multiple selectable profiles', () => {
+            const profiles = [
+                {
+                    studyId: 'ovary_geomx_gray_foundation_2024',
+                    molecularProfileId:
+                        'ovary_geomx_gray_foundation_2024_cycif_cell_type_fractions',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'ovary_geomx_gray_foundation_2024',
+                    molecularProfileId:
+                        'ovary_geomx_gray_foundation_2024_mrna_seq_read_counts_Zscores',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'ovary_geomx_gray_foundation_2024',
+                    molecularProfileId:
+                        'ovary_geomx_gray_foundation_2024_rfu_p53_marker_intensity',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getDefaultProfileSuffixWhenNoMutationData(profiles),
+                'mrna_seq_read_counts_Zscores'
+            );
+        });
+
+        it('returns undefined when mutation profile exists', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_rna',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.isUndefined(
+                getDefaultProfileSuffixWhenNoMutationData(profiles)
+            );
+        });
+    });
+
     describe('getFilteredMolecularProfiles single-profile fallback', () => {
         it('selects the only RNA profile when mutation/CNA defaults are empty', () => {
             const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_geo_mx',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            const out = getFilteredMolecularProfiles(profiles, undefined, 0);
+            assert.equal(out.length, 1);
+            assert.equal(out[0]!.molecularProfileId, 'g_geo_mx');
+        });
+
+        it('selects mRNA when multiple profiles exist but no mutation/CNA/SV', () => {
+            const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_cycif',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
                 {
                     studyId: 'g',
                     molecularProfileId: 'g_geo_mx',

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -1,6 +1,11 @@
 import { assert } from 'chai';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
-import { getSuffixOfMolecularProfile } from './molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from './molecularProfileUtils';
+import { getFilteredMolecularProfiles } from './getDefaultMolecularProfiles';
+import { AlterationTypeConstants } from 'shared/constants';
 
 describe('MolecularProfileUtils', () => {
     describe('getSuffixOfMolecularProfile', () => {
@@ -12,6 +17,81 @@ describe('MolecularProfileUtils', () => {
             const suffix = 'CCLE_drug_treatment_IC50';
             const result = getSuffixOfMolecularProfile(profile);
             assert.equal(result, suffix);
+        });
+    });
+
+    describe('getSingleSelectableProfileSuffixIfUnique', () => {
+        it('returns suffix when exactly one showProfileInAnalysisTab profile', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_rna_geo',
+                    molecularAlterationType: 'MRNA_EXPRESSION',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getSingleSelectableProfileSuffixIfUnique(profiles),
+                'rna_geo'
+            );
+        });
+
+        it('returns undefined when two distinct suffixes exist', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_gistic',
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.isUndefined(
+                getSingleSelectableProfileSuffixIfUnique(profiles)
+            );
+        });
+
+        it('returns one suffix when two studies share the same suffix', () => {
+            const profiles = [
+                {
+                    studyId: 'a',
+                    molecularProfileId: 'a_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'b',
+                    molecularProfileId: 'b_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getSingleSelectableProfileSuffixIfUnique(profiles),
+                'mutations'
+            );
+        });
+    });
+
+    describe('getFilteredMolecularProfiles single-profile fallback', () => {
+        it('selects the only RNA profile when mutation/CNA defaults are empty', () => {
+            const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_geo_mx',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            const out = getFilteredMolecularProfiles(profiles, undefined, 0);
+            assert.equal(out.length, 1);
+            assert.equal(out[0]!.molecularProfileId, 'g_geo_mx');
         });
     });
 });

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -1,7 +1,8 @@
 import { assert } from 'chai';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import {
-    getDefaultProfileSuffixWhenNoMutationData,
+    getFallbackSelectableProfileSuffix,
+    getFirstSelectableProfile,
     getSingleSelectableProfileSuffixIfUnique,
     getSuffixOfMolecularProfile,
 } from './molecularProfileUtils';
@@ -79,8 +80,8 @@ describe('MolecularProfileUtils', () => {
         });
     });
 
-    describe('getDefaultProfileSuffixWhenNoMutationData', () => {
-        it('returns mRNA suffix when no mutation/CNA/SV but multiple selectable profiles', () => {
+    describe('getFallbackSelectableProfileSuffix', () => {
+        it('returns first selectable suffix when no Mut/SV/CNA but multiple profiles', () => {
             const profiles = [
                 {
                     studyId: 'ovary_geomx_gray_foundation_2024',
@@ -105,10 +106,30 @@ describe('MolecularProfileUtils', () => {
                     showProfileInAnalysisTab: true,
                 },
             ] as MolecularProfile[];
+            // MRNA_EXPRESSION is preferred over GENERIC_ASSAY by type order
             assert.equal(
-                getDefaultProfileSuffixWhenNoMutationData(profiles),
+                getFallbackSelectableProfileSuffix(profiles),
                 'mrna_seq_read_counts_Zscores'
             );
+        });
+
+        it('returns protein profile suffix when only protein is selectable', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_rppa',
+                    molecularAlterationType:
+                        AlterationTypeConstants.PROTEIN_LEVEL,
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_other_assay',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(getFallbackSelectableProfileSuffix(profiles), 'rppa');
         });
 
         it('returns undefined when mutation profile exists', () => {
@@ -127,13 +148,35 @@ describe('MolecularProfileUtils', () => {
                     showProfileInAnalysisTab: true,
                 },
             ] as MolecularProfile[];
-            assert.isUndefined(
-                getDefaultProfileSuffixWhenNoMutationData(profiles)
+            assert.isUndefined(getFallbackSelectableProfileSuffix(profiles));
+        });
+    });
+
+    describe('getFirstSelectableProfile', () => {
+        it('prefers earlier alteration types over generic assay', () => {
+            const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_cycif',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_protein',
+                    molecularAlterationType:
+                        AlterationTypeConstants.PROTEIN_LEVEL,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getFirstSelectableProfile(profiles)!.molecularProfileId,
+                'g_protein'
             );
         });
     });
 
-    describe('getFilteredMolecularProfiles single-profile fallback', () => {
+    describe('getFilteredMolecularProfiles fallback', () => {
         it('selects the only RNA profile when mutation/CNA defaults are empty', () => {
             const profiles = [
                 {
@@ -149,7 +192,7 @@ describe('MolecularProfileUtils', () => {
             assert.equal(out[0]!.molecularProfileId, 'g_geo_mx');
         });
 
-        it('selects mRNA when multiple profiles exist but no mutation/CNA/SV', () => {
+        it('selects first selectable profile when no mutation/CNA/SV', () => {
             const profiles = [
                 {
                     studyId: 'g',

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -1,5 +1,6 @@
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import _ from 'lodash';
+import { AlterationTypeConstants } from 'shared/constants';
 
 export function getSuffixOfMolecularProfile(profile: MolecularProfile) {
     return profile.molecularProfileId.replace(profile.studyId + '_', '');
@@ -28,4 +29,44 @@ export function getSingleSelectableProfileSuffixIfUnique(
     const bySuffix = _.groupBy(selectable, p => getSuffixOfMolecularProfile(p));
     const suffixes = Object.keys(bySuffix);
     return suffixes.length === 1 ? suffixes[0] : undefined;
+}
+
+/**
+ * Profile suffix to default when a study has no mutation/CNA/SV data but does
+ * have other queryable profiles (e.g. RNA + generic assay). Aligns with
+ * QueryStore.shouldSelectDefaultProfile (#11569).
+ */
+export function getDefaultProfileSuffixWhenNoMutationData(
+    profiles: MolecularProfile[],
+    options?: { forDownloadTab?: boolean }
+): string | undefined {
+    const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+        profiles,
+        options
+    );
+    if (singleSuffix) {
+        return singleSuffix;
+    }
+    const forDownloadTab = options?.forDownloadTab ?? false;
+    const selectable = profiles.filter(
+        p => p.showProfileInAnalysisTab || forDownloadTab
+    );
+    const hasAlterationProfile = selectable.some(
+        p =>
+            p.molecularAlterationType ===
+                AlterationTypeConstants.MUTATION_EXTENDED ||
+            p.molecularAlterationType ===
+                AlterationTypeConstants.COPY_NUMBER_ALTERATION ||
+            p.molecularAlterationType ===
+                AlterationTypeConstants.STRUCTURAL_VARIANT
+    );
+    if (hasAlterationProfile) {
+        return undefined;
+    }
+    const mrnaProfile = selectable.find(
+        p =>
+            p.molecularAlterationType ===
+            AlterationTypeConstants.MRNA_EXPRESSION
+    );
+    return mrnaProfile ? getSuffixOfMolecularProfile(mrnaProfile) : undefined;
 }

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -1,5 +1,31 @@
 import { MolecularProfile } from 'cbioportal-ts-api-client';
+import _ from 'lodash';
 
 export function getSuffixOfMolecularProfile(profile: MolecularProfile) {
     return profile.molecularProfileId.replace(profile.studyId + '_', '');
+}
+
+/**
+ * When the cohort exposes exactly one selectable analysis profile (one suffix),
+ * return that suffix so the query UI can default-check it. Covers RNA-only and
+ * other single-profile studies (#11569). Multiple studies sharing the same
+ * suffix still count as one checkbox column — one suffix is returned.
+ */
+export function getSingleSelectableProfileSuffixIfUnique(
+    profiles: MolecularProfile[],
+    options?: { forDownloadTab?: boolean }
+): string | undefined {
+    if (!profiles?.length) {
+        return undefined;
+    }
+    const forDownloadTab = options?.forDownloadTab ?? false;
+    const selectable = profiles.filter(
+        p => p.showProfileInAnalysisTab || forDownloadTab
+    );
+    if (!selectable.length) {
+        return undefined;
+    }
+    const bySuffix = _.groupBy(selectable, p => getSuffixOfMolecularProfile(p));
+    const suffixes = Object.keys(bySuffix);
+    return suffixes.length === 1 ? suffixes[0] : undefined;
 }

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -31,42 +31,63 @@ export function getSingleSelectableProfileSuffixIfUnique(
     return suffixes.length === 1 ? suffixes[0] : undefined;
 }
 
+function isDefaultAlterationProfile(profile: MolecularProfile) {
+    return (
+        profile.molecularAlterationType ===
+            AlterationTypeConstants.MUTATION_EXTENDED ||
+        profile.molecularAlterationType ===
+            AlterationTypeConstants.COPY_NUMBER_ALTERATION ||
+        profile.molecularAlterationType ===
+            AlterationTypeConstants.STRUCTURAL_VARIANT
+    );
+}
+
 /**
- * Profile suffix to default when a study has no mutation/CNA/SV data but does
- * have other queryable profiles (e.g. RNA + generic assay). Aligns with
- * QueryStore.shouldSelectDefaultProfile (#11569).
+ * First selectable profile (showProfileInAnalysisTab), preferring the same
+ * alteration-type order as QueryStore.defaultProfileToSelect.
  */
-export function getDefaultProfileSuffixWhenNoMutationData(
+export function getFirstSelectableProfile(
     profiles: MolecularProfile[],
     options?: { forDownloadTab?: boolean }
-): string | undefined {
-    const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
-        profiles,
-        options
-    );
-    if (singleSuffix) {
-        return singleSuffix;
+): MolecularProfile | undefined {
+    if (!profiles?.length) {
+        return undefined;
     }
     const forDownloadTab = options?.forDownloadTab ?? false;
     const selectable = profiles.filter(
         p => p.showProfileInAnalysisTab || forDownloadTab
     );
-    const hasAlterationProfile = selectable.some(
-        p =>
-            p.molecularAlterationType ===
-                AlterationTypeConstants.MUTATION_EXTENDED ||
-            p.molecularAlterationType ===
-                AlterationTypeConstants.COPY_NUMBER_ALTERATION ||
-            p.molecularAlterationType ===
-                AlterationTypeConstants.STRUCTURAL_VARIANT
-    );
-    if (hasAlterationProfile) {
+    if (!selectable.length) {
         return undefined;
     }
-    const mrnaProfile = selectable.find(
-        p =>
-            p.molecularAlterationType ===
-            AlterationTypeConstants.MRNA_EXPRESSION
-    );
-    return mrnaProfile ? getSuffixOfMolecularProfile(mrnaProfile) : undefined;
+    for (const profileType of Object.values(AlterationTypeConstants)) {
+        const match = selectable.find(
+            p => p.molecularAlterationType === profileType
+        );
+        if (match) {
+            return match;
+        }
+    }
+    return selectable[0];
+}
+
+/**
+ * When Mutations / Structural Variant / Copy Number Alterations profiles are
+ * missing, fall back to the first selectable profile (e.g. mRNA, protein, or
+ * other analysis profiles). See #11569.
+ */
+export function getFallbackSelectableProfileSuffix(
+    profiles: MolecularProfile[],
+    options?: { forDownloadTab?: boolean }
+): string | undefined {
+    if (!profiles?.length) {
+        return undefined;
+    }
+    if (profiles.some(isDefaultAlterationProfile)) {
+        return undefined;
+    }
+    const firstSelectable = getFirstSelectableProfile(profiles, options);
+    return firstSelectable
+        ? getSuffixOfMolecularProfile(firstSelectable)
+        : undefined;
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785403801&installation_id=126502837&pr_number=5636&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5636&signature=f452ce4d791163a84231405fa037f72e8fb2b988b5363f8f206cb4da80bd22c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->