### PR TITLE
Move generic assay title defaults into frontend config

### DIFF
--- a/src/config/serverConfigDefaults.ts
+++ b/src/config/serverConfigDefaults.ts
@@ -195,8 +195,7 @@ export const ServerConfigDefaults: Partial<IServerConfig> = {
 
     skin_geneset_hierarchy_default_p_value: 0.05,
 
-    generic_assay_display_text:
-        'TREATMENT_RESPONSE:Treatment Response,MUTATIONAL_SIGNATURE:Mutational Signature,ARMLEVEL_CNA:Arm-level CNA',
+    generic_assay_display_text: '',
 
     saml_logout_local: false,
 

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
@@ -10,8 +10,6 @@ import {
     makeGenericAssayPlotsTabOption,
     filterGenericAssayOptionsByGenes,
 } from './GenericAssayCommonUtils';
-import { getServerConfig } from 'config/config';
-import ServerConfigDefaults from 'config/serverConfigDefaults';
 import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
 import { ISelectOption } from 'shared/lib/GenericAssayUtils/GenericAssaySelectionUtils';
 
@@ -259,13 +257,24 @@ describe('GenericAssayCommonUtils', () => {
     });
 
     describe('deriveDisplayTextFromGenericAssayType()', () => {
-        beforeAll(() => {
-            getServerConfig().generic_assay_display_text = ServerConfigDefaults.generic_assay_display_text!;
-        });
-        it('derive from the existing display text', () => {
+        it('uses the built-in display text for treatment response', () => {
             const displayText = 'Treatment Response';
             const derivedText = deriveDisplayTextFromGenericAssayType(
                 GenericAssayTypeConstants.TREATMENT_RESPONSE
+            );
+            assert.equal(displayText, derivedText);
+        });
+        it('uses the built-in display text for mutational signature', () => {
+            const displayText = 'Mutational Signature';
+            const derivedText = deriveDisplayTextFromGenericAssayType(
+                GenericAssayTypeConstants.MUTATIONAL_SIGNATURE
+            );
+            assert.equal(displayText, derivedText);
+        });
+        it('uses the built-in display text for arm-level CNA', () => {
+            const displayText = 'Arm-level CNA';
+            const derivedText = deriveDisplayTextFromGenericAssayType(
+                GenericAssayTypeConstants.ARMLEVEL_CNA
             );
             assert.equal(displayText, derivedText);
         });
@@ -283,7 +292,7 @@ describe('GenericAssayCommonUtils', () => {
             );
             assert.equal(displayText, derivedText);
         });
-        it('derive from the existing display text - plural', () => {
+        it('pluralizes the built-in display text', () => {
             const displayText = 'Treatment Responses';
             const derivedText = deriveDisplayTextFromGenericAssayType(
                 GenericAssayTypeConstants.TREATMENT_RESPONSE,

--- a/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayCommonUtils.spec.ts
@@ -10,7 +10,12 @@ import {
     makeGenericAssayPlotsTabOption,
     filterGenericAssayOptionsByGenes,
 } from './GenericAssayCommonUtils';
-import { GenericAssayTypeConstants } from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
+import { getServerConfig } from 'config/config';
+import {
+    GENERIC_ASSAY_CONFIG,
+    GenericAssayTypeConstants,
+    initializeGenericAssayServerConfig,
+} from 'shared/lib/GenericAssayUtils/GenericAssayConfig';
 import { ISelectOption } from 'shared/lib/GenericAssayUtils/GenericAssaySelectionUtils';
 
 describe('GenericAssayCommonUtils', () => {
@@ -284,6 +289,31 @@ describe('GenericAssayCommonUtils', () => {
                 GenericAssayTypeConstants.LOH_HLA
             );
             assert.equal(displayText, derivedText);
+        });
+        it('lets server config override a built-in display text', () => {
+            const originalDisplayText =
+                GENERIC_ASSAY_CONFIG.genericAssayConfigByType[
+                    GenericAssayTypeConstants.TREATMENT_RESPONSE
+                ].displayTitleText;
+            const originalServerDisplayText =
+                getServerConfig().generic_assay_display_text;
+
+            try {
+                getServerConfig().generic_assay_display_text =
+                    'TREATMENT_RESPONSE:Drug Response';
+                initializeGenericAssayServerConfig();
+
+                const derivedText = deriveDisplayTextFromGenericAssayType(
+                    GenericAssayTypeConstants.TREATMENT_RESPONSE
+                );
+                assert.equal('Drug Response', derivedText);
+            } finally {
+                getServerConfig().generic_assay_display_text =
+                    originalServerDisplayText;
+                GENERIC_ASSAY_CONFIG.genericAssayConfigByType[
+                    GenericAssayTypeConstants.TREATMENT_RESPONSE
+                ].displayTitleText = originalDisplayText;
+            }
         });
         it('derive from the type', () => {
             const displayText = 'New Type';

--- a/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
+++ b/src/shared/lib/GenericAssayUtils/GenericAssayConfig.ts
@@ -104,7 +104,14 @@ export function initializeGenericAssayServerConfig() {
 
 const DEFAULT_GENERIC_ASSAY_CONFIG: GenericAssayConfig = {
     genericAssayConfigByType: {
+        [GenericAssayTypeConstants.TREATMENT_RESPONSE]: {
+            displayTitleText: 'Treatment Response',
+        },
+        [GenericAssayTypeConstants.MUTATIONAL_SIGNATURE]: {
+            displayTitleText: 'Mutational Signature',
+        },
         [GenericAssayTypeConstants.ARMLEVEL_CNA]: {
+            displayTitleText: 'Arm-level CNA',
             frequencyTableConfig: {
                 categoryPriority: [
                     ['loss', 'deletion', 'gain', 'amp', 'amplification'],


### PR DESCRIPTION
 ## Summary

   Move built-in Generic Assay display titles out of `serverConfigDefaults.ts` and into `GenericAssayConfig.ts`, so backend `generic_assay_display_text` remains an optional override channel instead of being pre-populated by frontend defaults.

   ## What changed

   - Added built-in `displayTitleText` values in `GenericAssayConfig.ts` for:
     - `TREATMENT_RESPONSE`
     - `MUTATIONAL_SIGNATURE`
     - `ARMLEVEL_CNA`
   - Changed `ServerConfigDefaults.generic_assay_display_text` to an empty string
   - Updated the focused Generic Assay display-text spec to assert built-in per-type titles directly

   ## Why

   Before this change, the frontend was seeding `generic_assay_display_text` through `serverConfigDefaults.ts`. Since server defaults are merged into runtime config before backend overrides, that made the backend override channel look like the
  source of built-in frontend defaults.

   This change keeps the built-in labels in frontend type config and leaves `generic_assay_display_text` available for portal-specific backend customization.

   ## Behavior

   - Without backend override, built-in titles still display as:
     - `Treatment Response`
     - `Mutational Signature`
     - `Arm-level CNA`
     - `HLA LOH`
   - If backend `generic_assay_display_text` is provided, it can still override those titles

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786029692&installation_id=126502837&pr_number=5643&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5643&signature=84251474affcb1485d9d99f422e083b9833dd4850b8be124a9e98d6a1371ea1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->