### PR TITLE
Fix flaky igv tab e2e test by stubbing the genome registry fetch

### DIFF
--- a/end-to-end-test-playwright/tests/helpers/common.ts
+++ b/end-to-end-test-playwright/tests/helpers/common.ts
@@ -197,19 +197,45 @@ export async function setCheckboxChecked(
 }
 
 /**
- * igv.js resolves the bare 'hg19' genome id against its own registry,
- * which points cytoband and RefSeq gene-track data at UCSC's
- * hgdownload server. Those fetches hang indefinitely from CI's network
- * path rather than erroring, stalling IGV's initialization forever
- * (cBioPortal/cbioportal#12314) — and a missing RefSeq track also
- * makes igv.js fall back to resolving gene-symbol loci (e.g. "TP53")
- * via the equally unreliable igv.org/genomes/locus.php. Stub both
- * hgdownload fetches with the real (static, unchanging) files so
- * tests don't depend on a third-party host being reachable from CI.
+ * igv.js resolves the bare 'hg19' genome id by fetching a genome
+ * *registry* (igv.org/genomes/genomes.json, falling back to an S3
+ * mirror) and reading that registry's hg19 entry for where to pull
+ * fasta/cytoband/RefSeq data from. Both hops are third-party and have
+ * each independently broken CI (cBioPortal/cbioportal#12314):
+ *  - the registry's hg19 entry currently points fastaURL/indexURL/
+ *    cytobandURL at an S3 bucket (igv-genepattern-org) that now
+ *    returns 403 for all three files — igv.js's genome load then
+ *    rejects, IGV never mounts, and `.igv-column-container` stays at
+ *    0 height forever;
+ *  - the RefSeq gene track and (previously) cytoband URL point at
+ *    UCSC's hgdownload server, whose fetches have hung indefinitely
+ *    from CI's network path rather than erroring, likewise stalling
+ *    IGV's initialization forever. A missing RefSeq track also makes
+ *    igv.js fall back to resolving gene-symbol loci (e.g. "TP53") via
+ *    the equally unreliable igv.org/genomes/locus.php.
+ * Stub the registry fetch itself so hg19 always resolves to a fixed,
+ * known-good entry: fasta/index/cytoband point at the
+ * igv.broadinstitute.org S3 bucket (the same host production code
+ * already trusts for these files — see `defaultGrch37ReferenceProps`
+ * in src/shared/lib/IGVUtils.ts), and the RefSeq track points at the
+ * local fixture below instead of hgdownload. This removes every
+ * external host from hg19 genome resolution except the one bucket
+ * cbioportal already depends on elsewhere.
  * Must be called before whatever navigation/interaction triggers IGV
  * to load the 'hg19' genome.
  */
 export async function stubUcscHg19Fetches(page: Page): Promise<void> {
+    // Matches both the primary (igv.org/genomes/genomes.json) and
+    // backup (s3.amazonaws.com/igv.org.genomes/genomes.json) registry
+    // URLs igv.js tries in turn — the backup's bucket name
+    // ("igv.org.genomes") means the path doesn't contain a "/genomes/"
+    // segment, so the glob only anchors on the shared "genomes.json" tail.
+    await page.route('**/genomes.json**', route =>
+        route.fulfill({
+            path: path.join(__dirname, 'fixtures', 'genomes.hg19.json'),
+            contentType: 'application/json',
+        })
+    );
     await page.route('**/goldenPath/hg19/database/cytoBand.txt.gz', route =>
         route.fulfill({
             path: path.join(__dirname, 'fixtures', 'cytoBand.hg19.txt.gz'),

--- a/end-to-end-test-playwright/tests/helpers/fixtures/genomes.hg19.json
+++ b/end-to-end-test-playwright/tests/helpers/fixtures/genomes.hg19.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "hg19",
+        "name": "Human (GRCh37/hg19)",
+        "fastaURL": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta",
+        "indexURL": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta.fai",
+        "cytobandURL": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt",
+        "aliasURL": "https://s3.amazonaws.com/igv.org.genomes/hg19/hg19_alias.tab",
+        "tracks": [
+            {
+                "name": "Refseq Genes",
+                "format": "refgene",
+                "id": "hg19_genes",
+                "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/ncbiRefSeq.txt.gz",
+                "indexed": false,
+                "order": 1000000,
+                "infoURL": "https://www.ncbi.nlm.nih.gov/gene/?term=$$"
+            }
+        ],
+        "chromosomeOrder": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY"
+    }
+]


### PR DESCRIPTION
waitForIgvRendered still times out at 60s despite #5684's hgdownload stubs. The live igv.js hg19 registry entry (fetched from igv.org/genomes/genomes.json, falling back to an S3 mirror) has since drifted: its fastaURL/indexURL/cytobandURL now point at an S3 bucket (igv-genepattern-org) that returns 403 Forbidden for all three files (verified live). That rejects igv.js's genome load; IGV never mounts, so .igv-column-container stays at 0 height and waitForIgvRendered spins until timeout even though the app's own LoadingIndicator is correctly cleared.

Stub the genomes.json fetch itself (both the primary and S3-backup registry URLs) so hg19 always resolves to a fixed, known-good entry pointing fasta/index/cytoband at the igv.broadinstitute.org bucket — the same host defaultGrch37ReferenceProps() in IGVUtils.ts already trusts elsewhere in this codebase — and the RefSeq track at the existing local fixture instead of hgdownload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790965677&installation_model_id=19627&pr_number=5692&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5692&signature=f1761c62e8a82c55e42dc609aee351f47d40a0e0ed1b461625cfa548ab473932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->