### PR TITLE
Fix homepage news feed after docs site layout change

### DIFF
--- a/src/shared/lib/parseNews.ts
+++ b/src/shared/lib/parseNews.ts
@@ -4,9 +4,22 @@ const MAX_ITEM_HEIGHT = 400; // Maximum height in pixels before truncating
 // we have to consider the abreviated month names
 const dateIdPattern = /^(january|jan|february|feb|march|mar|april|apr|may|june|jun|july|jul|august|aug|september|sep|sept|october|oct|november|nov|december|dec)-\d{1,2}-\d{4}/;
 
+// Locate the container holding the news entries. The docs site's layout (and
+// its container ids) vary by documentation generator, so prefer finding the
+// parent of a date-ID heading over hardcoding a container id.
+function findNewsContainer($html: JQuery) {
+    const dateHeadings = $html
+        .find('[id]')
+        .filter((i, el) => dateIdPattern.test(el.id));
+    if (dateHeadings.length > 0) {
+        return dateHeadings.first().parent();
+    }
+    // Fallback to known container ids (Retype layout, legacy docs layout)
+    return $html.find('#retype-content, #docs-content').first();
+}
+
 export default function parseNews(html: string) {
-    const contentItems = $(html)
-        .find('#docs-content')
+    const contentItems = findNewsContainer($(html))
         .children()
         .filter((i, el) => {
             // Match date IDs like "november-15-2025", "december-18-2024", etc.


### PR DESCRIPTION
## Summary

The homepage news feed (RightBar) has been empty because the docs news page migrated to a **Retype**-based layout. The old `#docs-content` container was replaced by `#retype-content`, so `parseNews` found nothing and rendered an empty feed.

The date-ID headings (`may-26-2026`, `april-10-2026`, …) still exist under the new container, so instead of swapping one hardcoded id for another, this locates the news container by the **parent of the first date-ID heading**. That keeps the parser working across future docs layout changes, with a fallback to known container ids (`#retype-content`, `#docs-content`) when no date heading is present.

## Reproduction

- Production (broken): https://www.cbioportal.org/
- Deploy preview (fixed): https://deploy-preview-5640.preview.cbioportal.org/

## Verification

Verified locally with Puppeteer against the dev server: the news feed renders 200 dated entries, links open in new tabs (`target="_blank"`), images are responsive (`max-width: 100%`), and long paragraphs truncate with "Read more" links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)