### PR TITLE
Shrink oncoprint SVG export by coalescing identical adjacent columns

### DIFF
--- a/packages/oncoprintjs/src/js/makesvgelement.ts
+++ b/packages/oncoprintjs/src/js/makesvgelement.ts
@@ -1,9 +1,12 @@
 export default function makesvgelement(tag: string, attrs: any) {
     const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
     for (const k in attrs) {
-        if (k in attrs) {
-            el.setAttribute(k, attrs[k]);
+        // skip absent attributes - setAttribute would stringify them, putting
+        // literal fill="undefined" into the exported document
+        if (attrs[k] === undefined || attrs[k] === null) {
+            continue;
         }
+        el.setAttribute(k, attrs[k]);
     }
     return el;
 }

--- a/packages/oncoprintjs/src/js/oncoprintshapetosvg.ts
+++ b/packages/oncoprintjs/src/js/oncoprintshapetosvg.ts
@@ -7,6 +7,7 @@ import {
     ComputedShapeParams,
     ComputedTriangleParams,
 } from './oncoprintshape';
+import { RGBAColor } from './oncoprintruleset';
 import { rgbString } from './utils';
 
 function extractColor(str: string) {
@@ -30,21 +31,75 @@ function extractColor(str: string) {
     };
 }
 
+// Coordinates come out of the shape system as running floating point sums, so
+// they carry the full 17 significant digits of a double. That precision is far
+// below what the geometry can express, and on a large oncoprint the extra
+// digits dominate the size of the exported document.
+function round(n: number) {
+    if (!isFinite(n)) {
+        return n;
+    }
+    // A cell can be a small fraction of a pixel wide when zoomed out, and a
+    // shape's width is derived from the difference of two rounded edges (see
+    // roundSpan), so the grid has to stay fine enough that quantising the edges
+    // doesn't visibly change the width of a sub-pixel cell.
+    const factor = Math.abs(n) < 1 ? 1e6 : 1e4;
+    return Math.round(n * factor) / factor;
+}
+
+// Rounding a position and a length independently opens sub-pixel seams between
+// neighbours, because one shape's right edge and the next one's left edge stop
+// agreeing. Round both edges onto the same grid and derive the length from
+// them, so touching shapes keep touching.
+function roundSpan(start: number, length: number) {
+    const from = round(start);
+    // the subtraction of two rounded values reintroduces float noise, so round
+    // the result as well
+    let size = round(round(start + length) - from);
+    if (size === 0 && length > 0) {
+        // don't let a very thin shape disappear entirely
+        size = round(length) || length;
+    }
+    return { from, size };
+}
+
+// A stroke with zero width or zero opacity paints nothing, and fill-opacity
+// defaults to 1, so writing them is pure overhead.
+function strokeAttrs(params: {
+    stroke: RGBAColor;
+    'stroke-width': number;
+}): { [attr: string]: string | number } {
+    if (!params['stroke-width'] || !params.stroke[3]) {
+        return {};
+    }
+    return {
+        stroke: rgbString(params.stroke),
+        'stroke-opacity': params.stroke[3],
+        'stroke-width': params['stroke-width'],
+    };
+}
+
+function fillAttrs(fill: RGBAColor) {
+    return {
+        fill: rgbString(fill),
+        'fill-opacity': fill[3] === 1 ? undefined : fill[3],
+    };
+}
+
 function rectangleToSVG(
     params: ComputedRectangleParams,
     offset_x: number,
     offset_y: number
 ) {
+    const horz = roundSpan(params.x + offset_x, params.width);
+    const vert = roundSpan(params.y + offset_y, params.height);
     return makeSVGElement('rect', {
-        width: params.width,
-        height: params.height,
-        x: params.x + offset_x,
-        y: params.y + offset_y,
-        stroke: rgbString(params.stroke),
-        'stroke-opacity': params.stroke[3],
-        'stroke-width': params['stroke-width'],
-        fill: rgbString(params.fill),
-        'fill-opacity': params.fill[3],
+        width: horz.size,
+        height: vert.size,
+        x: horz.from,
+        y: vert.from,
+        ...strokeAttrs(params),
+        ...fillAttrs(params.fill),
     });
 }
 
@@ -60,14 +115,11 @@ function triangleToSVG(
             [params.x3 + offset_x, params.y3 + offset_y],
         ]
             .map(function(a) {
-                return a[0] + ',' + a[1];
+                return round(a[0]) + ',' + round(a[1]);
             })
             .join(' '),
-        stroke: rgbString(params.stroke),
-        'stroke-opacity': params.stroke[3],
-        'stroke-width': params['stroke-width'],
-        fill: rgbString(params.fill),
-        'fill-opacity': params.fill[3],
+        ...strokeAttrs(params),
+        ...fillAttrs(params.fill),
     });
 }
 
@@ -77,15 +129,14 @@ function ellipseToSVG(
     offset_y: number
 ) {
     return makeSVGElement('ellipse', {
-        rx: params.width / 2,
-        height: params.height / 2,
-        cx: params.x + offset_x,
-        cy: params.y + offset_y,
-        stroke: rgbString(params.stroke),
-        'stroke-opacity': params.stroke[3],
-        'stroke-width': params['stroke-width'],
-        fill: rgbString(params.fill),
-        'fill-opacity': params.fill[3],
+        rx: round(params.width / 2),
+        // was `height`, which SVG ignores on an ellipse - every exported ellipse
+        // fell back to an auto ry and rendered as a circle
+        ry: round(params.height / 2),
+        cx: round(params.x + offset_x),
+        cy: round(params.y + offset_y),
+        ...strokeAttrs(params),
+        ...fillAttrs(params.fill),
     });
 }
 
@@ -95,10 +146,11 @@ function lineToSVG(
     offset_y: number
 ) {
     return makeSVGElement('line', {
-        x1: params.x1 + offset_x,
-        y1: params.y1 + offset_y,
-        x2: params.x2 + offset_x,
-        y2: params.y2 + offset_y,
+        x1: round(params.x1 + offset_x),
+        y1: round(params.y1 + offset_y),
+        x2: round(params.x2 + offset_x),
+        y2: round(params.y2 + offset_y),
+        // a line is nothing but its stroke, so always write it
         stroke: rgbString(params.stroke),
         'stroke-opacity': params.stroke[3],
         'stroke-width': params['stroke-width'],

--- a/packages/oncoprintjs/src/js/oncoprintwebglcellview.ts
+++ b/packages/oncoprintjs/src/js/oncoprintwebglcellview.ts
@@ -25,6 +25,47 @@ import _ from 'lodash';
 import MouseUpEvent = JQuery.MouseUpEvent;
 import MouseMoveEvent = JQuery.MouseMoveEvent;
 
+// tolerance for comparing coordinates that were produced by the same
+// floating point arithmetic - see toSVGGroup
+const COALESCE_EPSILON = 1e-9;
+
+function shapeListsEqual(a: ComputedShapeParams[], b: ComputedShapeParams[]) {
+    if (a.length !== b.length) {
+        return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+        // Shape.getCachedShape interns computed shapes, so two columns that are
+        // painted identically share the same frozen object
+        if (a[i] !== b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function shapeListIsCoalescable(
+    shapes: ComputedShapeParams[],
+    columnWidth: number
+) {
+    // Only rectangles that span the whole column tile into a wider rectangle.
+    // Triangles, ellipses and lines - and rectangles inset within the column -
+    // stay one element per column.
+    if (shapes.length === 0) {
+        return false;
+    }
+    for (let i = 0; i < shapes.length; i++) {
+        const shape = shapes[i];
+        if (
+            shape.type !== 'rectangle' ||
+            shape.x !== 0 ||
+            Math.abs(shape.width - columnWidth) > COALESCE_EPSILON
+        ) {
+            return false;
+        }
+    }
+    return true;
+}
+
 type ColorBankIndex = number; // index into vertex bank (e.g. 0, 4, 8, ...)
 type ColorBank = number[]; // flat list of color: [c0,c0,c0,c0,v1,v1,v1,c1,c1,c1,c1,...]
 type ColumnIdIndex = number;
@@ -2063,33 +2104,88 @@ export default class OncoprintWebGLCellView {
                 }
             }
 
+            // Emit one element per *run* of identically-painted adjacent
+            // columns rather than one per column. On a zoomed-out oncoprint a
+            // column can be a small fraction of a pixel wide, so a track that
+            // is visually a handful of solid bars would otherwise be written
+            // out as tens of thousands of sub-pixel rectangles - which is both
+            // enormous and, because each one antialiases independently, renders
+            // washed out instead of solid.
+            const columnWidth = model.getCellWidth() + model.getCellPadding();
+            const shapeListById: { [id: string]: ComputedShapeParams[] } = {};
             for (let j = 0; j < identified_shape_list_list.length; j++) {
-                const id_sl = identified_shape_list_list[j];
-                const id = id_sl.id;
-                const sl = id_sl.shape_list;
-                const offset_x = zoomedColumnLeft[id];
-                if (typeof offset_x === 'undefined') {
-                    // hidden id
-                    continue;
-                }
+                shapeListById[identified_shape_list_list[j].id] =
+                    identified_shape_list_list[j].shape_list;
+            }
 
-                // draw universal shapes first
-                for (let h = 0; h < universal_shapes.length; h++) {
+            let run: {
+                x: number;
+                end: number;
+                columns: number;
+                shapes: ComputedShapeParams[];
+            } | null = null;
+
+            const flushRun = () => {
+                if (run === null) {
+                    return;
+                }
+                const single = run.columns === 1;
+                for (let h = 0; h < run.shapes.length; h++) {
+                    const shape = run.shapes[h];
                     root.appendChild(
                         svgfactory.fromShape(
-                            universal_shapes[h],
-                            offset_x,
+                            single
+                                ? shape
+                                : {
+                                      ...shape,
+                                      x: 0,
+                                      width: run.end - run.x,
+                                  },
+                            run.x,
                             offset_y
                         )
                     );
                 }
-                // next draw specific shapes
-                for (let h = 0; h < sl.length; h++) {
-                    root.appendChild(
-                        svgfactory.fromShape(sl[h], offset_x, offset_y)
-                    );
+                run = null;
+            };
+
+            const id_order = model.getIdOrder();
+            for (let j = 0; j < id_order.length; j++) {
+                const id = id_order[j];
+                const sl = shapeListById[id];
+                const offset_x = zoomedColumnLeft[id];
+                if (
+                    typeof sl === 'undefined' ||
+                    typeof offset_x === 'undefined'
+                ) {
+                    // no data in this track for this column, or hidden id
+                    flushRun();
+                    continue;
                 }
+                // universal shapes are drawn first, then the specific ones
+                const shapes = universal_shapes.concat(sl);
+
+                if (
+                    run !== null &&
+                    // the previous column ends exactly where this one starts,
+                    // so the merged rectangle covers the same area
+                    Math.abs(offset_x - run.end) < COALESCE_EPSILON &&
+                    shapeListsEqual(run.shapes, shapes) &&
+                    shapeListIsCoalescable(shapes, columnWidth)
+                ) {
+                    run.end = offset_x + columnWidth;
+                    run.columns += 1;
+                    continue;
+                }
+                flushRun();
+                run = {
+                    x: offset_x,
+                    end: offset_x + columnWidth,
+                    columns: 1,
+                    shapes,
+                };
             }
+            flushRun();
         }
         // add column labels
         const labels = model.getColumnLabels();


### PR DESCRIPTION
## The problem

This oncoprint — four genes over `msk_impact_50k_2026`, 48,179 patient columns —
exports as a **49.4 MB SVG** containing **274,436 `<rect>` elements**:

```
/results/oncoprint?cancer_study_list=msk_impact_50k_2026&...&gene_list=CDKN2A%20MDM2%20MDM4%20TP53
```

47.5 MB of the file is attribute text. 192,729 of the rects are the genetic
ruleset's universal "No alterations" background shape, re-emitted once per
column even though a universal shape by definition does not depend on the datum
(`geneticrules.ts` declares it under `always:`, which `LookupRuleSet` promotes
to the ruleset's universal rule).

At that width each column is **0.046 px**, so a track that is visually a handful
of solid bars gets written out as tens of thousands of sub-pixel rectangles.
A single one of them costs 179 bytes to paint 1/22nd of a pixel:

```xml
<rect width="0.046036128431424905" height="23" x="1350.1015385088956" y="81"
      stroke="rgb(0,0,0)" stroke-opacity="0" stroke-width="0"
      fill="rgb(190,190,190)" fill-opacity="1"/>
```

### It also renders the wrong colours

Because each sub-pixel rect is antialiased independently and then composited,
22 edges at 4.6% alpha converge to about 64% coverage, not 100%. The exported
SVG therefore does not match what the user saw on screen:

| alteration | source | current export | this PR |
| --- | --- | --- | --- |
| Deep deletion | `#0000ff` | `rgb(110,110,220)` | `rgb(0,0,255)` |
| Amplification | `#ff0000` | `rgb(221,108,108)` | `rgb(255,0,0)` |
| Truncating mutation | `#000000` | `rgb(107,107,107)` | `rgb(0,0,0)` |
| Missense mutation | `#008000` | `rgb(108,167,108)` | `rgb(0,128,0)` |
| No alterations | `#BEBEBE` | `rgb(208,208,208)` | `rgb(190,190,190)` |

This affects the PDF and PNG exports too, since both are built from `toSVG()`.

## The change

`OncoprintWebGLCellView.toSVGGroup()` now walks columns in x order and holds a
run open while **(a)** the next column starts exactly where the previous one
ended and **(b)** its shape list is identical. Computed shapes are already
interned by `Shape.getCachedShape`, so identity is a reference comparison.

Coalescing is deliberately conservative — `shapeListIsCoalescable` only merges
rectangles that span the whole column:

```js
shape.type === 'rectangle' && shape.x === 0 && shape.width === columnWidth
```

Triangles, ellipses, lines and inset rectangles fall back to one element per
column, as does anything drawn with column padding on, where cells genuinely do
not tile. Because a run only closes when the shape list changes, and shapes
inside a run are emitted in their original z-sorted order, painting order is
preserved exactly.

Alongside that, in `oncoprintshapetosvg.ts`:

- Skip `stroke`/`stroke-opacity`/`stroke-width` when the stroke paints nothing,
  and `fill-opacity` when it is 1. Those were written on every rect — 20 MB of
  text that changed no pixel.
- Round coordinates. `roundSpan()` rounds a shape's two edges onto the same grid
  and derives the length from them, so touching shapes keep touching; rounding a
  position and a length independently opens sub-pixel seams.
- **Bug fix:** `ellipseToSVG` set `height` where SVG expects `ry`, so every
  exported ellipse fell back to an auto `ry` and rendered as a circle.
- **Bug fix:** `makesvgelement` no longer stringifies `undefined` attribute
  values, which were reaching the document as `fill="undefined"` and
  `text-decoration="undefined"` (49 occurrences in the export above).

## Result

```
before   274,436 rects   49,434,162 bytes
after      9,843 rects      819,173 bytes      60x smaller
```

The four gene tracks collapse to 63/91/113/545 rects — the oncoprint is sorted,
so alterations cluster into long uniform runs. The remaining ~9,000 come from
the "# Samples per Patient" bar track, where bar height genuinely varies per
patient; that is real signal and no lossless rule can remove it.

## Verification

Every case below was exported twice from a running dev server — once from
`master`, once from this branch — and the two outputs compared.

```
CASE                      ORIG RECTS  NEW RECTS   ORIG BYTES   NEW BYTES   COALESCED
tiny-base                        522        522        77504       39011   no
tiny-whitespace-off              522         78        77471        8782   yes (6.7x)
tiny-clinical                    880        880       142400       73413   no
tiny-clinical-nows               880        380       142347       39027   yes (2.3x)
tiny-zoomout                     522        522        92969       42825   no
tiny-samples                     522        522        77504       39011   no
tiny-unaltered-hidden            297        297        45734       23666   no
tiny-sort-by-data                522        522        77504       39011   no
tiny-gaps                        791        791       125257       64913   no
tiny-gaps-nows                   791        277       125212       29726   yes (2.9x)
small-base                      7486        711      1300601       68076   yes (10.5x)
small-whitespace-off            7486        711      1300601       68076   yes (10.5x)
small-zoomin                    7486       7486      1073324      546695   no
small-zoomin-nows               7486        711      1072792       62055   yes (10.5x)
small-clinical                 10473       3677      1873069      323720   yes (2.8x)
small-gaps                      8484       2078      1489506      192035   yes (4.1x)
small-gaps-nows                 8484       2078      1489506      192035   yes (4.1x)
big-base                      274436       9843     49434162      819173   yes (27.9x)
big-whitespace-off            274436       9843     49434162      819173   yes (27.9x)
```

tiny = `acc_tcga_pan_can_atlas_2018` (92 columns), small =
`brca_tcga_pan_can_atlas_2018` (1,084), big = `msk_impact_50k_2026` (48,179).

Equivalence was checked two independent ways on all 19 cases:

1. **Painted area per fill + edge displacement** — area preserved per fill to
   within 1e-4 relative, and no edge anywhere moved more than **0.00005 px**.
2. **Scanline sampling under painter's algorithm** — for a dense grid of sample
   points, the topmost fill must match. **Zero differing samples**, out of
   400k–3M samples per case.

Notes on two rows that look surprising:

- **"Show whitespace between columns" turns coalescing off, by design.** With
  padding on, cells do not tile, the contiguity test fails, and output is
  element-for-element identical to today (`522 -> 522`, `880 -> 880`,
  `7486 -> 7486`); those rows still shrink from the attribute hygiene alone.
  This costs nothing on the exports that actually hurt, because the oncoprint
  already auto-disables padding once cells drop below
  `cell_padding_off_cell_width_threshold` (2 px) — which is why `big-base` and
  `big-whitespace-off` are byte-identical.
- **Gaps / column grouping** is the case the contiguity test exists for. At a
  group boundary `zoomedColumnLeft` advances by an extra `gapSize`, the test
  fails, and the run closes, so a merged rectangle never spans a gap. Gaps were
  confirmed present in those exports (discontinuities up to 236 px) before
  comparing.

Test suites: `oncoprintjs` 27/27, main suite 2,184 passed / 0 failed.

**Not covered:** heatmap / gradient tracks, which use `svgfactory.gradient()`
and emit `<linearGradient>` fills rather than flat ones. They should fall
through the `shapeListIsCoalescable` guard unchanged, but I did not exercise
them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789654118&installation_model_id=19627&pr_number=5679&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5679&signature=d2a5337f2452db90e6f2b547ed9405b30213e61c8efcaebcd63102d832edd6ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->