### PR TITLE
Show Chat Beta link by default on public portal

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -13,7 +13,6 @@ import { Dropdown } from 'react-bootstrap';
 import { DataAccessTokensDropdown } from '../../shared/components/dataAccessTokens/DataAccessTokensDropdown';
 import { getLoadConfig, getServerConfig } from 'config/config';
 import FontAwesome from 'react-fontawesome';
-import { FeatureFlagEnum } from 'shared/featureFlags';
 
 @observer
 export default class PortalHeader extends React.Component<
@@ -130,15 +129,10 @@ export default class PortalHeader extends React.Component<
                 internal: false,
                 hide: () => {
                     const appName = getServerConfig().app_name;
-                    // Always show on the MSK portal; gate every other
-                    // instance behind the CHAT feature flag.
-                    if (appName === 'mskcc-portal') {
-                        return false;
-                    }
+                    // Only the MSK and public portals have a chat deployment.
                     return (
-                        !this.props.appStore.featureFlagStore.has(
-                            FeatureFlagEnum.CHAT
-                        ) || appName !== 'public-portal'
+                        appName !== 'mskcc-portal' &&
+                        appName !== 'public-portal'
                     );
                 },
             },

--- a/src/shared/featureFlags.ts
+++ b/src/shared/featureFlags.ts
@@ -1,6 +1,5 @@
 export enum FeatureFlagEnum {
     LEFT_TRUNCATION_ADJUSTMENT = 'LEFT_TRUNCATION_ADJUSTMENT',
-    CHAT = 'CHAT',
     PATIENT_MRNA_TAB = 'patientMRNATab',
     GENE_SPECIFIC_VIOLIN_PLOT = 'geneSpecificViolinPlot',
     EMBEDDINGS = 'EMBEDDINGS',


### PR DESCRIPTION
The "Chat Beta!" nav item on the public portal was gated behind the `CHAT` feature flag, so it only appeared with `?featureFlags=CHAT` in the URL (or the flag set in localStorage).

This removes the flag check. The chat link is now shown on the portals that have a chat deployment — `mskcc-portal` and `public-portal` — and stays hidden on all other instances. The link points to https://chat.cbioportal.org on the public portal and https://chat.cbioportal.aws.mskcc.org on the MSK portal, unchanged.

The `CHAT` entry in `FeatureFlagEnum` had no remaining usages after this, so it is removed too.

## Preview

- https://deploy-preview-5673.preview.cbioportal.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xHbfaApxSTde7ykFDkdeD