### PR TITLE
Enhancing tooltip for more information and removing hardcoded values

### DIFF
--- a/src/pages/studyView/tabs/EmbeddingsTab.tsx
+++ b/src/pages/studyView/tabs/EmbeddingsTab.tsx
@@ -362,7 +362,7 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
         return maps.patientValueMap;
     }
 
-    @computed get osMonthlyValueMap(): Map<string, string> {
+    @computed get osMonthsValueMap(): Map<string, string> {
         const osMonthsAttr = this.clinicalAttributes.find(
             attr => attr.clinicalAttributeId === 'OS_MONTHS'
         );
@@ -1534,7 +1534,7 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
             onUnpinPoint: this.unpinPoint,
             selectedTooltipFields: new Set(this.selectedTooltipFields), //Clone to ensure prop identity changes and the tooltip re-renders reliably
             cancerTypeDetailedValueMap: this.cancerTypeDetailedValueMap,
-            osMonthlyValueMap: this.osMonthlyValueMap,
+            osMonthsValueMap: this.osMonthsValueMap,
             osStatusValueMap: this.osStatusValueMap,
             sampleTypeValueMap: this.sampleTypeValueMap,
         };

--- a/src/pages/studyView/tabs/EmbeddingsTab.tsx
+++ b/src/pages/studyView/tabs/EmbeddingsTab.tsx
@@ -1688,9 +1688,7 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                         >
                             <TooltipDropdown
                                 selectedFields={this.selectedTooltipFields}
-                                onSelectionChange={
-                                    this.onTooltipFieldsChange
-                                }
+                                onSelectionChange={this.onTooltipFieldsChange}
                             />
                         </div>
                     </div>

--- a/src/pages/studyView/tabs/EmbeddingsTab.tsx
+++ b/src/pages/studyView/tabs/EmbeddingsTab.tsx
@@ -30,7 +30,8 @@ import {
     EmbeddingPoint,
 } from 'shared/components/embeddings/EmbeddingTypes';
 import { calculateDataBounds } from 'shared/components/embeddings/utils/dataUtils';
-
+import { TOOLTIP_FIELD_OPTIONS } from 'shared/components/embeddings/controls/TooltipDisplay';
+import { preComputeClinicalDataMaps } from 'shared/lib/PatientMolecularDataUtils';
 export interface IEmbeddingsTabProps {
     store: StudyViewPageStore;
 }
@@ -38,6 +39,10 @@ export interface IEmbeddingsTabProps {
 // Base URL for embedding data
 const EMBEDDING_BASE_URL =
     'https://datahub.assets.cbioportal.org/embeddings/msk_mosaic_2026';
+
+// Only this study currently has real embedding data seeded in the column-store backend.
+// All other studies keep using the static EMBEDDING_BASE_URL data above for backward compatibility.
+const REAL_EMBEDDING_STUDY_ID = 'study_es_0';
 
 // Module-level singleton remote data loaders for embeddings
 // These are shared across all component instances to prevent duplicate fetches
@@ -72,6 +77,11 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
     };
     @observable private windowHeight = window.innerHeight;
     @observable private hiddenCategories = new Set<string>();
+    @observable private selectedTooltipFields = new Set<string>([
+        'patientId',
+        'position',
+    ]);
+    @observable private isTooltipFieldPickerOpen = false;
     @observable.ref private pinnedPoint: EmbeddingPoint | null = null;
     private urlParameterReactionDisposer?: () => void;
     private urlSyncReactionDisposer?: () => void;
@@ -329,6 +339,96 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
         ]);
     }
 
+    @computed get cancerTypeDetailedValueMap(): Map<string, string> {
+        const cancerTypeAttr = this.clinicalAttributes.find(
+            attr => attr.clinicalAttributeId === 'CANCER_TYPE_DETAILED'
+        );
+        if (!cancerTypeAttr) {
+            return new Map();
+        }
+
+        const cacheEntry = this.props.store.clinicalDataCache.get(
+            cancerTypeAttr
+        );
+        if (!cacheEntry?.isComplete || !cacheEntry.result) {
+            return new Map();
+        }
+        const maps = preComputeClinicalDataMaps(
+            cacheEntry.result.data,
+            null,
+            cacheEntry.result.numericalValueToColor,
+            cancerTypeAttr.patientAttribute || false
+        );
+        return maps.patientValueMap;
+    }
+
+    @computed get osMonthlyValueMap(): Map<string, string> {
+        const osMonthsAttr = this.clinicalAttributes.find(
+            attr => attr.clinicalAttributeId === 'OS_MONTHS'
+        );
+        if (!osMonthsAttr) {
+            return new Map();
+        }
+
+        const cacheEntry = this.props.store.clinicalDataCache.get(osMonthsAttr);
+        if (!cacheEntry?.isComplete || !cacheEntry.result) {
+            return new Map();
+        }
+        const maps = preComputeClinicalDataMaps(
+            cacheEntry.result.data,
+            null,
+            cacheEntry.result.numericalValueToColor,
+            osMonthsAttr.patientAttribute || false
+        );
+        return maps.patientValueMap;
+    }
+
+    @computed get osStatusValueMap(): Map<string, string> {
+        const osStatusAttr = this.clinicalAttributes.find(
+            attr => attr.clinicalAttributeId === 'OS_STATUS'
+        );
+
+        if (!osStatusAttr) {
+            return new Map();
+        }
+
+        const cacheEntry = this.props.store.clinicalDataCache.get(osStatusAttr);
+        if (!cacheEntry?.isComplete || !cacheEntry.result) {
+            return new Map();
+        }
+        const maps = preComputeClinicalDataMaps(
+            cacheEntry.result.data,
+            null,
+            cacheEntry.result.numericalValueToColor,
+            osStatusAttr.patientAttribute || false
+        );
+        return maps.patientValueMap;
+    }
+
+    @computed get sampleTypeValueMap(): Map<string, string> {
+        const sampleTypeAttr = this.clinicalAttributes.find(
+            attr => attr.clinicalAttributeId === 'SAMPLE_TYPE'
+        );
+
+        if (!sampleTypeAttr) {
+            return new Map();
+        }
+
+        const cacheEntry = this.props.store.clinicalDataCache.get(
+            sampleTypeAttr
+        );
+        if (!cacheEntry?.isComplete || !cacheEntry.result) {
+            return new Map();
+        }
+        const maps = preComputeClinicalDataMaps(
+            cacheEntry.result.data,
+            null,
+            cacheEntry.result.numericalValueToColor,
+            sampleTypeAttr.patientAttribute || false
+        );
+        return maps.patientValueMap;
+    }
+
     @computed get embeddingDataGroups(): ColoringMenuOmnibarGroup[] {
         const embeddingDataFields = this.selectedEmbedding?.data
             ? getEmbeddingDataFields(this.selectedEmbedding.data)
@@ -448,6 +548,34 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
         return !!this.props.store.plotsTabStore.structuralVariantCache;
     }
 
+    // Real embedding data from the column-store backend, scoped to REAL_EMBEDDING_STUDY_ID only.
+    readonly realEmbeddingData = remoteData<EmbeddingData | null>({
+        await: () => [this.props.store.queriedPhysicalStudyIds],
+        invoke: async () => {
+            if (!this.currentStudyIds.includes(REAL_EMBEDDING_STUDY_ID)) {
+                return null;
+            }
+            const dto = await this.props.store.internalClient.fetchEmbeddingInStudyUsingPOST(
+                {
+                    embeddingFilter: {
+                        studyIds: [REAL_EMBEDDING_STUDY_ID],
+                        reductionTechnique: 'umap',
+                        embeddingType: 'PATIENT',
+                    },
+                }
+            );
+            // Backend returns embedding_type as 'PATIENT'/'SAMPLE'; frontend expects 'patients'/'samples'
+            const embeddingType: 'patients' | 'samples' =
+                dto.embedding_type.toUpperCase() === 'PATIENT'
+                    ? 'patients'
+                    : 'samples';
+            return {
+                ...dto,
+                embedding_type: embeddingType,
+            } as EmbeddingData;
+        },
+    });
+
     @computed get allEmbeddingOptions(): EmbeddingDataOption[] {
         const options: EmbeddingDataOption[] = [];
 
@@ -457,6 +585,17 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                 value: 'msk_mosaic_2026_he',
                 label: boehmHeData.result.title,
                 data: boehmHeData.result,
+            });
+        }
+
+        if (
+            this.realEmbeddingData.isComplete &&
+            this.realEmbeddingData.result
+        ) {
+            options.push({
+                value: 'study_es_0_umap',
+                label: this.realEmbeddingData.result.title,
+                data: this.realEmbeddingData.result,
             });
         }
 
@@ -482,7 +621,7 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
     }
 
     @computed get isEmbeddingDataLoading(): boolean {
-        return boehmHeData.isPending;
+        return boehmHeData.isPending || this.realEmbeddingData.isPending;
     }
 
     @computed get hasEmbeddingSupport(): boolean {
@@ -1220,6 +1359,21 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
         }
     }
 
+    // added when creatong the prop for tooltipdisplay to work but will change
+    @action.bound
+    private toggleTooltipOptionVisibility(option: string) {
+        if (this.selectedTooltipFields.has(option)) {
+            this.selectedTooltipFields.delete(option);
+        } else {
+            this.selectedTooltipFields.add(option);
+        }
+    }
+
+    @action.bound
+    private toggleTooltipFieldPicker() {
+        this.isTooltipFieldPickerOpen = !this.isTooltipFieldPickerOpen;
+    }
+
     @action.bound
     private toggleAllCategories() {
         // Define embedding configuration categories that should never be affected by Show All/Hide All
@@ -1388,6 +1542,11 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
             pinnedPoint: this.pinnedPoint,
             onPinPoint: this.pinPoint,
             onUnpinPoint: this.unpinPoint,
+            selectedTooltipFields: new Set(this.selectedTooltipFields), // constructing new set to update the tooltip due to a bug in the tooltip component that doesn't update when the original set is modified
+            cancerTypeDetailedValueMap: this.cancerTypeDetailedValueMap,
+            osMonthlyValueMap: this.osMonthlyValueMap,
+            osStatusValueMap: this.osStatusValueMap,
+            sampleTypeValueMap: this.sampleTypeValueMap,
         };
 
         return (
@@ -1486,6 +1645,76 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                                     }}
                                 />
                             </div>
+                        </div>
+
+                        <div
+                            style={{
+                                display: 'inline-block',
+                                marginRight: '20px',
+                                verticalAlign: 'middle',
+                                position: 'relative',
+                            }}
+                        >
+                            <button
+                                onClick={this.toggleTooltipFieldPicker}
+                                style={{
+                                    fontSize: '14px',
+                                    padding: '6px 10px',
+                                    cursor: 'pointer',
+                                    border: '1px solid #ccc',
+                                    borderRadius: '4px',
+                                    background: 'white',
+                                }}
+                            >
+                                Tooltip fields ▾
+                            </button>
+                            {this.isTooltipFieldPickerOpen && (
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        top: '100%',
+                                        left: 0,
+                                        marginTop: '4px',
+                                        backgroundColor: 'white',
+                                        border: '1px solid #ccc',
+                                        borderRadius: '4px',
+                                        padding: '8px 12px',
+                                        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+                                        zIndex: 9999,
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                >
+                                    {TOOLTIP_FIELD_OPTIONS.map(opt => (
+                                        <div
+                                            key={opt.value}
+                                            style={{ marginBottom: '4px' }}
+                                        >
+                                            <label
+                                                style={{
+                                                    fontSize: '13px',
+                                                    cursor: 'pointer',
+                                                }}
+                                            >
+                                                <input
+                                                    type="checkbox"
+                                                    checked={this.selectedTooltipFields.has(
+                                                        opt.value
+                                                    )}
+                                                    onChange={() =>
+                                                        this.toggleTooltipOptionVisibility(
+                                                            opt.value
+                                                        )
+                                                    }
+                                                    style={{
+                                                        marginRight: '6px',
+                                                    }}
+                                                />
+                                                {opt.label}
+                                            </label>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
                         </div>
 
                         <div

--- a/src/pages/studyView/tabs/EmbeddingsTab.tsx
+++ b/src/pages/studyView/tabs/EmbeddingsTab.tsx
@@ -30,7 +30,7 @@ import {
     EmbeddingPoint,
 } from 'shared/components/embeddings/EmbeddingTypes';
 import { calculateDataBounds } from 'shared/components/embeddings/utils/dataUtils';
-import { TOOLTIP_FIELD_OPTIONS } from 'shared/components/embeddings/controls/TooltipDisplay';
+import { TooltipDropdown } from 'shared/components/embeddings/controls/TooltipDropdown';
 import { preComputeClinicalDataMaps } from 'shared/lib/PatientMolecularDataUtils';
 export interface IEmbeddingsTabProps {
     store: StudyViewPageStore;
@@ -81,7 +81,6 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
         'patientId',
         'position',
     ]);
-    @observable private isTooltipFieldPickerOpen = false;
     @observable.ref private pinnedPoint: EmbeddingPoint | null = null;
     private urlParameterReactionDisposer?: () => void;
     private urlSyncReactionDisposer?: () => void;
@@ -1359,19 +1358,9 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
         }
     }
 
-    // added when creatong the prop for tooltipdisplay to work but will change
     @action.bound
-    private toggleTooltipOptionVisibility(option: string) {
-        if (this.selectedTooltipFields.has(option)) {
-            this.selectedTooltipFields.delete(option);
-        } else {
-            this.selectedTooltipFields.add(option);
-        }
-    }
-
-    @action.bound
-    private toggleTooltipFieldPicker() {
-        this.isTooltipFieldPickerOpen = !this.isTooltipFieldPickerOpen;
+    private onTooltipFieldsChange(selectedFields: Set<string>) {
+        this.selectedTooltipFields = selectedFields;
     }
 
     @action.bound
@@ -1646,77 +1635,6 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                                 />
                             </div>
                         </div>
-
-                        <div
-                            style={{
-                                display: 'inline-block',
-                                marginRight: '20px',
-                                verticalAlign: 'middle',
-                                position: 'relative',
-                            }}
-                        >
-                            <button
-                                onClick={this.toggleTooltipFieldPicker}
-                                style={{
-                                    fontSize: '14px',
-                                    padding: '6px 10px',
-                                    cursor: 'pointer',
-                                    border: '1px solid #ccc',
-                                    borderRadius: '4px',
-                                    background: 'white',
-                                }}
-                            >
-                                Tooltip fields ▾
-                            </button>
-                            {this.isTooltipFieldPickerOpen && (
-                                <div
-                                    style={{
-                                        position: 'absolute',
-                                        top: '100%',
-                                        left: 0,
-                                        marginTop: '4px',
-                                        backgroundColor: 'white',
-                                        border: '1px solid #ccc',
-                                        borderRadius: '4px',
-                                        padding: '8px 12px',
-                                        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                                        zIndex: 9999,
-                                        whiteSpace: 'nowrap',
-                                    }}
-                                >
-                                    {TOOLTIP_FIELD_OPTIONS.map(opt => (
-                                        <div
-                                            key={opt.value}
-                                            style={{ marginBottom: '4px' }}
-                                        >
-                                            <label
-                                                style={{
-                                                    fontSize: '13px',
-                                                    cursor: 'pointer',
-                                                }}
-                                            >
-                                                <input
-                                                    type="checkbox"
-                                                    checked={this.selectedTooltipFields.has(
-                                                        opt.value
-                                                    )}
-                                                    onChange={() =>
-                                                        this.toggleTooltipOptionVisibility(
-                                                            opt.value
-                                                        )
-                                                    }
-                                                    style={{
-                                                        marginRight: '6px',
-                                                    }}
-                                                />
-                                                {opt.label}
-                                            </label>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
-
                         <div
                             className="coloring-menu"
                             style={{
@@ -1758,6 +1676,20 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                                 onCopyNumberToggle={this.onCopyNumberToggle}
                                 onStructuralVariantToggle={
                                     this.onStructuralVariantToggle
+                                }
+                            />
+                        </div>
+                        <div
+                            style={{
+                                display: 'inline-block',
+                                marginRight: '20px',
+                                verticalAlign: 'middle',
+                            }}
+                        >
+                            <TooltipDropdown
+                                selectedFields={this.selectedTooltipFields}
+                                onSelectionChange={
+                                    this.onTooltipFieldsChange
                                 }
                             />
                         </div>

--- a/src/pages/studyView/tabs/EmbeddingsTab.tsx
+++ b/src/pages/studyView/tabs/EmbeddingsTab.tsx
@@ -80,6 +80,7 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
     @observable private selectedTooltipFields = new Set<string>([
         'patientId',
         'position',
+        'category',
     ]);
     @observable.ref private pinnedPoint: EmbeddingPoint | null = null;
     private urlParameterReactionDisposer?: () => void;
@@ -592,7 +593,7 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
             this.realEmbeddingData.result
         ) {
             options.push({
-                value: 'study_es_0_umap',
+                value:`${REAL_EMBEDDING_STUDY_ID}_umap`,
                 label: this.realEmbeddingData.result.title,
                 data: this.realEmbeddingData.result,
             });
@@ -1531,7 +1532,7 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
             pinnedPoint: this.pinnedPoint,
             onPinPoint: this.pinPoint,
             onUnpinPoint: this.unpinPoint,
-            selectedTooltipFields: new Set(this.selectedTooltipFields), // constructing new set to update the tooltip due to a bug in the tooltip component that doesn't update when the original set is modified
+            selectedTooltipFields: new Set(this.selectedTooltipFields), //Clone to ensure prop identity changes and the tooltip re-renders reliably
             cancerTypeDetailedValueMap: this.cancerTypeDetailedValueMap,
             osMonthlyValueMap: this.osMonthlyValueMap,
             osStatusValueMap: this.osStatusValueMap,

--- a/src/shared/components/embeddings/EmbeddingDeckGLVisualization.tsx
+++ b/src/shared/components/embeddings/EmbeddingDeckGLVisualization.tsx
@@ -172,14 +172,13 @@ export class EmbeddingDeckGLVisualization extends React.Component<
         return (
             <TooltipDisplay
                 hoveredPoint={displayedPoint}
-                embeddingType={this.props.embeddingType}
                 isPinned={isPinned}
                 onUnpin={this.onUnpin}
                 selectedTooltipFields={this.props.selectedTooltipFields}
                 cancerTypeDetailedValueMap={
                     this.props.cancerTypeDetailedValueMap
                 }
-                osMonthlyValueMap={this.props.osMonthlyValueMap}
+                osMonthlyValueMap={this.props.osMonthsValueMap}
                 osStatusValueMap={this.props.osStatusValueMap}
                 sampleTypeValueMap={this.props.sampleTypeValueMap}
             />

--- a/src/shared/components/embeddings/EmbeddingDeckGLVisualization.tsx
+++ b/src/shared/components/embeddings/EmbeddingDeckGLVisualization.tsx
@@ -178,7 +178,7 @@ export class EmbeddingDeckGLVisualization extends React.Component<
                 cancerTypeDetailedValueMap={
                     this.props.cancerTypeDetailedValueMap
                 }
-                osMonthlyValueMap={this.props.osMonthsValueMap}
+                osMonthsValueMap={this.props.osMonthsValueMap}
                 osStatusValueMap={this.props.osStatusValueMap}
                 sampleTypeValueMap={this.props.sampleTypeValueMap}
             />

--- a/src/shared/components/embeddings/EmbeddingDeckGLVisualization.tsx
+++ b/src/shared/components/embeddings/EmbeddingDeckGLVisualization.tsx
@@ -175,6 +175,13 @@ export class EmbeddingDeckGLVisualization extends React.Component<
                 embeddingType={this.props.embeddingType}
                 isPinned={isPinned}
                 onUnpin={this.onUnpin}
+                selectedTooltipFields={this.props.selectedTooltipFields}
+                cancerTypeDetailedValueMap={
+                    this.props.cancerTypeDetailedValueMap
+                }
+                osMonthlyValueMap={this.props.osMonthlyValueMap}
+                osStatusValueMap={this.props.osStatusValueMap}
+                sampleTypeValueMap={this.props.sampleTypeValueMap}
             />
         );
     }

--- a/src/shared/components/embeddings/EmbeddingTypes.tsx
+++ b/src/shared/components/embeddings/EmbeddingTypes.tsx
@@ -91,6 +91,11 @@ export interface EmbeddingVisualizationProps {
     pinnedPoint?: EmbeddingPoint | null;
     onPinPoint?: (point: EmbeddingPoint) => void;
     onUnpinPoint?: () => void;
+    selectedTooltipFields?: Set<string>;
+    cancerTypeDetailedValueMap?: Map<string, string>;
+    osMonthlyValueMap?: Map<string, string>;
+    osStatusValueMap?: Map<string, string>;
+    sampleTypeValueMap?: Map<string, string>;
 }
 
 export interface EmbeddingControlsProps {

--- a/src/shared/components/embeddings/EmbeddingTypes.tsx
+++ b/src/shared/components/embeddings/EmbeddingTypes.tsx
@@ -93,7 +93,7 @@ export interface EmbeddingVisualizationProps {
     onUnpinPoint?: () => void;
     selectedTooltipFields?: Set<string>;
     cancerTypeDetailedValueMap?: Map<string, string>;
-    osMonthlyValueMap?: Map<string, string>;
+    osMonthsValueMap?: Map<string, string>;
     osStatusValueMap?: Map<string, string>;
     sampleTypeValueMap?: Map<string, string>;
 }

--- a/src/shared/components/embeddings/controls/TooltipDisplay.tsx
+++ b/src/shared/components/embeddings/controls/TooltipDisplay.tsx
@@ -1,48 +1,127 @@
 import * as React from 'react';
 import { EmbeddingPoint } from '../EmbeddingTypes';
 
+export interface TooltipFieldValueMaps {
+    cancerTypeDetailedValueMap?: Map<string, string>;
+    osMonthlyValueMap?: Map<string, string>;
+    osStatusValueMap?: Map<string, string>;
+    sampleTypeValueMap?: Map<string, string>;
+}
+
 export interface TooltipDisplayProps {
     hoveredPoint: EmbeddingPoint | null;
     embeddingType?: 'patients' | 'samples';
     isPinned?: boolean;
     onUnpin?: () => void;
+    selectedTooltipFields?: Set<string>;
+    cancerTypeDetailedValueMap?: Map<string, string>;
+    osMonthlyValueMap?: Map<string, string>;
+    osStatusValueMap?: Map<string, string>;
+    sampleTypeValueMap?: Map<string, string>;
 }
+
+const fieldLabelMap: {
+    [key: string]: {
+        label: string;
+        getValue: (
+            point: EmbeddingPoint,
+            valueMaps: TooltipFieldValueMaps
+        ) => string;
+    };
+} = {
+    patientId: {
+        label: 'Patient ID',
+        getValue: (point: EmbeddingPoint) => point.patientId || '',
+    },
+    sampleId: {
+        label: 'Sample ID',
+        getValue: (point: EmbeddingPoint) => point.sampleId || '',
+    },
+    position: {
+        label: 'Position',
+        getValue: (point: EmbeddingPoint) =>
+            `(${point.x.toFixed(2)}, ${point.y.toFixed(2)})`,
+    },
+    category: {
+        label: 'Category',
+        getValue: (point: EmbeddingPoint) => point.displayLabel || '',
+    },
+    cancerTypeDetailed: {
+        label: 'Cancer Type Detailed',
+        getValue: (point: EmbeddingPoint, valueMaps: TooltipFieldValueMaps) =>
+            valueMaps.cancerTypeDetailedValueMap?.get(point.patientId || '') ||
+            '',
+    },
+    osMonthly: {
+        label: 'Overall Survival (Months)',
+        getValue: (point: EmbeddingPoint, valueMaps: TooltipFieldValueMaps) => {
+            const value = valueMaps.osMonthlyValueMap?.get(
+                point.patientId || ''
+            );
+            return value ? `${value} months` : '';
+        },
+    },
+    osStatus: {
+        label: 'Overall Survival Status',
+        getValue: (point: EmbeddingPoint, valueMaps: TooltipFieldValueMaps) => {
+            const value = valueMaps.osStatusValueMap?.get(
+                point.patientId || ''
+            );
+            return value || '';
+        },
+    },
+    sampleType: {
+        label: 'Sample Type',
+        getValue: (point: EmbeddingPoint, valueMaps: TooltipFieldValueMaps) => {
+            const value = valueMaps.sampleTypeValueMap?.get(
+                point.patientId || ''
+            );
+            return value || '';
+        },
+    },
+};
+
+export const TOOLTIP_FIELD_OPTIONS: {
+    value: string;
+    label: string;
+}[] = Object.keys(fieldLabelMap).map(key => ({
+    value: key,
+    label: fieldLabelMap[key].label,
+}));
 
 export const TooltipDisplay: React.FC<TooltipDisplayProps> = ({
     hoveredPoint,
     embeddingType,
     isPinned,
     onUnpin,
+    selectedTooltipFields,
+    cancerTypeDetailedValueMap,
+    osMonthlyValueMap,
+    osStatusValueMap,
+    sampleTypeValueMap,
 }) => {
     const [copied, setCopied] = React.useState(false);
 
     if (!hoveredPoint) return null;
 
-    // Show appropriate ID based on embedding type
-    const idLabel = embeddingType === 'samples' ? 'Sample ID' : 'Patient ID';
-    const idValue =
-        embeddingType === 'samples'
-            ? hoveredPoint.sampleId
-            : hoveredPoint.patientId;
+    const valueMaps: TooltipFieldValueMaps = {
+        cancerTypeDetailedValueMap,
+        osMonthlyValueMap,
+        osStatusValueMap,
+        sampleTypeValueMap,
+    };
 
-    // Build fields list - read directly from point properties
     const fields: { label: string; value: string }[] = [];
 
-    fields.push({ label: idLabel, value: idValue || '' });
-
-    // For patient embeddings, show sample ID if available
-    if (embeddingType === 'patients' && hoveredPoint.sampleId) {
-        fields.push({ label: 'Sample ID', value: hoveredPoint.sampleId });
-    }
-
-    fields.push({
-        label: 'Position',
-        value: `(${hoveredPoint.x.toFixed(2)}, ${hoveredPoint.y.toFixed(2)})`,
+    selectedTooltipFields?.forEach(field => {
+        if (fieldLabelMap[field]) {
+            const { label, getValue } = fieldLabelMap[field];
+            fields.push({
+                label,
+                value: getValue(hoveredPoint, valueMaps),
+            });
+        }
     });
-
-    if (hoveredPoint.displayLabel) {
-        fields.push({ label: 'Category', value: hoveredPoint.displayLabel });
-    }
 
     const handleCopy = () => {
         const text = fields.map(f => `${f.label}: ${f.value}`).join('\n');

--- a/src/shared/components/embeddings/controls/TooltipDisplay.tsx
+++ b/src/shared/components/embeddings/controls/TooltipDisplay.tsx
@@ -91,7 +91,6 @@ export const TOOLTIP_FIELD_OPTIONS: {
 
 export const TooltipDisplay: React.FC<TooltipDisplayProps> = ({
     hoveredPoint,
-    embeddingType,
     isPinned,
     onUnpin,
     selectedTooltipFields,
@@ -115,11 +114,12 @@ export const TooltipDisplay: React.FC<TooltipDisplayProps> = ({
 
     selectedTooltipFields?.forEach(field => {
         if (fieldLabelMap[field]) {
-            const { label, getValue } = fieldLabelMap[field];
-            fields.push({
-                label,
-                value: getValue(hoveredPoint, valueMaps),
-            });
+            const def = fieldLabelMap[field];
+            if (!def) return;
+            const value = def.getValue(hoveredPoint, valueMaps);
+            if(value!== '') {
+                fields.push({ label: def.label, value });
+            }
         }
     });
 

--- a/src/shared/components/embeddings/controls/TooltipDisplay.tsx
+++ b/src/shared/components/embeddings/controls/TooltipDisplay.tsx
@@ -3,7 +3,7 @@ import { EmbeddingPoint } from '../EmbeddingTypes';
 
 export interface TooltipFieldValueMaps {
     cancerTypeDetailedValueMap?: Map<string, string>;
-    osMonthlyValueMap?: Map<string, string>;
+    osMonthsValueMap?: Map<string, string>;
     osStatusValueMap?: Map<string, string>;
     sampleTypeValueMap?: Map<string, string>;
 }
@@ -15,7 +15,7 @@ export interface TooltipDisplayProps {
     onUnpin?: () => void;
     selectedTooltipFields?: Set<string>;
     cancerTypeDetailedValueMap?: Map<string, string>;
-    osMonthlyValueMap?: Map<string, string>;
+    osMonthsValueMap?: Map<string, string>;
     osStatusValueMap?: Map<string, string>;
     sampleTypeValueMap?: Map<string, string>;
 }
@@ -52,10 +52,10 @@ const fieldLabelMap: {
             valueMaps.cancerTypeDetailedValueMap?.get(point.patientId || '') ||
             '',
     },
-    osMonthly: {
+    osMonths: {
         label: 'Overall Survival (Months)',
         getValue: (point: EmbeddingPoint, valueMaps: TooltipFieldValueMaps) => {
-            const value = valueMaps.osMonthlyValueMap?.get(
+            const value = valueMaps.osMonthsValueMap?.get(
                 point.patientId || ''
             );
             return value ? `${value} months` : '';
@@ -95,7 +95,7 @@ export const TooltipDisplay: React.FC<TooltipDisplayProps> = ({
     onUnpin,
     selectedTooltipFields,
     cancerTypeDetailedValueMap,
-    osMonthlyValueMap,
+    osMonthsValueMap,
     osStatusValueMap,
     sampleTypeValueMap,
 }) => {
@@ -105,7 +105,7 @@ export const TooltipDisplay: React.FC<TooltipDisplayProps> = ({
 
     const valueMaps: TooltipFieldValueMaps = {
         cancerTypeDetailedValueMap,
-        osMonthlyValueMap,
+        osMonthsValueMap,
         osStatusValueMap,
         sampleTypeValueMap,
     };

--- a/src/shared/components/embeddings/controls/TooltipDropdown.tsx
+++ b/src/shared/components/embeddings/controls/TooltipDropdown.tsx
@@ -28,6 +28,7 @@ export class TooltipDropdown extends React.Component<TooltipDropDownProps> {
         return (
             <div style={{ display: 'flex', alignItems: 'center' }}>
                 <label
+                    htmlFor="tooltip-fields-select"
                     style={{
                         marginRight: '8px',
                         whiteSpace: 'nowrap',
@@ -37,6 +38,8 @@ export class TooltipDropdown extends React.Component<TooltipDropDownProps> {
                     Tooltip fields:
                 </label>
                 <Select
+                    inputId="tooltip-fields-select"
+                    aria-label="Tooltip fields"
                     name="tooltip-fields-select"
                     isMulti
                     closeMenuOnSelect={false}

--- a/src/shared/components/embeddings/controls/TooltipDropdown.tsx
+++ b/src/shared/components/embeddings/controls/TooltipDropdown.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import Select from 'react-select';
+import { TOOLTIP_FIELD_OPTIONS } from './TooltipDisplay';
+
+export interface TooltipDropDownProps {
+    // current selection of tooltip fields
+    selectedFields: Set<string>;
+
+    // event handler for when the selection changes
+    onSelectionChange: (selectedFields: Set<string>) => void;
+}
+
+export class TooltipDropdown extends React.Component<TooltipDropDownProps> {
+    private handleSelectionChange = (
+        selected: { value: string; label: string }[] | null
+    ) => {
+        const newSelectedFields = new Set(
+            (selected || []).map(option => option.value)
+        );
+        this.props.onSelectionChange(newSelectedFields);
+    };
+
+    render() {
+        const selectedOptions = TOOLTIP_FIELD_OPTIONS.filter(opt =>
+            this.props.selectedFields.has(opt.value)
+        );
+
+        return (
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+                <label
+                    style={{
+                        marginRight: '8px',
+                        whiteSpace: 'nowrap',
+                        fontSize: '14px',
+                    }}
+                >
+                    Tooltip fields:
+                </label>
+                <Select
+                    name="tooltip-fields-select"
+                    isMulti
+                    closeMenuOnSelect={false}
+                    hideSelectedOptions={false}
+                    options={TOOLTIP_FIELD_OPTIONS}
+                    value={selectedOptions}
+                    onChange={this.handleSelectionChange}
+                    styles={{
+                        container: (base: any) => ({
+                            ...base,
+                            width: '300px',
+                        }),
+                        control: (base: any) => ({
+                            ...base,
+                            fontSize: '14px',
+                            minHeight: '34px',
+                        }),
+                        valueContainer: (base: any) => ({
+                            ...base,
+                            flexWrap: 'nowrap',
+                            overflowX: 'auto',
+                        }),
+                        multiValue: (base: any) => ({
+                            ...base,
+                            flexShrink: 0,
+                        }),
+                        menu: (base: any) => ({
+                            ...base,
+                            zIndex: 9999,
+                        }),
+                    }}
+                />
+            </div>
+        );
+    }
+}
+
+export default TooltipDropdown;


### PR DESCRIPTION
Fix cBioPortal/cbioportal# (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
-  Add user-selectable tooltip fields for the embedding plot (Similarity Maps), replacing the previous fixed set of hardcoded tooltip fields
- New `TooltipDropdown` component: a searchable multi-select control for choosing which fields display, styled to match the existing "Color by" dropdown (`ColorSamplesByDropdown`) for visual consistency
-  Add four new clinical-attribute-backed tooltip fields, computed via the existing `clinicalDataCache` / `preComputeClinicalDataMaps` pattern: Cancer Type Detailed, Overall Survival (Months), Overall Survival Status, Sample Type

## Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

## Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

After 
<img width="2910" height="1296" alt="image" src="https://github.com/user-attachments/assets/03a4b79f-f9fb-41d9-adab-ed16e0428b25" />


## Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789146518&installation_model_id=19627&pr_number=5675&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5675&signature=417bc470350a5f543140607056a4ab6432459909833df76e67b0e59136f390f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->