### PR TITLE
Fix Download tab crash for studies with no mutation/CNA profiles

### DIFF
--- a/src/pages/resultsView/download/CaseAlterationTable.tsx
+++ b/src/pages/resultsView/download/CaseAlterationTable.tsx
@@ -444,63 +444,72 @@ export default class CaseAlterationTable extends React.Component<
 
         _.forEach(uniqGenes, gene => {
             //add column for each gene alteration combination
-            this.props.geneAlterationTypesMap[gene].forEach(alteration => {
-                const oql_line = parsedOQLAlterationToSourceOQL(alteration);
-                const alterationType = alteration.alteration_type.toUpperCase();
-                const alterationName = `${gene}: ${oql_line}`;
-                if (
-                    _.isEmpty(
-                        columns.find(column => column.name === alterationName)
-                    )
-                ) {
-                    columns.push({
-                        name: `${gene}: ${oql_line}`,
-                        headerDownload: (name: string) =>
-                            `${gene}: ${oql_line}`,
-                        render: (data: ICaseAlteration) => {
-                            const pseudoOqlSummary = generatePseudoOqlSummary(
-                                data.oqlDataByGene,
-                                gene,
-                                alterationType
-                            );
+            // genes queried in studies with no mutation/CNA/other alteration
+            // profiles have no entry here, since there is no alteration type
+            // to build a pseudo-OQL column for
+            (this.props.geneAlterationTypesMap[gene] || []).forEach(
+                alteration => {
+                    const oql_line = parsedOQLAlterationToSourceOQL(alteration);
+                    const alterationType = alteration.alteration_type.toUpperCase();
+                    const alterationName = `${gene}: ${oql_line}`;
+                    if (
+                        _.isEmpty(
+                            columns.find(
+                                column => column.name === alterationName
+                            )
+                        )
+                    ) {
+                        columns.push({
+                            name: `${gene}: ${oql_line}`,
+                            headerDownload: (name: string) =>
+                                `${gene}: ${oql_line}`,
+                            render: (data: ICaseAlteration) => {
+                                const pseudoOqlSummary = generatePseudoOqlSummary(
+                                    data.oqlDataByGene,
+                                    gene,
+                                    alterationType
+                                );
 
-                            return (
-                                <span
-                                    className={pseudoOqlSummary!.summaryClass}
-                                >
-                                    {pseudoOqlSummary!.summaryContent}
-                                </span>
-                            );
-                        },
-                        download: (data: ICaseAlteration) =>
-                            generatePseudoOqlSummary(
-                                data.oqlDataByGene,
-                                gene,
-                                alterationType,
-                                true
-                            )!.summaryContent,
-                        sortBy: (data: ICaseAlteration) =>
-                            generatePseudoOqlSummary(
-                                data.oqlDataByGene,
-                                gene,
-                                alterationType
-                            )!.summaryContent,
-                        filter: (
-                            data: ICaseAlteration,
-                            filterString: string
-                        ) => {
-                            return new RegExp(filterString, 'i').test(
+                                return (
+                                    <span
+                                        className={
+                                            pseudoOqlSummary!.summaryClass
+                                        }
+                                    >
+                                        {pseudoOqlSummary!.summaryContent}
+                                    </span>
+                                );
+                            },
+                            download: (data: ICaseAlteration) =>
+                                generatePseudoOqlSummary(
+                                    data.oqlDataByGene,
+                                    gene,
+                                    alterationType,
+                                    true
+                                )!.summaryContent,
+                            sortBy: (data: ICaseAlteration) =>
                                 generatePseudoOqlSummary(
                                     data.oqlDataByGene,
                                     gene,
                                     alterationType
-                                )!.summaryContent
-                            );
-                        },
-                        visible: false,
-                    });
+                                )!.summaryContent,
+                            filter: (
+                                data: ICaseAlteration,
+                                filterString: string
+                            ) => {
+                                return new RegExp(filterString, 'i').test(
+                                    generatePseudoOqlSummary(
+                                        data.oqlDataByGene,
+                                        gene,
+                                        alterationType
+                                    )!.summaryContent
+                                );
+                            },
+                            visible: false,
+                        });
+                    }
                 }
-            });
+            );
         });
 
         return (

--- a/src/pages/resultsView/download/CaseAlterationTable.tsx
+++ b/src/pages/resultsView/download/CaseAlterationTable.tsx
@@ -265,9 +265,12 @@ export function computeAlterationTypes(
 export function getPseudoOqlSummaryByAlterationTypes(
     oqlData: { [oqlLine: string]: IOqlData },
     oqlLine: string,
-    alterationTypes: string[],
+    alterationTypes: string[] | undefined,
     forDownload?: boolean
 ): PseudoOqlSummary {
+    // tracks/genes with no alteration-type profile selected (e.g. studies
+    // with only an mRNA profile) have no entry in the alteration types map
+    alterationTypes = alterationTypes || [];
     const pseudoOqlSummaries = _.map(alterationTypes, type =>
         generatePseudoOqlSummary(oqlData, oqlLine, type, forDownload)
     );


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/12284
### Problem

The Results View Download tab crashes for studies with no mutation/CNA (or other alteration-type) profile — e.g. mRNA-only studies like `ovary_geomx_gray_foundation_2024`. Reported [here](https://groups.google.com/g/cbioportal/c/yF-z4q5U1IE/m/cPaMlr1DBwAJ).

### Cause

In such studies, genes/tracks queried without explicit OQL syntax (e.g. bare gene names) have no default alteration type, so `CaseAlterationTable.tsx`'s `geneAlterationTypesMap` and `trackAlterationTypesMap` have no entry for them. Two spots in `CaseAlterationTable.tsx` assumed an entry always exists and crashed on the undefined value (`.forEach` and `.length`).

### Fix

Default both lookups to an empty array when missing, so genes/tracks with no alteration type simply contribute no extra columns instead of crashing.