### PR TITLE
Make all SV columns available in Patient View SV table (hidden by default)

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -2570,6 +2570,9 @@ export class PatientViewPageStore {
 
                 return internalClient.fetchStructuralVariantsUsingPOST({
                     structuralVariantFilter,
+                    $queryParameters: {
+                        projection: 'DETAILED',
+                    },
                 });
             }
             return [];

--- a/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
+++ b/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
@@ -138,8 +138,6 @@ const ADDITIONAL_STRUCTURAL_VARIANT_FIELD_COLUMNS: IStructuralVariantFieldColumn
         order: 113,
     },
     { field: 'tumorVariantCount', name: 'Tumor Variant Count', order: 114 },
-    { field: 'uniquePatientKey', name: 'Unique Patient Key', order: 115 },
-    { field: 'uniqueSampleKey', name: 'Unique Sample Key', order: 116 },
     {
         field: 'namespaceColumns',
         name: 'Namespace Columns (Raw)',

--- a/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
+++ b/src/pages/patientView/structuralVariant/StructuralVariantTableWrapper.tsx
@@ -48,11 +48,104 @@ export interface IStructuralVariantTableWrapperProps {
 
 type SVTableColumn = Column<StructuralVariant[]> & { order: number };
 
+type StructuralVariantField = keyof StructuralVariant;
+
+interface IStructuralVariantFieldColumnConfig {
+    field: StructuralVariantField;
+    name: string;
+    order: number;
+    visible?: boolean;
+}
+
 class StructuralVariantTableComponent extends LazyMobXTable<
     StructuralVariant[]
 > {}
 
 const ANNOTATION_ELEMENT_ID = 'sv-annotation';
+
+const ADDITIONAL_STRUCTURAL_VARIANT_FIELD_COLUMNS: IStructuralVariantFieldColumnConfig[] = [
+    { field: 'comments', name: 'Comments', order: 81 },
+    { field: 'dnaSupport', name: 'DNA Support', order: 82 },
+    { field: 'driverFilter', name: 'Driver Filter', order: 83 },
+    { field: 'driverFilterAnn', name: 'Driver Filter Annotation', order: 84 },
+    { field: 'driverTiersFilter', name: 'Driver Tiers Filter', order: 85 },
+    {
+        field: 'driverTiersFilterAnn',
+        name: 'Driver Tiers Filter Annotation',
+        order: 86,
+    },
+    { field: 'length', name: 'Length', order: 87 },
+    {
+        field: 'molecularProfileId',
+        name: 'Molecular Profile Id',
+        order: 88,
+    },
+    { field: 'ncbiBuild', name: 'NCBI Build', order: 89 },
+    {
+        field: 'normalPairedEndReadCount',
+        name: 'Normal Paired End Read Count',
+        order: 90,
+    },
+    { field: 'normalReadCount', name: 'Normal Read Count', order: 91 },
+    {
+        field: 'normalSplitReadCount',
+        name: 'Normal Split Read Count',
+        order: 92,
+    },
+    {
+        field: 'normalVariantCount',
+        name: 'Normal Variant Count',
+        order: 93,
+    },
+    { field: 'patientId', name: 'Patient Id', order: 94 },
+    { field: 'rnaSupport', name: 'RNA Support', order: 95 },
+    { field: 'sampleId', name: 'Sample Id', order: 96 },
+    { field: 'site1Contig', name: 'Site1 Contig', order: 97 },
+    { field: 'site1Description', name: 'Site1 Description', order: 98 },
+    {
+        field: 'site1EnsemblTranscriptId',
+        name: 'Site1 Ensembl Transcript Id',
+        order: 99,
+    },
+    { field: 'site1EntrezGeneId', name: 'Site1 Entrez Gene Id', order: 100 },
+    { field: 'site1Region', name: 'Site1 Region', order: 101 },
+    { field: 'site1RegionNumber', name: 'Site1 Region Number', order: 102 },
+    { field: 'site2Contig', name: 'Site2 Contig', order: 103 },
+    { field: 'site2Description', name: 'Site2 Description', order: 104 },
+    {
+        field: 'site2EffectOnFrame',
+        name: 'Site2 Effect On Frame',
+        order: 105,
+    },
+    {
+        field: 'site2EnsemblTranscriptId',
+        name: 'Site2 Ensembl Transcript Id',
+        order: 106,
+    },
+    { field: 'site2EntrezGeneId', name: 'Site2 Entrez Gene Id', order: 107 },
+    { field: 'site2Region', name: 'Site2 Region', order: 108 },
+    { field: 'site2RegionNumber', name: 'Site2 Region Number', order: 109 },
+    { field: 'studyId', name: 'Study Id', order: 110 },
+    {
+        field: 'tumorPairedEndReadCount',
+        name: 'Tumor Paired End Read Count',
+        order: 111,
+    },
+    { field: 'tumorReadCount', name: 'Tumor Read Count', order: 112 },
+    {
+        field: 'tumorSplitReadCount',
+        name: 'Tumor Split Read Count',
+        order: 113,
+    },
+    { field: 'tumorVariantCount', name: 'Tumor Variant Count', order: 114 },
+    { field: 'uniquePatientKey', name: 'Unique Patient Key', order: 115 },
+    { field: 'uniqueSampleKey', name: 'Unique Sample Key', order: 116 },
+    {
+        field: 'namespaceColumns',
+        name: 'Namespace Columns (Raw)',
+        order: 117,
+    },
+];
 
 @observer
 export default class StructuralVariantTableWrapper extends React.Component<
@@ -531,6 +624,8 @@ export default class StructuralVariantTableWrapper extends React.Component<
                 order: 80,
             });
 
+            columns.push(...createAdditionalStructVarFieldColumns());
+
             columns.push(
                 ...createStructVarNamespaceColumns(this.props.namespaceColumns)
             );
@@ -635,4 +730,46 @@ function createStructVarNamespaceColumns(
     ) as SVTableColumn[];
     namespaceColumns.forEach(c => (c.visible = false));
     return namespaceColumns;
+}
+
+function createAdditionalStructVarFieldColumns(): SVTableColumn[] {
+    return ADDITIONAL_STRUCTURAL_VARIANT_FIELD_COLUMNS.map(config => ({
+        name: config.name,
+        render: (d: StructuralVariant[]) => (
+            <span>
+                {formatStructuralVariantFieldValue(d[0]?.[config.field])}
+            </span>
+        ),
+        download: (d: StructuralVariant[]) =>
+            formatStructuralVariantFieldValue(d[0]?.[config.field]),
+        sortBy: (d: StructuralVariant[]) =>
+            getStructuralVariantSortValue(d[0]?.[config.field]),
+        filter: (
+            d: StructuralVariant[],
+            filterString: string,
+            filterStringUpper: string
+        ) =>
+            formatStructuralVariantFieldValue(d[0]?.[config.field])
+                .toUpperCase()
+                .includes(filterStringUpper),
+        visible: config.visible ?? false,
+        order: config.order,
+    }));
+}
+
+function formatStructuralVariantFieldValue(value: unknown): string {
+    if (value === null || value === undefined) {
+        return '';
+    }
+    if (typeof value === 'object') {
+        return JSON.stringify(value);
+    }
+    return `${value}`;
+}
+
+function getStructuralVariantSortValue(value: unknown): number | string {
+    if (typeof value === 'number') {
+        return value;
+    }
+    return formatStructuralVariantFieldValue(value).toUpperCase();
 }


### PR DESCRIPTION
List of columns before:

```
Gene 1
Gene 2
Gene panel
Status
Annotation
Custom Driver
Custom Driver Tiers
Variant Class
Site1 Chromosome
Site2 Chromosome
Site1 Position
Site2 Position
Event Info
Connection Type
Breakpoint Type
Additional Annotation
```

List of columns after:

```
Gene 1
Gene 2
Gene panel
Status
Annotation
Custom Driver
Custom Driver Tiers
Variant Class
Site1 Chromosome
Site2 Chromosome
Site1 Position
Site2 Position
Event Info
Connection Type
Breakpoint Type
Additional Annotation
Comments
DNA Support
Driver Filter
Driver Filter Annotation
Driver Tiers Filter
Driver Tiers Filter Annotation
Length
Molecular Profile Id
NCBI Build
Normal Paired End Read Count
Normal Read Count
Normal Split Read Count
Normal Variant Count
Patient Id
RNA Support
Sample Id
Site1 Contig
Site1 Description
Site1 Ensembl Transcript Id
Site1 Entrez Gene Id
Site1 Region
Site1 Region Number
Site2 Contig
Site2 Description
Site2 Effect On Frame
Site2 Ensembl Transcript Id
Site2 Entrez Gene Id
Site2 Region
Site2 Region Number
Study Id
Tumor Paired End Read Count
Tumor Read Count
Tumor Split Read Count
Tumor Variant Count
Unique Patient Key
Unique Sample Key
Namespace Columns (Raw)
```

An example patient with SV data: https://deploy-preview-5670.preview.cbioportal.org/patient?studyId=chol_tcga_pan_can_atlas_2018&caseId=TCGA-W5-AA2Q

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788720179&installation_model_id=19627&pr_number=5670&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5670&signature=45ed3f66b46513dc098c9d0da051471415e5ef598e32e50fdaa7a949a093c367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->