### PR TITLE
fix(query): default-select sole molecular profile

### DIFF
--- a/end-to-end-test-playwright/tests/home.spec.ts
+++ b/end-to-end-test-playwright/tests/home.spec.ts
@@ -19,7 +19,7 @@ import {
  *    modify-study flows.
  *  - OQL-driven auto-selection of mrna/protein profiles.
  *  - fallback profile auto-selection when a study has no Mutations/CNA/SV
- *    profiles (cBioPortal/cbioportal#11569).
+ *    profiles.
  *  - results-page quick-OQL edit rejecting unsupported PROT queries.
  */
 

--- a/end-to-end-test-playwright/tests/home.spec.ts
+++ b/end-to-end-test-playwright/tests/home.spec.ts
@@ -568,15 +568,13 @@ test.describe(
     'default profile fallback when Mutations/CNA/SV are absent',
     () => {
         /**
-         * Reproduces the query-page repro steps from
-         * https://github.com/cBioPortal/cbioportal/issues/11569:
          * ovary_geomx_gray_foundation_2024 has no Mutations / Structural
          * Variant / Copy Number Alterations profiles (only CyCIF and p53
-         * marker generic-assay profiles plus mRNA-Seq Expression GeoMx),
-         * so previously nothing was checked by default in "Select Genomic
-         * Profiles". The fallback should now auto-check the first
-         * selectable profile — mRNA-Seq Expression GeoMx, since
-         * MRNA_EXPRESSION precedes GENERIC_ASSAY in alteration-type order.
+         * marker generic-assay profiles plus mRNA-Seq Expression GeoMx).
+         * In "Select Genomic Profiles", the first selectable profile
+         * should be auto-checked by default — mRNA-Seq Expression GeoMx,
+         * since MRNA_EXPRESSION precedes GENERIC_ASSAY in alteration-type
+         * order.
          */
         test('auto-checks the mRNA profile for a study with only generic-assay/expression profiles', async ({
             page,

--- a/end-to-end-test-playwright/tests/home.spec.ts
+++ b/end-to-end-test-playwright/tests/home.spec.ts
@@ -18,6 +18,8 @@ import {
  *  - default genetic-profile selection (mutations + CNA, MRNA off) across
  *    modify-study flows.
  *  - OQL-driven auto-selection of mrna/protein profiles.
+ *  - fallback profile auto-selection when a study has no Mutations/CNA/SV
+ *    profiles (cBioPortal/cbioportal#11569).
  *  - results-page quick-OQL edit rejecting unsupported PROT queries.
  */
 
@@ -558,6 +560,47 @@ test.describe.serial(
                     `${MOLECULAR_CHECKBOX}[data-test="MRNA_EXPRESSION"]`
                 )
             ).not.toBeChecked();
+        });
+    }
+);
+
+test.describe(
+    'default profile fallback when Mutations/CNA/SV are absent',
+    () => {
+        /**
+         * Reproduces the query-page repro steps from
+         * https://github.com/cBioPortal/cbioportal/issues/11569:
+         * ovary_geomx_gray_foundation_2024 has no Mutations / Structural
+         * Variant / Copy Number Alterations profiles (only CyCIF and p53
+         * marker generic-assay profiles plus mRNA-Seq Expression GeoMx),
+         * so previously nothing was checked by default in "Select Genomic
+         * Profiles". The fallback should now auto-check the first
+         * selectable profile — mRNA-Seq Expression GeoMx, since
+         * MRNA_EXPRESSION precedes GENERIC_ASSAY in alteration-type order.
+         */
+        test('auto-checks the mRNA profile for a study with only generic-assay/expression profiles', async ({
+            page,
+        }) => {
+            await page.goto('/');
+            await expect(
+                page
+                    .locator('.studyItem_ovary_geomx_gray_foundation_2024')
+                    .first()
+            ).toBeVisible({ timeout: 20000 });
+            await page
+                .locator('.studyItem_ovary_geomx_gray_foundation_2024')
+                .first()
+                .click();
+            await clickQueryByGeneButton(page);
+
+            await expect(
+                page.locator(MOLECULAR_CHECKBOX).first()
+            ).toBeAttached({ timeout: 10000 });
+            await expect(
+                page.locator(
+                    `${MOLECULAR_CHECKBOX}[data-test="MRNA_EXPRESSION"]`
+                )
+            ).toBeChecked({ timeout: 10000 });
         });
     }
 );

--- a/end-to-end-test-playwright/tests/studyview.spec.ts
+++ b/end-to-end-test-playwright/tests/studyview.spec.ts
@@ -23,7 +23,7 @@ import { getTextInOncoprintLegend } from './helpers/oncoprint';
  *  - TCGA pancancer atlas load, virtual study load, multi-study layout
  *  - gene panel tooltip/modal, submit-to-results-view OQL flows
  *  - fallback profile auto-selection for a plain gene query on a study
- *    with no Mutations/CNA/SV profiles (cBioPortal/cbioportal#11569)
+ *    with no Mutations/CNA/SV profiles
  *  - treatments tables (gbm_columbia_2019 + lgg_ucsf_2014)
  *  - msk_impact_2017 mutations-table and custom data chart validation
  */

--- a/end-to-end-test-playwright/tests/studyview.spec.ts
+++ b/end-to-end-test-playwright/tests/studyview.spec.ts
@@ -1138,14 +1138,12 @@ test.describe('studyview tests', () => {
         });
 
         /**
-         * Reproduces the study-page repro steps from
-         * https://github.com/cBioPortal/cbioportal/issues/11569: a study
-         * with no Mutations / Structural Variant / Copy Number
-         * Alterations profiles (only GeoMx CyCIF, mRNA, and p53 marker
-         * generic-assay/expression profiles) previously left the query
-         * with no molecular profile selected, so a plain gene query (no
-         * OQL data-type operator) rendered "N/P" (not profiled) on
-         * OncoPrint instead of the study's mRNA expression data.
+         * For a study with no Mutations / Structural Variant / Copy
+         * Number Alterations profiles (only GeoMx CyCIF, mRNA, and p53
+         * marker generic-assay/expression profiles), a plain gene query
+         * (no OQL data-type operator) should fall back to the study's
+         * sole selectable profile — mRNA expression — and render its
+         * data on OncoPrint.
          */
         test('auto-selects the sole non-Mut/CNA/SV profile for a plain gene query on an RNA-only study', async ({
             page,
@@ -1159,16 +1157,12 @@ test.describe('studyview tests', () => {
                 state: 'attached',
                 timeout: 10000,
             });
-            // Plain gene symbol, no OQL data-type operator (":EXP" etc.) —
-            // this is the exact query used to report #11569.
+            // Plain gene symbol, no OQL data-type operator (":EXP" etc.).
             await setInputText(page, 'textarea[data-test="geneSet"]', 'SOX9');
 
-            // Before the fix, no profile was auto-selected in this
-            // scenario, so the query could still be submitted but with an
-            // empty profile filter (OncoPrint then shows "N/P" for every
-            // sample). The submit button itself was never disabled here,
-            // so the meaningful assertions are on the resulting profileFilter
-            // and OncoPrint content below.
+            // The submit button should be enabled even with no explicit
+            // profile selected; the meaningful assertions are on the
+            // resulting profileFilter and OncoPrint content below.
             await expect(
                 page.locator('button[data-test="geneSetSubmit"]')
             ).toBeEnabled({ timeout: 10000 });
@@ -1200,8 +1194,7 @@ test.describe('studyview tests', () => {
 
             // Confirm OncoPrint actually rendered expression data (mRNA
             // High/Low legend entries) rather than leaving every sample
-            // unprofiled, which is what happened before the fix when no
-            // profile was auto-selected.
+            // unprofiled.
             const legendText = await getTextInOncoprintLegend(resultsPage);
             expect(/mRNA (High|Low)/.test(legendText)).toBe(true);
         });

--- a/end-to-end-test-playwright/tests/studyview.spec.ts
+++ b/end-to-end-test-playwright/tests/studyview.spec.ts
@@ -8,6 +8,7 @@ import {
     waitForNetworkQuiet,
     waitForStudyView,
 } from './helpers/common';
+import { getTextInOncoprintLegend } from './helpers/oncoprint';
 
 /**
  * Port of end-to-end-test/remote/specs/core/studyview.spec.js.
@@ -21,6 +22,8 @@ import {
  *  - lgg_tcga bar chart log scale, pie chart controls, table sorting
  *  - TCGA pancancer atlas load, virtual study load, multi-study layout
  *  - gene panel tooltip/modal, submit-to-results-view OQL flows
+ *  - fallback profile auto-selection for a plain gene query on a study
+ *    with no Mutations/CNA/SV profiles (cBioPortal/cbioportal#11569)
  *  - treatments tables (gbm_columbia_2019 + lgg_ucsf_2014)
  *  - msk_impact_2017 mutations-table and custom data chart validation
  */
@@ -1132,6 +1135,75 @@ test.describe('studyview tests', () => {
             expect(
                 profileFilter.includes('rna_seq_v2_mrna_median_Zscores')
             ).toBe(true);
+        });
+
+        /**
+         * Reproduces the study-page repro steps from
+         * https://github.com/cBioPortal/cbioportal/issues/11569: a study
+         * with no Mutations / Structural Variant / Copy Number
+         * Alterations profiles (only GeoMx CyCIF, mRNA, and p53 marker
+         * generic-assay/expression profiles) previously left the query
+         * with no molecular profile selected, so a plain gene query (no
+         * OQL data-type operator) rendered "N/P" (not profiled) on
+         * OncoPrint instead of the study's mRNA expression data.
+         */
+        test('auto-selects the sole non-Mut/CNA/SV profile for a plain gene query on an RNA-only study', async ({
+            page,
+            context,
+        }) => {
+            await page.goto(
+                '/study/summary?id=ovary_geomx_gray_foundation_2024'
+            );
+
+            await page.locator('textarea[data-test="geneSet"]').waitFor({
+                state: 'attached',
+                timeout: 10000,
+            });
+            // Plain gene symbol, no OQL data-type operator (":EXP" etc.) —
+            // this is the exact query used to report #11569.
+            await setInputText(page, 'textarea[data-test="geneSet"]', 'SOX9');
+
+            // Before the fix, no profile was auto-selected in this
+            // scenario, so the query could still be submitted but with an
+            // empty profile filter (OncoPrint then shows "N/P" for every
+            // sample). The submit button itself was never disabled here,
+            // so the meaningful assertions are on the resulting profileFilter
+            // and OncoPrint content below.
+            await expect(
+                page.locator('button[data-test="geneSetSubmit"]')
+            ).toBeEnabled({ timeout: 10000 });
+
+            const pagePromise = context.waitForEvent('page');
+            await page.locator('button[data-test="geneSetSubmit"]').click();
+            const resultsPage = await pagePromise;
+            await resultsPage.waitForLoadState('domcontentloaded');
+
+            await resultsPage.waitForTimeout(2000);
+            await resultsPage
+                .locator('#oncoprintDiv')
+                .waitFor({ state: 'visible', timeout: 60000 });
+            await waitForNetworkQuiet(resultsPage);
+
+            const profileFilter = await resultsPage.evaluate(() => {
+                const query = (window as any).urlWrapper?.query ?? {};
+                return query.profileFilter ?? '';
+            });
+            // No Mutations / CNA / SV profile exists in this study, so the
+            // fallback must pick the mRNA-Seq Expression GeoMx profile
+            // (first selectable profile in AlterationTypeConstants order,
+            // ahead of the two GENERIC_ASSAY profiles).
+            expect(profileFilter.includes('mutations')).toBe(false);
+            expect(profileFilter.includes('gistic')).toBe(false);
+            expect(profileFilter.includes('mrna_seq_read_counts_Zscores')).toBe(
+                true
+            );
+
+            // Confirm OncoPrint actually rendered expression data (mRNA
+            // High/Low legend entries) rather than leaving every sample
+            // unprofiled, which is what happened before the fix when no
+            // profile was auto-selected.
+            const legendText = await getTextInOncoprintLegend(resultsPage);
+            expect(/mRNA (High|Low)/.test(legendText)).toBe(true);
         });
     });
 

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -287,7 +287,10 @@ import StudyViewURLWrapper from './StudyViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
-import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from 'shared/lib/molecularProfileUtils';
 import {
     MRNA_TAB_GENE_GROUPS,
     STUDY_VIEW_DEFAULT_GENE_SPECIFIC_VIOLIN_GROUP_ID,
@@ -11467,6 +11470,20 @@ export class StudyViewPageStore
                 .map(profile => getSuffixOfMolecularProfile(profile))
                 .uniq()
                 .value();
+        }
+
+        if (
+            this.filteredVirtualStudies.result.length === 0 &&
+            this.studyIds.length === 1 &&
+            molecularProfileFilters.length === 0 &&
+            this.molecularProfiles.isComplete
+        ) {
+            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+                this.molecularProfiles.result
+            );
+            if (singleSuffix) {
+                molecularProfileFilters.push(singleSuffix);
+            }
         }
 
         if (molecularProfileFilters.length > 0) {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -288,7 +288,7 @@ import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
 import {
-    getSingleSelectableProfileSuffixIfUnique,
+    getDefaultProfileSuffixWhenNoMutationData,
     getSuffixOfMolecularProfile,
 } from 'shared/lib/molecularProfileUtils';
 import {
@@ -11478,11 +11478,11 @@ export class StudyViewPageStore
             molecularProfileFilters.length === 0 &&
             this.molecularProfiles.isComplete
         ) {
-            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+            const defaultSuffix = getDefaultProfileSuffixWhenNoMutationData(
                 this.molecularProfiles.result
             );
-            if (singleSuffix) {
-                molecularProfileFilters.push(singleSuffix);
+            if (defaultSuffix) {
+                molecularProfileFilters.push(defaultSuffix);
             }
         }
 

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -11472,6 +11472,13 @@ export class StudyViewPageStore
                 .value();
         }
 
+        // #11569: if the query built above ended up with no molecular
+        // profile filter (e.g. the study has no Mutations / Structural
+        // Variant / Copy Number Alterations profiles), fall back to the
+        // first selectable profile (mRNA, protein, etc.) so the query page
+        // still defaults to something instead of nothing selected.
+        // Restricted to a single, non-virtual study, since virtual/multi
+        // studies already computed their own filters above.
         if (
             this.filteredVirtualStudies.result.length === 0 &&
             this.studyIds.length === 1 &&

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -288,7 +288,7 @@ import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import { Datalabel } from 'shared/lib/DataUtils';
 import PromisePlus from 'shared/lib/PromisePlus';
 import {
-    getDefaultProfileSuffixWhenNoMutationData,
+    getFallbackSelectableProfileSuffix,
     getSuffixOfMolecularProfile,
 } from 'shared/lib/molecularProfileUtils';
 import {
@@ -11478,7 +11478,7 @@ export class StudyViewPageStore
             molecularProfileFilters.length === 0 &&
             this.molecularProfiles.isComplete
         ) {
-            const defaultSuffix = getDefaultProfileSuffixWhenNoMutationData(
+            const defaultSuffix = getFallbackSelectableProfileSuffix(
                 this.molecularProfiles.result
             );
             if (defaultSuffix) {

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -11472,7 +11472,7 @@ export class StudyViewPageStore
                 .value();
         }
 
-        // #11569: if the query built above ended up with no molecular
+        // If the query built above ended up with no molecular
         // profile filter (e.g. the study has no Mutations / Structural
         // Variant / Copy Number Alterations profiles), fall back to the
         // first selectable profile (mRNA, protein, etc.) so the query page

--- a/src/pages/studyView/StudyViewPageStore.ts
+++ b/src/pages/studyView/StudyViewPageStore.ts
@@ -11485,11 +11485,11 @@ export class StudyViewPageStore
             molecularProfileFilters.length === 0 &&
             this.molecularProfiles.isComplete
         ) {
-            const defaultSuffix = getFallbackSelectableProfileSuffix(
+            const fallbackProfileSuffix = getFallbackSelectableProfileSuffix(
                 this.molecularProfiles.result
             );
-            if (defaultSuffix) {
-                molecularProfileFilters.push(defaultSuffix);
+            if (fallbackProfileSuffix) {
+                molecularProfileFilters.push(fallbackProfileSuffix);
             }
         }
 

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -66,7 +66,10 @@ import {
     ResultsViewURLQueryEnum,
 } from 'pages/resultsView/ResultsViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
-import { getSuffixOfMolecularProfile } from 'shared/lib/molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from 'shared/lib/molecularProfileUtils';
 import { VirtualStudy } from 'shared/api/session-service/sessionServiceModels';
 import { isQueriedStudyAuthorized } from 'pages/studyView/StudyViewUtils';
 import { toQueryString } from 'shared/lib/query/textQueryUtils';
@@ -463,6 +466,23 @@ export class QueryStore {
                 }
             } else {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());
+            }
+        }
+        // #11569: default-select the only molecular profile when nothing else
+        // matched (e.g. RNA-only studies). Only when selection is still empty so we
+        // do not override mutation/CNA/SV defaults in mixed cohorts (see PR #5462).
+        if (
+            this.validProfileIdSetForSelectedStudies.isComplete &&
+            _.isEmpty(selectedIdSet) &&
+            _.isEmpty(this.profileFilterSetFromUrl) &&
+            _.isEmpty(this.profileIdsFromUrl)
+        ) {
+            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+                this.molecularProfilesInSelectedStudies.result || [],
+                { forDownloadTab: this.forDownloadTab }
+            );
+            if (singleSuffix) {
+                selectedIdSet[singleSuffix] = true;
             }
         }
         return selectedIdSet;
@@ -1091,6 +1111,13 @@ export class QueryStore {
                 this.studiesHaveChangedSinceInitialization
             ) {
                 this.profileFilterSet = undefined;
+
+                // Keep default auto-selection in the load lifecycle so UI
+                // reflects the checked profile immediately after profiles load.
+                const defaultProfile = this.defaultProfileToSelect;
+                if (defaultProfile) {
+                    this.selectMolecularProfile(defaultProfile, true);
+                }
             }
         },
     });
@@ -1795,6 +1822,58 @@ export class QueryStore {
         );
     }
 
+    @computed get shouldSelectDefaultProfile() {
+        if (Object.keys(this.selectedProfileIdSet).length > 0) {
+            return false;
+        }
+        if (
+            !_.isEmpty(this.profileFilterSetFromUrl) ||
+            !_.isEmpty(this.profileIdsFromUrl)
+        ) {
+            return false;
+        }
+
+        let profileTypeCount = 0;
+        Object.values(AlterationTypeConstants).forEach(profileType => {
+            if (
+                this.getFilteredProfiles(
+                    profileType as MolecularProfile['molecularAlterationType']
+                ).length > 0
+            ) {
+                profileTypeCount++;
+            }
+        });
+
+        if (profileTypeCount === 1) {
+            return true;
+        }
+
+        const hasMutationProfile =
+            this.getFilteredProfiles(AlterationTypeConstants.MUTATION_EXTENDED)
+                .length > 0;
+        const hasMrnaProfile =
+            this.getFilteredProfiles(AlterationTypeConstants.MRNA_EXPRESSION)
+                .length > 0;
+
+        return !hasMutationProfile && hasMrnaProfile;
+    }
+
+    @computed get defaultProfileToSelect() {
+        if (!this.shouldSelectDefaultProfile) {
+            return undefined;
+        }
+
+        for (const profileType of Object.values(AlterationTypeConstants)) {
+            const profiles = this.getFilteredProfiles(
+                profileType as MolecularProfile['molecularAlterationType']
+            );
+            if (profiles.length > 0) {
+                return profiles[0];
+            }
+        }
+        return undefined;
+    }
+
     // SAMPLE LIST
 
     @computed get defaultSelectedSampleListId() {
@@ -2255,6 +2334,7 @@ export class QueryStore {
         );
 
         this.profileIdsFromUrl = _.compact(profileIds);
+        this.profileFilterSetFromUrl = undefined;
         this.zScoreThreshold = params.Z_SCORE_THRESHOLD || '2.0';
         this.rppaScoreThreshold = params.RPPA_SCORE_THRESHOLD || '2.0';
         if (params.data_priority) {
@@ -2262,7 +2342,9 @@ export class QueryStore {
         }
         if (params.profileFilter) {
             if (isNaN(parseInt(params.profileFilter, 10))) {
-                this.profileFilterSetFromUrl = params.profileFilter.split(',');
+                this.profileFilterSetFromUrl = _.compact(
+                    params.profileFilter.split(',')
+                );
             }
         }
 

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -67,7 +67,7 @@ import {
 } from 'pages/resultsView/ResultsViewURLWrapper';
 import { isMixedReferenceGenome } from 'shared/lib/referenceGenomeUtils';
 import {
-    getSingleSelectableProfileSuffixIfUnique,
+    getFallbackSelectableProfileSuffix,
     getSuffixOfMolecularProfile,
 } from 'shared/lib/molecularProfileUtils';
 import { VirtualStudy } from 'shared/api/session-service/sessionServiceModels';
@@ -468,8 +468,8 @@ export class QueryStore {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());
             }
         }
-        // #11569: default-select the only molecular profile when nothing else
-        // matched (e.g. RNA-only studies). Only when selection is still empty so we
+        // #11569: when Mutations / SV / CNA defaults did not match, fall back to
+        // the first selectable profile. Only when selection is still empty so we
         // do not override mutation/CNA/SV defaults in mixed cohorts (see PR #5462).
         if (
             this.validProfileIdSetForSelectedStudies.isComplete &&
@@ -477,12 +477,12 @@ export class QueryStore {
             _.isEmpty(this.profileFilterSetFromUrl) &&
             _.isEmpty(this.profileIdsFromUrl)
         ) {
-            const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+            const fallbackSuffix = getFallbackSelectableProfileSuffix(
                 this.molecularProfilesInSelectedStudies.result || [],
                 { forDownloadTab: this.forDownloadTab }
             );
-            if (singleSuffix) {
-                selectedIdSet[singleSuffix] = true;
+            if (fallbackSuffix) {
+                selectedIdSet[fallbackSuffix] = true;
             }
         }
         return selectedIdSet;
@@ -1848,16 +1848,31 @@ export class QueryStore {
             return true;
         }
 
+        // When Mutations / Structural Variant / Copy Number Alterations are
+        // missing, fall back to the first available selectable profile
+        // (mRNA, protein, etc.) — do not special-case a single data type.
         const hasMutationProfile =
             this.getFilteredProfiles(
                 AlterationTypeConstants.MUTATION_EXTENDED as MolecularProfile['molecularAlterationType']
             ).length > 0;
-        const hasMrnaProfile =
+        const hasCnaProfile =
             this.getFilteredProfiles(
-                AlterationTypeConstants.MRNA_EXPRESSION as MolecularProfile['molecularAlterationType']
+                AlterationTypeConstants.COPY_NUMBER_ALTERATION as MolecularProfile['molecularAlterationType']
+            ).length > 0;
+        const hasStructuralVariantProfile =
+            this.getFilteredProfiles(
+                AlterationTypeConstants.STRUCTURAL_VARIANT as MolecularProfile['molecularAlterationType']
             ).length > 0;
 
-        return !hasMutationProfile && hasMrnaProfile;
+        if (
+            hasMutationProfile ||
+            hasCnaProfile ||
+            hasStructuralVariantProfile
+        ) {
+            return false;
+        }
+
+        return profileTypeCount > 0;
     }
 
     @computed get defaultProfileToSelect() {

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1849,11 +1849,13 @@ export class QueryStore {
         }
 
         const hasMutationProfile =
-            this.getFilteredProfiles(AlterationTypeConstants.MUTATION_EXTENDED)
-                .length > 0;
+            this.getFilteredProfiles(
+                AlterationTypeConstants.MUTATION_EXTENDED as MolecularProfile['molecularAlterationType']
+            ).length > 0;
         const hasMrnaProfile =
-            this.getFilteredProfiles(AlterationTypeConstants.MRNA_EXPRESSION)
-                .length > 0;
+            this.getFilteredProfiles(
+                AlterationTypeConstants.MRNA_EXPRESSION as MolecularProfile['molecularAlterationType']
+            ).length > 0;
 
         return !hasMutationProfile && hasMrnaProfile;
     }

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -1111,13 +1111,6 @@ export class QueryStore {
                 this.studiesHaveChangedSinceInitialization
             ) {
                 this.profileFilterSet = undefined;
-
-                // Keep default auto-selection in the load lifecycle so UI
-                // reflects the checked profile immediately after profiles load.
-                const defaultProfile = this.defaultProfileToSelect;
-                if (defaultProfile) {
-                    this.selectMolecularProfile(defaultProfile, true);
-                }
             }
         },
     });
@@ -1820,75 +1813,6 @@ export class QueryStore {
             this.defaultProfilesForOql &&
             this.defaultProfilesForOql[AlterationTypeConstants.PROTEIN_LEVEL]
         );
-    }
-
-    @computed get shouldSelectDefaultProfile() {
-        if (Object.keys(this.selectedProfileIdSet).length > 0) {
-            return false;
-        }
-        if (
-            !_.isEmpty(this.profileFilterSetFromUrl) ||
-            !_.isEmpty(this.profileIdsFromUrl)
-        ) {
-            return false;
-        }
-
-        let profileTypeCount = 0;
-        Object.values(AlterationTypeConstants).forEach(profileType => {
-            if (
-                this.getFilteredProfiles(
-                    profileType as MolecularProfile['molecularAlterationType']
-                ).length > 0
-            ) {
-                profileTypeCount++;
-            }
-        });
-
-        if (profileTypeCount === 1) {
-            return true;
-        }
-
-        // When Mutations / Structural Variant / Copy Number Alterations are
-        // missing, fall back to the first available selectable profile
-        // (mRNA, protein, etc.) — do not special-case a single data type.
-        const hasMutationProfile =
-            this.getFilteredProfiles(
-                AlterationTypeConstants.MUTATION_EXTENDED as MolecularProfile['molecularAlterationType']
-            ).length > 0;
-        const hasCnaProfile =
-            this.getFilteredProfiles(
-                AlterationTypeConstants.COPY_NUMBER_ALTERATION as MolecularProfile['molecularAlterationType']
-            ).length > 0;
-        const hasStructuralVariantProfile =
-            this.getFilteredProfiles(
-                AlterationTypeConstants.STRUCTURAL_VARIANT as MolecularProfile['molecularAlterationType']
-            ).length > 0;
-
-        if (
-            hasMutationProfile ||
-            hasCnaProfile ||
-            hasStructuralVariantProfile
-        ) {
-            return false;
-        }
-
-        return profileTypeCount > 0;
-    }
-
-    @computed get defaultProfileToSelect() {
-        if (!this.shouldSelectDefaultProfile) {
-            return undefined;
-        }
-
-        for (const profileType of Object.values(AlterationTypeConstants)) {
-            const profiles = this.getFilteredProfiles(
-                profileType as MolecularProfile['molecularAlterationType']
-            );
-            if (profiles.length > 0) {
-                return profiles[0];
-            }
-        }
-        return undefined;
     }
 
     // SAMPLE LIST

--- a/src/shared/components/query/QueryStore.ts
+++ b/src/shared/components/query/QueryStore.ts
@@ -468,7 +468,7 @@ export class QueryStore {
                 selectedIdSet = _.fromPairs(this.profileFilterSet.toJSON());
             }
         }
-        // #11569: when Mutations / SV / CNA defaults did not match, fall back to
+        // When Mutations / SV / CNA defaults did not match, fall back to
         // the first selectable profile. Only when selection is still empty so we
         // do not override mutation/CNA/SV defaults in mixed cohorts (see PR #5462).
         if (

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -106,6 +106,16 @@ export function getDefaultStructuralVariantProfile(
     );
 }
 
+export function getDefaultMrnaProfile(profiles: MolecularProfile[]) {
+    return _.find(
+        profiles,
+        profile =>
+            profile.molecularAlterationType ===
+                AlterationTypeConstants.MRNA_EXPRESSION &&
+            profile.showProfileInAnalysisTab
+    );
+}
+
 export function getDefaultGeneSetProfile(profiles: MolecularProfile[]) {
     return _.find(
         profiles,
@@ -157,6 +167,15 @@ export function getFilteredMolecularProfiles(
         const selectable = profiles.filter(p => p.showProfileInAnalysisTab);
         if (selectable.length === 1) {
             defaultProfiles = [selectable[0]];
+        } else {
+            const mrnaProfile = getDefaultMrnaProfile(profiles);
+            const hasAlterationProfile =
+                !!getDefaultMutationProfile(profiles) ||
+                !!getDefaultCNAProfile(profiles) ||
+                !!getDefaultStructuralVariantProfile(profiles);
+            if (mrnaProfile && !hasAlterationProfile) {
+                defaultProfiles = [mrnaProfile];
+            }
         }
     }
     return _.compact(defaultProfiles);

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -153,6 +153,11 @@ export function getFilteredMolecularProfiles(
                 );
         }
     }
-    // get rid of any undefined items
+    if (_.compact(defaultProfiles).length === 0) {
+        const selectable = profiles.filter(p => p.showProfileInAnalysisTab);
+        if (selectable.length === 1) {
+            defaultProfiles = [selectable[0]];
+        }
+    }
     return _.compact(defaultProfiles);
 }

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -2,7 +2,10 @@ import { MolecularProfile } from 'cbioportal-ts-api-client';
 import _ from 'lodash';
 import { AlterationTypeConstants } from 'shared/constants';
 import { GeneSetProfilesEnum } from 'shared/components/query/QueryStoreUtils';
-import { getSuffixOfMolecularProfile } from './molecularProfileUtils';
+import {
+    getFirstSelectableProfile,
+    getSuffixOfMolecularProfile,
+} from './molecularProfileUtils';
 
 export enum MolecularProfileFilterEnum {
     MutationAndCNA = 0,
@@ -106,16 +109,6 @@ export function getDefaultStructuralVariantProfile(
     );
 }
 
-export function getDefaultMrnaProfile(profiles: MolecularProfile[]) {
-    return _.find(
-        profiles,
-        profile =>
-            profile.molecularAlterationType ===
-                AlterationTypeConstants.MRNA_EXPRESSION &&
-            profile.showProfileInAnalysisTab
-    );
-}
-
 export function getDefaultGeneSetProfile(profiles: MolecularProfile[]) {
     return _.find(
         profiles,
@@ -164,18 +157,10 @@ export function getFilteredMolecularProfiles(
         }
     }
     if (_.compact(defaultProfiles).length === 0) {
-        const selectable = profiles.filter(p => p.showProfileInAnalysisTab);
-        if (selectable.length === 1) {
-            defaultProfiles = [selectable[0]];
-        } else {
-            const mrnaProfile = getDefaultMrnaProfile(profiles);
-            const hasAlterationProfile =
-                !!getDefaultMutationProfile(profiles) ||
-                !!getDefaultCNAProfile(profiles) ||
-                !!getDefaultStructuralVariantProfile(profiles);
-            if (mrnaProfile && !hasAlterationProfile) {
-                defaultProfiles = [mrnaProfile];
-            }
+        // No Mutations / SV / CNA defaults — fall back to first selectable profile
+        const fallback = getFirstSelectableProfile(profiles);
+        if (fallback) {
+            defaultProfiles = [fallback];
         }
     }
     return _.compact(defaultProfiles);

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -163,5 +163,6 @@ export function getFilteredMolecularProfiles(
             defaultProfiles = [fallback];
         }
     }
+    // get rid of any undefined items
     return _.compact(defaultProfiles);
 }

--- a/src/shared/lib/getDefaultMolecularProfiles.ts
+++ b/src/shared/lib/getDefaultMolecularProfiles.ts
@@ -158,9 +158,11 @@ export function getFilteredMolecularProfiles(
     }
     if (_.compact(defaultProfiles).length === 0) {
         // No Mutations / SV / CNA defaults — fall back to first selectable profile
-        const fallback = getFirstSelectableProfile(profiles);
-        if (fallback) {
-            defaultProfiles = [fallback];
+        const firstSelectableFallbackProfile = getFirstSelectableProfile(
+            profiles
+        );
+        if (firstSelectableFallbackProfile) {
+            defaultProfiles = [firstSelectableFallbackProfile];
         }
     }
     // get rid of any undefined items

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import {
+    getDefaultProfileSuffixWhenNoMutationData,
     getSingleSelectableProfileSuffixIfUnique,
     getSuffixOfMolecularProfile,
 } from './molecularProfileUtils';
@@ -78,9 +79,84 @@ describe('MolecularProfileUtils', () => {
         });
     });
 
+    describe('getDefaultProfileSuffixWhenNoMutationData', () => {
+        it('returns mRNA suffix when no mutation/CNA/SV but multiple selectable profiles', () => {
+            const profiles = [
+                {
+                    studyId: 'ovary_geomx_gray_foundation_2024',
+                    molecularProfileId:
+                        'ovary_geomx_gray_foundation_2024_cycif_cell_type_fractions',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'ovary_geomx_gray_foundation_2024',
+                    molecularProfileId:
+                        'ovary_geomx_gray_foundation_2024_mrna_seq_read_counts_Zscores',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'ovary_geomx_gray_foundation_2024',
+                    molecularProfileId:
+                        'ovary_geomx_gray_foundation_2024_rfu_p53_marker_intensity',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getDefaultProfileSuffixWhenNoMutationData(profiles),
+                'mrna_seq_read_counts_Zscores'
+            );
+        });
+
+        it('returns undefined when mutation profile exists', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_rna',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.isUndefined(
+                getDefaultProfileSuffixWhenNoMutationData(profiles)
+            );
+        });
+    });
+
     describe('getFilteredMolecularProfiles single-profile fallback', () => {
         it('selects the only RNA profile when mutation/CNA defaults are empty', () => {
             const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_geo_mx',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            const out = getFilteredMolecularProfiles(profiles, undefined, 0);
+            assert.equal(out.length, 1);
+            assert.equal(out[0]!.molecularProfileId, 'g_geo_mx');
+        });
+
+        it('selects mRNA when multiple profiles exist but no mutation/CNA/SV', () => {
+            const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_cycif',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
                 {
                     studyId: 'g',
                     molecularProfileId: 'g_geo_mx',

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -1,6 +1,11 @@
 import { assert } from 'chai';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
-import { getSuffixOfMolecularProfile } from './molecularProfileUtils';
+import {
+    getSingleSelectableProfileSuffixIfUnique,
+    getSuffixOfMolecularProfile,
+} from './molecularProfileUtils';
+import { getFilteredMolecularProfiles } from './getDefaultMolecularProfiles';
+import { AlterationTypeConstants } from 'shared/constants';
 
 describe('MolecularProfileUtils', () => {
     describe('getSuffixOfMolecularProfile', () => {
@@ -12,6 +17,81 @@ describe('MolecularProfileUtils', () => {
             const suffix = 'CCLE_drug_treatment_IC50';
             const result = getSuffixOfMolecularProfile(profile);
             assert.equal(result, suffix);
+        });
+    });
+
+    describe('getSingleSelectableProfileSuffixIfUnique', () => {
+        it('returns suffix when exactly one showProfileInAnalysisTab profile', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_rna_geo',
+                    molecularAlterationType: 'MRNA_EXPRESSION',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getSingleSelectableProfileSuffixIfUnique(profiles),
+                'rna_geo'
+            );
+        });
+
+        it('returns undefined when two distinct suffixes exist', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_gistic',
+                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.isUndefined(
+                getSingleSelectableProfileSuffixIfUnique(profiles)
+            );
+        });
+
+        it('returns one suffix when two studies share the same suffix', () => {
+            const profiles = [
+                {
+                    studyId: 'a',
+                    molecularProfileId: 'a_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'b',
+                    molecularProfileId: 'b_mutations',
+                    molecularAlterationType: 'MUTATION_EXTENDED',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getSingleSelectableProfileSuffixIfUnique(profiles),
+                'mutations'
+            );
+        });
+    });
+
+    describe('getFilteredMolecularProfiles single-profile fallback', () => {
+        it('selects the only RNA profile when mutation/CNA defaults are empty', () => {
+            const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_geo_mx',
+                    molecularAlterationType:
+                        AlterationTypeConstants.MRNA_EXPRESSION,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            const out = getFilteredMolecularProfiles(profiles, undefined, 0);
+            assert.equal(out.length, 1);
+            assert.equal(out[0]!.molecularProfileId, 'g_geo_mx');
         });
     });
 });

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -1,7 +1,8 @@
 import { assert } from 'chai';
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import {
-    getDefaultProfileSuffixWhenNoMutationData,
+    getFallbackSelectableProfileSuffix,
+    getFirstSelectableProfile,
     getSingleSelectableProfileSuffixIfUnique,
     getSuffixOfMolecularProfile,
 } from './molecularProfileUtils';
@@ -79,8 +80,8 @@ describe('MolecularProfileUtils', () => {
         });
     });
 
-    describe('getDefaultProfileSuffixWhenNoMutationData', () => {
-        it('returns mRNA suffix when no mutation/CNA/SV but multiple selectable profiles', () => {
+    describe('getFallbackSelectableProfileSuffix', () => {
+        it('returns first selectable suffix when no Mut/SV/CNA but multiple profiles', () => {
             const profiles = [
                 {
                     studyId: 'ovary_geomx_gray_foundation_2024',
@@ -105,10 +106,30 @@ describe('MolecularProfileUtils', () => {
                     showProfileInAnalysisTab: true,
                 },
             ] as MolecularProfile[];
+            // MRNA_EXPRESSION is preferred over GENERIC_ASSAY by type order
             assert.equal(
-                getDefaultProfileSuffixWhenNoMutationData(profiles),
+                getFallbackSelectableProfileSuffix(profiles),
                 'mrna_seq_read_counts_Zscores'
             );
+        });
+
+        it('returns protein profile suffix when only protein is selectable', () => {
+            const profiles = [
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_rppa',
+                    molecularAlterationType:
+                        AlterationTypeConstants.PROTEIN_LEVEL,
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 's1',
+                    molecularProfileId: 's1_other_assay',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(getFallbackSelectableProfileSuffix(profiles), 'rppa');
         });
 
         it('returns undefined when mutation profile exists', () => {
@@ -127,13 +148,35 @@ describe('MolecularProfileUtils', () => {
                     showProfileInAnalysisTab: true,
                 },
             ] as MolecularProfile[];
-            assert.isUndefined(
-                getDefaultProfileSuffixWhenNoMutationData(profiles)
+            assert.isUndefined(getFallbackSelectableProfileSuffix(profiles));
+        });
+    });
+
+    describe('getFirstSelectableProfile', () => {
+        it('prefers earlier alteration types over generic assay', () => {
+            const profiles = [
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_cycif',
+                    molecularAlterationType: 'GENERIC_ASSAY',
+                    showProfileInAnalysisTab: true,
+                },
+                {
+                    studyId: 'g',
+                    molecularProfileId: 'g_protein',
+                    molecularAlterationType:
+                        AlterationTypeConstants.PROTEIN_LEVEL,
+                    showProfileInAnalysisTab: true,
+                },
+            ] as MolecularProfile[];
+            assert.equal(
+                getFirstSelectableProfile(profiles)!.molecularProfileId,
+                'g_protein'
             );
         });
     });
 
-    describe('getFilteredMolecularProfiles single-profile fallback', () => {
+    describe('getFilteredMolecularProfiles fallback', () => {
         it('selects the only RNA profile when mutation/CNA defaults are empty', () => {
             const profiles = [
                 {
@@ -149,7 +192,7 @@ describe('MolecularProfileUtils', () => {
             assert.equal(out[0]!.molecularProfileId, 'g_geo_mx');
         });
 
-        it('selects mRNA when multiple profiles exist but no mutation/CNA/SV', () => {
+        it('selects first selectable profile when no mutation/CNA/SV', () => {
             const profiles = [
                 {
                     studyId: 'g',

--- a/src/shared/lib/molecularProfileUtils.spec.ts
+++ b/src/shared/lib/molecularProfileUtils.spec.ts
@@ -3,7 +3,6 @@ import { MolecularProfile } from 'cbioportal-ts-api-client';
 import {
     getFallbackSelectableProfileSuffix,
     getFirstSelectableProfile,
-    getSingleSelectableProfileSuffixIfUnique,
     getSuffixOfMolecularProfile,
 } from './molecularProfileUtils';
 import { getFilteredMolecularProfiles } from './getDefaultMolecularProfiles';
@@ -19,64 +18,6 @@ describe('MolecularProfileUtils', () => {
             const suffix = 'CCLE_drug_treatment_IC50';
             const result = getSuffixOfMolecularProfile(profile);
             assert.equal(result, suffix);
-        });
-    });
-
-    describe('getSingleSelectableProfileSuffixIfUnique', () => {
-        it('returns suffix when exactly one showProfileInAnalysisTab profile', () => {
-            const profiles = [
-                {
-                    studyId: 's1',
-                    molecularProfileId: 's1_rna_geo',
-                    molecularAlterationType: 'MRNA_EXPRESSION',
-                    showProfileInAnalysisTab: true,
-                },
-            ] as MolecularProfile[];
-            assert.equal(
-                getSingleSelectableProfileSuffixIfUnique(profiles),
-                'rna_geo'
-            );
-        });
-
-        it('returns undefined when two distinct suffixes exist', () => {
-            const profiles = [
-                {
-                    studyId: 's1',
-                    molecularProfileId: 's1_mutations',
-                    molecularAlterationType: 'MUTATION_EXTENDED',
-                    showProfileInAnalysisTab: true,
-                },
-                {
-                    studyId: 's1',
-                    molecularProfileId: 's1_gistic',
-                    molecularAlterationType: 'COPY_NUMBER_ALTERATION',
-                    showProfileInAnalysisTab: true,
-                },
-            ] as MolecularProfile[];
-            assert.isUndefined(
-                getSingleSelectableProfileSuffixIfUnique(profiles)
-            );
-        });
-
-        it('returns one suffix when two studies share the same suffix', () => {
-            const profiles = [
-                {
-                    studyId: 'a',
-                    molecularProfileId: 'a_mutations',
-                    molecularAlterationType: 'MUTATION_EXTENDED',
-                    showProfileInAnalysisTab: true,
-                },
-                {
-                    studyId: 'b',
-                    molecularProfileId: 'b_mutations',
-                    molecularAlterationType: 'MUTATION_EXTENDED',
-                    showProfileInAnalysisTab: true,
-                },
-            ] as MolecularProfile[];
-            assert.equal(
-                getSingleSelectableProfileSuffixIfUnique(profiles),
-                'mutations'
-            );
         });
     });
 

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -1,5 +1,6 @@
 import { MolecularProfile } from 'cbioportal-ts-api-client';
 import _ from 'lodash';
+import { AlterationTypeConstants } from 'shared/constants';
 
 export function getSuffixOfMolecularProfile(profile: MolecularProfile) {
     return profile.molecularProfileId.replace(profile.studyId + '_', '');
@@ -28,4 +29,44 @@ export function getSingleSelectableProfileSuffixIfUnique(
     const bySuffix = _.groupBy(selectable, p => getSuffixOfMolecularProfile(p));
     const suffixes = Object.keys(bySuffix);
     return suffixes.length === 1 ? suffixes[0] : undefined;
+}
+
+/**
+ * Profile suffix to default when a study has no mutation/CNA/SV data but does
+ * have other queryable profiles (e.g. RNA + generic assay). Aligns with
+ * QueryStore.shouldSelectDefaultProfile (#11569).
+ */
+export function getDefaultProfileSuffixWhenNoMutationData(
+    profiles: MolecularProfile[],
+    options?: { forDownloadTab?: boolean }
+): string | undefined {
+    const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
+        profiles,
+        options
+    );
+    if (singleSuffix) {
+        return singleSuffix;
+    }
+    const forDownloadTab = options?.forDownloadTab ?? false;
+    const selectable = profiles.filter(
+        p => p.showProfileInAnalysisTab || forDownloadTab
+    );
+    const hasAlterationProfile = selectable.some(
+        p =>
+            p.molecularAlterationType ===
+                AlterationTypeConstants.MUTATION_EXTENDED ||
+            p.molecularAlterationType ===
+                AlterationTypeConstants.COPY_NUMBER_ALTERATION ||
+            p.molecularAlterationType ===
+                AlterationTypeConstants.STRUCTURAL_VARIANT
+    );
+    if (hasAlterationProfile) {
+        return undefined;
+    }
+    const mrnaProfile = selectable.find(
+        p =>
+            p.molecularAlterationType ===
+            AlterationTypeConstants.MRNA_EXPRESSION
+    );
+    return mrnaProfile ? getSuffixOfMolecularProfile(mrnaProfile) : undefined;
 }

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -1,5 +1,31 @@
 import { MolecularProfile } from 'cbioportal-ts-api-client';
+import _ from 'lodash';
 
 export function getSuffixOfMolecularProfile(profile: MolecularProfile) {
     return profile.molecularProfileId.replace(profile.studyId + '_', '');
+}
+
+/**
+ * When the cohort exposes exactly one selectable analysis profile (one suffix),
+ * return that suffix so the query UI can default-check it. Covers RNA-only and
+ * other single-profile studies (#11569). Multiple studies sharing the same
+ * suffix still count as one checkbox column — one suffix is returned.
+ */
+export function getSingleSelectableProfileSuffixIfUnique(
+    profiles: MolecularProfile[],
+    options?: { forDownloadTab?: boolean }
+): string | undefined {
+    if (!profiles?.length) {
+        return undefined;
+    }
+    const forDownloadTab = options?.forDownloadTab ?? false;
+    const selectable = profiles.filter(
+        p => p.showProfileInAnalysisTab || forDownloadTab
+    );
+    if (!selectable.length) {
+        return undefined;
+    }
+    const bySuffix = _.groupBy(selectable, p => getSuffixOfMolecularProfile(p));
+    const suffixes = Object.keys(bySuffix);
+    return suffixes.length === 1 ? suffixes[0] : undefined;
 }

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -31,42 +31,63 @@ export function getSingleSelectableProfileSuffixIfUnique(
     return suffixes.length === 1 ? suffixes[0] : undefined;
 }
 
+function isDefaultAlterationProfile(profile: MolecularProfile) {
+    return (
+        profile.molecularAlterationType ===
+            AlterationTypeConstants.MUTATION_EXTENDED ||
+        profile.molecularAlterationType ===
+            AlterationTypeConstants.COPY_NUMBER_ALTERATION ||
+        profile.molecularAlterationType ===
+            AlterationTypeConstants.STRUCTURAL_VARIANT
+    );
+}
+
 /**
- * Profile suffix to default when a study has no mutation/CNA/SV data but does
- * have other queryable profiles (e.g. RNA + generic assay). Aligns with
- * QueryStore.shouldSelectDefaultProfile (#11569).
+ * First selectable profile (showProfileInAnalysisTab), preferring the same
+ * alteration-type order as QueryStore.defaultProfileToSelect.
  */
-export function getDefaultProfileSuffixWhenNoMutationData(
+export function getFirstSelectableProfile(
     profiles: MolecularProfile[],
     options?: { forDownloadTab?: boolean }
-): string | undefined {
-    const singleSuffix = getSingleSelectableProfileSuffixIfUnique(
-        profiles,
-        options
-    );
-    if (singleSuffix) {
-        return singleSuffix;
+): MolecularProfile | undefined {
+    if (!profiles?.length) {
+        return undefined;
     }
     const forDownloadTab = options?.forDownloadTab ?? false;
     const selectable = profiles.filter(
         p => p.showProfileInAnalysisTab || forDownloadTab
     );
-    const hasAlterationProfile = selectable.some(
-        p =>
-            p.molecularAlterationType ===
-                AlterationTypeConstants.MUTATION_EXTENDED ||
-            p.molecularAlterationType ===
-                AlterationTypeConstants.COPY_NUMBER_ALTERATION ||
-            p.molecularAlterationType ===
-                AlterationTypeConstants.STRUCTURAL_VARIANT
-    );
-    if (hasAlterationProfile) {
+    if (!selectable.length) {
         return undefined;
     }
-    const mrnaProfile = selectable.find(
-        p =>
-            p.molecularAlterationType ===
-            AlterationTypeConstants.MRNA_EXPRESSION
-    );
-    return mrnaProfile ? getSuffixOfMolecularProfile(mrnaProfile) : undefined;
+    for (const profileType of Object.values(AlterationTypeConstants)) {
+        const match = selectable.find(
+            p => p.molecularAlterationType === profileType
+        );
+        if (match) {
+            return match;
+        }
+    }
+    return selectable[0];
+}
+
+/**
+ * When Mutations / Structural Variant / Copy Number Alterations profiles are
+ * missing, fall back to the first selectable profile (e.g. mRNA, protein, or
+ * other analysis profiles). See #11569.
+ */
+export function getFallbackSelectableProfileSuffix(
+    profiles: MolecularProfile[],
+    options?: { forDownloadTab?: boolean }
+): string | undefined {
+    if (!profiles?.length) {
+        return undefined;
+    }
+    if (profiles.some(isDefaultAlterationProfile)) {
+        return undefined;
+    }
+    const firstSelectable = getFirstSelectableProfile(profiles, options);
+    return firstSelectable
+        ? getSuffixOfMolecularProfile(firstSelectable)
+        : undefined;
 }

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -6,31 +6,6 @@ export function getSuffixOfMolecularProfile(profile: MolecularProfile) {
     return profile.molecularProfileId.replace(profile.studyId + '_', '');
 }
 
-/**
- * When the cohort exposes exactly one selectable analysis profile (one suffix),
- * return that suffix so the query UI can default-check it. Covers RNA-only and
- * other single-profile studies (#11569). Multiple studies sharing the same
- * suffix still count as one checkbox column — one suffix is returned.
- */
-export function getSingleSelectableProfileSuffixIfUnique(
-    profiles: MolecularProfile[],
-    options?: { forDownloadTab?: boolean }
-): string | undefined {
-    if (!profiles?.length) {
-        return undefined;
-    }
-    const forDownloadTab = options?.forDownloadTab ?? false;
-    const selectable = profiles.filter(
-        p => p.showProfileInAnalysisTab || forDownloadTab
-    );
-    if (!selectable.length) {
-        return undefined;
-    }
-    const bySuffix = _.groupBy(selectable, p => getSuffixOfMolecularProfile(p));
-    const suffixes = Object.keys(bySuffix);
-    return suffixes.length === 1 ? suffixes[0] : undefined;
-}
-
 function isDefaultAlterationProfile(profile: MolecularProfile) {
     return (
         profile.molecularAlterationType ===
@@ -43,8 +18,9 @@ function isDefaultAlterationProfile(profile: MolecularProfile) {
 }
 
 /**
- * First selectable profile (showProfileInAnalysisTab), preferring the same
- * alteration-type order as QueryStore.defaultProfileToSelect.
+ * First selectable profile (showProfileInAnalysisTab), preferring
+ * Mutations > Structural Variant > Copy Number Alterations > other
+ * alteration types, in `AlterationTypeConstants` declaration order.
  */
 export function getFirstSelectableProfile(
     profiles: MolecularProfile[],

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -50,7 +50,7 @@ export function getFirstSelectableProfile(
 /**
  * When Mutations / Structural Variant / Copy Number Alterations profiles are
  * missing, fall back to the first selectable profile (e.g. mRNA, protein, or
- * other analysis profiles). See #11569.
+ * other analysis profiles).
  */
 export function getFallbackSelectableProfileSuffix(
     profiles: MolecularProfile[],

--- a/src/shared/lib/molecularProfileUtils.ts
+++ b/src/shared/lib/molecularProfileUtils.ts
@@ -1,5 +1,4 @@
 import { MolecularProfile } from 'cbioportal-ts-api-client';
-import _ from 'lodash';
 import { AlterationTypeConstants } from 'shared/constants';
 
 export function getSuffixOfMolecularProfile(profile: MolecularProfile) {


### PR DESCRIPTION
  Fix [#11569](https://github.com/cBioPortal/cbioportal/issues/11569)
   ## Summary                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                               
   When a study/cohort has no Mutations / Structural Variant / Copy Number Alterations profiles (e.g. RNA-only or protein-only studies), the Query page and study-page gene box now default-select the first available selectable molecular profile instead of leaving nothing 
   checked. Previously, submitting a plain gene query (no OQL data-type operator) against such a study produced an empty profile filter, so OncoPrint rendered every sample as "Not profiled" even though usable expression/profile data existed.                              
                                                                                                                                                                                                                                                                               
   The fallback picks the first selectable profile in `AlterationTypeConstants` order (e.g. mRNA expression takes priority over generic-assay profiles), reusing the existing shared `getFallbackSelectableProfileSuffix`/`getFirstSelectableProfile` utilities so both the    
   query form and the study-view submit path derive the same selection consistently.                                                                                                                                                                                           
                                                                                                                                                                                                                                                                               
   ## Testing                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                               
   - Unit tests: `molecularProfileUtils.spec.ts`, `QueryStore.spec.ts`, `QueryStoreUtils.spec.ts` — all passing.                                                                                                                                                               
   - `tsc --noEmit`: no errors.                                                                                                                                                                                                                                                
   - `prettier --check` on all touched files: passing.                                                                                                                                                                                                                         
   - Added two new Playwright e2e tests against `ovary_geomx_gray_foundation_2024` (a real study with only generic-assay/expression profiles, no Mutations/CNA/SV):                                                                                                            
     - `studyview.spec.ts`: a plain gene query on the study page results in a profileFilter that selects the mRNA expression profile, and OncoPrint renders real mRNA High/Low data.                                                                                           
     - `home.spec.ts`: the Query page's "Select Genomic Profiles" auto-checks the mRNA expression profile by default for this study.                                                                                                                                           
     - Both were verified to fail against the current production build (confirming they reproduce the bug) and pass with this fix applied.                                                                                                                                     
                                                                                                                                                                                                                                                                               
   ## Credit                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                               
   Original fix and investigation by @Pragati5-DEBUG in #5636 — thank you for tracking down and fixing #11569! This PR carries their commits forward and adds the review-requested cleanup so the fix can be merged.