### PR TITLE
Show the default gene specific violin plot for internal test study

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8699,7 +8699,9 @@ export class StudyViewPageStore
             if (
                 this.appStore.featureFlagStore.has(
                     FeatureFlagEnum.GENE_SPECIFIC_VIOLIN_PLOT
-                )
+                ) ||
+                (this.studyIds.length === 1 &&
+                    this.studyIds[0] === 'msk_target_test')
             ) {
                 const isSingleStudy =
                     (this.queriedPhysicalStudyIds.result?.length ?? 0) === 1;


### PR DESCRIPTION
Note that most of the changes are due to skipped prettier in previous PRs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786116671&installation_id=126502837&pr_number=5644&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5644&signature=b61d73e2087d0e3c51635621ee4e8b588ec3fb87961a8a74f1fea09090456e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->