### PR TITLE
Fix StudyView not refreshing when only the studyId changes

### DIFF
--- a/src/pages/studyView/StudyViewPage.tsx
+++ b/src/pages/studyView/StudyViewPage.tsx
@@ -178,42 +178,10 @@ export default class StudyViewPage extends React.Component<
             return;
         }
 
-        const query = props.routing.query;
-        const hash = props.routing.location.hash;
-        // clear hash if any
-        //props.routing.location.hash = '';
-        const newStudyViewFilter: StudyViewURLQuery = _.pick(query, [
-            'id',
-            'studyId',
-            'cancer_study_id',
-            'filterAttributeId',
-            'filterValues',
-        ]);
-
-        newStudyViewFilter.filterJson = query['filters'];
-
-        let hashString: string = hash || getBrowserWindow().studyPageFilter;
-        delete (window as any).studyPageFilter;
-
-        if (hashString) {
-            const params = parse(hashString) as Partial<StudyViewURLQuery>;
-
-            if (params.filterJson) {
-                newStudyViewFilter.filterJson = params.filterJson;
-            }
-            if (params.sharedGroups) {
-                newStudyViewFilter.sharedGroups = params.sharedGroups;
-            }
-            if (params.sharedCustomData) {
-                newStudyViewFilter.sharedCustomData = params.sharedCustomData;
-            }
-        }
-
-        // Overrite filterJson from URL with what is defined in postData
-        const postDataFilterJson = this.getFilterJsonFromPostData();
-        if (postDataFilterJson) {
-            newStudyViewFilter.filterJson = postDataFilterJson;
-        }
+        const newStudyViewFilter = this.computeStudyViewFilterFromRouting(
+            props.routing.query,
+            props.routing.location.hash
+        );
 
         let updateStoreFromURLPromise = remoteData(() => Promise.resolve([]));
         if (!_.isEqual(newStudyViewFilter, this.store.studyViewQueryFilter)) {
@@ -239,6 +207,82 @@ export default class StudyViewPage extends React.Component<
                 });
             }
         );
+    }
+
+    // Builds the store's filter object from the current URL. Shared by the
+    // constructor (initial mount) and componentDidUpdate (switching to a
+    // different study while already on this page) so both stay in sync —
+    // previously only the constructor read this, so navigating from one
+    // study straight to another via client-side routing (no full page
+    // reload/remount) left the page showing the old study's data.
+    private computeStudyViewFilterFromRouting(
+        query: any,
+        hash: string
+    ): StudyViewURLQuery {
+        const newStudyViewFilter: StudyViewURLQuery = _.pick(query, [
+            'id',
+            'studyId',
+            'cancer_study_id',
+            'filterAttributeId',
+            'filterValues',
+        ]);
+
+        newStudyViewFilter.filterJson = query['filters'];
+
+        // studyPageFilter is a one-time bootstrap value injected for the
+        // initial server-rendered page load, hence the delete — irrelevant
+        // (and already gone) on subsequent client-side navigations.
+        let hashString: string = hash || getBrowserWindow().studyPageFilter;
+        delete (window as any).studyPageFilter;
+
+        if (hashString) {
+            const params = parse(hashString) as Partial<StudyViewURLQuery>;
+
+            if (params.filterJson) {
+                newStudyViewFilter.filterJson = params.filterJson;
+            }
+            if (params.sharedGroups) {
+                newStudyViewFilter.sharedGroups = params.sharedGroups;
+            }
+            if (params.sharedCustomData) {
+                newStudyViewFilter.sharedCustomData = params.sharedCustomData;
+            }
+        }
+
+        // Overrite filterJson from URL with what is defined in postData
+        const postDataFilterJson = this.getFilterJsonFromPostData();
+        if (postDataFilterJson) {
+            newStudyViewFilter.filterJson = postDataFilterJson;
+        }
+
+        return newStudyViewFilter;
+    }
+
+    componentDidUpdate() {
+        if (
+            !getBrowserWindow().globalStores.routing.location.pathname.includes(
+                '/study'
+            )
+        ) {
+            return;
+        }
+
+        const newStudyViewFilter = this.computeStudyViewFilterFromRouting(
+            this.props.routing.query,
+            this.props.routing.location.hash
+        );
+
+        if (!_.isEqual(newStudyViewFilter, this.store.studyViewQueryFilter)) {
+            this.store.studyViewQueryFilter = newStudyViewFilter;
+            this.store
+                .updateStoreFromURL(newStudyViewFilter)
+                .catch((error: any) =>
+                    console.error(
+                        'Failed to update StudyViewPageStore from URL change:',
+                        error
+                    )
+                );
+        }
     }
 
     componentDidMount() {


### PR DESCRIPTION
Problem:
- Switching to a different study while already on a StudyView page (via client-side navigation, no full page reload) left the page showing the previous study's data.

Cause:
- The route (/study/:tab?) only matches on path, not query string, so React Router reuses the same mounted StudyViewPage instance when only the id/studyId/cancer_study_id query param changes.
- The URL was only ever read once, in the constructor, so the new studyId was never picked up.

Fix:
- Extract the constructor's query-parsing logic into computeStudyViewFilterFromRouting().
- Call it again from a new componentDidUpdate(), reusing the existing updateStoreFromURL() entry point — already designed to be callable repeatedly, since it just updates the observable studyIds that the rest of the store reactively derives from.

Note:
- Deliberately skip initializeReaction() in the update path — it registers new reaction disposers on every call and is only meant to run once at mount; calling it again would leak duplicate reactions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788032991&installation_model_id=19627&pr_number=5664&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5664&signature=f1c19c19acd60164aa42a70188564fa94c5e0c80eee7856933a458df71f6ad17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->