### PR TITLE
Stabilize patient view default and namespace columns e2e localdb test

### DIFF
--- a/end-to-end-test-playwright/tests/local/init-columns-in-mutation-tables.spec.ts
+++ b/end-to-end-test-playwright/tests/local/init-columns-in-mutation-tables.spec.ts
@@ -33,14 +33,34 @@ async function isHeaderVisible(page: Page, text: string) {
     return await headerLocator(page, text).isVisible();
 }
 
+// Copy # and Cohort populate from molecular profile / cohort data that
+// resolves via a separate async request after the table's first paint
+// (see discreteCNAMolecularProfileId and variantCountCache in
+// PatientViewMutationTable), so a plain isVisible() snapshot can run
+// before that data arrives and false-negative under CI load. Poll for
+// visibility instead of taking a single snapshot when a column is
+// expected to be present. 30s gives that async data enough headroom on
+// a loaded CI runner.
+async function waitHeaderVisible(page: Page, text: string, timeout = 30000) {
+    try {
+        await headerLocator(page, text).waitFor({ state: 'visible', timeout });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 async function defaultResultColumnsAreDisplayed(page: Page) {
     return (
-        (await isHeaderVisible(page, DEFAULT_RESULT_COLS.SAMPLE_ID)) &&
-        (await isHeaderVisible(page, DEFAULT_RESULT_COLS.PROTEIN_CHANGE)) &&
-        (await isHeaderVisible(page, DEFAULT_RESULT_COLS.ANNOTATION)) &&
-        (await isHeaderVisible(page, DEFAULT_RESULT_COLS.MUTATION_TYPE)) &&
-        (await isHeaderVisible(page, DEFAULT_RESULT_COLS.COPY_NUM)) &&
-        (await isHeaderVisible(page, DEFAULT_RESULT_COLS.NUM_MUT_IN_SAMPLE)) &&
+        (await waitHeaderVisible(page, DEFAULT_RESULT_COLS.SAMPLE_ID)) &&
+        (await waitHeaderVisible(page, DEFAULT_RESULT_COLS.PROTEIN_CHANGE)) &&
+        (await waitHeaderVisible(page, DEFAULT_RESULT_COLS.ANNOTATION)) &&
+        (await waitHeaderVisible(page, DEFAULT_RESULT_COLS.MUTATION_TYPE)) &&
+        (await waitHeaderVisible(page, DEFAULT_RESULT_COLS.COPY_NUM)) &&
+        (await waitHeaderVisible(
+            page,
+            DEFAULT_RESULT_COLS.NUM_MUT_IN_SAMPLE
+        )) &&
         !(await isHeaderVisible(page, 'Functional Impact')) &&
         !(await isHeaderVisible(page, 'Variant Type'))
     );
@@ -48,12 +68,12 @@ async function defaultResultColumnsAreDisplayed(page: Page) {
 
 async function defaultPatientColumnsAreDisplayed(page: Page) {
     return (
-        (await isHeaderVisible(page, DEFAULT_PATIENT_COLS.GENE)) &&
-        (await isHeaderVisible(page, DEFAULT_PATIENT_COLS.PROTEIN_CHANGE)) &&
-        (await isHeaderVisible(page, DEFAULT_PATIENT_COLS.ANNOTATION)) &&
-        (await isHeaderVisible(page, DEFAULT_PATIENT_COLS.MUTATION_TYPE)) &&
-        (await isHeaderVisible(page, DEFAULT_PATIENT_COLS.COPY_NUM)) &&
-        (await isHeaderVisible(page, DEFAULT_PATIENT_COLS.COHORT)) &&
+        (await waitHeaderVisible(page, DEFAULT_PATIENT_COLS.GENE)) &&
+        (await waitHeaderVisible(page, DEFAULT_PATIENT_COLS.PROTEIN_CHANGE)) &&
+        (await waitHeaderVisible(page, DEFAULT_PATIENT_COLS.ANNOTATION)) &&
+        (await waitHeaderVisible(page, DEFAULT_PATIENT_COLS.MUTATION_TYPE)) &&
+        (await waitHeaderVisible(page, DEFAULT_PATIENT_COLS.COPY_NUM)) &&
+        (await waitHeaderVisible(page, DEFAULT_PATIENT_COLS.COHORT)) &&
         !(await isHeaderVisible(page, 'Functional Impact')) &&
         !(await isHeaderVisible(page, 'Variant Type'))
     );
@@ -61,8 +81,8 @@ async function defaultPatientColumnsAreDisplayed(page: Page) {
 
 async function namespaceColumnsAreDisplayed(page: Page) {
     return (
-        (await isHeaderVisible(page, 'Zygosity Code')) &&
-        (await isHeaderVisible(page, 'Zygosity Name'))
+        (await waitHeaderVisible(page, 'Zygosity Code')) &&
+        (await waitHeaderVisible(page, 'Zygosity Name'))
     );
 }
 
@@ -74,7 +94,7 @@ async function namespaceColumnsAreNotDisplayed(page: Page) {
 }
 
 async function columnIsDisplayed(page: Page, column: string) {
-    return await isHeaderVisible(page, column);
+    return await waitHeaderVisible(page, column);
 }
 
 async function columnIsNotDisplayed(page: Page, column: string) {
@@ -232,12 +252,6 @@ test.describe('default init columns in mutation tables', () => {
                 {}
             );
             await waitForPatientViewMutationTable(page);
-            // Copy # loads after a separate async copy-number request; wait for
-            // it so the no-timeout isVisible() checks in
-            // defaultPatientColumnsAreDisplayed see the complete column set.
-            await expect(
-                headerLocator(page, DEFAULT_PATIENT_COLS.COPY_NUM)
-            ).toBeVisible({ timeout: 15000 });
             expect(await defaultPatientColumnsAreDisplayed(page)).toBe(true);
             expect(await namespaceColumnsAreNotDisplayed(page)).toBe(true);
         });
@@ -254,11 +268,6 @@ test.describe('default init columns in mutation tables', () => {
                 }
             );
             await waitForPatientViewMutationTable(page);
-            // Same async race as above: wait for Copy # before the no-timeout
-            // isVisible() checks.
-            await expect(
-                headerLocator(page, DEFAULT_PATIENT_COLS.COPY_NUM)
-            ).toBeVisible({ timeout: 15000 });
             expect(await defaultPatientColumnsAreDisplayed(page)).toBe(true);
             expect(await namespaceColumnsAreDisplayed(page)).toBe(true);
         });

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -555,6 +555,10 @@ export default class MutationTable<
             defaultSortDirection: 'desc',
         };
 
+        // captured so the "visible" getter below can read the always-current
+        // discreteCNACache prop rather than a value snapshotted at construction time
+        const mutationTableComponent = this;
+        let copyNumVisibleOverride: boolean | undefined = undefined;
         this._columns[MutationTableColumnType.COPY_NUM] = {
             name: MutationTableColumnType.COPY_NUM,
             render: (d: Mutation[]) => {
@@ -622,9 +626,23 @@ export default class MutationTable<
                     return false;
                 }
             },
-            visible: DiscreteCNAColumnFormatter.isVisible(
-                this.props.discreteCNACache as DiscreteCNACache
-            ),
+            // a getter/setter (not a static snapshot) so default visibility
+            // stays in sync as discreteCNACache becomes active after this
+            // column's definition is generated (generateColumns() runs once,
+            // in the constructor). The setter allows explicit overrides, e.g.
+            // adjustVisibility() forcing a column on/off based on a
+            // show-on-init property, to still take precedence.
+            get visible(): boolean {
+                return copyNumVisibleOverride !== undefined
+                    ? copyNumVisibleOverride
+                    : DiscreteCNAColumnFormatter.isVisible(
+                          mutationTableComponent.props
+                              .discreteCNACache as DiscreteCNACache
+                      );
+            },
+            set visible(value: boolean) {
+                copyNumVisibleOverride = value;
+            },
         };
 
         this._columns[MutationTableColumnType.REF_READS_N] = {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785960908&installation_id=126502837&pr_number=5642&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5642&signature=f9473cd9d8e7b0a1ac144454feebe67f39671a99a22696e9d1f1aa8da94973e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->