### PR TITLE
Support configurable Bedrock models and AWS credentials

### DIFF
--- a/packages/chat-sidebar-server/.env.example
+++ b/packages/chat-sidebar-server/.env.example
@@ -13,16 +13,22 @@ GOOGLE_VERTEX_PROJECT=
 GOOGLE_VERTEX_LOCATION=
 
 # bedrock
-# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY aren't read directly by this
-# server — they're picked up by the AWS SDK's default credential chain.
+# Credentials use the AWS SDK default provider chain. This includes environment
+# variables, shared ~/.aws config/credentials files, SSO, web identity, and
+# ECS/EC2 credentials. Set AWS_PROFILE to select a named shared-file profile.
 AWS_REGION=
+AWS_PROFILE=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
-BEDROCK_SONNET_MODEL_ID=
+AWS_SESSION_TOKEN=
+# Bedrock model ID, inference profile ID, or ARN supported by Converse streaming
+# and the tool-use features used by this application.
+BEDROCK_MODEL_ID=
 
 # langfuse (system prompt) — LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY/
 # LANGFUSE_HOST are expected in the shell environment, not here. src/
-# systemPrompt.md is only the fallback if this can't be reached.
+# systemPrompt.md is used directly when credentials are absent and as the
+# fallback if a configured Langfuse instance can't be reached.
 
 # mcp — each is optional and independent; a server with no URL set here is
 # simply not offered to the model (no hardcoded remote fallback).

--- a/packages/chat-sidebar-server/package.json
+++ b/packages/chat-sidebar-server/package.json
@@ -14,6 +14,7 @@
         "@ai-sdk/anthropic": "^4.0.20",
         "@ai-sdk/google-vertex": "^5.0.30",
         "@ai-sdk/mcp": "^2.0.16",
+        "@aws-sdk/credential-provider-node": "3.972.82",
         "@langfuse/client": "^5.9.1",
         "@opentelemetry/api": "^1.9.1",
         "ai": "^7.0.37",

--- a/packages/chat-sidebar-server/src/core.ts
+++ b/packages/chat-sidebar-server/src/core.ts
@@ -18,6 +18,7 @@ import { anthropic } from '@ai-sdk/anthropic';
 import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createMCPClient, MCPClient } from '@ai-sdk/mcp';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { LangfuseClient } from '@langfuse/client';
 
 const vertexAnthropic = createVertexAnthropic({
@@ -27,13 +28,12 @@ const vertexAnthropic = createVertexAnthropic({
 
 const bedrock = createAmazonBedrock({
     region: process.env.AWS_REGION,
+    credentialProvider: defaultProvider(),
 });
 
-// Bedrock uses region-prefixed inference-profile ids, not Anthropic model
-// names — no default.
-const BEDROCK_SONNET_MODEL_ID = process.env.BEDROCK_SONNET_MODEL_ID;
+const BEDROCK_MODEL_ID = process.env.BEDROCK_MODEL_ID;
 
-// Only Sonnet 5 is available via this account's Vertex/Bedrock access.
+// Direct Anthropic and Vertex access currently use Sonnet 5.
 const CLAUDE_MODEL_ID = 'claude-sonnet-5';
 
 // Fallback for the Langfuse prompt fetch, if it's unreachable.
@@ -44,18 +44,26 @@ const LOCAL_SYSTEM_PROMPT_TEXT = readFileSync(
 );
 
 // Accept LANGFUSE_HOST too — this deployment's shell env uses the older name.
-const langfuse = new LangfuseClient({
-    baseUrl: process.env.LANGFUSE_BASE_URL || process.env.LANGFUSE_HOST,
-});
+const langfuse =
+    process.env.LANGFUSE_PUBLIC_KEY && process.env.LANGFUSE_SECRET_KEY
+        ? new LangfuseClient({
+              baseUrl:
+                  process.env.LANGFUSE_BASE_URL || process.env.LANGFUSE_HOST,
+          })
+        : undefined;
 
 async function getSystemPrompt(pageHref?: string): Promise<string> {
-    const result = await langfuse.prompt.get('cBioChat Sidebar System Prompt', {
-        label: 'latest',
-        fallback: LOCAL_SYSTEM_PROMPT_TEXT,
-    });
+    const systemPrompt = langfuse
+        ? (
+              await langfuse.prompt.get('cBioChat Sidebar System Prompt', {
+                  label: 'latest',
+                  fallback: LOCAL_SYSTEM_PROMPT_TEXT,
+              })
+          ).prompt
+        : LOCAL_SYSTEM_PROMPT_TEXT;
     return pageHref
-        ? `${result.prompt}\n\nThe user is currently viewing this cBioPortal page: ${pageHref}`
-        : result.prompt;
+        ? `${systemPrompt}\n\nThe user is currently viewing this cBioPortal page: ${pageHref}`
+        : systemPrompt;
 }
 
 // Optional and independent — unset means that server's tools aren't offered
@@ -190,17 +198,19 @@ const getPageDetailsTool = tool({
 
 // Ids are "<provider>:<model>".
 function getModel(id: string): LanguageModel {
-    const [provider, modelId] = id.split(':');
+    const separatorIndex = id.indexOf(':');
+    const provider = id.slice(0, separatorIndex);
+    const modelId = id.slice(separatorIndex + 1);
     switch (provider) {
         case 'anthropic':
             return anthropic(modelId);
         case 'vertex':
             return vertexAnthropic(modelId);
         case 'bedrock':
-            if (!BEDROCK_SONNET_MODEL_ID) {
-                throw new Error('BEDROCK_SONNET_MODEL_ID is not set.');
+            if (!BEDROCK_MODEL_ID || modelId !== BEDROCK_MODEL_ID) {
+                throw new Error(`Unknown Bedrock model id: "${modelId}"`);
             }
-            return bedrock(BEDROCK_SONNET_MODEL_ID);
+            return bedrock(BEDROCK_MODEL_ID);
         default:
             throw new Error(`Unknown model id: "${id}"`);
     }
@@ -221,9 +231,9 @@ export const AVAILABLE_MODELS: readonly ModelInfo[] = [
         id: `vertex:${CLAUDE_MODEL_ID}`,
         name: 'Claude Sonnet 5 (Vertex)',
     },
-    BEDROCK_SONNET_MODEL_ID && {
-        id: `bedrock:${CLAUDE_MODEL_ID}`,
-        name: 'Claude Sonnet 5 (Bedrock)',
+    BEDROCK_MODEL_ID && {
+        id: `bedrock:${BEDROCK_MODEL_ID}`,
+        name: `${BEDROCK_MODEL_ID} (Amazon Bedrock)`,
     },
 ].filter((m): m is ModelInfo => Boolean(m));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -983,6 +983,9 @@ importers:
       '@ai-sdk/mcp':
         specifier: ^2.0.16
         version: 2.0.34(zod@3.25.76)
+      '@aws-sdk/credential-provider-node':
+        specifier: 3.972.82
+        version: 3.972.82
       '@langfuse/client':
         specifier: ^5.9.1
         version: 5.11.0(@opentelemetry/api@1.9.1)
@@ -1294,6 +1297,66 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    resolution: {integrity: sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -3499,12 +3562,32 @@ packages:
     resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/eventstream-codec@4.5.2':
     resolution: {integrity: sha512-u4EAkaviMcQYlorFSnxFUgF/Dnbgiu2TzGmqOU4h3CL4MbvrYyNCXpFkcBwvAEU11EvspKX2zzS2uX7q+43VdQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.8.0':
+    resolution: {integrity: sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.12.1':
+    resolution: {integrity: sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.17.2':
     resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.18.0':
+    resolution: {integrity: sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@4.5.2':
@@ -5238,6 +5321,9 @@ packages:
 
   bowser@1.9.4:
     resolution: {integrity: sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -13859,6 +13945,140 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -16338,12 +16558,40 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/eventstream-codec@4.5.2':
     dependencies:
       '@smithy/core': 3.33.3
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.8.0':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.12.1':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.18.0':
     dependencies:
       tslib: 2.8.1
 
@@ -19013,6 +19261,8 @@ snapshots:
   bootstrap@3.4.1: {}
 
   bowser@1.9.4: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.14:
     dependencies:


### PR DESCRIPTION
- Use the AWS SDK default credential provider chain
- Replace the Sonnet-specific `BEDROCK_SONNET_MODEL_ID` setting with the generic `BEDROCK_MODEL_ID`
- Skip Langfuse requests when its credentials are not configured and use the local system prompt directly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cBioPortal/codesmith/cbioportal-frontend/pr/5696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791150303&installation_model_id=19627&pr_number=5696&repository=cBioPortal%2Fcbioportal-frontend&return_to=https%3A%2F%2Fgithub.com%2FcBioPortal%2Fcbioportal-frontend%2Fpull%2F5696&signature=2ddc3de9719ae929e055b1db4de6f71bff416f27dcf1ccbe7e75dbe6ac0f10e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->