### PR TITLE
Hide embeddings status bar while its sample counts are still loading

### DIFF
--- a/src/pages/studyView/tabs/EmbeddingsTab.tsx
+++ b/src/pages/studyView/tabs/EmbeddingsTab.tsx
@@ -515,7 +515,8 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                                     {this.reportedTotalSampleCount.toLocaleString()}{' '}
                                     {this.unitLabel} visible
                                 </>
-                            ) : this.panelCount === 1 || this.sharedLockMap ? (
+                            ) : (this.panelCount === 1 || this.sharedLockMap) &&
+                              this.reportedTotalSampleCount > 0 ? (
                                 <>
                                     {this.reportedTotalSampleCount.toLocaleString()}{' '}
                                     {this.unitLabel} embedded in{' '}
@@ -552,7 +553,8 @@ export class EmbeddingsTab extends React.Component<IEmbeddingsTabProps, {}> {
                             ) : null}
                         </span>
                         {!isFilterActive &&
-                            (this.panelCount === 1 || this.sharedLockMap) && (
+                            (this.panelCount === 1 || this.sharedLockMap) &&
+                            this.reportedTotalSampleCount > 0 && (
                                 <DefaultTooltip
                                     placement="bottom"
                                     overlay={


### PR DESCRIPTION
## Summary

Follow-up to #5695/#5701. The status bar sentence ("N samples embedded in
[Map] (constructed using M samples)") and its "missing samples" warning icon
briefly rendered with misleading zeros ("0 samples embedded in ...") before
the panel's sample counts loaded. Both are now gated on
`reportedTotalSampleCount > 0` instead of always rendering.

This was originally pushed as a second commit to #5701, but landed 15
minutes after that PR was merged, so it never made it in - re-opening as its
own PR.

## Preview

- https://deploy-preview-5704.preview.cbioportal.org/study/embeddings?id=brca_tcga_pan_can_atlas_2018&featureFlags=EMBEDDINGS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012E3iMpRk28njveVybcEhTi