### PR TITLE
Use descriptive column headers in Study Summary table downloads

### DIFF
--- a/src/pages/studyView/StudyViewUtils.spec.tsx
+++ b/src/pages/studyView/StudyViewUtils.spec.tsx
@@ -47,6 +47,13 @@ import {
     getFrequencyStr,
     getChartSettingsMap,
     getGenericAssayFrequencyTableDownloadData,
+    getMutatedGenesDownloadData,
+    getStructuralVariantGenesDownloadData,
+    getGenesCNADownloadData,
+    getPatientTreatmentDownloadData,
+    getSampleTreatmentDownloadData,
+    getMutationTypesDownloadData,
+    getVariantAnnotationTypesDownloadData,
     getGenericAssayFrequencyTableSelectedRowKeyGroups,
     getGenericAssayFrequencyTableSelectedRowKeys,
     getGroupedClinicalDataByBins,
@@ -4348,7 +4355,7 @@ describe('StudyViewUtils', () => {
                 assert.equal(
                     downloadData,
                     [
-                        'Entity\tCategory\t#\tFreq',
+                        'Entity\tCategory\tNumber of samples with one or more generic assay events\tPercentage of samples with one or more generic assay events',
                         'Entity A Label\tSubtype A\t4\t40.0%',
                     ].join('\n')
                 );
@@ -5798,6 +5805,158 @@ describe('StudyViewUtils', () => {
                     { AMP: true, HOMDEL: false }
                 );
             });
+        });
+    });
+
+    describe('study summary table download headers', () => {
+        const row = {
+            label: 'TP53',
+            matchingGenePanelIds: [],
+            numberOfAlteredCases: 3,
+            numberOfProfiledCases: 10,
+            qValue: 0.001,
+            totalCount: 5,
+            alteration: 2,
+            cytoband: '17p13.1',
+            uniqueKey: 'TP53',
+            isCancerGene: true,
+            oncokbAnnotated: true,
+            isOncokbOncogene: true,
+            isOncokbTumorSuppressorGene: false,
+        };
+        const promise = { result: [row] } as any;
+
+        function headerOf(downloadData: string): string[] {
+            return downloadData.split('\n')[0].split('\t');
+        }
+
+        it('describes mutated genes table columns', async () => {
+            const data = await getMutatedGenesDownloadData(promise, true);
+            assert.deepEqual(headerOf(data), [
+                'Gene',
+                'MutSig(Q-value)',
+                'Total number of mutations',
+                'Number of samples with one or more mutations',
+                'Number of profiled samples',
+                'Percentage of samples with one or more mutations',
+                'Is Cancer Gene (source: OncoKB)',
+            ]);
+            assert.equal(
+                data.split('\n')[1],
+                'TP53\t1.000e-3\t5\t3\t10\t30.0%\tYes'
+            );
+        });
+
+        it('omits the cancer gene column when the OncoKB filter is disabled', async () => {
+            const data = await getMutatedGenesDownloadData(promise, false);
+            assert.equal(headerOf(data).length, 6);
+            assert.equal(
+                data.split('\n')[1],
+                'TP53\t1.000e-3\t5\t3\t10\t30.0%'
+            );
+        });
+
+        it('describes structural variant genes table columns', () => {
+            const data = getStructuralVariantGenesDownloadData(promise, false);
+            assert.deepEqual(headerOf(data), [
+                'Gene',
+                'Total number of structural variants',
+                'Number of samples with one or more structural variants',
+                'Number of profiled samples',
+                'Percentage of samples with one or more structural variants',
+            ]);
+            assert.equal(data.split('\n')[1], 'TP53\t5\t3\t10\t30.0%');
+        });
+
+        it('describes CNA genes table columns in the same order as the data', async () => {
+            const data = await getGenesCNADownloadData(promise, false);
+            assert.deepEqual(headerOf(data), [
+                'Gene',
+                'Gistic(Q-value)',
+                'Cytoband',
+                'CNA',
+                'Number of samples with one or more copy number alterations',
+                'Number of profiled samples',
+                'Percentage of samples with one or more copy number alterations',
+            ]);
+            assert.equal(
+                data.split('\n')[1],
+                'TP53\t1.000e-3\t17p13.1\tAMP\t3\t10\t30.0%'
+            );
+        });
+
+        it('describes mutation types table columns', async () => {
+            const data = await getMutationTypesDownloadData(promise);
+            assert.deepEqual(headerOf(data), [
+                'Mutation Event',
+                'Total number of mutations',
+                'Number of samples with one or more mutations',
+                'Number of profiled samples',
+                'Percentage of samples with one or more mutations',
+            ]);
+        });
+
+        it('describes variant annotation types table columns', async () => {
+            const data = await getVariantAnnotationTypesDownloadData(promise);
+            assert.deepEqual(headerOf(data), [
+                'Annotation',
+                'Total number of variant annotations',
+                'Number of samples with one or more variant annotations',
+                'Number of profiled samples',
+                'Percentage of samples with one or more variant annotations',
+            ]);
+        });
+
+        it('describes patient treatments table columns', async () => {
+            const data = await getPatientTreatmentDownloadData({
+                result: {
+                    patientTreatments: [{ treatment: 'Drug A', count: 7 }],
+                },
+            } as any);
+            assert.deepEqual(headerOf(data), [
+                'Treatment',
+                'Number of patients treated',
+            ]);
+            assert.equal(data.split('\n')[1], 'Drug A\t7');
+        });
+
+        it('describes sample treatments table columns', async () => {
+            const data = await getSampleTreatmentDownloadData({
+                result: {
+                    treatments: [
+                        { treatment: 'Drug A', time: 'Pre', count: 4 },
+                    ],
+                },
+            } as any);
+            assert.deepEqual(headerOf(data), [
+                'Treatment',
+                'Pre/Post',
+                'Number of samples acquired before treatment or after/on treatment',
+            ]);
+            assert.equal(data.split('\n')[1], 'Drug A\tPre\t4');
+        });
+
+        it('describes generic assay frequency table columns without a category', () => {
+            const data = getGenericAssayFrequencyTableDownloadData(
+                {
+                    result: [
+                        {
+                            uniqueKey: 'entityA::profile_type',
+                            entityStableId: 'entityA',
+                            entityLabel: 'Entity A',
+                            profileType: 'profile_type',
+                            count: 4,
+                            totalCount: 10,
+                        },
+                    ],
+                } as any,
+                false
+            );
+            assert.deepEqual(headerOf(data), [
+                'Entity',
+                'Number of samples with one or more generic assay events',
+                'Percentage of samples with one or more generic assay events',
+            ]);
         });
     });
 });

--- a/src/pages/studyView/StudyViewUtils.tsx
+++ b/src/pages/studyView/StudyViewUtils.tsx
@@ -914,7 +914,9 @@ export function getGenericAssayFrequencyTableRowUniqueKey(
     return `${stableId}::${value}::${profileType}`;
 }
 
-export function splitGenericAssayFrequencyTableRowUniqueKey(uniqueKey: string): {
+export function splitGenericAssayFrequencyTableRowUniqueKey(
+    uniqueKey: string
+): {
     stableId: string;
     value: string;
     profileType: string;
@@ -4576,7 +4578,7 @@ export function buildGenericAssayFrequencyTableDataFilters(
                 entityRow =>
                     ({
                         value: entityRow.category,
-                    }) as DataFilterValue
+                    } as DataFilterValue)
             ),
         }))
         .value();
@@ -4590,8 +4592,10 @@ export function buildGenericAssaySelectionFilter(
     const values = selectedRowKeyGroups
         .map(group =>
             _.uniq(group).map(rowKey => {
-                const { stableId, value } =
-                    splitGenericAssayFrequencyTableRowUniqueKey(rowKey);
+                const {
+                    stableId,
+                    value,
+                } = splitGenericAssayFrequencyTableRowUniqueKey(rowKey);
                 return {
                     stableId,
                     value,
@@ -5082,21 +5086,59 @@ export function getSurvivalDownloadData(
     }
 }
 
+export type DownloadAlterationType =
+    | 'mutations'
+    | 'structural variants'
+    | 'copy number alterations'
+    | 'variant annotations'
+    | 'generic assay events';
+
+/**
+ * Descriptive column headers for the data tables downloaded from the Study
+ * Summary page. Shared by every download function so the wording stays
+ * consistent across tables; independent of the abbreviated on-screen headers.
+ */
+export const DownloadTableHeader = {
+    GENE: 'Gene',
+    MUTSIG_Q_VALUE: 'MutSig(Q-value)',
+    GISTIC_Q_VALUE: 'Gistic(Q-value)',
+    CYTOBAND: 'Cytoband',
+    CNA: 'CNA',
+    MUTATION_EVENT: 'Mutation Event',
+    ANNOTATION: 'Annotation',
+    ENTITY: 'Entity',
+    CATEGORY: 'Category',
+    TREATMENT: 'Treatment',
+    PRE_POST: 'Pre/Post',
+    IS_CANCER_GENE: 'Is Cancer Gene (source: OncoKB)',
+    TOTAL_MUTATIONS: 'Total number of mutations',
+    TOTAL_STRUCTURAL_VARIANTS: 'Total number of structural variants',
+    TOTAL_VARIANT_ANNOTATIONS: 'Total number of variant annotations',
+    PROFILED_SAMPLES: 'Number of profiled samples',
+    NUMBER_OF_PATIENTS_TREATED: 'Number of patients treated',
+    NUMBER_OF_SAMPLES_TREATED:
+        'Number of samples acquired before treatment or after/on treatment',
+    numberOfSamplesWith: (alterationType: DownloadAlterationType) =>
+        `Number of samples with one or more ${alterationType}`,
+    percentageOfSamplesWith: (alterationType: DownloadAlterationType) =>
+        `Percentage of samples with one or more ${alterationType}`,
+};
+
 export async function getMutatedGenesDownloadData(
     promise: MobxPromise<MultiSelectionTableRow[]>,
     oncokbCancerGeneFilterEnabled: boolean
 ): Promise<string> {
     if (promise.result) {
         let header = [
-            'Gene',
-            'MutSig(Q-value)',
-            '# Mut',
-            '#',
-            'Profiled Samples',
-            'Freq',
+            DownloadTableHeader.GENE,
+            DownloadTableHeader.MUTSIG_Q_VALUE,
+            DownloadTableHeader.TOTAL_MUTATIONS,
+            DownloadTableHeader.numberOfSamplesWith('mutations'),
+            DownloadTableHeader.PROFILED_SAMPLES,
+            DownloadTableHeader.percentageOfSamplesWith('mutations'),
         ];
         if (oncokbCancerGeneFilterEnabled) {
-            header.push('Is Cancer Gene (source: OncoKB)');
+            header.push(DownloadTableHeader.IS_CANCER_GENE);
         }
         let data = [header.join('\t')];
         _.each(promise.result, (record: MultiSelectionTableRow) => {
@@ -5136,8 +5178,21 @@ export function formatGenericAssayFrequencyTableDownloadData(
     }
 
     const header = showCategoryColumn
-        ? ['Entity', 'Category', '#', 'Freq']
-        : ['Entity', '#', 'Freq'];
+        ? [
+              DownloadTableHeader.ENTITY,
+              DownloadTableHeader.CATEGORY,
+              DownloadTableHeader.numberOfSamplesWith('generic assay events'),
+              DownloadTableHeader.percentageOfSamplesWith(
+                  'generic assay events'
+              ),
+          ]
+        : [
+              DownloadTableHeader.ENTITY,
+              DownloadTableHeader.numberOfSamplesWith('generic assay events'),
+              DownloadTableHeader.percentageOfSamplesWith(
+                  'generic assay events'
+              ),
+          ];
     const data = [header.join('\t')];
 
     _.each(rows, record => {
@@ -5181,14 +5236,14 @@ export function getStructuralVariantGenesDownloadData(
 ): string {
     if (promise.result) {
         const header = [
-            'Gene',
-            '# Structural Variant',
-            '#',
-            'Profiled Samples',
-            'Freq',
+            DownloadTableHeader.GENE,
+            DownloadTableHeader.TOTAL_STRUCTURAL_VARIANTS,
+            DownloadTableHeader.numberOfSamplesWith('structural variants'),
+            DownloadTableHeader.PROFILED_SAMPLES,
+            DownloadTableHeader.percentageOfSamplesWith('structural variants'),
         ];
         if (oncokbCancerGeneFilterEnabled) {
-            header.push('Is Cancer Gene (source: OncoKB)');
+            header.push(DownloadTableHeader.IS_CANCER_GENE);
         }
         const data = [header.join('\t')];
         _.each(promise.result, (record: MultiSelectionTableRow) => {
@@ -5224,16 +5279,18 @@ export async function getGenesCNADownloadData(
 ): Promise<string> {
     if (promise.result) {
         let header = [
-            'Gene',
-            'Gistic(Q-value)',
-            'Cytoband',
-            'CNA',
-            'Profiled Samples',
-            '#',
-            'Freq',
+            DownloadTableHeader.GENE,
+            DownloadTableHeader.GISTIC_Q_VALUE,
+            DownloadTableHeader.CYTOBAND,
+            DownloadTableHeader.CNA,
+            DownloadTableHeader.numberOfSamplesWith('copy number alterations'),
+            DownloadTableHeader.PROFILED_SAMPLES,
+            DownloadTableHeader.percentageOfSamplesWith(
+                'copy number alterations'
+            ),
         ];
         if (oncokbCancerGeneFilterEnabled) {
-            header.push('Is Cancer Gene (source: OncoKB)');
+            header.push(DownloadTableHeader.IS_CANCER_GENE);
         }
         let data = [header.join('\t')];
         _.each(promise.result, (record: MultiSelectionTableRow) => {
@@ -5269,7 +5326,10 @@ export async function getPatientTreatmentDownloadData(
     promise: MobxPromise<PatientTreatmentReport>
 ): Promise<string> {
     if (promise.result) {
-        const header = ['Treatment', '#'];
+        const header = [
+            DownloadTableHeader.TREATMENT,
+            DownloadTableHeader.NUMBER_OF_PATIENTS_TREATED,
+        ];
         let data = [header.join('\t')];
         _.each(
             promise.result.patientTreatments,
@@ -5286,7 +5346,11 @@ export async function getSampleTreatmentDownloadData(
     promise: MobxPromise<SampleTreatmentReport>
 ): Promise<string> {
     if (promise.result) {
-        const header = ['Treatment', 'Pre/Post', '#'];
+        const header = [
+            DownloadTableHeader.TREATMENT,
+            DownloadTableHeader.PRE_POST,
+            DownloadTableHeader.NUMBER_OF_SAMPLES_TREATED,
+        ];
         let data = [header.join('\t')];
         _.each(promise.result.treatments, (record: SampleTreatmentRow) => {
             let rowData = [record.treatment, record.time, record.count];
@@ -5301,11 +5365,11 @@ export async function getMutationTypesDownloadData(
 ): Promise<string> {
     if (promise.result) {
         let header = [
-            'Mutation Event',
-            '# Mut',
-            '#',
-            'Profiled Samples',
-            'Freq',
+            DownloadTableHeader.MUTATION_EVENT,
+            DownloadTableHeader.TOTAL_MUTATIONS,
+            DownloadTableHeader.numberOfSamplesWith('mutations'),
+            DownloadTableHeader.PROFILED_SAMPLES,
+            DownloadTableHeader.percentageOfSamplesWith('mutations'),
         ];
         let data = [header.join('\t')];
         _.each(promise.result, (record: MultiSelectionTableRow) => {
@@ -5330,7 +5394,13 @@ export async function getVariantAnnotationTypesDownloadData(
     promise: MobxPromise<MultiSelectionTableRow[]>
 ): Promise<string> {
     if (promise.result) {
-        let header = ['Annotation', '# VA', '#', 'Profiled Samples', 'Freq'];
+        let header = [
+            DownloadTableHeader.ANNOTATION,
+            DownloadTableHeader.TOTAL_VARIANT_ANNOTATIONS,
+            DownloadTableHeader.numberOfSamplesWith('variant annotations'),
+            DownloadTableHeader.PROFILED_SAMPLES,
+            DownloadTableHeader.percentageOfSamplesWith('variant annotations'),
+        ];
         let data = [header.join('\t')];
         _.each(promise.result, (record: MultiSelectionTableRow) => {
             let rowData = [


### PR DESCRIPTION
Fixes cBioPortal/cbioportal#11832

## Summary

The TSVs downloaded via the **Download → Data** button on the Study Summary tables used cryptic column headers (`#`, `# Mut`, `# SV`, `# VA`, `Freq`, `Profiled Samples`). They now use the full wording that the on-screen header tooltips already show, e.g.

| Before | After |
| --- | --- |
| `# Mut` | `Total number of mutations` |
| `# Structural Variant` | `Total number of structural variants` |
| `# VA` | `Total number of variant annotations` |
| `#` (genes tables) | `Number of samples with one or more mutations` / `… copy number alterations` / `… structural variants` / `… variant annotations` / `… generic assay events` |
| `#` (patient treatments) | `Number of patients treated` |
| `#` (sample treatments) | `Number of samples acquired before treatment or after/on treatment` |
| `Profiled Samples` | `Number of profiled samples` |
| `Freq` | `Percentage of samples with one or more mutations` (etc., per table) |

- All download functions now read from a single `DownloadTableHeader` mapping in `StudyViewUtils.tsx`, so wording can't drift between tables again.
- The on-screen table headers are unchanged — this only affects the downloaded file.
- Bug fix in passing: the CNA genes download listed `Profiled Samples` before `#` in the header, but wrote altered-sample count before profiled-sample count in the rows, so those two columns were mislabelled. The header now matches the data.
- Adds unit tests asserting the header row (and a data row) of every Study Summary download function.
- The three unrelated formatting hunks in `StudyViewUtils.tsx` are from the repo's pinned prettier 1.19.1, which the file on `master` currently fails.

## Preview

- https://deploy-preview-5687.preview.cbioportal.org/study/summary?id=msk_impact_2017 — open any of the Mutated Genes / CNA Genes / Structural Variants / Treatments tables, click the download icon → **Data**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiF9HThAuBVd6xK73McucR
