### PR TITLE
Fix color picker in OncoPrint clinical tracks 

### DIFF
--- a/src/shared/components/oncoprint/ClinicalTrackColorPicker.tsx
+++ b/src/shared/components/oncoprint/ClinicalTrackColorPicker.tsx
@@ -76,12 +76,6 @@ export default class ClinicalTrackColorPicker extends React.Component<
         return (
             <Popover>
                 <div
-                    onMouseDown={e => {
-                        e.nativeEvent.stopImmediatePropagation();
-                    }}
-                    onClick={e => {
-                        e.nativeEvent.stopImmediatePropagation();
-                    }}
                 >
                     <CirclePicker
                         colors={this.colorList}
@@ -110,7 +104,7 @@ export default class ClinicalTrackColorPicker extends React.Component<
                         'Optional: Select color for clinical track value to be used in oncoprint. If no color is selected, the default color will be applied.'
                     }
                 >
-                    <span>
+                    <span onClick={e => e.nativeEvent.stopImmediatePropagation()}>
                         <ColorPickerIcon
                             color={
                                 rgbaToHex(this.props.color) || COLOR_UNDEFINED


### PR DESCRIPTION
Fixes cBioPortal/cbioportal#12281 (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Restored `rootClose={true}` so the E2E tests pass correctly.
- Fixed the React 17 instant-close bug by moving `stopImmediatePropagation()` from the popover wrapper to the trigger `span` instead.
- This successfully intercepts the native click event before it reaches the document, fixing the bug without breaking `react-color`.


## Checks
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test. *(Note: No specific test added as this is a strict UI library interaction bug related to React 17 event delegation that is difficult to reliably test in standard unit tests without full DOM integration.)*
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

*(No visual changes, simply restored broken color picker functionality).*

## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788015621&installation_model_id=19627&pr_number=5663&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5663&signature=5ccb35af47f4229e1f388839073a86ca2e4598f1bc1f1b5b696a03dfb336647b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->