### PR TITLE
Improve study view gene specific violin plot

### DIFF
--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -9718,7 +9718,7 @@ export class StudyViewPageStore
                         f =>
                             !(
                                 symbolSet.has(f.hugoGeneSymbol.toUpperCase()) &&
-                                (!profileType || f.profileType === profileType)
+                                f.profileType === profileType
                             )
                     );
                     // No filter active at all (not even our own) → full cohort,

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -7617,6 +7617,27 @@ export class StudyViewPageStore
         return this._geneSpecificViolinChartMap.get(uniqueKey);
     }
 
+    /** True when at least one gene in this chart has an active drag-selection. */
+    public hasActiveViolinSelectionsForChart(uniqueKey: string): boolean {
+        const chart = this._geneSpecificViolinChartMap.get(uniqueKey);
+        if (!chart) return false;
+        return chart.genes.some(
+            gene =>
+                this.getMrnaViolinSelection(gene, chart.profileType) !==
+                undefined
+        );
+    }
+
+    /** Clear every gene's range selection for this chart. */
+    @action.bound
+    public clearAllViolinSelectionsForChart(uniqueKey: string): void {
+        const chart = this._geneSpecificViolinChartMap.get(uniqueKey);
+        if (!chart) return;
+        for (const gene of chart.genes) {
+            this.updateMrnaViolinSelection(gene, chart.profileType, null);
+        }
+    }
+
     public isGeneSpecificViolinLogScale(uniqueKey: string): boolean {
         return !!this._geneSpecificViolinLogScale.get(uniqueKey);
     }

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -8720,7 +8720,9 @@ export class StudyViewPageStore
             if (
                 this.appStore.featureFlagStore.has(
                     FeatureFlagEnum.GENE_SPECIFIC_VIOLIN_PLOT
-                )
+                ) ||
+                (this.studyIds.length === 1 &&
+                    this.studyIds[0] === 'msk_target_test')
             ) {
                 const isSingleStudy =
                     (this.queriedPhysicalStudyIds.result?.length ?? 0) === 1;

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -465,6 +465,7 @@ export type GenomicChart = {
     hugoGeneSymbol: string;
     dataType?: string;
     mutationOptionType?: string;
+    disableViolinAggregation?: boolean;
 };
 
 export type GenericAssayChart = {
@@ -7528,6 +7529,7 @@ export class StudyViewPageStore
                 c =>
                     c.dataType === DataType.NUMBER &&
                     !c.mutationOptionType &&
+                    !c.disableViolinAggregation &&
                     c.profileType === newCharts[0].profileType
             )
         );

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -9720,7 +9720,8 @@ export class StudyViewPageStore
                         f =>
                             !(
                                 symbolSet.has(f.hugoGeneSymbol.toUpperCase()) &&
-                                f.profileType === profileType
+                                (profileType === null ||
+                                    f.profileType === profileType)
                             )
                     );
                     // No filter active at all (not even our own) → full cohort,

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -56,7 +56,6 @@ import { openSocialAuthWindow } from 'shared/lib/openSocialAuthWindow';
 import { CustomChartData } from 'shared/api/session-service/sessionServiceModels';
 import ReactSelect from 'react-select';
 import { DataTypeConstants } from 'shared/constants';
-import { Else, If, Then } from 'react-if';
 import SaveChartSettingsButton from './SaveChartSettingsButton';
 import { ServerConfigHelpers } from 'config/config';
 
@@ -441,8 +440,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                     description: option.description,
                     profileType: option.value,
                     genericAssayType,
-                    genericAssayEntityId:
-                        GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
+                    genericAssayEntityId: GENERIC_ASSAY_FREQUENCY_TABLE_ENTITY_ID,
                     dataType: option.dataType,
                     patientLevel: option.patientLevel,
                     chartKind: 'PROFILE_FREQUENCY_TABLE',
@@ -464,8 +462,9 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
     ): GenericAssaySelectableChartOption[] {
         const allChartTypes = _.fromPairs(this.props.store.chartsType.toJSON());
         const genericAssayChartMeta =
-            this.groupedChartMetaByDataType[ChartMetaDataTypeEnum.GENERIC_ASSAY] ||
-            [];
+            this.groupedChartMetaByDataType[
+                ChartMetaDataTypeEnum.GENERIC_ASSAY
+            ] || [];
         const frequencyTableUniqueKey = getGenericAssayFrequencyTableUniqueKey(
             option.value
         );
@@ -550,7 +549,10 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
     private onClearAllGenericAssayChartOptions(keys: string[]) {
         keys.forEach(key => {
             if (this.selectedAttrs.includes(key)) {
-                this.props.store.resetFilterAndChangeChartVisibility(key, false);
+                this.props.store.resetFilterAndChangeChartVisibility(
+                    key,
+                    false
+                );
             }
         });
         this.updateInfoMessage(
@@ -1044,7 +1046,6 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                             molecularProfileOptionsPromise={
                                 this.props.store.molecularProfileOptions
                             }
-                            submitButtonText={'Add Chart'}
                             onSubmit={(charts: GenomicChart[]) => {
                                 if (charts.length === 1) {
                                     const uniqueKey = getGenomicChartUniqueKey(

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
@@ -42,7 +42,7 @@ describe('GeneLevelSelection', () => {
         } as any);
     }
 
-    it('shows violin plot button text for multi-gene numeric selections', () => {
+    it('shows violin and bar chart radio options for multi-gene numeric selections', () => {
         const component = createComponent({
             value: 'mrna',
             count: 100,
@@ -53,27 +53,15 @@ describe('GeneLevelSelection', () => {
         });
         initValidGeneQuery(component, ['TP53', 'EGFR']);
 
-        assert.equal((component as any).submitButtonText, 'Add 1 Violin Plot');
-    });
-
-    it('shows alternative bar chart button text for multi-gene numeric selections', () => {
-        const component = createComponent({
-            value: 'mrna',
-            count: 100,
-            label: 'mRNA Expression',
-            description: 'mRNA expression profile',
-            dataType: DataType.NUMBER,
-            alterationType: 'MRNA_EXPRESSION',
-        });
-        initValidGeneQuery(component, ['TP53', 'EGFR']);
-
-        assert.equal(
-            (component as any).barChartAlternativeButtonText,
-            'Add 2 Bar Charts'
+        assert.deepEqual(
+            (component as any).chartSelectionOptions.map((option: any) =>
+                (component as any).getChartOptionLabel(option)
+            ),
+            ['Add 1 Violin Plot', 'Add 2 Bar Charts']
         );
     });
 
-    it('shows full alternative bar chart count for larger multi-gene selections', () => {
+    it('shows full bar chart radio option count for larger multi-gene selections', () => {
         const component = createComponent({
             value: 'mrna',
             count: 100,
@@ -87,13 +75,15 @@ describe('GeneLevelSelection', () => {
             Array.from({ length: 12 }, (_, i) => `GENE${i + 1}`)
         );
 
-        assert.equal(
-            (component as any).barChartAlternativeButtonText,
-            'Add 12 Bar Charts'
+        assert.deepEqual(
+            (component as any).chartSelectionOptions.map((option: any) =>
+                (component as any).getChartOptionLabel(option)
+            ),
+            ['Add 1 Violin Plot', 'Add 12 Bar Charts']
         );
     });
 
-    it('submits individual bar charts when using the alternative button path', () => {
+    it('submits violin aggregation by default for multi-gene numeric selections', () => {
         let submittedCharts: any[] = [];
         const component = new GeneLevelSelection({
             molecularProfileOptionsPromise: {
@@ -119,7 +109,42 @@ describe('GeneLevelSelection', () => {
             Array.from({ length: 12 }, (_, i) => `GENE${i + 1}`)
         );
 
-        (component as any).onAddBarCharts();
+        (component as any).onAddChart();
+
+        assert.equal(submittedCharts.length, 12);
+        assert.isTrue(
+            submittedCharts.every(chart => !chart.disableViolinAggregation)
+        );
+    });
+
+    it('submits individual bar charts when bar chart radio option is selected', () => {
+        let submittedCharts: any[] = [];
+        const component = new GeneLevelSelection({
+            molecularProfileOptionsPromise: {
+                isComplete: true,
+                result: [
+                    {
+                        value: 'mrna',
+                        count: 100,
+                        label: 'mRNA Expression',
+                        description: 'mRNA expression profile',
+                        dataType: DataType.NUMBER,
+                        alterationType: 'MRNA_EXPRESSION',
+                    },
+                ],
+            },
+            onSubmit: (charts: any[]) => {
+                submittedCharts = charts;
+            },
+            containerWidth: 600,
+        } as any);
+        initValidGeneQuery(
+            component,
+            Array.from({ length: 12 }, (_, i) => `GENE${i + 1}`)
+        );
+
+        (component as any)._selectedChartOptionKey = 'bar';
+        (component as any).onAddChart();
 
         assert.equal(submittedCharts.length, 12);
         assert.isTrue(
@@ -142,10 +167,15 @@ describe('GeneLevelSelection', () => {
         });
         initValidGeneQuery(component, ['TP53']);
 
-        assert.equal((component as any).submitButtonText, 'Add 1 Bar Chart');
+        assert.deepEqual(
+            (component as any).chartSelectionOptions.map((option: any) =>
+                (component as any).getChartOptionLabel(option)
+            ),
+            ['Add 1 Bar Chart']
+        );
     });
 
-    it('shows pie chart button text for multi-gene categorical selections', () => {
+    it('shows pie chart radio option for multi-gene categorical selections', () => {
         const component = createComponent({
             value: 'cna',
             count: 100,
@@ -156,10 +186,15 @@ describe('GeneLevelSelection', () => {
         });
         initValidGeneQuery(component, ['TP53', 'EGFR']);
 
-        assert.equal((component as any).submitButtonText, 'Add 2 Pie Charts');
+        assert.deepEqual(
+            (component as any).chartSelectionOptions.map((option: any) =>
+                (component as any).getChartOptionLabel(option)
+            ),
+            ['Add 2 Pie Charts']
+        );
     });
 
-    it('shows mutation type chart button text when mutation-type sub-option is selected', () => {
+    it('shows mutation type chart radio option when mutation-type sub-option is selected', () => {
         const component = createComponent({
             value: 'mut',
             count: 100,
@@ -174,10 +209,26 @@ describe('GeneLevelSelection', () => {
             label: 'Mutation Type',
         };
 
-        assert.equal(
-            (component as any).submitButtonText,
-            'Add 2 Mutation Type Charts'
+        assert.deepEqual(
+            (component as any).chartSelectionOptions.map((option: any) =>
+                (component as any).getChartOptionLabel(option)
+            ),
+            ['Add 2 Mutation Type Charts']
         );
+    });
+
+    it('does not render chart type options when there are zero charts to add', () => {
+        const component = createComponent({
+            value: 'mrna',
+            count: 100,
+            label: 'mRNA Expression',
+            description: 'mRNA expression profile',
+            dataType: DataType.NUMBER,
+            alterationType: 'MRNA_EXPRESSION',
+        });
+
+        assert.deepEqual((component as any).chartSelectionOptions, []);
+        assert.isUndefined((component as any).selectedChartSelectionOption);
     });
 
     it('adds study-view default violin group right below User-defined List', () => {

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
@@ -1,0 +1,103 @@
+import { assert } from 'chai';
+import { Gene } from 'cbioportal-ts-api-client';
+import {
+    DataType,
+    MolecularProfileOption,
+} from 'pages/studyView/StudyViewUtils';
+import {
+    AlterationTypeConstants,
+    MutationOptionConstants,
+} from 'shared/constants';
+import GeneLevelSelection from './GeneLevelSelection';
+
+describe('GeneLevelSelection', () => {
+    function initValidGeneQuery(
+        component: GeneLevelSelection,
+        geneSymbols: string[]
+    ) {
+        (component as any)._queryStr = geneSymbols.join(' ');
+        (component as any)._oql = {
+            query: geneSymbols.map(() => ({ alterations: false })),
+        };
+        (component as any)._genes = {
+            found: geneSymbols.map(
+                gene => (({ hugoGeneSymbol: gene } as unknown) as Gene)
+            ),
+            suggestions: [],
+        };
+    }
+
+    function createComponent(profile: MolecularProfileOption) {
+        return new GeneLevelSelection({
+            molecularProfileOptionsPromise: {
+                isComplete: true,
+                result: [profile],
+            },
+            onSubmit: () => {},
+            containerWidth: 600,
+        } as any);
+    }
+
+    it('shows violin plot button text for multi-gene numeric selections', () => {
+        const component = createComponent({
+            value: 'mrna',
+            count: 100,
+            label: 'mRNA Expression',
+            description: 'mRNA expression profile',
+            dataType: DataType.NUMBER,
+            alterationType: 'MRNA_EXPRESSION',
+        });
+        initValidGeneQuery(component, ['TP53', 'EGFR']);
+
+        assert.equal((component as any).submitButtonText, 'Add 1 Violin Plot');
+    });
+
+    it('shows bar chart button text for single-gene numeric selections', () => {
+        const component = createComponent({
+            value: 'mrna',
+            count: 100,
+            label: 'mRNA Expression',
+            description: 'mRNA expression profile',
+            dataType: DataType.NUMBER,
+            alterationType: 'MRNA_EXPRESSION',
+        });
+        initValidGeneQuery(component, ['TP53']);
+
+        assert.equal((component as any).submitButtonText, 'Add 1 Bar Chart');
+    });
+
+    it('shows pie chart button text for multi-gene categorical selections', () => {
+        const component = createComponent({
+            value: 'cna',
+            count: 100,
+            label: 'Discrete CNA',
+            description: 'discrete cna profile',
+            dataType: DataType.STRING,
+            alterationType: 'COPY_NUMBER_ALTERATION',
+        });
+        initValidGeneQuery(component, ['TP53', 'EGFR']);
+
+        assert.equal((component as any).submitButtonText, 'Add 2 Pie Charts');
+    });
+
+    it('shows mutation type chart button text when mutation-type sub-option is selected', () => {
+        const component = createComponent({
+            value: 'mut',
+            count: 100,
+            label: 'Mutations',
+            description: 'mutation profile',
+            dataType: DataType.STRING,
+            alterationType: AlterationTypeConstants.MUTATION_EXTENDED,
+        });
+        initValidGeneQuery(component, ['TP53', 'EGFR']);
+        (component as any)._selectedSubProfileOption = {
+            value: MutationOptionConstants.MUTATION_TYPE,
+            label: 'Mutation Type',
+        };
+
+        assert.equal(
+            (component as any).submitButtonText,
+            'Add 2 Mutation Type Charts'
+        );
+    });
+});

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
@@ -52,6 +52,81 @@ describe('GeneLevelSelection', () => {
         assert.equal((component as any).submitButtonText, 'Add 1 Violin Plot');
     });
 
+    it('shows alternative bar chart button text for multi-gene numeric selections', () => {
+        const component = createComponent({
+            value: 'mrna',
+            count: 100,
+            label: 'mRNA Expression',
+            description: 'mRNA expression profile',
+            dataType: DataType.NUMBER,
+            alterationType: 'MRNA_EXPRESSION',
+        });
+        initValidGeneQuery(component, ['TP53', 'EGFR']);
+
+        assert.equal(
+            (component as any).barChartAlternativeButtonText,
+            'Add 2 Bar Charts'
+        );
+    });
+
+    it('shows full alternative bar chart count for larger multi-gene selections', () => {
+        const component = createComponent({
+            value: 'mrna',
+            count: 100,
+            label: 'mRNA Expression',
+            description: 'mRNA expression profile',
+            dataType: DataType.NUMBER,
+            alterationType: 'MRNA_EXPRESSION',
+        });
+        initValidGeneQuery(
+            component,
+            Array.from({ length: 12 }, (_, i) => `GENE${i + 1}`)
+        );
+
+        assert.equal(
+            (component as any).barChartAlternativeButtonText,
+            'Add 12 Bar Charts'
+        );
+    });
+
+    it('submits individual bar charts when using the alternative button path', () => {
+        let submittedCharts: any[] = [];
+        const component = new GeneLevelSelection({
+            molecularProfileOptionsPromise: {
+                isComplete: true,
+                result: [
+                    {
+                        value: 'mrna',
+                        count: 100,
+                        label: 'mRNA Expression',
+                        description: 'mRNA expression profile',
+                        dataType: DataType.NUMBER,
+                        alterationType: 'MRNA_EXPRESSION',
+                    },
+                ],
+            },
+            onSubmit: (charts: any[]) => {
+                submittedCharts = charts;
+            },
+            containerWidth: 600,
+        } as any);
+        initValidGeneQuery(
+            component,
+            Array.from({ length: 12 }, (_, i) => `GENE${i + 1}`)
+        );
+
+        (component as any).onAddBarCharts();
+
+        assert.equal(submittedCharts.length, 12);
+        assert.isTrue(
+            submittedCharts.every(chart => chart.disableViolinAggregation)
+        );
+        assert.deepEqual(
+            submittedCharts.map(chart => chart.hugoGeneSymbol),
+            Array.from({ length: 12 }, (_, i) => `GENE${i + 1}`)
+        );
+    });
+
     it('shows bar chart button text for single-gene numeric selections', () => {
         const component = createComponent({
             value: 'mrna',

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.spec.tsx
@@ -9,6 +9,10 @@ import {
     MutationOptionConstants,
 } from 'shared/constants';
 import GeneLevelSelection from './GeneLevelSelection';
+import {
+    MRNA_TAB_GENE_GROUPS,
+    STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
+} from 'pages/patientView/mrna/mrnaTabGeneGroups';
 
 describe('GeneLevelSelection', () => {
     function initValidGeneQuery(
@@ -173,6 +177,52 @@ describe('GeneLevelSelection', () => {
         assert.equal(
             (component as any).submitButtonText,
             'Add 2 Mutation Type Charts'
+        );
+    });
+
+    it('adds study-view default violin group right below User-defined List', () => {
+        const component = createComponent({
+            value: 'mrna',
+            count: 100,
+            label: 'mRNA Expression',
+            description: 'mRNA expression profile',
+            dataType: DataType.NUMBER,
+            alterationType: 'MRNA_EXPRESSION',
+        });
+
+        const defaultGroup = MRNA_TAB_GENE_GROUPS.find(
+            g => g.id === STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID
+        )!;
+
+        assert.equal(
+            (component as any).geneSetOptions[0].label,
+            'User-defined List'
+        );
+        assert.equal(
+            (component as any).geneSetOptions[1].label,
+            `ADC targets (${defaultGroup.genes.length} genes)`
+        );
+        assert.equal(
+            (component as any).geneSetOptions[1].value,
+            defaultGroup.genes.join(' ')
+        );
+    });
+
+    it('keeps user-defined list option available in the gene-set dropdown', () => {
+        const component = createComponent({
+            value: 'mrna',
+            count: 100,
+            label: 'mRNA Expression',
+            description: 'mRNA expression profile',
+            dataType: DataType.NUMBER,
+            alterationType: 'MRNA_EXPRESSION',
+        });
+
+        assert.isTrue(
+            (component as any).geneSetOptions.some(
+                (option: { label: string; value: string }) =>
+                    option.label === 'User-defined List' && option.value === ''
+            )
         );
     });
 });

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
@@ -28,6 +28,7 @@ import {
 import autobind from 'autobind-decorator';
 import gene_lists from 'shared/components/query/gene_lists';
 import { getServerConfig, ServerConfigHelpers } from 'config/config';
+import { ButtonGroup, Radio } from 'react-bootstrap';
 import {
     MRNA_TAB_GENE_GROUPS,
     STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
@@ -38,6 +39,13 @@ export interface IGeneLevelSelectionProps {
     onSubmit: (charts: GenomicChart[]) => void;
     containerWidth: number;
 }
+
+type ChartSelectionOption = {
+    key: string;
+    chartCount: number;
+    chartKind: string;
+    disableViolinAggregation?: boolean;
+};
 
 const molecularProfileSubOptions = [
     {
@@ -85,6 +93,7 @@ export default class GeneLevelSelection extends React.Component<
         suggestions: GeneReplacement[];
     };
     @observable.ref private _queryStr?: string;
+    @observable private _selectedChartOptionKey?: string;
 
     public static defaultProps = {
         disableGrouping: false,
@@ -92,17 +101,10 @@ export default class GeneLevelSelection extends React.Component<
 
     @action.bound
     private onAddChart() {
-        this.submitCharts();
+        this.submitCharts(this.selectedChartSelectionOption);
     }
 
-    @action.bound
-    private onAddBarCharts() {
-        this.submitCharts({
-            disableViolinAggregation: true,
-        });
-    }
-
-    private submitCharts(options?: { disableViolinAggregation?: boolean }) {
+    private submitCharts(option?: ChartSelectionOption) {
         if (this.selectedOption !== undefined) {
             const charts = this.validGenes.map(gene => {
                 return {
@@ -114,7 +116,7 @@ export default class GeneLevelSelection extends React.Component<
                     ...(this.selectedSubOption
                         ? { mutationOptionType: this.selectedSubOption.value }
                         : {}),
-                    ...(options?.disableViolinAggregation
+                    ...(option?.disableViolinAggregation
                         ? { disableViolinAggregation: true }
                         : {}),
                 };
@@ -194,6 +196,11 @@ export default class GeneLevelSelection extends React.Component<
         if (option && option.value) {
             this._selectedSubProfileOption = option;
         }
+    }
+
+    @action.bound
+    private handleChartOptionChange(event: any) {
+        this._selectedChartOptionKey = event.target.value;
     }
 
     @autobind
@@ -311,22 +318,46 @@ export default class GeneLevelSelection extends React.Component<
     }
 
     @computed
-    private get submitButtonText() {
+    private get chartSelectionOptions(): ChartSelectionOption[] {
         const { chartCount, chartKind } = this.chartPreview;
+        if (chartCount === 0) {
+            return [];
+        }
+        const options: ChartSelectionOption[] = [
+            {
+                key: 'default',
+                chartCount,
+                chartKind,
+            },
+        ];
+
+        if (chartKind === 'Violin Plot') {
+            options.push({
+                key: 'bar',
+                chartCount: this.validGenes.length,
+                chartKind: 'Bar Chart',
+                disableViolinAggregation: true,
+            });
+        }
+
+        return options;
+    }
+
+    @computed
+    private get selectedChartSelectionOption():
+        | ChartSelectionOption
+        | undefined {
+        return (
+            this.chartSelectionOptions.find(
+                option => option.key === this._selectedChartOptionKey
+            ) || this.chartSelectionOptions[0]
+        );
+    }
+
+    private getChartOptionLabel(option: ChartSelectionOption) {
+        const { chartCount, chartKind } = option;
         const suffix = chartCount === 1 ? '' : 's';
         return `Add ${chartCount} ${chartKind}${suffix}`;
-    }
-
-    @computed
-    private get showBarChartAlternativeButton() {
-        return this.chartPreview.chartKind === 'Violin Plot';
-    }
-
-    @computed
-    private get barChartAlternativeButtonText() {
-        const barChartCount = this.validGenes.length;
-        const suffix = barChartCount === 1 ? '' : 's';
-        return `Add ${barChartCount} Bar Chart${suffix}`;
     }
 
     @computed
@@ -420,29 +451,52 @@ export default class GeneLevelSelection extends React.Component<
                                 gap: '8px',
                             }}
                         >
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                }}
+                            >
+                                {this.chartSelectionOptions.length > 0 && (
+                                    <ButtonGroup>
+                                        {this.chartSelectionOptions.map(
+                                            option => (
+                                                <Radio
+                                                    key={option.key}
+                                                    value={option.key}
+                                                    checked={
+                                                        this
+                                                            .selectedChartSelectionOption
+                                                            ?.key === option.key
+                                                    }
+                                                    onChange={
+                                                        this
+                                                            .handleChartOptionChange
+                                                    }
+                                                    disabled={
+                                                        this.isQueryInvalid ||
+                                                        this.hasOQL
+                                                    }
+                                                    inline
+                                                    data-test={`GeneLevelSelectionChartTypeOption-${option.key}`}
+                                                >
+                                                    {this.getChartOptionLabel(
+                                                        option
+                                                    )}
+                                                </Radio>
+                                            )
+                                        )}
+                                    </ButtonGroup>
+                                )}
+                            </div>
                             <button
                                 disabled={this.isQueryInvalid || this.hasOQL}
                                 className="btn btn-primary btn-sm"
                                 data-test="GeneLevelSelectionSubmitButton"
                                 onClick={this.onAddChart}
                             >
-                                {this.submitButtonText}
+                                Add Chart(s)
                             </button>
-                            {this.showBarChartAlternativeButton && (
-                                <>
-                                    <span>or</span>
-                                    <button
-                                        disabled={
-                                            this.isQueryInvalid || this.hasOQL
-                                        }
-                                        className="btn btn-primary btn-sm"
-                                        data-test="GeneLevelSelectionAlternativeBarChartButton"
-                                        onClick={this.onAddBarCharts}
-                                    >
-                                        {this.barChartAlternativeButtonText}
-                                    </button>
-                                </>
-                            )}
                         </div>
                     </div>
 

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import _, { List } from 'lodash';
+import _ from 'lodash';
 import { GenomicChart } from 'pages/studyView/StudyViewPageStore';
 import { observer } from 'mobx-react';
 import { action, computed, makeObservable, observable } from 'mobx';
@@ -16,7 +16,10 @@ import { MakeMobxView } from 'shared/components/MobxView';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import ErrorMessage from 'shared/components/ErrorMessage';
 import { Gene } from 'cbioportal-ts-api-client';
-import { MolecularProfileOption } from 'pages/studyView/StudyViewUtils';
+import {
+    DataType,
+    MolecularProfileOption,
+} from 'pages/studyView/StudyViewUtils';
 import {
     AlterationTypeConstants,
     MutationOptionConstants,
@@ -28,7 +31,6 @@ import { getServerConfig, ServerConfigHelpers } from 'config/config';
 
 export interface IGeneLevelSelectionProps {
     molecularProfileOptionsPromise: MobxPromise<MolecularProfileOption[]>;
-    submitButtonText: string;
     onSubmit: (charts: GenomicChart[]) => void;
     containerWidth: number;
 }
@@ -234,6 +236,58 @@ export default class GeneLevelSelection extends React.Component<
     }
 
     @computed
+    private get chartPreview() {
+        const geneCount = this.validGenes.length;
+
+        if (geneCount === 0 || !this.selectedOption) {
+            return {
+                chartCount: 0,
+                chartKind: 'Chart',
+            };
+        }
+
+        if (
+            geneCount > 1 &&
+            this.selectedOption.dataType === DataType.NUMBER &&
+            !this.selectedSubOption
+        ) {
+            return {
+                chartCount: 1,
+                chartKind: 'Violin Plot',
+            };
+        }
+
+        if (
+            this.selectedSubOption?.value ===
+            MutationOptionConstants.MUTATION_TYPE
+        ) {
+            return {
+                chartCount: geneCount,
+                chartKind: 'Mutation Type Chart',
+            };
+        }
+
+        if (this.selectedOption.dataType === DataType.NUMBER) {
+            return {
+                chartCount: geneCount,
+                chartKind: 'Bar Chart',
+            };
+        }
+
+        return {
+            chartCount: geneCount,
+            chartKind: 'Pie Chart',
+        };
+    }
+
+    @computed
+    private get submitButtonText() {
+        const { chartCount, chartKind } = this.chartPreview;
+        const suffix = chartCount === 1 ? '' : 's';
+        return `Add ${chartCount} ${chartKind}${suffix}`;
+    }
+
+    @computed
     private get molecularProfileOptions() {
         if (this.props.molecularProfileOptionsPromise.isComplete) {
             return this.props.molecularProfileOptionsPromise.result!.map(
@@ -263,6 +317,30 @@ export default class GeneLevelSelection extends React.Component<
             }
             return (
                 <div style={{ width: this.props.containerWidth - 20 }}>
+                    <div style={{ marginBottom: '10px' }}>
+                        <ReactSelect
+                            value={this.selectedOption}
+                            onChange={this.handleSelect}
+                            options={this.molecularProfileOptions}
+                            isClearable={false}
+                            isSearchable={false}
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                    {this.selectedOption &&
+                        molecularProfileSubOptions
+                            .map(option => option.profileType)
+                            .includes(this.selectedOption.alterationType) && (
+                            <div style={{ width: '70%', marginBottom: '10px' }}>
+                                <ReactSelect
+                                    value={this.selectedSubOption}
+                                    onChange={this.handleSubSelect}
+                                    options={molecularProfileSubOptions}
+                                    isClearable={false}
+                                    isSearchable={false}
+                                />
+                            </div>
+                        )}
                     <div style={{ marginBottom: '5px' }}>
                         <ReactSelect
                             value={this.selectedGeneSetOption}
@@ -291,48 +369,17 @@ export default class GeneLevelSelection extends React.Component<
                             OQL not allowed
                         </div>
                     )}
-                    <div style={{ display: 'flex', marginTop: '10px' }}>
-                        <div
-                            style={{
-                                flex: 1,
-                                width: '50%',
-                                marginRight: '5%',
-                            }}
-                        >
-                            <ReactSelect
-                                value={this.selectedOption}
-                                onChange={this.handleSelect}
-                                options={this.molecularProfileOptions}
-                                isClearable={false}
-                                isSearchable={false}
-                                style={{ width: '100%' }}
-                            />
-                        </div>
+                    <div style={{ marginTop: '10px', display: 'flex' }}>
                         <button
                             disabled={this.isQueryInvalid || this.hasOQL}
                             className="btn btn-primary btn-sm"
                             data-test="GeneLevelSelectionSubmitButton"
                             onClick={this.onAddChart}
-                            style={{ width: '25%' }}
+                            style={{ marginLeft: 'auto' }}
                         >
-                            {this.props.submitButtonText}
+                            {this.submitButtonText}
                         </button>
                     </div>
-
-                    {this.selectedOption &&
-                        molecularProfileSubOptions
-                            .map(option => option.profileType)
-                            .includes(this.selectedOption.alterationType) && (
-                            <div style={{ width: '70%', marginTop: '5px' }}>
-                                <ReactSelect
-                                    value={this.selectedSubOption}
-                                    onChange={this.handleSubSelect}
-                                    options={molecularProfileSubOptions}
-                                    isClearable={false}
-                                    isSearchable={false}
-                                />
-                            </div>
-                        )}
 
                     {/* <div className={styles.operations}>
                         

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
@@ -28,6 +28,10 @@ import {
 import autobind from 'autobind-decorator';
 import gene_lists from 'shared/components/query/gene_lists';
 import { getServerConfig, ServerConfigHelpers } from 'config/config';
+import {
+    MRNA_TAB_GENE_GROUPS,
+    STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
+} from 'pages/patientView/mrna/mrnaTabGeneGroups';
 
 export interface IGeneLevelSelectionProps {
     molecularProfileOptionsPromise: MobxPromise<MolecularProfileOption[]>;
@@ -125,6 +129,11 @@ export default class GeneLevelSelection extends React.Component<
     @computed
     private get geneSetOptions() {
         let geneList: { id: string; genes: string[] }[] = gene_lists;
+        const studyViewDefaultGroup = MRNA_TAB_GENE_GROUPS.find(
+            group =>
+                group.id === STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID
+        );
+
         if (getServerConfig().query_sets_of_genes) {
             const parsed = ServerConfigHelpers.parseQuerySetsOfGenes(
                 getServerConfig().query_sets_of_genes!
@@ -133,13 +142,20 @@ export default class GeneLevelSelection extends React.Component<
                 geneList = parsed;
             }
         }
-        return [
-            { label: 'User-defined List', value: '' },
-            ...geneList.map(item => ({
-                label: `${item.id} (${item.genes.length} genes)`,
-                value: item.genes.join(' '),
-            })),
-        ];
+
+        const geneSetOptions = geneList.map(item => ({
+            label: `${item.id} (${item.genes.length} genes)`,
+            value: item.genes.join(' '),
+        }));
+
+        if (studyViewDefaultGroup) {
+            geneSetOptions.unshift({
+                label: `ADC targets (${studyViewDefaultGroup.genes.length} genes)`,
+                value: studyViewDefaultGroup.genes.join(' '),
+            });
+        }
+
+        return [{ label: 'User-defined List', value: '' }, ...geneSetOptions];
     }
 
     @computed

--- a/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
+++ b/src/pages/studyView/addChartButton/geneLevelSelection/GeneLevelSelection.tsx
@@ -88,6 +88,17 @@ export default class GeneLevelSelection extends React.Component<
 
     @action.bound
     private onAddChart() {
+        this.submitCharts();
+    }
+
+    @action.bound
+    private onAddBarCharts() {
+        this.submitCharts({
+            disableViolinAggregation: true,
+        });
+    }
+
+    private submitCharts(options?: { disableViolinAggregation?: boolean }) {
         if (this.selectedOption !== undefined) {
             const charts = this.validGenes.map(gene => {
                 return {
@@ -98,6 +109,9 @@ export default class GeneLevelSelection extends React.Component<
                     dataType: this.selectedOption!.dataType,
                     ...(this.selectedSubOption
                         ? { mutationOptionType: this.selectedSubOption.value }
+                        : {}),
+                    ...(options?.disableViolinAggregation
+                        ? { disableViolinAggregation: true }
                         : {}),
                 };
             });
@@ -288,6 +302,18 @@ export default class GeneLevelSelection extends React.Component<
     }
 
     @computed
+    private get showBarChartAlternativeButton() {
+        return this.chartPreview.chartKind === 'Violin Plot';
+    }
+
+    @computed
+    private get barChartAlternativeButtonText() {
+        const barChartCount = this.validGenes.length;
+        const suffix = barChartCount === 1 ? '' : 's';
+        return `Add ${barChartCount} Bar Chart${suffix}`;
+    }
+
+    @computed
     private get molecularProfileOptions() {
         if (this.props.molecularProfileOptionsPromise.isComplete) {
             return this.props.molecularProfileOptionsPromise.result!.map(
@@ -370,15 +396,38 @@ export default class GeneLevelSelection extends React.Component<
                         </div>
                     )}
                     <div style={{ marginTop: '10px', display: 'flex' }}>
-                        <button
-                            disabled={this.isQueryInvalid || this.hasOQL}
-                            className="btn btn-primary btn-sm"
-                            data-test="GeneLevelSelectionSubmitButton"
-                            onClick={this.onAddChart}
-                            style={{ marginLeft: 'auto' }}
+                        <div
+                            style={{
+                                marginLeft: 'auto',
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '8px',
+                            }}
                         >
-                            {this.submitButtonText}
-                        </button>
+                            <button
+                                disabled={this.isQueryInvalid || this.hasOQL}
+                                className="btn btn-primary btn-sm"
+                                data-test="GeneLevelSelectionSubmitButton"
+                                onClick={this.onAddChart}
+                            >
+                                {this.submitButtonText}
+                            </button>
+                            {this.showBarChartAlternativeButton && (
+                                <>
+                                    <span>or</span>
+                                    <button
+                                        disabled={
+                                            this.isQueryInvalid || this.hasOQL
+                                        }
+                                        className="btn btn-primary btn-sm"
+                                        data-test="GeneLevelSelectionAlternativeBarChartButton"
+                                        onClick={this.onAddBarCharts}
+                                    >
+                                        {this.barChartAlternativeButtonText}
+                                    </button>
+                                </>
+                            )}
+                        </div>
                     </div>
 
                     {/* <div className={styles.operations}>

--- a/src/pages/studyView/charts/ChartContainer.tsx
+++ b/src/pages/studyView/charts/ChartContainer.tsx
@@ -231,6 +231,12 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                 if (this.props.store.hesitateUpdate) {
                     this.alertContent =
                         'In manual submit mode, you can only clear filters using the filter tokens at the top of the page.';
+                } else if (
+                    this.chartType === ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT
+                ) {
+                    this.props.store.clearAllViolinSelectionsForChart(
+                        this.props.chartMeta.uniqueKey
+                    );
                 } else {
                     this.props.onResetSelection(this.props.chartMeta, []);
                 }
@@ -324,10 +330,10 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
     }
 
     @autobind
-    private async getDownloadData(
-        dataType?: DataType
-    ): Promise<string | null> {
-        if (this.props.chartType === ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE) {
+    private async getDownloadData(dataType?: DataType): Promise<string | null> {
+        if (
+            this.props.chartType === ChartTypeEnum.GENERIC_ASSAY_FREQUENCY_TABLE
+        ) {
             return formatGenericAssayFrequencyTableDownloadData(
                 this.genericAssayFrequencyTableRef?.getDownloadRowsData() || [],
                 this.props.store.getMolecularChartDataType(
@@ -418,9 +424,15 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
         if (this.comparisonPagePossible) {
             controls.showComparisonPageIcon = true;
         }
+        const showResetIcon =
+            this.chartType === ChartTypeEnum.GENE_SPECIFIC_VIOLIN_PLOT
+                ? this.props.store.hasActiveViolinSelectionsForChart(
+                      this.props.chartMeta.uniqueKey
+                  )
+                : !!(this.props.filters && this.props.filters.length > 0);
         return {
             ...controls,
-            showResetIcon: this.props.filters && this.props.filters.length > 0,
+            showResetIcon,
         } as ChartControls;
     }
 
@@ -687,7 +699,7 @@ export class ChartContainer extends React.Component<IChartContainerProps, {}> {
                         height={getTableHeightByDimension(
                             this.props.dimension,
                             this.chartHeaderHeight
-                        )                        }
+                        )}
                         filters={this.props.filters}
                         selectedRowsKeys={this.selectedRowsKeys}
                         onChangeSelectedRows={

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -773,7 +773,12 @@ export default class MrnaViolinPlotChart extends React.Component<
                     )
                     .join(' ');
                 const pathD = `M ${upperPts} L ${lowerPts} Z`;
-                const clipId = `violin-sel-${gene.entrezGeneId}`;
+                const clipId = `violin-sel-${this.profileType ?? 'auto'}-${[
+                    ...this.selectedSymbols,
+                ]
+                    .map(s => s.toUpperCase())
+                    .sort()
+                    .join('-')}-${gene.entrezGeneId}`;
                 shape = (
                     <g>
                         <path

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -27,8 +27,8 @@ const MAX_GENES = 10;
 const MAX_ROW_HEIGHT = 50;
 /** Fixed per-gene row height in gene-specific mode; enables scrolling over resize. */
 const GENE_SPECIFIC_FIXED_ROW_HEIGHT = 27;
-/** Width reserved for the vertical scrollbar in gene-specific mode. */
-const SCROLLBAR_WIDTH = 17;
+/** Extra breathing room so content never sits flush against the scrollbar. */
+const GENE_SPECIFIC_SCROLLBAR_SAFETY_GUTTER = 1;
 const MAX_SAMPLES = 1000;
 const KDE_POINTS = 80;
 const TOOLBAR_HEIGHT = 34;
@@ -179,8 +179,11 @@ export default class MrnaViolinPlotChart extends React.Component<
     // plus the row it is over so the line spans only that one track.
     @observable private hoverX: number | null = null;
     @observable private hoverRowIndex: number | null = null;
+    /** Measured vertical scrollbar width of the gene-specific scroll container. */
+    @observable private measuredScrollbarWidth = 0;
 
     private svgRef = React.createRef<SVGSVGElement>();
+    private scrollContainerRef = React.createRef<HTMLDivElement>();
 
     constructor(props: IMrnaViolinPlotChartProps) {
         super(props);
@@ -422,10 +425,14 @@ export default class MrnaViolinPlotChart extends React.Component<
         const marginBottom = 9;
         const geneCount = Math.max(1, this.selectedSymbols.length);
 
-        // In gene-specific mode the scrollbar sits inside the container, so
-        // the SVG must be narrower than the panel to avoid being clipped.
+        // Use the actual runtime scrollbar width (0 for overlay scrollbars).
         const svgWidth = this.isGeneSpecificMode
-            ? this.props.width - SCROLLBAR_WIDTH
+            ? Math.max(
+                  this.props.width -
+                      this.measuredScrollbarWidth -
+                      GENE_SPECIFIC_SCROLLBAR_SAFETY_GUTTER,
+                  0
+              )
             : this.props.width;
         const plotW = svgWidth - marginLeft - marginRight;
 
@@ -632,11 +639,6 @@ export default class MrnaViolinPlotChart extends React.Component<
     private onHoverLeave() {
         this.hoverX = null;
         this.hoverRowIndex = null;
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('mousemove', this.onDragMove);
-        window.removeEventListener('mouseup', this.onDragEnd);
     }
 
     @action.bound
@@ -1245,6 +1247,7 @@ export default class MrnaViolinPlotChart extends React.Component<
             // user can reach all genes without distorting the violin shapes.
             bodyContent = this.isGeneSpecificMode ? (
                 <div
+                    ref={this.scrollContainerRef}
                     style={{
                         flex: 1,
                         overflowY: 'auto',
@@ -1332,5 +1335,34 @@ export default class MrnaViolinPlotChart extends React.Component<
                 )}
             </div>
         );
+    }
+
+    @action.bound
+    private updateMeasuredScrollbarWidth() {
+        if (!this.isGeneSpecificMode) {
+            this.measuredScrollbarWidth = 0;
+            return;
+        }
+        const el = this.scrollContainerRef.current;
+        if (!el) return;
+        this.measuredScrollbarWidth = Math.max(
+            el.offsetWidth - el.clientWidth,
+            0
+        );
+    }
+
+    componentDidMount() {
+        window.addEventListener('resize', this.updateMeasuredScrollbarWidth);
+        this.updateMeasuredScrollbarWidth();
+    }
+
+    componentDidUpdate() {
+        this.updateMeasuredScrollbarWidth();
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('mousemove', this.onDragMove);
+        window.removeEventListener('mouseup', this.onDragEnd);
+        window.removeEventListener('resize', this.updateMeasuredScrollbarWidth);
     }
 }

--- a/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
+++ b/src/pages/studyView/charts/mrnaViolinPlot/MrnaViolinPlotChart.tsx
@@ -25,6 +25,10 @@ const DEFAULT_GENE_COUNT = 10;
 const MAX_GENES = 10;
 /** Cap per-gene track height when fewer than MAX_GENES genes fill the plot. */
 const MAX_ROW_HEIGHT = 50;
+/** Fixed per-gene row height in gene-specific mode; enables scrolling over resize. */
+const GENE_SPECIFIC_FIXED_ROW_HEIGHT = 27;
+/** Width reserved for the vertical scrollbar in gene-specific mode. */
+const SCROLLBAR_WIDTH = 17;
 const MAX_SAMPLES = 1000;
 const KDE_POINTS = 80;
 const TOOLBAR_HEIGHT = 34;
@@ -416,19 +420,39 @@ export default class MrnaViolinPlotChart extends React.Component<
         const marginRight = 16;
         const marginTop = 38;
         const marginBottom = 9;
-        const svgHeight =
-            this.props.height - (this.showToolbar ? TOOLBAR_HEIGHT : 0);
-        const plotW = this.props.width - marginLeft - marginRight;
-        const plotH = svgHeight - marginTop - marginBottom;
-        // With a full slate of genes the rows divide the plot evenly. With
-        // fewer, scale each row up to fill the space instead of leaving it
-        // empty, but cap the height so a couple of genes don't produce absurdly
-        // tall tracks. More than MAX_GENES shrinks the rows to still fit.
         const geneCount = Math.max(1, this.selectedSymbols.length);
-        const rowH =
-            geneCount >= MAX_GENES
-                ? plotH / geneCount
-                : Math.min(MAX_ROW_HEIGHT, plotH / geneCount);
+
+        // In gene-specific mode the scrollbar sits inside the container, so
+        // the SVG must be narrower than the panel to avoid being clipped.
+        const svgWidth = this.isGeneSpecificMode
+            ? this.props.width - SCROLLBAR_WIDTH
+            : this.props.width;
+        const plotW = svgWidth - marginLeft - marginRight;
+
+        let rowH: number;
+        let svgHeight: number;
+
+        if (this.isGeneSpecificMode) {
+            // Fixed row height so the violin shape stays consistent regardless
+            // of how many genes are shown or how the panel is resized. The SVG
+            // grows with the gene count and the container scrolls.
+            rowH = GENE_SPECIFIC_FIXED_ROW_HEIGHT;
+            svgHeight = marginTop + geneCount * rowH + marginBottom;
+        } else {
+            svgHeight =
+                this.props.height - (this.showToolbar ? TOOLBAR_HEIGHT : 0);
+            const plotH = svgHeight - marginTop - marginBottom;
+            // With a full slate of genes the rows divide the plot evenly. With
+            // fewer, scale each row up to fill the space instead of leaving it
+            // empty, but cap the height so a couple of genes don't produce
+            // absurdly tall tracks. More than MAX_GENES shrinks the rows to fit.
+            rowH =
+                geneCount >= MAX_GENES
+                    ? plotH / geneCount
+                    : Math.min(MAX_ROW_HEIGHT, plotH / geneCount);
+        }
+
+        const plotH = svgHeight - marginTop - marginBottom;
         return {
             marginLeft,
             marginRight,
@@ -438,6 +462,7 @@ export default class MrnaViolinPlotChart extends React.Component<
             plotH,
             rowH,
             svgHeight,
+            svgWidth,
         };
     }
 
@@ -1022,16 +1047,20 @@ export default class MrnaViolinPlotChart extends React.Component<
                         </text>
                     </g>
                 ))}
-                <text
-                    x={plotW / 2}
-                    y={-20}
-                    textAnchor="middle"
-                    fontSize={10}
-                    fill="black"
-                >
-                    {isTruncated && <title>{rawLabel}</title>}
-                    {axisLabel}
-                </text>
+                {/* In gene-specific mode the profile name is already shown as
+                    the chart title, so skip the redundant axis label. */}
+                {!this.isGeneSpecificMode && (
+                    <text
+                        x={plotW / 2}
+                        y={-20}
+                        textAnchor="middle"
+                        fontSize={10}
+                        fill="black"
+                    >
+                        {isTruncated && <title>{rawLabel}</title>}
+                        {axisLabel}
+                    </text>
+                )}
             </g>
         );
     }
@@ -1128,7 +1157,13 @@ export default class MrnaViolinPlotChart extends React.Component<
 
     render() {
         const { width, height } = this.props;
-        const { marginLeft, marginTop, svgHeight, plotH, rowH } = this.layout;
+        const {
+            marginLeft,
+            marginTop,
+            svgHeight,
+            svgWidth,
+            rowH,
+        } = this.layout;
 
         const isPending =
             this.mrnaData.isPending || this.resolvedGenes.isPending;
@@ -1169,10 +1204,10 @@ export default class MrnaViolinPlotChart extends React.Component<
                 </div>
             );
         } else {
-            bodyContent = (
+            const svgEl = (
                 <svg
                     ref={this.svgRef}
-                    width={width}
+                    width={svgWidth}
                     height={svgHeight}
                     style={{ display: 'block' }}
                     onMouseLeave={this.onHoverLeave}
@@ -1199,6 +1234,22 @@ export default class MrnaViolinPlotChart extends React.Component<
                         {this.renderHoverLine()}
                     </g>
                 </svg>
+            );
+            // Gene-specific mode: rows have a fixed height so the SVG may be
+            // taller than the panel. Wrap it in a scrollable container so the
+            // user can reach all genes without distorting the violin shapes.
+            bodyContent = this.isGeneSpecificMode ? (
+                <div
+                    style={{
+                        flex: 1,
+                        overflowY: 'auto',
+                        overflowX: 'hidden',
+                    }}
+                >
+                    {svgEl}
+                </div>
+            ) : (
+                svgEl
             );
         }
 


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/12253

Charts menu UI improvements:

(Before)
<img width="729" height="329" alt="Screenshot 2026-07-22 at 4 10 34 PM" src="https://github.com/user-attachments/assets/5a2f135a-ba95-4034-a83e-f4b0e4cce6b7" />

(After)
<img width="720" height="361" alt="Screenshot 2026-07-22 at 4 11 07 PM" src="https://github.com/user-attachments/assets/b29480cb-9f27-46fd-aa07-aee0d670cc7e" />


Violin Plot improvements:

(Before)
<img width="405" height="359" alt="Screenshot 2026-07-22 at 4 11 54 PM" src="https://github.com/user-attachments/assets/a0162fea-69d1-4ea3-a2cc-93b0c3c3ecdc" />

(After)
<img width="408" height="355" alt="Screenshot 2026-07-22 at 4 12 38 PM" src="https://github.com/user-attachments/assets/70db0d58-e199-4899-b54b-30be3cdb67ea" />

---

## Overview

This PR improves the gene-specific violin plot feature in the Study View, focusing on usability enhancements to the chart selection UI, adding a reset-filters button, a scrollbar, and other UX polish.

---

## Changes by Area

### `GeneLevelSelection.tsx` — Chart selection UI overhaul

- **Radio buttons for chart type selection:** Instead of updating the "Add Chart" button text dynamically, the component now shows radio buttons so the user can explicitly choose between chart types (e.g., Violin Plot vs. individual Bar Charts) before submitting.
- **Chart preview logic (`chartPreview` computed):** Derives the predicted chart count and chart kind (Violin Plot, Bar Chart, Pie Chart, Mutation Type Chart) based on the currently selected gene list, profile, and sub-option, giving the user clear feedback before adding charts.
- **Chart selection options (`chartSelectionOptions` computed):** When a Violin Plot would be generated (multiple genes + numeric profile), an alternative "individual Bar Charts" option is offered alongside the default, letting users opt out of violin aggregation.
- **`disableViolinAggregation` flag:** Passed through to `onSubmit` when the user selects the individual bar chart option, so downstream chart creation knows to skip violin aggregation.
- **ADC targets gene group:** The `STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID` gene group (ADC targets) is prepended as the first option in the gene set dropdown, making it the most prominent preset.
- **Removed `submitButtonText` prop:** The submit button text is now derived internally from the chart preview, removing an external prop.
- **Cleanup:** Removed unused `List` import from lodash; added `DataType` and `ButtonGroup`/`Radio` imports.

### `GeneLevelSelection.spec.tsx` — New/expanded tests

- Added comprehensive tests covering the new radio button UI, chart preview computation, ADC targets gene group ordering, and `disableViolinAggregation` behavior.

### `MrnaViolinPlotChart.tsx` — Scrollbar & reset filters

- **Scrollbar:** Added a scrollbar to the gene-specific violin chart when the content overflows, replacing the previously hard-coded `SCROLLBAR_WIDTH` constant with a runtime measurement for accuracy across platforms and zoom levels.
- **Reset filters button:** Added a "Reset Filters" button to the violin chart header, allowing users to clear any active filters on the chart without navigating away.

### `ChartContainer.tsx` — Violin chart integration

- Updated to support the new `disableViolinAggregation` option when rendering chart containers for gene-specific charts.
- Minor layout/rendering adjustments to accommodate the scrollbar and reset filters button.

### `StudyViewPageStore.ts` — Store-level support

- Extended chart configuration to carry the `disableViolinAggregation` flag through the store so it is persisted and respected when charts are re-rendered.
- Added logic to show the default gene-specific violin plot for the internal test study.

### `AddChartButton.tsx` — Props update

- Removed the `submitButtonText` prop passed to `GeneLevelSelection`, since the button text is now derived internally.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786545369&installation_id=126502837&pr_number=5649&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5649&signature=2c20a318c3bd50188beb773349544a860f61eae87dd428f16a1c73cdb63d98d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->