### PR TITLE
Fix group color picker not opening in study view groups menu (React 18 regression)

### DIFF
--- a/end-to-end-test-playwright/tests/local/group-color-chooser.spec.ts
+++ b/end-to-end-test-playwright/tests/local/group-color-chooser.spec.ts
@@ -52,26 +52,9 @@ test.describe.serial('color chooser for groups menu in study view', () => {
             typeof icon === 'string' ? page.locator(icon) : icon;
         for (let attempt = 0; attempt < 3; attempt++) {
             if (!(await page.locator(swatchSel).isVisible())) {
-                // react-overlays 0.7.x's RootCloseWrapper adds its document-level
-                // close handler during the opening click's event processing (inside
-                // componentDidMount, which React runs while the click is still
-                // bubbling from #reactRoot to document in React 18).  That handler
-                // then fires when the same click reaches document — immediately
-                // closing the picker that was just opened.
-                //
-                // Fix: register a bubble-phase listener on document BEFORE the
-                // click fires.  Listeners fire in FIFO order per element/phase, so
-                // ours always runs before the RootCloseWrapper handler (which is
-                // only registered partway through the event's propagation).
-                // stopImmediatePropagation silences all subsequent listeners at
-                // document for this one event.
-                await page.evaluate(() => {
-                    document.addEventListener(
-                        'click',
-                        e => e.stopImmediatePropagation(),
-                        { capture: false, once: true }
-                    );
-                });
+                // A plain click must open the picker. Do not paper over
+                // RootCloseWrapper/React 18 close-on-open behavior here; that
+                // is handled in GroupCheckbox and is what this test guards.
                 await iconLocator.click();
                 // circle-picker does a secondary layout re-render right after
                 // mounting; wait for it to settle before trying to click a swatch.

--- a/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
@@ -132,7 +132,18 @@ export default class GroupCheckbox extends React.Component<
 
     buildColorChooserWidget = () => (
         <Popover>
-            <div>
+            {/* The popover is portaled to document.body, outside the Groups
+                menu (an rc-tooltip). Stop native mousedown/click here so
+                rc-trigger's document listener doesn't treat a swatch click
+                as an outside click and close the whole menu. */}
+            <div
+                onMouseDown={e => {
+                    e.nativeEvent.stopImmediatePropagation();
+                }}
+                onClick={e => {
+                    e.nativeEvent.stopImmediatePropagation();
+                }}
+            >
                 <CirclePicker
                     colors={this.colorList}
                     circleSize={20}

--- a/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
+++ b/src/pages/groupComparison/comparisonGroupManager/GroupCheckbox.tsx
@@ -132,14 +132,7 @@ export default class GroupCheckbox extends React.Component<
 
     buildColorChooserWidget = () => (
         <Popover>
-            <div
-                onMouseDown={e => {
-                    e.nativeEvent.stopImmediatePropagation();
-                }}
-                onClick={e => {
-                    e.nativeEvent.stopImmediatePropagation();
-                }}
-            >
+            <div>
                 <CirclePicker
                     colors={this.colorList}
                     circleSize={20}
@@ -237,6 +230,14 @@ export default class GroupCheckbox extends React.Component<
                                             marginTop: 2,
                                             marginRight: 2,
                                         }}
+                                        // Stop the native click before it reaches
+                                        // document: under React 18, RootCloseWrapper
+                                        // attaches its document listener during the
+                                        // opening click's dispatch and would otherwise
+                                        // close the popover immediately.
+                                        onClick={e =>
+                                            e.nativeEvent.stopImmediatePropagation()
+                                        }
                                     >
                                         <ColorPickerIcon
                                             color={


### PR DESCRIPTION
## Bug
On the study view page (e.g. https://www.cbioportal.org/study/summary?id=coadread_tcga_pub), open the Groups menu, create a group, and click the color chooser icon — nothing happens.

## Root cause
Same React 18 regression as #5620 and #5663. React 18 moved event delegation from `document` to the React root container. `OverlayTrigger` (`trigger="click" rootClose`) opens the popover, and in the same commit `RootCloseWrapper` attaches an outside-click listener on `document`. The native click is still bubbling, reaches that new listener, is treated as "outside", and the popover closes within the same frame.

## Fix
Mirrors #5663 (`ClinicalTrackColorPicker`): add `onClick={e => e.nativeEvent.stopImmediatePropagation()}` on the trigger `<span>` around `ColorPickerIcon` so the opening click never reaches `document`.

Unlike #5663, the existing `onMouseDown`/`onClick` guards on the popover's inner div are **kept**: here the picker lives inside the Groups menu (an rc-tooltip), and the popover is portaled to `document.body`, so without them rc-trigger's document `mousedown` listener treats a swatch click as an outside click and closes the whole menu before a color is applied.

## Why CI didn't catch this
`end-to-end-test-playwright/tests/local/group-color-chooser.spec.ts` covers this flow, but #5624/#5632 "stabilized" it by injecting a `document` click listener calling `stopImmediatePropagation()` before opening the picker — i.e. the test worked around the app bug, so `e2e_localdb_shards` stayed green. That workaround is removed here so the test clicks the icon plainly and actually guards the behavior. (The old WDIO `e2e_localdb_tests` job is disabled in CircleCI, so the legacy spec never ran.)

`tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdSd3qz8Z7TSqXjRvrKazm
