### PR TITLE
Pin Biobank Tissue and Biobank Biofluid tracks adjacent in patient view timeline

### DIFF
--- a/src/pages/patientView/timeline/timeline_helpers.tsx
+++ b/src/pages/patientView/timeline/timeline_helpers.tsx
@@ -302,6 +302,8 @@ export function buildBaseConfig(
             'Sample Acquisition',
             'Sequencing',
             'Surgery',
+            'Biobank Tissue',
+            'Biobank Biofluid',
             'Med Onc',
             'Med Onc Assessment',
             'Status',


### PR DESCRIPTION
These two tracks were previously falling wherever their first event occurred chronologically among unlisted tracks, allowing tracks like PROCEDURES to land between them. Adding both to sortOrder guarantees they stay adjacent regardless of event timing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790955938&installation_model_id=19627&pr_number=5690&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5690&signature=e6561d5d1f31880921d5316974ce5529d33850eb96ea1c2dbf9011aafde2e499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->