### PR TITLE
Hide redundant sample count in embeddings status bar

### DIFF
--- a/src/pages/studyView/tabs/EmbeddingsTab.tsx
+++ b/src/pages/studyView/tabs/EmbeddingsTab.tsx
@@ -540,9 +540,14 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                                             styles={MAP_SELECT_STYLES}
                                         />
                                     ) : null}{' '}
-                                    (constructed using{' '}
-                                    {this.reportedEmbeddingSampleSize.toLocaleString()}{' '}
-                                    {this.unitLabel})
+                                    {this.reportedEmbeddingSampleSize !==
+                                        this.reportedTotalSampleCount && (
+                                        <>
+                                            (constructed using{' '}
+                                            {this.reportedEmbeddingSampleSize.toLocaleString()}{' '}
+                                            {this.unitLabel})
+                                        </>
+                                    )}
                                 </>
                             ) : null}
                         </span>


### PR DESCRIPTION
## Summary

Small follow-up to #5695. The status bar sentence in the Similarity Maps tab
("N samples embedded in [Map] (constructed using M samples)") showed the
parenthetical count even when it exactly matched the leading count - now it's
hidden in that case since repeating the same number added nothing.

## Preview

- https://deploy-preview-5701.preview.cbioportal.org/study/embeddings?id=brca_tcga_pan_can_atlas_2018&featureFlags=EMBEDDINGS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012E3iMpRk28njveVybcEhTi