### PR TITLE
Stabilize results mutations table default columns localdb test

### DIFF
--- a/end-to-end-test-playwright/tests/local/init-columns-in-mutation-tables.spec.ts
+++ b/end-to-end-test-playwright/tests/local/init-columns-in-mutation-tables.spec.ts
@@ -101,19 +101,23 @@ async function columnIsNotDisplayed(page: Page, column: string) {
     return !(await isHeaderVisible(page, column));
 }
 
+// Uses the same 30s headroom as waitHeaderVisible below: the table
+// only mounts once mutation data resolves over the network, which can
+// take longer than Playwright's default 5s assertion timeout on a
+// loaded CI runner.
 async function waitForMutationTable(page: Page) {
     await expect(
         page.locator('[data-test=LazyMobXTable]').first()
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30000 });
 }
 
 async function waitForPatientViewMutationTable(page: Page) {
     await expect(
         page.locator('[data-test=patientview-mutation-table]')
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30000 });
     await expect(
         page.locator('[data-test=LazyMobXTable]').first()
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30000 });
 }
 
 test.describe('default init columns in mutation tables', () => {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786309000&installation_id=126502837&pr_number=5648&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5648&signature=d6c8fe3d23097a44f1faad649485214e28392fe3bc54f3732d572288b49e4360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->