### PR TITLE
Declare oncokb-frontend-commons' dependency on cbioportal-ts-api-client

### DIFF
--- a/packages/oncokb-frontend-commons/package.json
+++ b/packages/oncokb-frontend-commons/package.json
@@ -34,6 +34,7 @@
     "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
+    "cbioportal-ts-api-client": "workspace:*",
     "cbioportal-utils": "workspace:*",
     "classnames": "^2.2.5",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -940,6 +940,9 @@ importers:
 
   packages/oncokb-frontend-commons:
     dependencies:
+      cbioportal-ts-api-client:
+        specifier: workspace:*
+        version: link:../cbioportal-ts-api-client
       cbioportal-utils:
         specifier: workspace:*
         version: link:../cbioportal-utils
@@ -963,7 +966,7 @@ importers:
         version: 0.31.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-collapse:
         specifier: ^4.0.3
-        version: 4.0.3(react-motion@0.4.8(react@18.3.1))(react@18.3.1)
+        version: 4.0.3(react-motion@0.5.2(react@18.3.1))(react@18.3.1)
       react-if:
         specifier: ^2.1.0
         version: 2.2.2(prop-types@15.7.2)(react@18.3.1)


### PR DESCRIPTION
## Summary
  - Adds `cbioportal-ts-api-client` as an explicit dependency of `oncokb-frontend-commons` in `package.json`.
  - `src/util/OncoKbUtils.ts` imports `StructuralVariant` from `cbioportal-ts-api-client`, but the package was never declared as a dependency — a full monorepo `pnpm install` hides this via workspace hoisting, but a `--filter`-scoped install (which only installs/links
  declared dependencies) fails to build this package with `Cannot find module 'cbioportal-ts-api-client'`.

  ## Why
  Undeclared workspace dependencies like this only surface when something does a scoped/filtered install instead of a full monorepo install — which made this hard to notice until a CI job doing exactly that broke on it. Declaring it explicitly keeps the dependency graph
  accurate and makes scoped installs (faster in CI) reliable for this package and anything that depends on it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787435419&installation_model_id=19627&pr_number=5658&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5658&signature=85a391d6aec77e1f110f6a8b98d8e3021693e852df05a6a4f675cd68e015e16b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->