### PR TITLE
Update e2e test related to cancer hotspots data v3

### DIFF
--- a/end-to-end-test-playwright/tests/mutations-tab.spec.ts
+++ b/end-to-end-test-playwright/tests/mutations-tab.spec.ts
@@ -127,7 +127,7 @@ test.describe('mutations tab — alteration badges', () => {
         await byTestHandle(page, 'annotateOncoKb').click();
         await setSettingsMenuOpen(page, false);
         await expect(page.locator('.lollipop-svgnode').first()).toBeVisible();
-        await expect(driverBadge).toHaveText('64');
+        await expect(driverBadge).toHaveText('65');
 
         // Toggle it back on → count restored.
         await setSettingsMenuOpen(page, true);


### PR DESCRIPTION
V3 cancer hotspots data changes the mutations count in https://bit.ly/4xuONea
Was 64 mutations after toggle off oncokb, but there is a new v3 cancer hotspots `A138V` mutation so the count is changed to 65.
<img width="1542" height="436" alt="image (10)" src="https://github.com/user-attachments/assets/9bf52e0c-c17b-431b-b2b7-e2f9a4f03103" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788965474&installation_model_id=19627&pr_number=5671&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5671&signature=dceb6f36b049a06c9616d4081ddb8f4187e06a8ba7f6143f5e4ce5f53d062bc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->