### PR TITLE
Fix results pathway rendering e2e test

### DIFF
--- a/end-to-end-test-playwright/tests/screenshot-misc.spec.ts
+++ b/end-to-end-test-playwright/tests/screenshot-misc.spec.ts
@@ -234,6 +234,13 @@ test.describe('results page pathways tab with unprofiled genes', () => {
         );
         await expect(page.locator('#cy')).toBeVisible({ timeout: 30000 });
         await waitForNetworkQuiet(page, 30000);
+        // The diagram keeps fetching alteration data for genes added by the
+        // pathway (separate from the initial page network calls), showing a
+        // "Loading alteration data..." banner while gene percentages/colors
+        // are still updating. Wait for it to clear before snapshotting.
+        await expect(
+            page.locator('[data-test="pathwayMapperMessageBox"]')
+        ).toBeHidden({ timeout: 30000 });
         await snapshot(
             page,
             '[data-test="pathwayMapperTabDiv"]',


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786226773&installation_id=126502837&pr_number=5647&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5647&signature=17dfdfe2eb56ecdc2b67f9331aecda7db4d3b31a19a82cff742d4fe7c4767da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->