### PR TITLE
Rename "Web API" header tab to "API & MCP"

### DIFF
--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -45,7 +45,7 @@ export default class PortalHeader extends React.Component<
 
             {
                 id: 'webAPI',
-                text: 'Web API',
+                text: 'Web API & MCP',
                 address: 'https://docs.cbioportal.org/web-api-and-clients/',
                 internal: false,
                 hide: () => getServerConfig().skin_show_web_api_tab === false,

--- a/src/appShell/App/PortalHeader.tsx
+++ b/src/appShell/App/PortalHeader.tsx
@@ -45,7 +45,7 @@ export default class PortalHeader extends React.Component<
 
             {
                 id: 'webAPI',
-                text: 'Web API & MCP',
+                text: 'API & MCP',
                 address: 'https://docs.cbioportal.org/web-api-and-clients/',
                 internal: false,
                 hide: () => getServerConfig().skin_show_web_api_tab === false,


### PR DESCRIPTION
## What

cBioPortal now exposes a hosted MCP endpoint (`https://mcp.cbioportal.org/db/mcp`) alongside the REST API. This renames the header nav tab from **Web API** to **API & MCP** so users can discover both.

The tab keeps linking to the API & clients docs page, which is updated in a companion docs PR (cBioPortal/cbioportal#12294) to add an MCP section documenting the hosted endpoint.

Only the tab label changes; visibility still respects `skin_show_web_api_tab`.

## Preview

- https://deploy-preview-5677.preview.cbioportal.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789331073&installation_model_id=19627&pr_number=5677&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5677&signature=e2048da9de70b273ed6ac6364132c6fb466548e680c8fac0c09706630fc01536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

