### PR TITLE
Surface profile data caveats as a per-track warning in OncoPrint

### DIFF
--- a/packages/oncoprintjs/src/js/oncoprinttrackinfoview.ts
+++ b/packages/oncoprintjs/src/js/oncoprinttrackinfoview.ts
@@ -84,8 +84,10 @@ export default class OncoprintTrackInfoView {
                 let formattedPercent = '';
 
                 if (isNaN(float)) {
-                    formattedPercent = 'N/P';
-                    suffix = ''; // we don't want any suffix in this case
+                    // Non-numeric info (the "N/P" sentinel, or a warning glyph)
+                    // is shown verbatim rather than coerced to a percentage.
+                    formattedPercent = text;
+                    suffix = '';
                 } else if (isNumber(float)) {
                     formattedPercent =
                         float < 1 && float > 0

--- a/src/shared/components/oncoprint/DeltaUtils.ts
+++ b/src/shared/components/oncoprint/DeltaUtils.ts
@@ -1560,6 +1560,9 @@ export function transitionHeatmapTrack(
                     nextProps.caseLinkOutInTooltips
                 ),
             track_info: nextSpec.info || '',
+            $track_info_tooltip_elt: nextSpec.infoTooltip
+                ? $('<div>' + nextSpec.infoTooltip + '</div>')
+                : undefined,
             onSortDirectionChange: nextProps.onTrackSortDirectionChange,
             expansion_of: expansionParentKey
                 ? trackSpecKeyToTrackId[expansionParentKey]
@@ -1626,6 +1629,14 @@ export function transitionHeatmapTrack(
         }
         if (nextSpec.info !== prevSpec.info && nextSpec.info !== undefined) {
             oncoprint.setTrackInfo(trackId, nextSpec.info);
+        }
+        if (nextSpec.infoTooltip !== prevSpec.infoTooltip) {
+            oncoprint.setTrackInfoTooltip(
+                trackId,
+                nextSpec.infoTooltip
+                    ? $('<div>' + nextSpec.infoTooltip + '</div>')
+                    : undefined
+            );
         }
         if (
             nextSpec.movable !== prevSpec.movable &&
@@ -1733,6 +1744,9 @@ export function transitionCategoricalTrack(
                 nextProps.caseLinkOutInTooltips
             ),
             track_info: nextSpec.info || '',
+            $track_info_tooltip_elt: nextSpec.infoTooltip
+                ? $('<div>' + nextSpec.infoTooltip + '</div>')
+                : undefined,
             onSortDirectionChange: nextProps.onTrackSortDirectionChange,
         };
         const newTrackId = oncoprint.addTracks([trackParams])[0];

--- a/src/shared/components/oncoprint/Oncoprint.tsx
+++ b/src/shared/components/oncoprint/Oncoprint.tsx
@@ -214,6 +214,7 @@ export interface IHeatmapTrackSpec extends IBaseHeatmapTrackSpec {
     data: IBaseHeatmapTrackDatum[]; // can be IGeneHeatmapTrackDatum or IGenericAssayHeatmapTrackDatum
     naLegendLabel?: string;
     info?: string;
+    infoTooltip?: string;
     labelColor?: string;
     labelCircleColor?: string;
     labelFontWeight?: string;
@@ -256,6 +257,7 @@ export interface ICategoricalTrackSpec {
     naLegendLabel?: string;
     description?: string;
     info?: string;
+    infoTooltip?: string;
 }
 
 export const GENETIC_TRACK_GROUP_INDEX = 1;

--- a/src/shared/components/oncoprint/OncoprintUtils.ts
+++ b/src/shared/components/oncoprint/OncoprintUtils.ts
@@ -74,6 +74,10 @@ import {
     isGenericAssayCategoricalProfile,
     isGenericAssayHeatmapProfile,
 } from 'shared/components/oncoprint/ResultsViewOncoprintUtils';
+import { getProfileDescriptionCaveat } from 'shared/lib/GenericAssayUtils/GenericAssayCommonUtils';
+
+// Warning glyph shown in a track's info slot when its profile carries a caveat.
+export const PROFILE_CAVEAT_GLYPH = '⚠';
 import { ExtendedClinicalAttribute } from 'pages/resultsView/ResultsViewPageStoreUtils';
 import { CaseAggregatedData } from 'shared/model/CaseAggregatedData';
 import { AnnotatedExtendedAlteration } from 'shared/model/AnnotatedExtendedAlteration';
@@ -1651,11 +1655,16 @@ export function makeGenericAssayProfileCategoricalTracksMobxPromise(
                 const entityLinkMap = oncoprint.genericAssayPromises
                     .genericAssayEntitiesGroupedByGenericAssayTypeLinkMap
                     .result![profile.genericAssayType];
+                const caveat = getProfileDescriptionCaveat(profile.description);
 
                 return {
                     key: `GENERICASSAYCATEGORICALTRACK_${molecularProfileId},${entityId}`,
                     label: query.entityName,
                     description: query.description,
+                    info: caveat ? PROFILE_CAVEAT_GLYPH : undefined,
+                    infoTooltip: caveat
+                        ? `<b>${PROFILE_CAVEAT_GLYPH} Caveat:</b> ${caveat}`
+                        : undefined,
                     molecularProfileId: query.molecularProfileId,
                     molecularProfileName:
                         molecularProfileIdToMolecularProfile[molecularProfileId]
@@ -1760,11 +1769,16 @@ export function makeGenericAssayProfileHeatmapTracksMobxPromise(
                 const entityLinkMap = oncoprint.genericAssayPromises
                     .genericAssayEntitiesGroupedByGenericAssayTypeLinkMap
                     .result![profile.genericAssayType];
+                const caveat = getProfileDescriptionCaveat(profile.description);
 
                 return {
                     key: `GENERICASSAYHEATMAPTRACK_${molecularProfileId},${entityId}`,
                     label: query.entityName,
                     description: query.description,
+                    info: caveat ? PROFILE_CAVEAT_GLYPH : undefined,
+                    infoTooltip: caveat
+                        ? `<b>${PROFILE_CAVEAT_GLYPH} Caveat:</b> ${caveat}`
+                        : undefined,
                     molecularProfileId: query.molecularProfileId,
                     molecularProfileName:
                         molecularProfileIdToMolecularProfile[molecularProfileId]

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
@@ -9,6 +9,7 @@ import {
     filterGenericAssayEntitiesByGenes,
     makeGenericAssayPlotsTabOption,
     filterGenericAssayOptionsByGenes,
+    getProfileDescriptionCaveat,
 } from './GenericAssayCommonUtils';
 import { getServerConfig } from 'config/config';
 import ServerConfigDefaults from 'config/serverConfigDefaults';
@@ -468,6 +469,41 @@ describe('GenericAssayCommonUtils', () => {
                     TARGET_GENE_LIST
                 ).length,
                 0
+            );
+        });
+    });
+
+    describe('getProfileDescriptionCaveat()', () => {
+        it('returns undefined when description is undefined or empty', () => {
+            assert.isUndefined(getProfileDescriptionCaveat(undefined));
+            assert.isUndefined(getProfileDescriptionCaveat(''));
+        });
+
+        it('returns undefined when there is no caveat marker', () => {
+            assert.isUndefined(
+                getProfileDescriptionCaveat('Cell Type Relative Fractions.')
+            );
+        });
+
+        it('extracts the caveat text after the marker', () => {
+            assert.equal(
+                getProfileDescriptionCaveat(
+                    'Cell Type Relative Fractions. Caveat: Fractions are derived from CD45 FACS-sorted scRNA-seq.'
+                ),
+                'Fractions are derived from CD45 FACS-sorted scRNA-seq.'
+            );
+        });
+
+        it('is case-insensitive on the marker', () => {
+            assert.equal(
+                getProfileDescriptionCaveat('caveat: something to note'),
+                'something to note'
+            );
+        });
+
+        it('returns undefined when the marker has no following text', () => {
+            assert.isUndefined(
+                getProfileDescriptionCaveat('Some description. Caveat:   ')
             );
         });
     });

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.ts
@@ -118,9 +118,8 @@ export async function fetchGenericAssayMetaByMolecularProfileIdsGroupByMolecular
     } = {};
     for (const profile of genericAssayProfiles) {
         const suffix = getSuffixOfMolecularProfile(profile);
-        genericAssayMetaGroupByMolecularProfileId[
-            profile.molecularProfileId
-        ] = metaBySuffix[suffix] || [];
+        genericAssayMetaGroupByMolecularProfileId[profile.molecularProfileId] =
+            metaBySuffix[suffix] || [];
     }
 
     return genericAssayMetaGroupByMolecularProfileId;
@@ -228,12 +227,14 @@ export function fetchGenericAssayDataByStableIdsAndMolecularIds(
     stableIds: string[],
     molecularProfileIds: string[]
 ) {
-    return getClient().fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST({
-        genericAssayDataMultipleStudyFilter: {
-            genericAssayStableIds: stableIds,
-            molecularProfileIds: molecularProfileIds,
-        } as GenericAssayDataMultipleStudyFilter,
-    });
+    return getClient().fetchGenericAssayDataInMultipleMolecularProfilesUsingPOST(
+        {
+            genericAssayDataMultipleStudyFilter: {
+                genericAssayStableIds: stableIds,
+                molecularProfileIds: molecularProfileIds,
+            } as GenericAssayDataMultipleStudyFilter,
+        }
+    );
 }
 
 export function makeGenericAssayOption(meta: GenericAssayMeta) {
@@ -354,6 +355,21 @@ export function getCategoryOrderByGenericAssayType(genericAssayType: string) {
     return genericAssayType in RESERVED_CATEGORY_ORDER_DICT
         ? RESERVED_CATEGORY_ORDER_DICT[genericAssayType]
         : undefined;
+}
+
+// A profile description may carry a curated caveat about how its data should be
+// interpreted, flagged with a "Caveat:" marker (e.g. data derived from a sorted
+// cell population). Everything after the marker is the caveat text, surfaced as
+// a per-track warning so viewers see it without reading the profile description.
+export function getProfileDescriptionCaveat(
+    description: string | undefined
+): string | undefined {
+    if (!description) {
+        return undefined;
+    }
+    const match = /caveat:\s*([\s\S]+)/i.exec(description);
+    const caveat = match && match[1].trim();
+    return caveat ? caveat : undefined;
 }
 
 export function constructGeneRegex(hugoGeneSymbol: string) {


### PR DESCRIPTION
## What

A molecular profile whose `profile_description` contains a **`Caveat:`** marker now shows a ⚠ warning icon on **every** OncoPrint track from that profile, with the caveat text in a hover tooltip. This lets study curators flag how data should be interpreted — e.g. cell-type fractions derived from a sorted cell population — without the caveat being buried in the profile description where viewers won't see it.

Motivating case: the `msk_spectrum_tme_2022` single-cell cell-type fraction profiles are derived from **CD45 FACS-sorted** scRNA-seq, so a sample's composition reflects its sort gate (some samples are immune-only or non-immune-only) rather than whole-tumor cellularity. A 100%-summing stacked/heatmap track is misleading without surfacing that.

## Screenshot

Each cell-type track shows a ⚠ (the genetic BRCA1 track is unaffected — numeric percents still render). Hovering the ⚠ shows the caveat text, e.g. *"Fractions are derived from CD45 FACS-sorted scRNA-seq, so each sample composition reflects its sort gate (some samples are immune-only or non-immune-only) rather than whole-tumor cellularity."*

![Caveat warning icons on generic-assay tracks](https://raw.githubusercontent.com/inodb/cbioportal-frontend/caveat-assets/caveat-warning.png)

_(Captured locally with the caveat injected, since the live study data doesn't carry the `Caveat:` marker until [cBioPortal/datahub#2342](https://github.com/cBioPortal/datahub/pull/2342) merges — the deploy preview won't show the ⚠ until then.)_

## How

- `getProfileDescriptionCaveat()` parses the `Caveat:` marker (case-insensitive) from a profile description.
- The generic-assay **heatmap** and **categorical** track builders set the ⚠ glyph + caveat tooltip when the profile is caveated.
- `IHeatmapTrackSpec` / `ICategoricalTrackSpec` gain `infoTooltip` (genetic tracks already had it); wired through `DeltaUtils` to `$track_info_tooltip_elt`.
- **oncoprintjs**: the track-info view now renders non-numeric info verbatim instead of coercing it to `N/P`, so the ⚠ glyph displays. `N/P` is still shown for the not-profiled sentinel and numeric percents are unchanged.

The convention is generic — any profile gets the warning for free by writing `Caveat: …` in its description. Companion datahub change: [cBioPortal/datahub#2342](https://github.com/cBioPortal/datahub/pull/2342). Docs change to follow.

## Preview

- https://deploy-preview-5637.preview.cbioportal.org/results/oncoprint?cancer_study_list=msk_spectrum_tme_2022&tab_index=tab_visualize&case_set_id=msk_spectrum_tme_2022_all&Action=Submit&gene_list=BRCA1&generic_assay_groups=msk_spectrum_tme_2022_cell_type_relative_counts%2CB_cell%2CT_cell%2CMonocyte%2COvarian_cancer_cell%2CFibroblast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
